### PR TITLE
[FLINK-21396][table-common] Add ResolvedCatalog(View/Table) and Catalog(View/Table).of

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -21,8 +21,8 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
@@ -38,7 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.flink.table.catalog.config.CatalogConfig.IS_GENERIC;
+import static org.apache.flink.table.catalog.CatalogPropertiesUtil.IS_GENERIC;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_ENABLE;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_PARTITION_INCLUDE;
 
@@ -81,7 +81,9 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
     public DynamicTableSink createDynamicTableSink(Context context) {
         boolean isGeneric =
                 Boolean.parseBoolean(
-                        context.getCatalogTable().getOptions().get(CatalogConfig.IS_GENERIC));
+                        context.getCatalogTable()
+                                .getOptions()
+                                .get(CatalogPropertiesUtil.IS_GENERIC));
 
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic
         if (!isGeneric && !context.isTemporary()) {
@@ -109,7 +111,9 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
     public DynamicTableSource createDynamicTableSource(Context context) {
         boolean isGeneric =
                 Boolean.parseBoolean(
-                        context.getCatalogTable().getOptions().get(CatalogConfig.IS_GENERIC));
+                        context.getCatalogTable()
+                                .getOptions()
+                                .get(CatalogPropertiesUtil.IS_GENERIC));
 
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic
         if (!isGeneric && !context.isTemporary()) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
@@ -51,7 +51,8 @@ public class HiveTableFactory implements TableSourceFactory, TableSinkFactory {
         CatalogTable table = checkNotNull(context.getTable());
         Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
-        boolean isGeneric = Boolean.parseBoolean(table.getOptions().get(CatalogConfig.IS_GENERIC));
+        boolean isGeneric =
+                Boolean.parseBoolean(table.getOptions().get(CatalogPropertiesUtil.IS_GENERIC));
 
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic
         if (!isGeneric && !context.isTemporary()) {
@@ -67,7 +68,8 @@ public class HiveTableFactory implements TableSourceFactory, TableSinkFactory {
         CatalogTable table = checkNotNull(context.getTable());
         Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
-        boolean isGeneric = Boolean.parseBoolean(table.getOptions().get(CatalogConfig.IS_GENERIC));
+        boolean isGeneric =
+                Boolean.parseBoolean(table.getOptions().get(CatalogPropertiesUtil.IS_GENERIC));
 
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic
         if (!isGeneric && !context.isTemporary()) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -37,12 +37,12 @@ import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionImpl;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.CatalogViewImpl;
 import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -121,7 +121,7 @@ import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.HiveTableS
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.NOT_NULL_COLS;
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.NOT_NULL_CONSTRAINT_TRAITS;
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.PK_CONSTRAINT_TRAIT;
-import static org.apache.flink.table.catalog.config.CatalogConfig.FLINK_PROPERTY_PREFIX;
+import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
 import static org.apache.flink.table.catalog.hive.util.HiveStatsUtil.parsePositiveIntStat;
 import static org.apache.flink.table.catalog.hive.util.HiveStatsUtil.parsePositiveLongStat;
 import static org.apache.flink.table.catalog.hive.util.HiveTableUtil.getHadoopConfiguration;
@@ -710,7 +710,7 @@ public class HiveCatalog extends AbstractCatalog {
             // remove the schema from properties
             properties = CatalogTableImpl.removeRedundant(properties, tableSchema, partitionKeys);
         } else {
-            properties.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+            properties.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
             // Table schema
             List<FieldSchema> fields = getNonPartitionFields(hiveConf, hiveTable);
             Set<String> notNullColumns =
@@ -772,7 +772,7 @@ public class HiveCatalog extends AbstractCatalog {
                 .filter(
                         e ->
                                 e.getKey().startsWith(FLINK_PROPERTY_PREFIX)
-                                        || e.getKey().equals(CatalogConfig.IS_GENERIC))
+                                        || e.getKey().equals(CatalogPropertiesUtil.IS_GENERIC))
                 .collect(
                         Collectors.toMap(
                                 e -> e.getKey().replace(FLINK_PROPERTY_PREFIX, ""),
@@ -813,7 +813,7 @@ public class HiveCatalog extends AbstractCatalog {
         checkNotNull(partition, "Partition cannot be null");
 
         boolean isGeneric =
-                Boolean.valueOf(partition.getProperties().get(CatalogConfig.IS_GENERIC));
+                Boolean.valueOf(partition.getProperties().get(CatalogPropertiesUtil.IS_GENERIC));
 
         if (isGeneric) {
             throw new CatalogException("Currently only supports non-generic CatalogPartition");
@@ -1672,12 +1672,12 @@ public class HiveCatalog extends AbstractCatalog {
             return true;
         }
         boolean isGeneric;
-        if (!properties.containsKey(CatalogConfig.IS_GENERIC)) {
+        if (!properties.containsKey(CatalogPropertiesUtil.IS_GENERIC)) {
             // must be a generic object
             isGeneric = true;
-            properties.put(CatalogConfig.IS_GENERIC, String.valueOf(true));
+            properties.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(true));
         } else {
-            isGeneric = Boolean.parseBoolean(properties.get(CatalogConfig.IS_GENERIC));
+            isGeneric = Boolean.parseBoolean(properties.get(CatalogPropertiesUtil.IS_GENERIC));
         }
         return isGeneric;
     }
@@ -1687,7 +1687,8 @@ public class HiveCatalog extends AbstractCatalog {
         // otherwise, this is a Hive object if 1) the key is missing 2) is_generic = false
         // this is opposite to creating an object. See createObjectIsGeneric()
         return properties != null
-                && Boolean.parseBoolean(properties.getOrDefault(CatalogConfig.IS_GENERIC, "false"));
+                && Boolean.parseBoolean(
+                        properties.getOrDefault(CatalogPropertiesUtil.IS_GENERIC, "false"));
     }
 
     public static void disallowChangeIsGeneric(boolean oldIsGeneric, boolean newIsGeneric) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -25,12 +25,12 @@ import org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.HiveTableRowForma
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
 import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.CatalogView;
 import org.apache.flink.table.catalog.CatalogViewImpl;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveCatalogConfig;
@@ -81,7 +81,7 @@ import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.HiveTableS
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.HiveTableStoredAs.STORED_AS_OUTPUT_FORMAT;
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.TABLE_IS_EXTERNAL;
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.TABLE_LOCATION_URI;
-import static org.apache.flink.table.catalog.config.CatalogConfig.FLINK_PROPERTY_PREFIX;
+import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Utils to for Hive-backed table. */
@@ -428,7 +428,7 @@ public class HiveTableUtil {
                 .map(
                         e ->
                                 new Tuple2<>(
-                                        e.getKey().equals(CatalogConfig.IS_GENERIC)
+                                        e.getKey().equals(CatalogPropertiesUtil.IS_GENERIC)
                                                 ? e.getKey()
                                                 : FLINK_PROPERTY_PREFIX + e.getKey(),
                                         e.getValue()))

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -26,9 +26,9 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.delegation.Parser;
@@ -124,7 +124,7 @@ public class HiveDialectITCase {
         tableEnv.executeSql("create database db1 comment 'db1 comment'");
         Database db = hiveCatalog.getHiveDatabase("db1");
         assertEquals("db1 comment", db.getDescription());
-        assertFalse(Boolean.parseBoolean(db.getParameters().get(CatalogConfig.IS_GENERIC)));
+        assertFalse(Boolean.parseBoolean(db.getParameters().get(CatalogPropertiesUtil.IS_GENERIC)));
 
         String db2Location = warehouse + "/db2_location";
         tableEnv.executeSql(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -22,11 +22,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -74,7 +74,7 @@ public class HiveTableFactoryTest {
                         .build();
 
         Map<String, String> properties = new HashMap<>();
-        properties.put(CatalogConfig.IS_GENERIC, String.valueOf(true));
+        properties.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(true));
         properties.put("connector", "COLLECTION");
 
         catalog.createDatabase("mydb", new CatalogDatabaseImpl(new HashMap<>(), ""), true);
@@ -112,7 +112,7 @@ public class HiveTableFactoryTest {
                         .build();
 
         Map<String, String> properties = new HashMap<>();
-        properties.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+        properties.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
 
         catalog.createDatabase("mydb", new CatalogDatabaseImpl(new HashMap<>(), ""), true);
         ObjectPath path = new ObjectPath("mydb", "mytable");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogDataTypeTest.java
@@ -22,10 +22,10 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -199,7 +199,7 @@ public class HiveCatalogDataTypeTest {
                 new HashMap<String, String>() {
                     {
                         put("is_streaming", "false");
-                        put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+                        put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
                     }
                 },
                 "");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -24,10 +24,10 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.functions.TestGenericUDF;
 import org.apache.flink.table.functions.TestSimpleUDF;
 import org.apache.flink.table.types.DataType;
@@ -120,7 +120,7 @@ public class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase 
             CatalogBaseTable catalogBaseTable = catalog.getTable(tablePath);
             assertTrue(
                     Boolean.parseBoolean(
-                            catalogBaseTable.getOptions().get(CatalogConfig.IS_GENERIC)));
+                            catalogBaseTable.getOptions().get(CatalogPropertiesUtil.IS_GENERIC)));
             TableSchema expectedSchema =
                     TableSchema.builder()
                             .fields(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -29,10 +29,10 @@ import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.CatalogTestUtil;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
@@ -266,7 +266,7 @@ public class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
         catalog.dropTable(path1, true);
 
         Map<String, String> properties = new HashMap<>();
-        properties.put(CatalogConfig.IS_GENERIC, "false");
+        properties.put(CatalogPropertiesUtil.IS_GENERIC, "false");
         properties.put(StatsSetupConst.ROW_COUNT, String.valueOf(inputStat));
         properties.put(StatsSetupConst.NUM_FILES, String.valueOf(inputStat));
         properties.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(inputStat));

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.table.catalog.hive;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
 import org.apache.flink.table.descriptors.FileSystem;
 
@@ -54,17 +54,17 @@ public class HiveCatalogTest {
                         HiveTestUtils.createHiveConf());
 
         Map<String, String> prop = hiveTable.getParameters();
-        assertEquals(prop.remove(CatalogConfig.IS_GENERIC), String.valueOf("true"));
+        assertEquals(prop.remove(CatalogPropertiesUtil.IS_GENERIC), String.valueOf("true"));
         assertTrue(
                 prop.keySet().stream()
-                        .allMatch(k -> k.startsWith(CatalogConfig.FLINK_PROPERTY_PREFIX)));
+                        .allMatch(k -> k.startsWith(CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX)));
     }
 
     @Test
     public void testCreateHiveTable() {
         Map<String, String> map = new HashMap<>(new FileSystem().path("/test_path").toProperties());
 
-        map.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+        map.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
 
         Table hiveTable =
                 HiveTableUtil.instantiateHiveTable(
@@ -73,9 +73,9 @@ public class HiveCatalogTest {
                         HiveTestUtils.createHiveConf());
 
         Map<String, String> prop = hiveTable.getParameters();
-        assertEquals(prop.remove(CatalogConfig.IS_GENERIC), String.valueOf(false));
+        assertEquals(prop.remove(CatalogPropertiesUtil.IS_GENERIC), String.valueOf(false));
         assertTrue(
                 prop.keySet().stream()
-                        .noneMatch(k -> k.startsWith(CatalogConfig.FLINK_PROPERTY_PREFIX)));
+                        .noneMatch(k -> k.startsWith(CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX)));
     }
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -26,11 +26,11 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
@@ -262,7 +262,7 @@ public class DependencyTest {
         @Override
         public List<String> supportedProperties() {
             List<String> list = super.supportedProperties();
-            list.add(CatalogConfig.IS_GENERIC);
+            list.add(CatalogPropertiesUtil.IS_GENERIC);
 
             return list;
         }
@@ -291,7 +291,9 @@ public class DependencyTest {
                                 TableSchema.builder().field("testcol", DataTypes.INT()).build(),
                                 new HashMap<String, String>() {
                                     {
-                                        put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+                                        put(
+                                                CatalogPropertiesUtil.IS_GENERIC,
+                                                String.valueOf(false));
                                     }
                                 },
                                 ""),
@@ -325,7 +327,7 @@ public class DependencyTest {
                     tableSchema,
                     new HashMap<String, String>() {
                         {
-                            put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+                            put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
                         }
                     },
                     "");

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
@@ -26,7 +26,7 @@ import org.apache.flink.sql.parser.hive.impl.ParseException;
 import org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec;
 import org.apache.flink.sql.parser.type.ExtendedSqlRowTypeNameSpec;
 import org.apache.flink.sql.parser.type.SqlMapTypeNameSpec;
-import org.apache.flink.table.catalog.config.CatalogConfig;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
 import org.apache.calcite.sql.SqlCall;
@@ -115,7 +115,7 @@ public class HiveDDLUtils {
             if (node instanceof SqlTableOption
                     && ((SqlTableOption) node)
                             .getKeyString()
-                            .equalsIgnoreCase(CatalogConfig.IS_GENERIC)) {
+                            .equalsIgnoreCase(CatalogPropertiesUtil.IS_GENERIC)) {
                 if (!((SqlTableOption) node).getValueString().equalsIgnoreCase("false")) {
                     throw new ParseException(
                             "Creating generic object with Hive dialect is not allowed");

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveDatabase.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveDatabase.java
@@ -21,7 +21,7 @@ package org.apache.flink.sql.parser.hive.ddl;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.hive.impl.ParseException;
-import org.apache.flink.table.catalog.config.CatalogConfig;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -56,7 +56,8 @@ public class SqlCreateHiveDatabase extends SqlCreateDatabase {
         HiveDDLUtils.ensureNonGeneric(propertyList);
         originPropList = new SqlNodeList(propertyList.getList(), propertyList.getParserPosition());
         // mark it as a hive database
-        propertyList.add(HiveDDLUtils.toTableOption(CatalogConfig.IS_GENERIC, "false", pos));
+        propertyList.add(
+                HiveDDLUtils.toTableOption(CatalogPropertiesUtil.IS_GENERIC, "false", pos));
         if (location != null) {
             propertyList.add(
                     new SqlTableOption(

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveTable.java
@@ -24,7 +24,7 @@ import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.hive.impl.ParseException;
-import org.apache.flink.table.catalog.config.CatalogConfig;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -97,7 +97,8 @@ public class SqlCreateHiveTable extends SqlCreateTable {
         originPropList = new SqlNodeList(propertyList.getList(), propertyList.getParserPosition());
         // mark it as a hive table
         HiveDDLUtils.ensureNonGeneric(propertyList);
-        propertyList.add(HiveDDLUtils.toTableOption(CatalogConfig.IS_GENERIC, "false", pos));
+        propertyList.add(
+                HiveDDLUtils.toTableOption(CatalogPropertiesUtil.IS_GENERIC, "false", pos));
         // set external
         this.isExternal = isExternal;
         if (isExternal) {

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveView.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlCreateHiveView.java
@@ -19,7 +19,7 @@
 package org.apache.flink.sql.parser.hive.ddl;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateView;
-import org.apache.flink.table.catalog.config.CatalogConfig;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -59,7 +59,7 @@ public class SqlCreateHiveView extends SqlCreateView {
         HiveDDLUtils.unescapeProperties(properties);
         originPropList = new SqlNodeList(properties.getList(), properties.getParserPosition());
         // mark it as a hive view
-        properties.add(HiveDDLUtils.toTableOption(CatalogConfig.IS_GENERIC, "false", pos));
+        properties.add(HiveDDLUtils.toTableOption(CatalogPropertiesUtil.IS_GENERIC, "false", pos));
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableBuilder.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
 import org.apache.flink.table.descriptors.Descriptor;
 import org.apache.flink.table.descriptors.DescriptorProperties;
@@ -103,7 +102,7 @@ public final class CatalogTableBuilder extends TableDescriptor<CatalogTableBuild
     protected Map<String, String> additionalProperties() {
         DescriptorProperties descriptorProperties = new DescriptorProperties();
 
-        descriptorProperties.putBoolean(CatalogConfig.IS_GENERIC, isGeneric);
+        descriptorProperties.putBoolean(CatalogPropertiesUtil.IS_GENERIC, isGeneric);
 
         descriptorProperties.putProperties(this.properties);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.descriptors.Schema;
 
@@ -72,7 +71,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
         descriptor.putPartitionKeys(getPartitionKeys());
 
         Map<String, String> properties = new HashMap<>(getOptions());
-        properties.remove(CatalogConfig.IS_GENERIC);
+        properties.remove(CatalogPropertiesUtil.IS_GENERIC);
 
         descriptor.putProperties(properties);
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
+import org.apache.flink.table.utils.ExpressionResolverMocks;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
+import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
+import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link CatalogTable} to {@link ResolvedCatalogTable} and {@link CatalogView} to {@link
+ * ResolvedCatalogView} including {@link CatalogPropertiesUtil}.
+ */
+public class CatalogBaseTableResolutionTest {
+
+    private static final String COMPUTED_SQL = "orig_ts - INTERVAL '60' MINUTE";
+
+    private static final ResolvedExpression COMPUTED_COLUMN_RESOLVED =
+            new ResolvedExpressionMock(DataTypes.TIMESTAMP(3), () -> COMPUTED_SQL);
+
+    private static final String WATERMARK_SQL = "ts - INTERVAL '5' SECOND";
+
+    private static final ResolvedExpression WATERMARK_RESOLVED =
+            new ResolvedExpressionMock(DataTypes.TIMESTAMP(3), () -> WATERMARK_SQL);
+
+    private static final Schema TABLE_SCHEMA =
+            Schema.newBuilder()
+                    .column("id", DataTypes.INT().notNull())
+                    .column("region", DataTypes.VARCHAR(200))
+                    .column("county", DataTypes.VARCHAR(200))
+                    .columnByMetadata("topic", DataTypes.VARCHAR(200), true)
+                    .columnByMetadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp")
+                    .columnByExpression("ts", COMPUTED_SQL)
+                    .watermark("ts", WATERMARK_SQL)
+                    .primaryKeyNamed("primary_constraint", "id")
+                    .build();
+
+    private static final TableSchema LEGACY_TABLE_SCHEMA =
+            TableSchema.builder()
+                    .add(TableColumn.physical("id", DataTypes.INT().notNull()))
+                    .add(TableColumn.physical("region", DataTypes.VARCHAR(200)))
+                    .add(TableColumn.physical("county", DataTypes.VARCHAR(200)))
+                    .add(TableColumn.metadata("topic", DataTypes.VARCHAR(200), true))
+                    .add(TableColumn.metadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp"))
+                    .add(TableColumn.computed("ts", DataTypes.TIMESTAMP(3), COMPUTED_SQL))
+                    .watermark("ts", WATERMARK_SQL, DataTypes.TIMESTAMP(3))
+                    .primaryKey("primary_constraint", new String[] {"id"})
+                    .build();
+
+    private static final Schema VIEW_SCHEMA =
+            Schema.newBuilder()
+                    .column("id", DataTypes.INT().notNull())
+                    .column("region", DataTypes.VARCHAR(200))
+                    .column("county", DataTypes.VARCHAR(200))
+                    .build();
+
+    private static final ResolvedSchema RESOLVED_TABLE_SCHEMA =
+            new ResolvedSchema(
+                    Arrays.asList(
+                            Column.physical("id", DataTypes.INT().notNull()),
+                            Column.physical("region", DataTypes.VARCHAR(200)),
+                            Column.physical("county", DataTypes.VARCHAR(200)),
+                            Column.metadata("topic", DataTypes.VARCHAR(200), null, true),
+                            Column.metadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp", false),
+                            Column.computed("ts", COMPUTED_COLUMN_RESOLVED)),
+                    Collections.singletonList(new WatermarkSpec("ts", WATERMARK_RESOLVED)),
+                    UniqueConstraint.primaryKey(
+                            "primary_constraint", Collections.singletonList("id")));
+
+    private static final ResolvedSchema RESOLVED_VIEW_SCHEMA =
+            new ResolvedSchema(
+                    Arrays.asList(
+                            Column.physical("id", DataTypes.INT().notNull()),
+                            Column.physical("region", DataTypes.VARCHAR(200)),
+                            Column.physical("county", DataTypes.VARCHAR(200))),
+                    Collections.emptyList(),
+                    null);
+
+    @Test
+    public void testCatalogTableResolution() {
+        final CatalogTable table = catalogTable();
+
+        // TODO uncomment
+        // assertNotNull(table.getUnresolvedSchema());
+
+        final ResolvedCatalogTable resolvedTable =
+                resolveCatalogBaseTable(ResolvedCatalogTable.class, table);
+
+        assertThat(resolvedTable.getResolvedSchema(), equalTo(RESOLVED_TABLE_SCHEMA));
+
+        assertThat(resolvedTable.getSchema(), equalTo(LEGACY_TABLE_SCHEMA));
+    }
+
+    @Test
+    public void testCatalogViewResolution() {
+        final CatalogView view = catalogView();
+
+        final ResolvedCatalogView resolvedView =
+                resolveCatalogBaseTable(ResolvedCatalogView.class, view);
+
+        assertThat(resolvedView.getResolvedSchema(), equalTo(RESOLVED_VIEW_SCHEMA));
+    }
+
+    @Test
+    public void testPropertyDeSerialization() {
+        final CatalogTable table = CatalogTable.fromProperties(catalogTableAsProperties());
+
+        final ResolvedCatalogTable resolvedTable =
+                resolveCatalogBaseTable(ResolvedCatalogTable.class, table);
+
+        assertThat(resolvedTable.toProperties(), equalTo(catalogTableAsProperties()));
+
+        assertThat(resolvedTable.getResolvedSchema(), equalTo(RESOLVED_TABLE_SCHEMA));
+    }
+
+    @Test
+    public void testPropertyDeserializationError() {
+        try {
+            final Map<String, String> properties = catalogTableAsProperties();
+            properties.remove("schema.4.data-type");
+            CatalogTable.fromProperties(properties);
+            fail();
+        } catch (Exception e) {
+            assertThat(e, containsMessage("Could not find property key 'schema.4.data-type'."));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Utilities
+    // --------------------------------------------------------------------------------------------
+
+    private static CatalogTable catalogTable() {
+        final String comment = "This is an example table.";
+
+        final List<String> partitionKeys = Arrays.asList("region", "county");
+
+        final Map<String, String> options = new HashMap<>();
+        options.put("connector", "custom");
+        options.put("version", "12");
+
+        return CatalogTable.of(TABLE_SCHEMA, comment, partitionKeys, options);
+    }
+
+    private static Map<String, String> catalogTableAsProperties() {
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("schema.0.name", "id");
+        properties.put("schema.0.data-type", "INT NOT NULL");
+        properties.put("schema.1.name", "region");
+        properties.put("schema.1.data-type", "VARCHAR(200)");
+        properties.put("schema.2.name", "county");
+        properties.put("schema.2.data-type", "VARCHAR(200)");
+        properties.put("schema.3.name", "topic");
+        properties.put("schema.3.data-type", "VARCHAR(200)");
+        properties.put("schema.3.metadata", "topic");
+        properties.put("schema.3.virtual", "true");
+        properties.put("schema.4.name", "orig_ts");
+        properties.put("schema.4.data-type", "TIMESTAMP(3)");
+        properties.put("schema.4.metadata", "timestamp");
+        properties.put("schema.4.virtual", "false");
+        properties.put("schema.5.name", "ts");
+        properties.put("schema.5.data-type", "TIMESTAMP(3)");
+        properties.put("schema.5.expr", "orig_ts - INTERVAL '60' MINUTE");
+        properties.put("schema.watermark.0.rowtime", "ts");
+        properties.put("schema.watermark.0.strategy.data-type", "TIMESTAMP(3)");
+        properties.put("schema.watermark.0.strategy.expr", "ts - INTERVAL '5' SECOND");
+        properties.put("schema.primary-key.name", "primary_constraint");
+        properties.put("schema.primary-key.columns", "id");
+        properties.put("partition.keys.0.name", "region");
+        properties.put("partition.keys.1.name", "county");
+        properties.put("version", "12");
+        properties.put("connector", "custom");
+        properties.put("comment", "This is an example table.");
+        return properties;
+    }
+
+    private static CatalogView catalogView() {
+        final String comment = "This is an example table.";
+
+        final String originalQuery = "SELECT * FROM T";
+
+        final String expandedQuery =
+                String.format(
+                        "SELECT id, region, county FROM %s.%s.T",
+                        DEFAULT_CATALOG, DEFAULT_DATABASE);
+
+        return CatalogView.of(
+                VIEW_SCHEMA, comment, originalQuery, expandedQuery, Collections.emptyMap());
+    }
+
+    private static <T extends CatalogBaseTable> T resolveCatalogBaseTable(
+            Class<T> expectedClass, CatalogBaseTable table) {
+        if (table instanceof DefaultCatalogTable) {
+            final DefaultCatalogTable catalogTable = (DefaultCatalogTable) table;
+            return expectedClass.cast(
+                    new ResolvedCatalogTable(
+                            catalogTable, resolveSchema(catalogTable.getUnresolvedSchema())));
+        } else if (table instanceof DefaultCatalogView) {
+            final DefaultCatalogView catalogView = (DefaultCatalogView) table;
+            return expectedClass.cast(
+                    new ResolvedCatalogView(
+                            catalogView, resolveSchema(catalogView.getUnresolvedSchema())));
+        }
+        throw new UnsupportedOperationException("Unknown catalog base table: " + table);
+    }
+
+    private static ResolvedSchema resolveSchema(Schema schema) {
+        final SchemaResolver resolver =
+                new DefaultSchemaResolver(
+                        true,
+                        true,
+                        new DataTypeFactoryMock(),
+                        ExpressionResolverMocks.forSqlExpression(
+                                CatalogBaseTableResolutionTest::resolveSqlExpression));
+        return resolver.resolve(schema);
+    }
+
+    private static ResolvedExpression resolveSqlExpression(
+            String sqlExpression, TableSchema inputSchema) {
+        switch (sqlExpression) {
+            case COMPUTED_SQL:
+                return COMPUTED_COLUMN_RESOLVED;
+            case WATERMARK_SQL:
+                return WATERMARK_RESOLVED;
+            default:
+                throw new UnsupportedOperationException("Unknown SQL expression.");
+        }
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.table.catalog.config.CatalogConfig;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,7 +62,7 @@ public abstract class CatalogTestBase extends CatalogTest {
     @Override
     public CatalogTable createStreamingTable() {
         Map<String, String> prop = getBatchTableProperties();
-        prop.put(CatalogConfig.IS_GENERIC, String.valueOf(false));
+        prop.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
 
         return new CatalogTableImpl(
                 createTableSchema(), getStreamingTableProperties(), TEST_COMMENT);
@@ -134,7 +132,7 @@ public abstract class CatalogTestBase extends CatalogTest {
     private Map<String, String> getGenericFlag(boolean isGeneric) {
         return new HashMap<String, String>() {
             {
-                put(CatalogConfig.IS_GENERIC, String.valueOf(isGeneric));
+                put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(isGeneric));
             }
         };
     }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExpressionResolverMocks.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExpressionResolverMocks.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.expressions.resolver.ExpressionResolver;
+import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
+import org.apache.flink.table.expressions.resolver.SqlExpressionResolver;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
+
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Mock implementations of {@link ExpressionResolver}/{@link ExpressionResolverBuilder} for testing
+ * purposes.
+ */
+public final class ExpressionResolverMocks {
+
+    public static ExpressionResolverBuilder forSqlExpression(
+            DataTypeFactory factory, SqlExpressionResolver resolver) {
+        return ExpressionResolver.resolverFor(
+                new TableConfig(),
+                name -> Optional.empty(),
+                new FunctionLookupMock(Collections.emptyMap()),
+                factory,
+                resolver);
+    }
+
+    public static ExpressionResolverBuilder forSqlExpression(Parser parser) {
+        return forSqlExpression(parser::parseSqlExpression);
+    }
+
+    public static ExpressionResolverBuilder forSqlExpression(SqlExpressionResolver resolver) {
+        return forSqlExpression(new DataTypeFactoryMock(), resolver);
+    }
+
+    public static ExpressionResolverBuilder dummyResolver() {
+        return forSqlExpression(
+                (sqlExpression, inputSchema) -> {
+                    throw new UnsupportedOperationException();
+                });
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -19,6 +19,31 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Schema.Builder;
+import org.apache.flink.table.catalog.Column.ComputedColumn;
+import org.apache.flink.table.catalog.Column.MetadataColumn;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Utilities for de/serializing {@link Catalog} objects into a map of string properties. */
 @Internal
@@ -39,6 +64,404 @@ public final class CatalogPropertiesUtil {
      * versions of metastore.
      */
     public static final String FLINK_PROPERTY_PREFIX = "flink.";
+
+    /** Serializes the given {@link ResolvedCatalogTable} into a map of string properties. */
+    public static Map<String, String> serializeCatalogTable(ResolvedCatalogTable resolvedTable) {
+        try {
+            final Map<String, String> properties = new HashMap<>();
+
+            serializeResolvedSchema(properties, resolvedTable.getResolvedSchema());
+
+            properties.put(COMMENT, resolvedTable.getComment());
+
+            serializePartitionKeys(properties, resolvedTable.getPartitionKeys());
+
+            properties.putAll(resolvedTable.getOptions());
+
+            properties.remove(IS_GENERIC); // reserved option
+
+            return properties;
+        } catch (Exception e) {
+            throw new CatalogException("Error in serializing catalog table.", e);
+        }
+    }
+
+    /** Deserializes the given map of string properties into an unresolved {@link CatalogTable}. */
+    public static CatalogTable deserializeCatalogTable(Map<String, String> properties) {
+        try {
+            final Schema schema = deserializeSchema(properties);
+
+            final @Nullable String comment = properties.get(COMMENT);
+
+            final List<String> partitionKeys = deserializePartitionKeys(properties);
+
+            final Map<String, String> options = deserializeOptions(properties);
+
+            return CatalogTable.of(schema, comment, partitionKeys, options);
+        } catch (Exception e) {
+            throw new CatalogException("Error in deserializing catalog table.", e);
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper methods and constants
+    // --------------------------------------------------------------------------------------------
+
+    private static final String SCHEMA = "schema";
+
+    private static final String NAME = "name";
+
+    private static final String DATA_TYPE = "data-type";
+
+    private static final String EXPR = "expr";
+
+    private static final String METADATA = "metadata";
+
+    private static final String VIRTUAL = "virtual";
+
+    private static final String PARTITION_KEYS = "partition.keys";
+
+    private static final String WATERMARK = "watermark";
+
+    private static final String WATERMARK_ROWTIME = "rowtime";
+
+    private static final String WATERMARK_STRATEGY = "strategy";
+
+    private static final String WATERMARK_STRATEGY_EXPR = WATERMARK_STRATEGY + '.' + EXPR;
+
+    private static final String WATERMARK_STRATEGY_DATA_TYPE = WATERMARK_STRATEGY + '.' + DATA_TYPE;
+
+    private static final String PRIMARY_KEY_NAME = "primary-key.name";
+
+    private static final String PRIMARY_KEY_COLUMNS = "primary-key.columns";
+
+    private static final String COMMENT = "comment";
+
+    private static Map<String, String> deserializeOptions(Map<String, String> map) {
+        return map.entrySet().stream()
+                .filter(
+                        e -> {
+                            final String key = e.getKey();
+                            return !key.startsWith(SCHEMA + '.')
+                                    && !key.startsWith(PARTITION_KEYS + '.')
+                                    && !key.equals(COMMENT);
+                        })
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static List<String> deserializePartitionKeys(Map<String, String> map) {
+        final int partitionCount = getCount(map, PARTITION_KEYS, NAME);
+        final List<String> partitionKeys = new ArrayList<>();
+        for (int i = 0; i < partitionCount; i++) {
+            final String partitionNameKey = PARTITION_KEYS + '.' + i + '.' + NAME;
+            final String partitionName = getValue(map, partitionNameKey);
+            partitionKeys.add(partitionName);
+        }
+        return partitionKeys;
+    }
+
+    private static Schema deserializeSchema(Map<String, String> map) {
+        final Builder builder = Schema.newBuilder();
+
+        deserializeColumns(map, builder);
+
+        deserializeWatermark(map, builder);
+
+        deserializePrimaryKey(map, builder);
+
+        return builder.build();
+    }
+
+    private static void deserializePrimaryKey(Map<String, String> map, Builder builder) {
+        final String constraintNameKey = SCHEMA + '.' + PRIMARY_KEY_NAME;
+        final String columnsKey = SCHEMA + '.' + PRIMARY_KEY_COLUMNS;
+        if (map.containsKey(constraintNameKey)) {
+            final String constraintName = getValue(map, constraintNameKey);
+            final String[] columns = getValue(map, columnsKey, s -> s.split(","));
+            builder.primaryKeyNamed(constraintName, columns);
+        }
+    }
+
+    private static void deserializeWatermark(Map<String, String> map, Builder builder) {
+        final String watermarkKey = SCHEMA + '.' + WATERMARK;
+        final int watermarkCount = getCount(map, watermarkKey, WATERMARK_ROWTIME);
+        for (int i = 0; i < watermarkCount; i++) {
+            final String rowtimeKey = watermarkKey + '.' + i + '.' + WATERMARK_ROWTIME;
+            final String exprKey = watermarkKey + '.' + i + '.' + WATERMARK_STRATEGY_EXPR;
+
+            final String rowtime = getValue(map, rowtimeKey);
+            final String expr = getValue(map, exprKey);
+            builder.watermark(rowtime, expr);
+        }
+    }
+
+    private static void deserializeColumns(Map<String, String> map, Builder builder) {
+        final int fieldCount = getCount(map, SCHEMA, NAME);
+
+        for (int i = 0; i < fieldCount; i++) {
+            final String nameKey = SCHEMA + '.' + i + '.' + NAME;
+            final String dataTypeKey = SCHEMA + '.' + i + '.' + DATA_TYPE;
+            final String exprKey = SCHEMA + '.' + i + '.' + EXPR;
+            final String metadataKey = SCHEMA + '.' + i + '.' + METADATA;
+            final String virtualKey = SCHEMA + '.' + i + '.' + VIRTUAL;
+
+            final String name = getValue(map, nameKey);
+
+            // computed column
+            if (map.containsKey(exprKey)) {
+                final String expr = getValue(map, exprKey);
+                builder.columnByExpression(name, expr);
+            }
+            // metadata column
+            else if (map.containsKey(metadataKey)) {
+                final String metadata = getValue(map, metadataKey);
+                final String dataType = getValue(map, dataTypeKey);
+                final boolean isVirtual = getValue(map, virtualKey, Boolean::parseBoolean);
+                if (metadata.equals(name)) {
+                    builder.columnByMetadata(name, dataType, isVirtual);
+                } else {
+                    builder.columnByMetadata(name, dataType, metadata, isVirtual);
+                }
+            }
+            // physical column
+            else {
+                final String dataType = getValue(map, dataTypeKey);
+                builder.column(name, dataType);
+            }
+        }
+    }
+
+    private static void serializePartitionKeys(Map<String, String> map, List<String> keys) {
+        checkNotNull(keys);
+
+        putIndexedProperties(
+                map,
+                PARTITION_KEYS,
+                Collections.singletonList(NAME),
+                keys.stream().map(Collections::singletonList).collect(Collectors.toList()));
+    }
+
+    private static void serializeResolvedSchema(Map<String, String> map, ResolvedSchema schema) {
+        checkNotNull(schema);
+
+        serializeColumns(map, schema.getColumns());
+
+        serializeWatermarkSpecs(map, schema.getWatermarkSpecs());
+
+        schema.getPrimaryKey().ifPresent(pk -> serializePrimaryKey(map, pk));
+    }
+
+    private static void serializePrimaryKey(Map<String, String> map, UniqueConstraint constraint) {
+        map.put(SCHEMA + '.' + PRIMARY_KEY_NAME, constraint.getName());
+        map.put(SCHEMA + '.' + PRIMARY_KEY_COLUMNS, String.join(",", constraint.getColumns()));
+    }
+
+    private static void serializeWatermarkSpecs(
+            Map<String, String> map, List<WatermarkSpec> specs) {
+        if (!specs.isEmpty()) {
+            final List<List<String>> watermarkValues = new ArrayList<>();
+            for (WatermarkSpec spec : specs) {
+                watermarkValues.add(
+                        Arrays.asList(
+                                spec.getRowtimeAttribute(),
+                                serializeResolvedExpression(spec.getWatermarkExpression()),
+                                serializeDataType(
+                                        spec.getWatermarkExpression().getOutputDataType())));
+            }
+            putIndexedProperties(
+                    map,
+                    SCHEMA + '.' + WATERMARK,
+                    Arrays.asList(
+                            WATERMARK_ROWTIME,
+                            WATERMARK_STRATEGY_EXPR,
+                            WATERMARK_STRATEGY_DATA_TYPE),
+                    watermarkValues);
+        }
+    }
+
+    private static void serializeColumns(Map<String, String> map, List<Column> columns) {
+        final String[] names = serializeColumnNames(columns);
+        final String[] dataTypes = serializeColumnDataTypes(columns);
+        final String[] expressions = serializeColumnComputations(columns);
+        final String[] metadata = serializeColumnMetadataKeys(columns);
+        final String[] virtual = serializeColumnVirtuality(columns);
+
+        final List<List<String>> values = new ArrayList<>();
+        for (int i = 0; i < columns.size(); i++) {
+            values.add(
+                    Arrays.asList(names[i], dataTypes[i], expressions[i], metadata[i], virtual[i]));
+        }
+
+        putIndexedProperties(
+                map, SCHEMA, Arrays.asList(NAME, DATA_TYPE, EXPR, METADATA, VIRTUAL), values);
+    }
+
+    private static String serializeResolvedExpression(ResolvedExpression resolvedExpression) {
+        try {
+            return resolvedExpression.asSerializableString();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Expression '%s' cannot be stored in a durable catalog. "
+                                    + "Currently, only SQL expressions have a well-defined string "
+                                    + "representation that is used to serialize a catalog object "
+                                    + "into a map of string-based properties.",
+                            resolvedExpression.asSummaryString()),
+                    e);
+        }
+    }
+
+    private static String serializeDataType(DataType dataType) {
+        final LogicalType type = dataType.getLogicalType();
+        try {
+            return type.asSerializableString();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Data type '%s' cannot be stored in a durable catalog. Only data types "
+                                    + "that have a well-defined string representation can be used "
+                                    + "when serializing a catalog object into a map of string-based "
+                                    + "properties. This excludes anonymously defined, unregistered "
+                                    + "types such as structured types in particular.",
+                            type.asSummaryString()),
+                    e);
+        }
+    }
+
+    private static String[] serializeColumnNames(List<Column> columns) {
+        return columns.stream().map(Column::getName).toArray(String[]::new);
+    }
+
+    private static String[] serializeColumnDataTypes(List<Column> columns) {
+        return columns.stream()
+                .map(Column::getDataType)
+                .map(CatalogPropertiesUtil::serializeDataType)
+                .toArray(String[]::new);
+    }
+
+    private static String[] serializeColumnComputations(List<Column> columns) {
+        return columns.stream()
+                .map(
+                        column -> {
+                            if (column instanceof ComputedColumn) {
+                                final ComputedColumn c = (ComputedColumn) column;
+                                return serializeResolvedExpression(c.getExpression());
+                            }
+                            return null;
+                        })
+                .toArray(String[]::new);
+    }
+
+    private static String[] serializeColumnMetadataKeys(List<Column> columns) {
+        return columns.stream()
+                .map(
+                        column -> {
+                            if (column instanceof MetadataColumn) {
+                                final MetadataColumn c = (MetadataColumn) column;
+                                return c.getMetadataKey().orElse(c.getName());
+                            }
+                            return null;
+                        })
+                .toArray(String[]::new);
+    }
+
+    private static String[] serializeColumnVirtuality(List<Column> columns) {
+        return columns.stream()
+                .map(
+                        column -> {
+                            if (column instanceof MetadataColumn) {
+                                final MetadataColumn c = (MetadataColumn) column;
+                                return Boolean.toString(c.isVirtual());
+                            }
+                            return null;
+                        })
+                .toArray(String[]::new);
+    }
+
+    /**
+     * Adds an indexed sequence of properties (with sub-properties) under a common key. It supports
+     * the property's value to be null, in which case it would be ignored. The sub-properties should
+     * at least have one non-null value.
+     *
+     * <p>For example:
+     *
+     * <pre>
+     *     schema.fields.0.type = INT, schema.fields.0.name = test
+     *     schema.fields.1.type = LONG, schema.fields.1.name = test2
+     *     schema.fields.2.type = LONG, schema.fields.2.name = test3, schema.fields.2.expr = test2 + 1
+     * </pre>
+     *
+     * <p>The arity of each subKeyValues must match the arity of propertyKeys.
+     */
+    private static void putIndexedProperties(
+            Map<String, String> map,
+            String key,
+            List<String> subKeys,
+            List<List<String>> subKeyValues) {
+        checkNotNull(key);
+        checkNotNull(subKeys);
+        checkNotNull(subKeyValues);
+        for (int idx = 0; idx < subKeyValues.size(); idx++) {
+            final List<String> values = subKeyValues.get(idx);
+            if (values == null || values.size() != subKeys.size()) {
+                throw new IllegalArgumentException("Values must have same arity as keys.");
+            }
+            if (values.stream().allMatch(Objects::isNull)) {
+                throw new IllegalArgumentException("Values must have at least one non-null value.");
+            }
+            for (int keyIdx = 0; keyIdx < values.size(); keyIdx++) {
+                String value = values.get(keyIdx);
+                if (value != null) {
+                    map.put(key + '.' + idx + '.' + subKeys.get(keyIdx), values.get(keyIdx));
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts the property count under the given key and suffix.
+     *
+     * <p>For example:
+     *
+     * <pre>
+     *     schema.0.name, schema.1.name -> 2
+     * </pre>
+     */
+    private static int getCount(Map<String, String> map, String key, String suffix) {
+        final String escapedKey = Pattern.quote(key);
+        final String escapedSuffix = Pattern.quote(suffix);
+        final Pattern pattern = Pattern.compile(escapedKey + "\\.(\\d+)\\." + escapedSuffix);
+        final IntStream indexes =
+                map.keySet().stream()
+                        .flatMapToInt(
+                                k -> {
+                                    final Matcher matcher = pattern.matcher(k);
+                                    if (matcher.find()) {
+                                        return IntStream.of(Integer.parseInt(matcher.group(1)));
+                                    }
+                                    return IntStream.empty();
+                                });
+
+        return indexes.max().orElse(-1) + 1;
+    }
+
+    private static String getValue(Map<String, String> map, String key) {
+        return getValue(map, key, Function.identity());
+    }
+
+    private static <T> T getValue(Map<String, String> map, String key, Function<String, T> parser) {
+        final String value = map.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    String.format("Could not find property key '%s'.", key));
+        }
+        try {
+            return parser.apply(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    String.format("Could not parse value for property key '%s': %s", key, value));
+        }
+    }
 
     private CatalogPropertiesUtil() {
         // no instantiation

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -33,10 +33,10 @@ public final class CatalogPropertiesUtil {
     public static final String IS_GENERIC = "is_generic";
 
     /**
-     * Globally reserved prefix for catalog properties. User defined properties should not with this
-     * prefix. Used to distinguish properties created by Hive and Flink, as Hive metastore has its
-     * own properties created upon table creation and migration between different versions of
-     * metastore.
+     * Globally reserved prefix for catalog properties. User-defined properties should not use this
+     * prefix. E.g. it is used to distinguish properties created by Hive and Flink, as Hive
+     * metastore has its own properties created upon table creation and migration between different
+     * versions of metastore.
      */
     public static final String FLINK_PROPERTY_PREFIX = "flink.";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Schema.Builder;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.Column.ComputedColumn;
 import org.apache.flink.table.catalog.Column.MetadataColumn;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
@@ -299,8 +300,8 @@ public final class CatalogPropertiesUtil {
     private static String serializeResolvedExpression(ResolvedExpression resolvedExpression) {
         try {
             return resolvedExpression.asSerializableString();
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
+        } catch (TableException e) {
+            throw new TableException(
                     String.format(
                             "Expression '%s' cannot be stored in a durable catalog. "
                                     + "Currently, only SQL expressions have a well-defined string "
@@ -315,8 +316,8 @@ public final class CatalogPropertiesUtil {
         final LogicalType type = dataType.getLogicalType();
         try {
             return type.asSerializableString();
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
+        } catch (TableException e) {
+            throw new TableException(
                     String.format(
                             "Data type '%s' cannot be stored in a durable catalog. Only data types "
                                     + "that have a well-defined string representation can be used "

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -16,18 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.catalog.config;
+package org.apache.flink.table.catalog;
 
-/** Config for catalog and catalog meta-objects. */
-public class CatalogConfig {
+import org.apache.flink.annotation.Internal;
 
-    /** Flag to distinguish if a meta-object is generic Flink object or not. */
+/** Utilities for de/serializing {@link Catalog} objects into a map of string properties. */
+@Internal
+public final class CatalogPropertiesUtil {
+
+    /**
+     * Flag to distinguish if a meta-object is a generic Flink object or not.
+     *
+     * <p>It is used to distinguish between Flink's generic connector discovery logic or specialized
+     * catalog connectors.
+     */
     public static final String IS_GENERIC = "is_generic";
 
-    // Globally reserved prefix for catalog properties.
-    // User defined properties should not with this prefix.
-    // Used to distinguish properties created by Hive and Flink,
-    // as Hive metastore has its own properties created upon table creation and migration between
-    // different versions of metastore.
+    /**
+     * Globally reserved prefix for catalog properties. User defined properties should not with this
+     * prefix. Used to distinguish properties created by Hive and Flink, as Hive metastore has its
+     * own properties created upon table creation and migration between different versions of
+     * metastore.
+     */
     public static final String FLINK_PROPERTY_PREFIX = "flink.";
+
+    private CatalogPropertiesUtil() {
+        // no instantiation
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogTable.java
@@ -18,11 +18,58 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.factories.DynamicTableFactory;
+
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Map;
 
-/** Represents a table in a catalog. */
+/**
+ * Represents the unresolved metadata of a table in a {@link Catalog}.
+ *
+ * <p>It contains all characteristics that can be expressed in a SQL {@code CREATE TABLE} statement.
+ * The framework will resolve instances of this interface to a {@link ResolvedCatalogTable} before
+ * passing it to a {@link DynamicTableFactory} for creating a connector to an external system.
+ *
+ * <p>A catalog implementer can either use {@link #of(Schema, String, List, Map)} for a basic
+ * implementation of this interface or create a custom class that allows passing catalog-specific
+ * objects all the way down to the connector creation (if necessary).
+ */
+@PublicEvolving
 public interface CatalogTable extends CatalogBaseTable {
+
+    /**
+     * Creates a basic implementation of this interface.
+     *
+     * <p>The signature is similar to a SQL {@code CREATE TABLE} statement.
+     *
+     * @param schema unresolved schema
+     * @param comment optional comment
+     * @param partitionKeys list of partition keys or an empty list if not partitioned
+     * @param options options to configure the connector
+     */
+    static CatalogTable of(
+            Schema schema,
+            @Nullable String comment,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        return new DefaultCatalogTable(schema, comment, partitionKeys, options);
+    }
+
+    /**
+     * Creates an instance of {@link CatalogTable} from a map of string properties that were
+     * previously created with {@link ResolvedCatalogTable#toProperties()}.
+     *
+     * @param properties serialized version of a {@link CatalogTable} that includes schema,
+     *     partition keys, and connector options
+     */
+    static CatalogTable fromProperties(Map<String, String> properties) {
+        return CatalogPropertiesUtil.deserializeCatalogTable(properties);
+    }
+
     /**
      * Check if the table is partitioned or not.
      *
@@ -50,6 +97,9 @@ public interface CatalogTable extends CatalogBaseTable {
      *
      * <p>Compared to the pure table options in {@link #getOptions()}, the map includes schema,
      * partitioning, and other characteristics in a serialized form.
+     *
+     * @deprecated Only a {@link ResolvedCatalogTable} is serializable to properties.
      */
+    @Deprecated
     Map<String, String> toProperties();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogView.java
@@ -18,8 +18,47 @@
 
 package org.apache.flink.table.catalog;
 
-/** Represents a view in a catalog. */
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.Schema;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/**
+ * Represents the unresolved metadata of a view in a {@link Catalog}.
+ *
+ * <p>It contains all characteristics that can be expressed in a SQL {@code CREATE VIEW} statement.
+ * The framework will resolve instances of this interface to a {@link ResolvedCatalogView} before
+ * usage.
+ *
+ * <p>A catalog implementer can either use {@link #of(Schema, String, String, String, Map)} for a
+ * basic implementation of this interface or create a custom class that allows passing
+ * catalog-specific objects (if necessary).
+ */
+@PublicEvolving
 public interface CatalogView extends CatalogBaseTable {
+
+    /**
+     * Creates a basic implementation of this interface.
+     *
+     * <p>The signature is similar to a SQL {@code CREATE VIEW} statement.
+     *
+     * @param schema unresolved schema
+     * @param comment optional comment
+     * @param originalQuery original text of the view definition
+     * @param expandedQuery expanded text of the original view definition with materialized
+     *     identifiers
+     * @param options options to configure the connector
+     */
+    static CatalogView of(
+            Schema schema,
+            @Nullable String comment,
+            String originalQuery,
+            String expandedQuery,
+            Map<String, String> options) {
+        return new DefaultCatalogView(schema, comment, originalQuery, expandedQuery, options);
+    }
 
     /**
      * Original text of the view definition that also preserves the original formatting.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableSchema;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implementation of a {@link CatalogTable}. */
+@Internal
+class DefaultCatalogTable implements CatalogTable {
+
+    private final Schema schema;
+    private final @Nullable String comment;
+    private final List<String> partitionKeys;
+    private final Map<String, String> options;
+
+    DefaultCatalogTable(
+            Schema schema,
+            @Nullable String comment,
+            List<String> partitionKeys,
+            Map<String, String> options) {
+        this.schema = checkNotNull(schema, "Schema must not be null.");
+        this.comment = comment;
+        this.partitionKeys = checkNotNull(partitionKeys, "Partition keys must not be null.");
+        this.options = checkNotNull(options, "Options must not be null.");
+
+        checkArgument(
+                options.entrySet().stream()
+                        .allMatch(e -> e.getKey() != null && e.getValue() != null),
+                "Options cannot have null keys or values.");
+    }
+
+    // TODO uncomment
+    // @Override
+    public Schema getUnresolvedSchema() {
+        return schema;
+    }
+
+    @Override
+    public TableSchema getSchema() {
+        // TODO move to upper class
+        return null;
+    }
+
+    @Override
+    public String getComment() {
+        return comment != null ? comment : "";
+    }
+
+    @Override
+    public boolean isPartitioned() {
+        return !partitionKeys.isEmpty();
+    }
+
+    @Override
+    public List<String> getPartitionKeys() {
+        return partitionKeys;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public CatalogBaseTable copy() {
+        return this;
+    }
+
+    @Override
+    public CatalogTable copy(Map<String, String> options) {
+        return new DefaultCatalogTable(schema, comment, partitionKeys, options);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getDetailedDescription() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, String> toProperties() {
+        throw new UnsupportedOperationException(
+                "Only a resolved catalog table can be serialized into map of string properties.");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultCatalogTable that = (DefaultCatalogTable) o;
+        return schema.equals(that.schema)
+                && Objects.equals(comment, that.comment)
+                && partitionKeys.equals(that.partitionKeys)
+                && options.equals(that.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, comment, partitionKeys, options);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogTable.java
@@ -91,7 +91,7 @@ class DefaultCatalogTable implements CatalogTable {
 
     @Override
     public CatalogBaseTable copy() {
-        return this;
+        return new DefaultCatalogTable(schema, comment, partitionKeys, options);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogView.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableSchema;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implementation of a {@link CatalogView}. */
+@Internal
+class DefaultCatalogView implements CatalogView {
+
+    private final Schema schema;
+    private final @Nullable String comment;
+    private final String originalQuery;
+    private final String expandedQuery;
+    private final Map<String, String> options;
+
+    DefaultCatalogView(
+            Schema schema,
+            @Nullable String comment,
+            String originalQuery,
+            String expandedQuery,
+            Map<String, String> options) {
+        this.schema = checkNotNull(schema, "Schema must not be null.");
+        this.comment = comment;
+        this.originalQuery = checkNotNull(originalQuery, "Original query must not be null.");
+        this.expandedQuery = checkNotNull(expandedQuery, "Expanded query must not be null.");
+        this.options = checkNotNull(options, "Options must not be null.");
+
+        checkArgument(
+                options.entrySet().stream()
+                        .allMatch(e -> e.getKey() != null && e.getValue() != null),
+                "Options cannot have null keys or values.");
+    }
+
+    // TODO uncomment
+    // @Override
+    public Schema getUnresolvedSchema() {
+        return schema;
+    }
+
+    @Override
+    public TableSchema getSchema() {
+        // TODO move to upper class
+        return null;
+    }
+
+    @Override
+    public String getComment() {
+        return comment != null ? comment : "";
+    }
+
+    @Override
+    public String getOriginalQuery() {
+        return originalQuery;
+    }
+
+    @Override
+    public String getExpandedQuery() {
+        return expandedQuery;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public CatalogBaseTable copy() {
+        return this;
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getDetailedDescription() {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultCatalogView that = (DefaultCatalogView) o;
+        return schema.equals(that.schema)
+                && Objects.equals(comment, that.comment)
+                && originalQuery.equals(that.originalQuery)
+                && expandedQuery.equals(that.expandedQuery)
+                && options.equals(that.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, comment, originalQuery, expandedQuery, options);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogView.java
@@ -93,7 +93,7 @@ class DefaultCatalogView implements CatalogView {
 
     @Override
     public CatalogBaseTable copy() {
-        return this;
+        return new DefaultCatalogView(schema, comment, originalQuery, expandedQuery, options);
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogBaseTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogBaseTable.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.table.api.TableSchema;
+
+/**
+ * A common parent that describes the <i>resolved</i> metadata of a table or view in a catalog.
+ *
+ * @param <T> {@link CatalogTable} or {@link CatalogView}
+ */
+public interface ResolvedCatalogBaseTable<T extends CatalogBaseTable> extends CatalogBaseTable {
+
+    /**
+     * Returns the original, unresolved metadata object from the {@link Catalog}.
+     *
+     * <p>This method might be useful if catalog-specific object instances should be directly
+     * forwarded from the catalog to a factory.
+     */
+    T getOrigin();
+
+    /**
+     * Returns a fully resolved and validated {@link ResolvedSchema}.
+     *
+     * <p>Connectors can configure themselves by accessing {@link ResolvedSchema#getPrimaryKey()}
+     * and {@link ResolvedSchema#toPhysicalRowDataType()}.
+     */
+    ResolvedSchema getResolvedSchema();
+
+    /**
+     * @deprecated This method returns the deprecated {@link TableSchema} class. The old class was a
+     *     hybrid of resolved and unresolved schema information. It has been replaced by the new
+     *     {@link ResolvedSchema} which is resolved by the framework and accessible via {@link
+     *     #getResolvedSchema()}.
+     */
+    @Deprecated
+    default TableSchema getSchema() {
+        return TableSchema.fromResolvedSchema(getResolvedSchema());
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogTable.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A validated {@link CatalogTable} that is backed by the original metadata coming from the {@link
+ * Catalog} but resolved by the framework.
+ *
+ * <p>Note: Compared to {@link CatalogTable}, instances of this class are serializable into a map of
+ * string properties.
+ */
+@PublicEvolving
+public final class ResolvedCatalogTable
+        implements ResolvedCatalogBaseTable<CatalogTable>, CatalogTable {
+
+    private final CatalogTable origin;
+
+    private final ResolvedSchema resolvedSchema;
+
+    public ResolvedCatalogTable(CatalogTable origin, ResolvedSchema resolvedSchema) {
+        this.origin =
+                Preconditions.checkNotNull(origin, "Original catalog table must not be null.");
+        this.resolvedSchema =
+                Preconditions.checkNotNull(resolvedSchema, "Resolved schema must not be null.");
+    }
+
+    @Override
+    public CatalogTable getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public ResolvedSchema getResolvedSchema() {
+        return resolvedSchema;
+    }
+
+    @Override
+    public Map<String, String> toProperties() {
+        return CatalogPropertiesUtil.serializeCatalogTable(this);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Delegations to original CatalogTable
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public Map<String, String> getOptions() {
+        return origin.getOptions();
+    }
+
+    // TODO uncomment
+    // @Override
+    // public Schema getUnresolvedSchema() {
+    //     return origin.getUnresolvedSchema();
+    // }
+
+    @Override
+    public String getComment() {
+        return origin.getComment();
+    }
+
+    @Override
+    public CatalogBaseTable copy() {
+        return new ResolvedCatalogTable((CatalogTable) origin.copy(), resolvedSchema);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return origin.getDescription();
+    }
+
+    @Override
+    public Optional<String> getDetailedDescription() {
+        return origin.getDetailedDescription();
+    }
+
+    @Override
+    public boolean isPartitioned() {
+        return origin.isPartitioned();
+    }
+
+    @Override
+    public List<String> getPartitionKeys() {
+        return origin.getPartitionKeys();
+    }
+
+    @Override
+    public CatalogTable copy(Map<String, String> options) {
+        return new ResolvedCatalogTable(origin.copy(options), resolvedSchema);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogView.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogView.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A validated {@link CatalogView} that is backed by the original metadata coming from the {@link
+ * Catalog} but resolved by the framework.
+ */
+@PublicEvolving
+public final class ResolvedCatalogView
+        implements ResolvedCatalogBaseTable<CatalogView>, CatalogView {
+
+    private final CatalogView origin;
+
+    private final ResolvedSchema resolvedSchema;
+
+    public ResolvedCatalogView(CatalogView origin, ResolvedSchema resolvedSchema) {
+        this.origin = Preconditions.checkNotNull(origin, "Original catalog view must not be null.");
+        this.resolvedSchema =
+                Preconditions.checkNotNull(resolvedSchema, "Resolved schema must not be null.");
+    }
+
+    @Override
+    public CatalogView getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public ResolvedSchema getResolvedSchema() {
+        return resolvedSchema;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Delegations to original CatalogView
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public Map<String, String> getOptions() {
+        return origin.getOptions();
+    }
+
+    // TODO uncomment
+    // @Override
+    // public Schema getUnresolvedSchema() {
+    //     return origin.getUnresolvedSchema();
+    // }
+
+    @Override
+    public String getComment() {
+        return origin.getComment();
+    }
+
+    @Override
+    public CatalogBaseTable copy() {
+        return new ResolvedCatalogView((CatalogView) origin.copy(), resolvedSchema);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return origin.getDescription();
+    }
+
+    @Override
+    public Optional<String> getDetailedDescription() {
+        return origin.getDetailedDescription();
+    }
+
+    @Override
+    public String getOriginalQuery() {
+        return origin.getOriginalQuery();
+    }
+
+    @Override
+    public String getExpandedQuery() {
+        return origin.getExpandedQuery();
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.descriptors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableColumn.ComputedColumn;
@@ -29,6 +30,8 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.WatermarkSpec;
+import org.apache.flink.table.catalog.CatalogPropertiesUtil;
+import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
@@ -73,7 +76,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * instead of connector.kafka.kafka-version use connector.kafka.version.
  *
  * <p>Properties with key normalization enabled contain only lower-case keys.
+ *
+ * @deprecated This utility will be dropped soon. {@link DynamicTableFactory} is based on {@link
+ *     ConfigOption} and catalogs use {@link CatalogPropertiesUtil}.
  */
+@Deprecated
 @Internal
 public class DescriptorProperties {
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTestUtil.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.catalog;
 
-import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBinary;
@@ -33,7 +32,7 @@ import org.apache.flink.table.plan.stats.TableStats;
 
 import java.util.Map;
 
-import static org.apache.flink.table.catalog.config.CatalogConfig.FLINK_PROPERTY_PREFIX;
+import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -49,12 +48,12 @@ public class CatalogTestUtil {
         assertEquals(t1.isPartitioned(), t2.isPartitioned());
 
         assertEquals(
-                t1.getOptions().get(CatalogConfig.IS_GENERIC),
-                t2.getOptions().get(CatalogConfig.IS_GENERIC));
+                t1.getOptions().get(CatalogPropertiesUtil.IS_GENERIC),
+                t2.getOptions().get(CatalogPropertiesUtil.IS_GENERIC));
 
         // Hive tables may have properties created by itself
         // thus properties of Hive table is a super set of those in its corresponding Flink table
-        if (Boolean.parseBoolean(t1.getOptions().get(CatalogConfig.IS_GENERIC))) {
+        if (Boolean.parseBoolean(t1.getOptions().get(CatalogPropertiesUtil.IS_GENERIC))) {
             assertEquals(t1.getOptions(), t2.getOptions());
         } else {
             assertTrue(
@@ -73,7 +72,7 @@ public class CatalogTestUtil {
 
         // Hive tables may have properties created by itself
         // thus properties of Hive table is a super set of those in its corresponding Flink table
-        if (Boolean.parseBoolean(v1.getOptions().get(CatalogConfig.IS_GENERIC))) {
+        if (Boolean.parseBoolean(v1.getOptions().get(CatalogPropertiesUtil.IS_GENERIC))) {
             assertEquals(v1.getOptions(), v2.getOptions());
         } else {
             assertTrue(
@@ -89,7 +88,7 @@ public class CatalogTestUtil {
 
         // Hive tables may have properties created by itself
         // thus properties of Hive table is a super set of those in its corresponding Flink table
-        if (Boolean.valueOf(p1.getProperties().get(CatalogConfig.IS_GENERIC))) {
+        if (Boolean.valueOf(p1.getProperties().get(CatalogPropertiesUtil.IS_GENERIC))) {
             assertEquals(p1.getProperties(), p2.getProperties());
         } else {
             assertTrue(p2.getProperties().entrySet().containsAll(p1.getProperties().entrySet()));


### PR DESCRIPTION
## What is the purpose of the change

This introduces `ResolvedCatalogTable` and `ResolvedCatalogView`. `ResolvedCatalogTable` uses a new `CatalogPropertiesUtil` for serialization into properties. We introduce a `CatalogTable.of` and `CatalogView.of` for creating instances easily and force implementers to not check against `CatalogTableImpl` which is actually an internal class.

This PR is based on #15096.

Note: This PR is not fully functional yet. We need to update the catalog manager first, which will happen in the next PR.

## Brief change log

- Introduce `ResolvedCatalogView` and `ResolvedCatalogTable`
- Introduce `CatalogTable.of` and `CatalogView.of`
- Deprecate `DescriptorProperties`

## Verifying this change

This change added tests and can be verified as follows: `CatalogBaseTableResolutionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
