### PR TITLE
[FLINK-13554][runtime] Add a timeout for worker registration.

### DIFF
--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -39,6 +39,12 @@
             <td>The time to wait before requesting new workers (Native Kubernetes / Yarn / Mesos) once the max failure rate of starting workers ('resourcemanager.start-worker.max-failure-rate') is reached.</td>
         </tr>
         <tr>
+            <td><h5>resourcemanager.taskmanager-registration.timeout</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>Timeout for TaskManagers to register at the active resource managers. If exceeded, active resource manager will release and try to re-request the resource for the worker. If not configured, fallback to 'taskmanager.registration.timeout'.</td>
+        </tr>
+        <tr>
             <td><h5>resourcemanager.taskmanager-timeout</h5></td>
             <td style="word-wrap: break-word;">30000</td>
             <td>Long</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -202,6 +202,20 @@ public class ResourceManagerOptions {
     public static final String CONTAINERIZED_TASK_MANAGER_ENV_PREFIX =
             "containerized.taskmanager.env.";
 
+    /** Timeout for TaskManagers to register at the active resource managers. */
+    public static final ConfigOption<Duration> TASK_MANAGER_REGISTRATION_TIMEOUT =
+            ConfigOptions.key("resourcemanager.taskmanager-registration.timeout")
+                    .durationType()
+                    .defaultValue(TaskManagerOptions.REGISTRATION_TIMEOUT.defaultValue())
+                    .withFallbackKeys(TaskManagerOptions.REGISTRATION_TIMEOUT.key())
+                    .withDescription(
+                            "Timeout for TaskManagers to register at the active resource managers. "
+                                    + "If exceeded, active resource manager will release and try to "
+                                    + "re-request the resource for the worker. If not configured, "
+                                    + "fallback to '"
+                                    + TaskManagerOptions.REGISTRATION_TIMEOUT.key()
+                                    + "'.");
+
     // ---------------------------------------------------------------------------------------------
 
     /** Not intended to be instantiated. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPod.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPod.java
@@ -21,6 +21,7 @@ package org.apache.flink.kubernetes.kubeclient.resources;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.Pod;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /** Represent KubernetesPod resource in kubernetes. */
@@ -38,6 +39,17 @@ public class KubernetesPod extends KubernetesResource<Pod> {
         if (getInternalResource().getStatus() != null) {
             return getInternalResource().getStatus().getContainerStatuses().stream()
                     .anyMatch(e -> e.getState() != null && e.getState().getTerminated() != null);
+        }
+        return false;
+    }
+
+    public boolean isScheduled() {
+        if (getInternalResource().getStatus() != null) {
+            return getInternalResource().getStatus().getConditions().stream()
+                    .anyMatch(
+                            e ->
+                                    Objects.equals(e.getType(), "PodScheduled")
+                                            && Objects.equals(e.getStatus(), "True"));
         }
         return false;
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -87,7 +87,12 @@ public class KubernetesResourceManagerDriverTest
                                                     .requestResource(TASK_EXECUTOR_PROCESS_SPEC)
                                                     .thenAccept(requestResourceFuture::complete));
                             final KubernetesPod pod =
-                                    createPodFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+                                    new TestingKubernetesPod(
+                                            createPodFuture
+                                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS)
+                                                    .getName(),
+                                            true,
+                                            false);
 
                             // prepare validation:
                             // - complete requestResourceFuture in main thread with correct
@@ -162,7 +167,7 @@ public class KubernetesResourceManagerDriverTest
         new Context() {
             {
                 final KubernetesPod previousAttemptPod =
-                        new TestingKubernetesPod(CLUSTER_ID + "-taskmanager-1-1", true);
+                        new TestingKubernetesPod(CLUSTER_ID + "-taskmanager-1-1", true, true);
                 final CompletableFuture<String> stopPodFuture = new CompletableFuture<>();
                 final CompletableFuture<Collection<KubernetesWorkerNode>> recoveredWorkersFuture =
                         new CompletableFuture<>();
@@ -261,7 +266,11 @@ public class KubernetesResourceManagerDriverTest
                         .setCreateTaskManagerPodFunction(
                                 (pod) -> {
                                     createTaskManagerPodFuture.complete(pod);
-                                    getPodCallbackHandler().onAdded(Collections.singletonList(pod));
+                                    getPodCallbackHandler()
+                                            .onAdded(
+                                                    Collections.singletonList(
+                                                            new TestingKubernetesPod(
+                                                                    pod.getName(), true, false)));
                                     return FutureUtils.completedVoidFuture();
                                 })
                         .setStopPodFunction(
@@ -419,7 +428,7 @@ public class KubernetesResourceManagerDriverTest
 
                         sendPodTerminatedEvent.accept(
                                 Collections.singletonList(
-                                        new TestingKubernetesPod(pod.getName(), true)));
+                                        new TestingKubernetesPod(pod.getName(), true, true)));
 
                         // make sure finishing validation
                         validationFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/TestingKubernetesPod.java
@@ -22,14 +22,16 @@ package org.apache.flink.kubernetes.kubeclient.resources;
 public class TestingKubernetesPod extends KubernetesPod {
     private final String name;
     private final boolean isTerminated;
+    private final boolean isScheduled;
 
     public TestingKubernetesPod(String name) {
-        this(name, false);
+        this(name, true, false);
     }
 
-    public TestingKubernetesPod(String name, boolean isTerminated) {
+    public TestingKubernetesPod(String name, boolean isScheduled, boolean isTerminated) {
         super(null);
         this.name = name;
+        this.isScheduled = isScheduled;
         this.isTerminated = isTerminated;
     }
 
@@ -41,6 +43,11 @@ public class TestingKubernetesPod extends KubernetesPod {
     @Override
     public boolean isTerminated() {
         return isTerminated;
+    }
+
+    @Override
+    public boolean isScheduled() {
+        return isScheduled;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -158,6 +158,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     /** The heartbeat manager with job managers. */
     private HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
 
+    private boolean hasLeadership = false;
+
     /**
      * Represents asynchronous state clearing work.
      *
@@ -1200,7 +1202,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
             startServicesOnLeadership();
 
-            return prepareLeadershipAsync().thenApply(ignored -> true);
+            return prepareLeadershipAsync().thenApply(ignored -> hasLeadership = true);
         } else {
             return CompletableFuture.completedFuture(false);
         }
@@ -1223,6 +1225,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     public void revokeLeadership() {
         runAsyncWithoutFencing(
                 () -> {
+                    hasLeadership = false;
+
                     log.info(
                             "ResourceManager {} was revoked leadership. Clearing fencing token.",
                             getAddress());
@@ -1268,6 +1272,10 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         onFatalError(
                 new ResourceManagerException(
                         "Received an error from the LeaderElectionService.", exception));
+    }
+
+    protected boolean hasLeadership() {
+        return hasLeadership;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -104,6 +104,8 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
         final ThresholdMeter failureRater = createStartWorkerFailureRater(configuration);
         final Duration retryInterval =
                 configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
+        final Duration workerRegistrationTimeout =
+                configuration.get(ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT);
         return new ActiveResourceManager<>(
                 createResourceManagerDriver(
                         configuration, webInterfaceUrl, rpcService.getAddress()),
@@ -120,6 +122,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 resourceManagerMetricGroup,
                 failureRater,
                 retryInterval,
+                workerRegistrationTimeout,
                 ioExecutor);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /** Tests for {@link ActiveResourceManager}. */
 public class ActiveResourceManagerTest extends TestLogger {
@@ -76,6 +77,7 @@ public class ActiveResourceManagerTest extends TestLogger {
     private static final long TIMEOUT_SEC = 5L;
     private static final Time TIMEOUT_TIME = Time.seconds(TIMEOUT_SEC);
     private static final Time TESTING_START_WORKER_INTERVAL = Time.milliseconds(50);
+    private static final long TESTING_START_WORKER_TIMEOUT_MS = 50;
 
     private static final WorkerResourceSpec WORKER_RESOURCE_SPEC = WorkerResourceSpec.ZERO;
 
@@ -711,6 +713,120 @@ public class ActiveResourceManagerTest extends TestLogger {
         };
     }
 
+    @Test
+    public void testWorkerRegistrationTimeout() throws Exception {
+        new Context() {
+            {
+                final ResourceID tmResourceId = ResourceID.generate();
+                final CompletableFuture<ResourceID> releaseResourceFuture =
+                        new CompletableFuture<>();
+
+                flinkConfig.set(
+                        ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT,
+                        Duration.ofMillis(TESTING_START_WORKER_TIMEOUT_MS));
+
+                driverBuilder
+                        .setRequestResourceFunction(
+                                taskExecutorProcessSpec ->
+                                        CompletableFuture.completedFuture(tmResourceId))
+                        .setReleaseResourceConsumer(releaseResourceFuture::complete);
+
+                runTest(
+                        () -> {
+                            // request new worker
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .startNewWorker(WORKER_RESOURCE_SPEC));
+
+                            // verify worker is released due to not registered in time
+                            assertThat(
+                                    releaseResourceFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    is(tmResourceId));
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testWorkerRegistrationTimeoutNotCountingAllocationTime() throws Exception {
+        new Context() {
+            {
+                final ResourceID tmResourceId = ResourceID.generate();
+                final CompletableFuture<ResourceID> requestResourceFuture =
+                        new CompletableFuture<>();
+                final CompletableFuture<ResourceID> releaseResourceFuture =
+                        new CompletableFuture<>();
+
+                flinkConfig.set(
+                        ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT,
+                        Duration.ofMillis(TESTING_START_WORKER_TIMEOUT_MS));
+
+                driverBuilder
+                        .setRequestResourceFunction(
+                                taskExecutorProcessSpec -> requestResourceFuture)
+                        .setReleaseResourceConsumer(releaseResourceFuture::complete);
+
+                runTest(
+                        () -> {
+                            // request new worker
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .startNewWorker(WORKER_RESOURCE_SPEC));
+
+                            // resource allocation takes longer than worker registration timeout
+                            try {
+                                Thread.sleep(TESTING_START_WORKER_TIMEOUT_MS * 2);
+                                requestResourceFuture.complete(tmResourceId);
+                            } catch (InterruptedException e) {
+                                fail();
+                            }
+
+                            // worker registered, verify not released due to timeout
+                            CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
+                                    registerTaskExecutor(tmResourceId);
+                            assertThat(
+                                    registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    instanceOf(RegistrationResponse.Success.class));
+                            assertFalse(releaseResourceFuture.isDone());
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testWorkerRegistrationTimeoutRecoveredFromPreviousAttempt() throws Exception {
+        new Context() {
+            {
+                final ResourceID tmResourceId = ResourceID.generate();
+                final CompletableFuture<ResourceID> releaseResourceFuture =
+                        new CompletableFuture<>();
+
+                flinkConfig.set(
+                        ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT,
+                        Duration.ofMillis(TESTING_START_WORKER_TIMEOUT_MS));
+
+                driverBuilder.setReleaseResourceConsumer(releaseResourceFuture::complete);
+
+                runTest(
+                        () -> {
+                            // workers recovered
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .onPreviousAttemptWorkersRecovered(
+                                                            Collections.singleton(tmResourceId)));
+
+                            // verify worker is released due to not registered in time
+                            assertThat(
+                                    releaseResourceFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    is(tmResourceId));
+                        });
+            }
+        };
+    }
+
     private static class Context {
 
         final Configuration flinkConfig = new Configuration();
@@ -754,6 +870,8 @@ public class ActiveResourceManagerTest extends TestLogger {
                     new MockResourceManagerRuntimeServices(rpcService, TIMEOUT_TIME, slotManager);
             final Duration retryInterval =
                     configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
+            final Duration workerRegistrationTimeout =
+                    configuration.get(ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT);
 
             final ActiveResourceManager<ResourceID> activeResourceManager =
                     new ActiveResourceManager<>(
@@ -772,6 +890,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             ActiveResourceManagerFactory.createStartWorkerFailureRater(
                                     configuration),
                             retryInterval,
+                            workerRegistrationTimeout,
                             ForkJoinPool.commonPool());
 
             activeResourceManager.start();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
