### PR TITLE
[FLINK-21606] Reject JobManager <-> TaskManager connection if JobManager is not responsible for job

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JMTMRegistrationRejection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JMTMRegistrationRejection.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.runtime.registration.RegistrationResponse;
+
+/**
+ * Message indicating a registration rejection from the {@link JobMaster} for the {@link
+ * org.apache.flink.runtime.taskexecutor.TaskExecutor}.
+ */
+public class JMTMRegistrationRejection extends RegistrationResponse.Rejection {
+    private static final long serialVersionUID = -5763721635090700901L;
+
+    private final String reason;
+
+    public JMTMRegistrationRejection(String reason) {
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        return "The JobManager has rejected the registration attempt because: " + reason;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -660,6 +660,7 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
     public CompletableFuture<RegistrationResponse> registerTaskManager(
             final String taskManagerRpcAddress,
             final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
+            final JobID jobId,
             final Time timeout) {
 
         final TaskManagerLocation taskManagerLocation;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1243,7 +1243,11 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
         }
 
         @Override
-        protected void onRegistrationRejection(RegistrationResponse.Rejection rejection) {}
+        protected void onRegistrationRejection(RegistrationResponse.Rejection rejection) {
+            handleJobMasterError(
+                    new IllegalStateException(
+                            "The ResourceManager should never reject a JobMaster registration."));
+        }
 
         @Override
         protected void onRegistrationFailure(final Throwable failure) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -663,6 +663,17 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
             final JobID jobId,
             final Time timeout) {
 
+        if (!jobGraph.getJobID().equals(jobId)) {
+            log.debug(
+                    "Rejecting TaskManager registration attempt because of wrong job id {}.",
+                    jobId);
+            return CompletableFuture.completedFuture(
+                    new JMTMRegistrationRejection(
+                            String.format(
+                                    "The JobManager is not responsible for job %s. Maybe the TaskManager used outdated connection information.",
+                                    jobId)));
+        }
+
         final TaskManagerLocation taskManagerLocation;
         try {
             if (retrieveTaskManagerHostName) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.time.Time;
@@ -167,6 +168,7 @@ public interface JobMasterGateway
      *
      * @param taskManagerRpcAddress the rpc address of the task manager
      * @param unresolvedTaskManagerLocation unresolved location of the task manager
+     * @param jobId jobId specifying the job for which the JobMaster should be responsible
      * @param timeout for the rpc call
      * @return Future registration response indicating whether the registration was successful or
      *     not
@@ -174,6 +176,7 @@ public interface JobMasterGateway
     CompletableFuture<RegistrationResponse> registerTaskManager(
             final String taskManagerRpcAddress,
             final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
+            final JobID jobId,
             @RpcTimeout final Time timeout);
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.registration;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.rpc.RpcGateway;
 
 import org.slf4j.Logger;
@@ -44,9 +43,13 @@ import static org.apache.flink.util.Preconditions.checkState;
  * @param <F> The type of the fencing token
  * @param <G> The type of the gateway to connect to.
  * @param <S> The type of the successful registration responses.
+ * @param <R> The type of the registration rejection responses.
  */
 public abstract class RegisteredRpcConnection<
-        F extends Serializable, G extends RpcGateway, S extends RegistrationResponse.Success> {
+        F extends Serializable,
+        G extends RpcGateway,
+        S extends RegistrationResponse.Success,
+        R extends RegistrationResponse.Rejection> {
 
     private static final AtomicReferenceFieldUpdater<RegisteredRpcConnection, RetryingRegistration>
             REGISTRATION_UPDATER =
@@ -71,7 +74,7 @@ public abstract class RegisteredRpcConnection<
     private final Executor executor;
 
     /** The Registration of this RPC connection. */
-    private volatile RetryingRegistration<F, G, S> pendingRegistration;
+    private volatile RetryingRegistration<F, G, S, R> pendingRegistration;
 
     /** The gateway to register, it's null until the registration is completed. */
     private volatile G targetGateway;
@@ -99,7 +102,7 @@ public abstract class RegisteredRpcConnection<
                 !isConnected() && pendingRegistration == null,
                 "The RPC connection is already started");
 
-        final RetryingRegistration<F, G, S> newRegistration = createNewRegistration();
+        final RetryingRegistration<F, G, S, R> newRegistration = createNewRegistration();
 
         if (REGISTRATION_UPDATER.compareAndSet(this, null, newRegistration)) {
             newRegistration.startRegistration();
@@ -122,13 +125,13 @@ public abstract class RegisteredRpcConnection<
         if (closed) {
             return false;
         } else {
-            final RetryingRegistration<F, G, S> currentPendingRegistration = pendingRegistration;
+            final RetryingRegistration<F, G, S, R> currentPendingRegistration = pendingRegistration;
 
             if (currentPendingRegistration != null) {
                 currentPendingRegistration.cancel();
             }
 
-            final RetryingRegistration<F, G, S> newRegistration = createNewRegistration();
+            final RetryingRegistration<F, G, S, R> newRegistration = createNewRegistration();
 
             if (REGISTRATION_UPDATER.compareAndSet(
                     this, currentPendingRegistration, newRegistration)) {
@@ -154,10 +157,17 @@ public abstract class RegisteredRpcConnection<
      * This method generate a specific Registration, for example TaskExecutor Registration at the
      * ResourceManager.
      */
-    protected abstract RetryingRegistration<F, G, S> generateRegistration();
+    protected abstract RetryingRegistration<F, G, S, R> generateRegistration();
 
     /** This method handle the Registration Response. */
     protected abstract void onRegistrationSuccess(S success);
+
+    /**
+     * This method handles the Registration rejection.
+     *
+     * @param rejection rejection containing additional information about the rejection
+     */
+    protected abstract void onRegistrationRejection(R rejection);
 
     /** This method handle the Registration failure. */
     protected abstract void onRegistrationFailure(Throwable failure);
@@ -229,13 +239,15 @@ public abstract class RegisteredRpcConnection<
     //  Internal methods
     // ------------------------------------------------------------------------
 
-    private RetryingRegistration<F, G, S> createNewRegistration() {
-        RetryingRegistration<F, G, S> newRegistration = checkNotNull(generateRegistration());
+    private RetryingRegistration<F, G, S, R> createNewRegistration() {
+        RetryingRegistration<F, G, S, R> newRegistration = checkNotNull(generateRegistration());
 
-        CompletableFuture<Tuple2<G, S>> future = newRegistration.getFuture();
+        CompletableFuture<RetryingRegistration.RetryingRegistrationResult<G, S, R>> future =
+                newRegistration.getFuture();
 
         future.whenCompleteAsync(
-                (Tuple2<G, S> result, Throwable failure) -> {
+                (RetryingRegistration.RetryingRegistrationResult<G, S, R> result,
+                        Throwable failure) -> {
                     if (failure != null) {
                         if (failure instanceof CancellationException) {
                             // we ignore cancellation exceptions because they originate from
@@ -250,8 +262,16 @@ public abstract class RegisteredRpcConnection<
                             onRegistrationFailure(failure);
                         }
                     } else {
-                        targetGateway = result.f0;
-                        onRegistrationSuccess(result.f1);
+                        if (result.isSuccess()) {
+                            targetGateway = result.getGateway();
+                            onRegistrationSuccess(result.getSuccess());
+                        } else if (result.isRejection()) {
+                            onRegistrationRejection(result.getRejection());
+                        } else {
+                            throw new IllegalArgumentException(
+                                    String.format(
+                                            "Unknown retrying registration response: %s.", result));
+                        }
                     }
                 },
                 executor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegistrationConnectionListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegistrationConnectionListener.java
@@ -23,7 +23,9 @@ package org.apache.flink.runtime.registration;
  * RegisteredRpcConnection} have to implement this interface.
  */
 public interface RegistrationConnectionListener<
-        T extends RegisteredRpcConnection<?, ?, S, ?>, S extends RegistrationResponse.Success> {
+        T extends RegisteredRpcConnection<?, ?, S, ?>,
+        S extends RegistrationResponse.Success,
+        R extends RegistrationResponse.Rejection> {
 
     /**
      * This method is called by the {@link RegisteredRpcConnection} when the registration is
@@ -40,4 +42,13 @@ public interface RegistrationConnectionListener<
      * @param failure The exception which causes the registration failure.
      */
     void onRegistrationFailure(Throwable failure);
+
+    /**
+     * This method is called by the {@link RegisteredRpcConnection} when the registration is
+     * rejected.
+     *
+     * @param targetAddress targetAddress from which the registration was rejected.
+     * @param rejection rejection containing more information.
+     */
+    void onRegistrationRejection(String targetAddress, R rejection);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegistrationConnectionListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegistrationConnectionListener.java
@@ -23,7 +23,7 @@ package org.apache.flink.runtime.registration;
  * RegisteredRpcConnection} have to implement this interface.
  */
 public interface RegistrationConnectionListener<
-        T extends RegisteredRpcConnection<?, ?, S>, S extends RegistrationResponse.Success> {
+        T extends RegisteredRpcConnection<?, ?, S, ?>, S extends RegistrationResponse.Success> {
 
     /**
      * This method is called by the {@link RegisteredRpcConnection} when the registration is

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -71,6 +71,7 @@ import org.apache.flink.runtime.taskexecutor.FileType;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorHeartbeatPayload;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationRejection;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -944,8 +945,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                             + "not recognize it",
                     taskExecutorResourceId.getStringWithMetadata(),
                     taskExecutorAddress);
-            return new RegistrationResponse.Failure(
-                    new FlinkException("unrecognized TaskExecutor"));
+            return new TaskExecutorRegistrationRejection(
+                    "The ResourceManager does not recognize this TaskExecutor.");
         } else {
             WorkerRegistration<WorkerType> registration =
                     new WorkerRegistration<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -392,7 +392,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                                                         + "This indicates that a JobMaster leader change has happened.",
                                                 leadingJobMasterId, jobMasterId);
                                 log.debug(declineMessage);
-                                return new RegistrationResponse.Decline(declineMessage);
+                                return new RegistrationResponse.Failure(
+                                        new FlinkException(declineMessage));
                             }
                         },
                         getMainThreadExecutor());
@@ -414,7 +415,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                                     jobManagerAddress);
                         }
 
-                        return new RegistrationResponse.Decline(throwable.getMessage());
+                        return new RegistrationResponse.Failure(throwable);
                     } else {
                         return registrationResponse;
                     }
@@ -440,7 +441,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                     if (taskExecutorGatewayFuture == taskExecutorGatewayFutures.get(resourceId)) {
                         taskExecutorGatewayFutures.remove(resourceId);
                         if (throwable != null) {
-                            return new RegistrationResponse.Decline(throwable.getMessage());
+                            return new RegistrationResponse.Failure(throwable);
                         } else {
                             return registerTaskExecutorInternal(
                                     taskExecutorGateway, taskExecutorRegistration);
@@ -449,8 +450,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                         log.debug(
                                 "Ignoring outdated TaskExecutorGateway connection for {}.",
                                 resourceId.getStringWithMetadata());
-                        return new RegistrationResponse.Decline(
-                                "Decline outdated task executor registration.");
+                        return new RegistrationResponse.Failure(
+                                new FlinkException("Decline outdated task executor registration."));
                     }
                 },
                 getMainThreadExecutor());
@@ -943,7 +944,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                             + "not recognize it",
                     taskExecutorResourceId.getStringWithMetadata(),
                     taskExecutorAddress);
-            return new RegistrationResponse.Decline("unrecognized TaskExecutor");
+            return new RegistrationResponse.Failure(
+                    new FlinkException("unrecognized TaskExecutor"));
         } else {
             WorkerRegistration<WorkerType> registration =
                     new WorkerRegistration<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderService.java
@@ -230,7 +230,11 @@ public class DefaultJobLeaderService implements JobLeaderService {
         /** Rpc connection to the job leader. */
         @GuardedBy("lock")
         @Nullable
-        private RegisteredRpcConnection<JobMasterId, JobMasterGateway, JMTMRegistrationSuccess>
+        private RegisteredRpcConnection<
+                        JobMasterId,
+                        JobMasterGateway,
+                        JMTMRegistrationSuccess,
+                        RegistrationResponse.Rejection>
                 rpcConnection;
 
         /** Leader id of the current job leader. */
@@ -371,7 +375,10 @@ public class DefaultJobLeaderService implements JobLeaderService {
         /** Rpc connection for the job manager <--> task manager connection. */
         private final class JobManagerRegisteredRpcConnection
                 extends RegisteredRpcConnection<
-                        JobMasterId, JobMasterGateway, JMTMRegistrationSuccess> {
+                        JobMasterId,
+                        JobMasterGateway,
+                        JMTMRegistrationSuccess,
+                        RegistrationResponse.Rejection> {
 
             JobManagerRegisteredRpcConnection(
                     Logger log, String targetAddress, JobMasterId jobMasterId, Executor executor) {
@@ -379,7 +386,11 @@ public class DefaultJobLeaderService implements JobLeaderService {
             }
 
             @Override
-            protected RetryingRegistration<JobMasterId, JobMasterGateway, JMTMRegistrationSuccess>
+            protected RetryingRegistration<
+                            JobMasterId,
+                            JobMasterGateway,
+                            JMTMRegistrationSuccess,
+                            RegistrationResponse.Rejection>
                     generateRegistration() {
                 return new DefaultJobLeaderService.JobManagerRetryingRegistration(
                         LOG,
@@ -414,6 +425,9 @@ public class DefaultJobLeaderService implements JobLeaderService {
             }
 
             @Override
+            protected void onRegistrationRejection(RegistrationResponse.Rejection rejection) {}
+
+            @Override
             protected void onRegistrationFailure(Throwable failure) {
                 // filter out old registration attempts
                 if (Objects.equals(getTargetLeaderId(), getCurrentJobMasterId())) {
@@ -435,7 +449,11 @@ public class DefaultJobLeaderService implements JobLeaderService {
 
     /** Retrying registration for the job manager <--> task manager connection. */
     private static final class JobManagerRetryingRegistration
-            extends RetryingRegistration<JobMasterId, JobMasterGateway, JMTMRegistrationSuccess> {
+            extends RetryingRegistration<
+                    JobMasterId,
+                    JobMasterGateway,
+                    JMTMRegistrationSuccess,
+                    RegistrationResponse.Rejection> {
 
         private final String taskManagerRpcAddress;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderService.java
@@ -390,7 +390,8 @@ public class DefaultJobLeaderService implements JobLeaderService {
                         getTargetLeaderId(),
                         retryingRegistrationConfiguration,
                         ownerAddress,
-                        ownLocation);
+                        ownLocation,
+                        jobId);
             }
 
             @Override
@@ -440,6 +441,8 @@ public class DefaultJobLeaderService implements JobLeaderService {
 
         private final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
 
+        private final JobID jobId;
+
         JobManagerRetryingRegistration(
                 Logger log,
                 RpcService rpcService,
@@ -449,7 +452,8 @@ public class DefaultJobLeaderService implements JobLeaderService {
                 JobMasterId jobMasterId,
                 RetryingRegistrationConfiguration retryingRegistrationConfiguration,
                 String taskManagerRpcAddress,
-                UnresolvedTaskManagerLocation unresolvedTaskManagerLocation) {
+                UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
+                JobID jobId) {
             super(
                     log,
                     rpcService,
@@ -462,6 +466,7 @@ public class DefaultJobLeaderService implements JobLeaderService {
             this.taskManagerRpcAddress = taskManagerRpcAddress;
             this.unresolvedTaskManagerLocation =
                     Preconditions.checkNotNull(unresolvedTaskManagerLocation);
+            this.jobId = Preconditions.checkNotNull(jobId);
         }
 
         @Override
@@ -470,6 +475,7 @@ public class DefaultJobLeaderService implements JobLeaderService {
             return gateway.registerTaskManager(
                     taskManagerRpcAddress,
                     unresolvedTaskManagerLocation,
+                    jobId,
                     Time.milliseconds(timeoutMillis));
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderListener.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmaster.JMTMRegistrationRejection;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -58,4 +59,14 @@ public interface JobLeaderListener {
      * @param throwable cause
      */
     void handleError(Throwable throwable);
+
+    /**
+     * Callback if a job manager rejected the connection attempts of a task manager.
+     *
+     * @param jobId jobId identifying the job to connect to
+     * @param targetAddress targetAddress of the responsible job manager
+     * @param rejection rejection containing more information about the rejection
+     */
+    void jobManagerRejectedRegistration(
+            JobID jobId, String targetAddress, JMTMRegistrationRejection rejection);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotInfo;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JMTMRegistrationRejection;
 import org.apache.flink.runtime.jobmaster.JMTMRegistrationSuccess;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -1660,6 +1661,45 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         jobManagerGateway.disconnectTaskManager(getResourceID(), cause);
     }
 
+    private void handleRejectedJobManagerConnection(
+            JobID jobId, String targetAddress, JMTMRegistrationRejection rejection) {
+        log.info(
+                "The JobManager under {} rejected the registration for job {}: {}. Releasing all job related resources.",
+                targetAddress,
+                jobId,
+                rejection.getReason());
+
+        releaseJobResources(
+                jobId,
+                new FlinkException(
+                        String.format("JobManager %s has rejected the registration.", jobId)));
+    }
+
+    private void releaseJobResources(JobID jobId, Exception cause) {
+        log.debug("Releasing job resources for job {}.", jobId, cause);
+
+        if (partitionTracker.isTrackingPartitionsFor(jobId)) {
+            // stop tracking job partitions
+            partitionTracker.stopTrackingAndReleaseJobPartitionsFor(jobId);
+        }
+
+        // free slots
+        final Set<AllocationID> allocationIds = taskSlotTable.getAllocationIdsPerJob(jobId);
+
+        if (!allocationIds.isEmpty()) {
+            for (AllocationID allocationId : allocationIds) {
+                freeSlotInternal(allocationId, cause);
+            }
+        }
+
+        jobLeaderService.removeJob(jobId);
+        jobTable.getJob(jobId)
+                .ifPresent(
+                        job -> {
+                            closeJob(job, cause);
+                        });
+    }
+
     private void scheduleResultPartitionCleanup(JobID jobId) {
         final Collection<CompletableFuture<ExecutionState>> taskTerminationFutures =
                 taskResultPartitionCleanupFuturesPerJob.remove(jobId);
@@ -1799,19 +1839,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         if (taskSlotTable.getAllocationIdsPerJob(jobId).isEmpty()
                 && !partitionTracker.isTrackingPartitionsFor(jobId)) {
             // we can remove the job from the job leader service
-            jobLeaderService.removeJob(jobId);
 
-            jobTable.getJob(jobId)
-                    .ifPresent(
-                            job ->
-                                    closeJob(
-                                            job,
-                                            new FlinkException(
-                                                    "TaskExecutor "
-                                                            + getAddress()
-                                                            + " has no more allocated slots for job "
-                                                            + jobId
-                                                            + '.')));
+            final FlinkException cause =
+                    new FlinkException(
+                            "TaskExecutor "
+                                    + getAddress()
+                                    + " has no more allocated slots for job "
+                                    + jobId
+                                    + '.');
+
+            releaseJobResources(jobId, cause);
         }
     }
 
@@ -2065,6 +2102,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         @Override
         public void handleError(Throwable throwable) {
             onFatalError(throwable);
+        }
+
+        @Override
+        public void jobManagerRejectedRegistration(
+                JobID jobId, String targetAddress, JMTMRegistrationRejection rejection) {
+            runAsync(() -> handleRejectedJobManagerConnection(jobId, targetAddress, rejection));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -2113,7 +2113,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     private final class ResourceManagerRegistrationListener
             implements RegistrationConnectionListener<
-                    TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess> {
+                    TaskExecutorToResourceManagerConnection,
+                    TaskExecutorRegistrationSuccess,
+                    TaskExecutorRegistrationRejection> {
 
         @Override
         public void onRegistrationSuccess(
@@ -2147,6 +2149,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         @Override
         public void onRegistrationFailure(Throwable failure) {
             onFatalError(failure);
+        }
+
+        @Override
+        public void onRegistrationRejection(
+                String targetAddress, TaskExecutorRegistrationRejection rejection) {
+            onFatalError(
+                    new FlinkException(
+                            String.format(
+                                    "The TaskExecutor's registration at the ResourceManager %s has been rejected: %s",
+                                    targetAddress, rejection)));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRegistrationRejection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRegistrationRejection.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+
+/** Rejection response from the {@link ResourceManager} for the {@link TaskExecutor}. */
+public class TaskExecutorRegistrationRejection extends RegistrationResponse.Rejection {
+    private static final long serialVersionUID = -7447810107639038319L;
+
+    private final String reason;
+
+    public TaskExecutorRegistrationRejection(String reason) {
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        return "Rejected TaskExecutor registration at the ResourceManger because: " + reason;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -39,7 +39,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** The connection between a TaskExecutor and the ResourceManager. */
 public class TaskExecutorToResourceManagerConnection
         extends RegisteredRpcConnection<
-                ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+                ResourceManagerId,
+                ResourceManagerGateway,
+                TaskExecutorRegistrationSuccess,
+                RegistrationResponse.Rejection> {
 
     private final RpcService rpcService;
 
@@ -74,7 +77,10 @@ public class TaskExecutorToResourceManagerConnection
 
     @Override
     protected RetryingRegistration<
-                    ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess>
+                    ResourceManagerId,
+                    ResourceManagerGateway,
+                    TaskExecutorRegistrationSuccess,
+                    RegistrationResponse.Rejection>
             generateRegistration() {
         return new TaskExecutorToResourceManagerConnection.ResourceManagerRegistration(
                 log,
@@ -96,6 +102,9 @@ public class TaskExecutorToResourceManagerConnection
     }
 
     @Override
+    protected void onRegistrationRejection(RegistrationResponse.Rejection rejection) {}
+
+    @Override
     protected void onRegistrationFailure(Throwable failure) {
         log.info("Failed to register at resource manager {}.", getTargetAddress(), failure);
 
@@ -108,7 +117,10 @@ public class TaskExecutorToResourceManagerConnection
 
     private static class ResourceManagerRegistration
             extends RetryingRegistration<
-                    ResourceManagerId, ResourceManagerGateway, TaskExecutorRegistrationSuccess> {
+                    ResourceManagerId,
+                    ResourceManagerGateway,
+                    TaskExecutorRegistrationSuccess,
+                    RegistrationResponse.Rejection> {
 
         private final TaskExecutorRegistration taskExecutorRegistration;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnection.java
@@ -42,14 +42,16 @@ public class TaskExecutorToResourceManagerConnection
                 ResourceManagerId,
                 ResourceManagerGateway,
                 TaskExecutorRegistrationSuccess,
-                RegistrationResponse.Rejection> {
+                TaskExecutorRegistrationRejection> {
 
     private final RpcService rpcService;
 
     private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
 
     private final RegistrationConnectionListener<
-                    TaskExecutorToResourceManagerConnection, TaskExecutorRegistrationSuccess>
+                    TaskExecutorToResourceManagerConnection,
+                    TaskExecutorRegistrationSuccess,
+                    TaskExecutorRegistrationRejection>
             registrationListener;
 
     private final TaskExecutorRegistration taskExecutorRegistration;
@@ -63,7 +65,8 @@ public class TaskExecutorToResourceManagerConnection
             Executor executor,
             RegistrationConnectionListener<
                             TaskExecutorToResourceManagerConnection,
-                            TaskExecutorRegistrationSuccess>
+                            TaskExecutorRegistrationSuccess,
+                            TaskExecutorRegistrationRejection>
                     registrationListener,
             TaskExecutorRegistration taskExecutorRegistration) {
 
@@ -80,7 +83,7 @@ public class TaskExecutorToResourceManagerConnection
                     ResourceManagerId,
                     ResourceManagerGateway,
                     TaskExecutorRegistrationSuccess,
-                    RegistrationResponse.Rejection>
+                    TaskExecutorRegistrationRejection>
             generateRegistration() {
         return new TaskExecutorToResourceManagerConnection.ResourceManagerRegistration(
                 log,
@@ -102,7 +105,9 @@ public class TaskExecutorToResourceManagerConnection
     }
 
     @Override
-    protected void onRegistrationRejection(RegistrationResponse.Rejection rejection) {}
+    protected void onRegistrationRejection(TaskExecutorRegistrationRejection rejection) {
+        registrationListener.onRegistrationRejection(getTargetAddress(), rejection);
+    }
 
     @Override
     protected void onRegistrationFailure(Throwable failure) {
@@ -120,7 +125,7 @@ public class TaskExecutorToResourceManagerConnection
                     ResourceManagerId,
                     ResourceManagerGateway,
                     TaskExecutorRegistrationSuccess,
-                    RegistrationResponse.Rejection> {
+                    TaskExecutorRegistrationRejection> {
 
         private final TaskExecutorRegistration taskExecutorRegistration;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.io.network.partition.TestingJobMasterPartitionTracker;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.utils.JobMasterBuilder;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
@@ -219,8 +220,9 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
             HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 5_000_000L);
 
+            final JobGraph jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
             jobMaster =
-                    new JobMasterBuilder(JobGraphTestUtils.singleNoOpJobGraph(), rpcService)
+                    new JobMasterBuilder(jobGraph, rpcService)
                             .withConfiguration(configuration)
                             .withHighAvailabilityServices(haServices)
                             .withJobManagerSharedServices(
@@ -232,12 +234,14 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
             jobMaster.start();
 
-            registerTaskExecutorAtJobMaster(rpcService, getJobMasterGateway(), taskExecutorGateway);
+            registerTaskExecutorAtJobMaster(
+                    rpcService, getJobMasterGateway(), jobGraph.getJobID(), taskExecutorGateway);
         }
 
         private void registerTaskExecutorAtJobMaster(
                 TestingRpcService rpcService,
                 JobMasterGateway jobMasterGateway,
+                JobID jobId,
                 TaskExecutorGateway taskExecutorGateway)
                 throws ExecutionException, InterruptedException {
 
@@ -247,6 +251,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
                     .registerTaskManager(
                             taskExecutorGateway.getAddress(),
                             localTaskManagerUnresolvedLocation,
+                            jobId,
                             testingTimeout)
                     .get();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterQueryableStateTest.java
@@ -116,7 +116,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-        registerSlotsRequiredForJobExecution(jobMasterGateway);
+        registerSlotsRequiredForJobExecution(jobMasterGateway, JOB_GRAPH.getJobID());
 
         try {
             // lookup location
@@ -140,7 +140,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-        registerSlotsRequiredForJobExecution(jobMasterGateway);
+        registerSlotsRequiredForJobExecution(jobMasterGateway, JOB_GRAPH.getJobID());
 
         try {
             // lookup location
@@ -163,7 +163,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-        registerSlotsRequiredForJobExecution(jobMasterGateway);
+        registerSlotsRequiredForJobExecution(jobMasterGateway, JOB_GRAPH.getJobID());
 
         try {
             // register an irrelevant KvState
@@ -186,7 +186,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-        registerSlotsRequiredForJobExecution(jobMasterGateway);
+        registerSlotsRequiredForJobExecution(jobMasterGateway, JOB_GRAPH.getJobID());
 
         try {
             final String registrationName = "register-me";
@@ -231,7 +231,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-        registerSlotsRequiredForJobExecution(jobMasterGateway);
+        registerSlotsRequiredForJobExecution(jobMasterGateway, JOB_GRAPH.getJobID());
 
         try {
             final String registrationName = "register-me";
@@ -279,7 +279,7 @@ public class JobMasterQueryableStateTest extends TestLogger {
 
         final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-        registerSlotsRequiredForJobExecution(jobMasterGateway);
+        registerSlotsRequiredForJobExecution(jobMasterGateway, JOB_GRAPH.getJobID());
 
         try {
             // duplicate registration fails task
@@ -309,10 +309,11 @@ public class JobMasterQueryableStateTest extends TestLogger {
         }
     }
 
-    private static void registerSlotsRequiredForJobExecution(JobMasterGateway jobMasterGateway)
+    private static void registerSlotsRequiredForJobExecution(
+            JobMasterGateway jobMasterGateway, JobID jobId)
             throws ExecutionException, InterruptedException {
         JobMasterTestUtils.registerTaskExecutorAndOfferSlots(
-                rpcService, jobMasterGateway, PARALLELISM, testingTimeout);
+                rpcService, jobMasterGateway, jobId, PARALLELISM, testingTimeout);
     }
 
     private static void registerKvState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1604,6 +1604,30 @@ public class JobMasterTest extends TestLogger {
                         });
     }
 
+    /**
+     * Tests that the JobMaster rejects a TaskExecutor registration attempt if the expected and
+     * actual JobID are not equal. See FLINK-21606.
+     */
+    @Test
+    public void testJobMasterRejectsTaskExecutorRegistrationIfJobIdsAreNotEqual() throws Exception {
+        final JobMaster jobMaster = new JobMasterBuilder(jobGraph, rpcService).createJobMaster();
+
+        try {
+            jobMaster.start();
+
+            final CompletableFuture<RegistrationResponse> registrationResponse =
+                    jobMaster.registerTaskManager(
+                            "foobar",
+                            new LocalUnresolvedTaskManagerLocation(),
+                            new JobID(),
+                            testingTimeout);
+
+            assertThat(registrationResponse.get(), instanceOf(JMTMRegistrationRejection.class));
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
     private void runJobFailureWhenTaskExecutorTerminatesTest(
             HeartbeatServices heartbeatServices,
             BiConsumer<LocalUnresolvedTaskManagerLocation, JobMasterGateway> jobReachedRunningState,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTestUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.jobmaster;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -42,6 +43,7 @@ public class JobMasterTestUtils {
     public static void registerTaskExecutorAndOfferSlots(
             TestingRpcService rpcService,
             JobMasterGateway jobMasterGateway,
+            JobID jobId,
             int numSlots,
             Time testingTimeout)
             throws ExecutionException, InterruptedException {
@@ -66,6 +68,7 @@ public class JobMasterTestUtils {
                 .registerTaskManager(
                         taskExecutorGateway.getAddress(),
                         unresolvedTaskManagerLocation,
+                        jobId,
                         testingTimeout)
                 .get();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -111,8 +111,11 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     @Nonnull private final TriConsumer<ResourceID, AllocationID, Throwable> failSlotConsumer;
 
     @Nonnull
-    private final BiFunction<
-                    String, UnresolvedTaskManagerLocation, CompletableFuture<RegistrationResponse>>
+    private final TriFunction<
+                    String,
+                    UnresolvedTaskManagerLocation,
+                    JobID,
+                    CompletableFuture<RegistrationResponse>>
             registerTaskManagerFunction;
 
     @Nonnull
@@ -211,9 +214,10 @@ public class TestingJobMasterGateway implements JobMasterGateway {
                             offerSlotsFunction,
             @Nonnull TriConsumer<ResourceID, AllocationID, Throwable> failSlotConsumer,
             @Nonnull
-                    BiFunction<
+                    TriFunction<
                                     String,
                                     UnresolvedTaskManagerLocation,
+                                    JobID,
                                     CompletableFuture<RegistrationResponse>>
                             registerTaskManagerFunction,
             @Nonnull
@@ -361,9 +365,10 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     public CompletableFuture<RegistrationResponse> registerTaskManager(
             String taskManagerRpcAddress,
             UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
+            JobID jobId,
             Time timeout) {
         return registerTaskManagerFunction.apply(
-                taskManagerRpcAddress, unresolvedTaskManagerLocation);
+                taskManagerRpcAddress, unresolvedTaskManagerLocation, jobId);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -101,10 +101,13 @@ public class TestingJobMasterGatewayBuilder {
                             CompletableFuture.completedFuture(Collections.emptyList());
     private TriConsumer<ResourceID, AllocationID, Throwable> failSlotConsumer =
             (ignoredA, ignoredB, ignoredC) -> {};
-    private BiFunction<
-                    String, UnresolvedTaskManagerLocation, CompletableFuture<RegistrationResponse>>
+    private TriFunction<
+                    String,
+                    UnresolvedTaskManagerLocation,
+                    JobID,
+                    CompletableFuture<RegistrationResponse>>
             registerTaskManagerFunction =
-                    (ignoredA, ignoredB) ->
+                    (ignoredA, ignoredB, ignoredC) ->
                             CompletableFuture.completedFuture(
                                     new JMTMRegistrationSuccess(RESOURCE_MANAGER_ID));
     private BiConsumer<ResourceID, TaskExecutorToJobManagerHeartbeatPayload>
@@ -235,9 +238,10 @@ public class TestingJobMasterGatewayBuilder {
     }
 
     public TestingJobMasterGatewayBuilder setRegisterTaskManagerFunction(
-            BiFunction<
+            TriFunction<
                             String,
                             UnresolvedTaskManagerLocation,
+                            JobID,
                             CompletableFuture<RegistrationResponse>>
                     registerTaskManagerFunction) {
         this.registerTaskManagerFunction = registerTaskManagerFunction;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/DefaultTestRegistrationGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/DefaultTestRegistrationGateway.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.registration;
+
+import org.apache.flink.util.FlinkException;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+
+/** Default {@link TestRegistrationGateway} implementation. */
+public class DefaultTestRegistrationGateway implements TestRegistrationGateway {
+    private final String address;
+    private final String hostname;
+    private final BiFunction<UUID, Long, CompletableFuture<RegistrationResponse>>
+            registrationFunction;
+
+    private DefaultTestRegistrationGateway(
+            String address,
+            String hostname,
+            BiFunction<UUID, Long, CompletableFuture<RegistrationResponse>> registrationFunction) {
+        this.address = address;
+        this.hostname = hostname;
+        this.registrationFunction = registrationFunction;
+    }
+
+    @Override
+    public String getAddress() {
+        return address;
+    }
+
+    @Override
+    public String getHostname() {
+        return hostname;
+    }
+
+    @Override
+    public CompletableFuture<RegistrationResponse> registrationCall(UUID leaderId, long timeout) {
+        return registrationFunction.apply(leaderId, timeout);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /** Builder for the {@link DefaultTestRegistrationGateway}. */
+    public static final class Builder {
+        private String address = "localhost";
+        private String hostname = "localhost";
+        private BiFunction<UUID, Long, CompletableFuture<RegistrationResponse>>
+                registrationFunction =
+                        (ignoredA, ignoredB) ->
+                                CompletableFuture.completedFuture(
+                                        new RegistrationResponse.Failure(
+                                                new FlinkException("Not configured")));
+
+        public Builder setAddress(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public Builder setHostname(String hostname) {
+            this.hostname = hostname;
+            return this;
+        }
+
+        public Builder setRegistrationFunction(
+                BiFunction<UUID, Long, CompletableFuture<RegistrationResponse>>
+                        registrationFunction) {
+            this.registrationFunction = registrationFunction;
+            return this;
+        }
+
+        public DefaultTestRegistrationGateway build() {
+            return new DefaultTestRegistrationGateway(address, hostname, registrationFunction);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/ManualResponseTestRegistrationGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/ManualResponseTestRegistrationGateway.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.registration;
+
+import org.apache.flink.runtime.rpc.TestingGatewayBase;
+import org.apache.flink.util.Preconditions;
+
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/** Mock gateway for {@link RegistrationResponse}. */
+public class ManualResponseTestRegistrationGateway extends TestingGatewayBase
+        implements TestRegistrationGateway {
+
+    private final BlockingQueue<RegistrationCall> invocations;
+
+    private final RegistrationResponse[] responses;
+
+    private int pos;
+
+    public ManualResponseTestRegistrationGateway(RegistrationResponse... responses) {
+        Preconditions.checkArgument(responses != null && responses.length > 0);
+
+        this.invocations = new LinkedBlockingQueue<>();
+        this.responses = responses;
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public CompletableFuture<RegistrationResponse> registrationCall(UUID leaderId, long timeout) {
+        invocations.add(new RegistrationCall(leaderId, timeout));
+
+        RegistrationResponse response = responses[pos];
+        if (pos < responses.length - 1) {
+            pos++;
+        }
+
+        // return a completed future (for a proper value), or one that never completes and will time
+        // out (for null)
+        return response != null
+                ? CompletableFuture.completedFuture(response)
+                : futureWithTimeout(timeout);
+    }
+
+    public BlockingQueue<RegistrationCall> getInvocations() {
+        return invocations;
+    }
+
+    // ------------------------------------------------------------------------
+
+    /** Invocation parameters. */
+    public static class RegistrationCall {
+        private final UUID leaderId;
+        private final long timeout;
+
+        public RegistrationCall(UUID leaderId, long timeout) {
+            this.leaderId = leaderId;
+            this.timeout = timeout;
+        }
+
+        public UUID leaderId() {
+            return leaderId;
+        }
+
+        public long timeout() {
+            return timeout;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
@@ -38,10 +38,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /** Tests for RegisteredRpcConnection, validating the successful, failure and close behavior. */
 public class RegisteredRpcConnectionTest extends TestLogger {
@@ -67,8 +63,8 @@ public class RegisteredRpcConnectionTest extends TestLogger {
         final String connectionID = "Test RPC Connection ID";
 
         // an endpoint that immediately returns success
-        TestRegistrationGateway testGateway =
-                new TestRegistrationGateway(
+        ManualResponseTestRegistrationGateway testGateway =
+                new ManualResponseTestRegistrationGateway(
                         new RetryingRegistrationTest.TestRegistrationSuccess(connectionID));
 
         try {
@@ -102,12 +98,17 @@ public class RegisteredRpcConnectionTest extends TestLogger {
         final String testRpcConnectionEndpointAddress = "<TestRpcConnectionEndpointAddress>";
         final UUID leaderId = UUID.randomUUID();
 
-        // gateway that upon calls Throw an exception
-        TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
         final RuntimeException registrationException =
                 new RuntimeException(connectionFailureMessage);
-        when(testGateway.registrationCall(any(UUID.class), anyLong()))
-                .thenThrow(registrationException);
+
+        // gateway that upon registration calls throws an exception
+        TestRegistrationGateway testGateway =
+                DefaultTestRegistrationGateway.newBuilder()
+                        .setRegistrationFunction(
+                                (uuid, aLong) -> {
+                                    throw registrationException;
+                                })
+                        .build();
 
         rpcService.registerGateway(testRpcConnectionEndpointAddress, testGateway);
 
@@ -140,8 +141,8 @@ public class RegisteredRpcConnectionTest extends TestLogger {
         final UUID leaderId = UUID.randomUUID();
         final String connectionID = "Test RPC Connection ID";
 
-        TestRegistrationGateway testGateway =
-                new TestRegistrationGateway(
+        ManualResponseTestRegistrationGateway testGateway =
+                new ManualResponseTestRegistrationGateway(
                         new RetryingRegistrationTest.TestRegistrationSuccess(connectionID));
 
         try {
@@ -173,7 +174,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
         final String testRpcConnectionEndpointAddress = "<TestRpcConnectionEndpointAddress>";
         final UUID leaderId = UUID.randomUUID();
         final TestRegistrationGateway testGateway =
-                new TestRegistrationGateway(
+                new ManualResponseTestRegistrationGateway(
                         new RetryingRegistrationTest.TestRegistrationSuccess(connectionId1),
                         new RetryingRegistrationTest.TestRegistrationSuccess(connectionId2));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.runtime.registration;
 
+import org.apache.flink.runtime.registration.RetryingRegistrationTest.TestRegistrationRejection;
 import org.apache.flink.runtime.registration.RetryingRegistrationTest.TestRegistrationSuccess;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.types.Either;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -33,9 +35,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -79,7 +83,12 @@ public class RegisteredRpcConnectionTest extends TestLogger {
             connection.start();
 
             // wait for connection established
-            final String actualConnectionId = connection.getConnectionFuture().get();
+            final Either<TestRegistrationSuccess, TestRegistrationRejection> connectionResult =
+                    connection.getConnectionFuture().get();
+
+            assertTrue(connectionResult.isLeft());
+
+            final String actualConnectionId = connectionResult.left().getCorrelationId();
 
             // validate correct invocation and result
             assertTrue(connection.isConnected());
@@ -136,6 +145,39 @@ public class RegisteredRpcConnectionTest extends TestLogger {
     }
 
     @Test
+    public void testRpcConnectionRejectionCallsOnRegistrationRejection() {
+        TestRegistrationGateway testRegistrationGateway =
+                DefaultTestRegistrationGateway.newBuilder()
+                        .setRegistrationFunction(
+                                (uuid, aLong) ->
+                                        CompletableFuture.completedFuture(
+                                                new TestRegistrationRejection(
+                                                        TestRegistrationRejection.RejectionReason
+                                                                .REJECTED)))
+                        .build();
+
+        rpcService.registerGateway(testRegistrationGateway.getAddress(), testRegistrationGateway);
+
+        TestRpcConnection connection =
+                new TestRpcConnection(
+                        testRegistrationGateway.getAddress(),
+                        UUID.randomUUID(),
+                        rpcService.getExecutor(),
+                        rpcService);
+        connection.start();
+
+        final Either<TestRegistrationSuccess, TestRegistrationRejection> connectionResult =
+                connection.getConnectionFuture().join();
+
+        assertTrue(connectionResult.isRight());
+        final TestRegistrationRejection registrationRejection = connectionResult.right();
+
+        assertThat(
+                registrationRejection.getRejectionReason(),
+                is(TestRegistrationRejection.RejectionReason.REJECTED));
+    }
+
+    @Test
     public void testRpcConnectionClose() throws Exception {
         final String testRpcConnectionEndpointAddress = "<TestRpcConnectionEndpointAddress>";
         final UUID leaderId = UUID.randomUUID();
@@ -188,13 +230,23 @@ public class RegisteredRpcConnectionTest extends TestLogger {
                         rpcService);
         connection.start();
 
-        final String actualConnectionId1 = connection.getConnectionFuture().get();
+        final Either<TestRegistrationSuccess, TestRegistrationRejection> firstConnectionResult =
+                connection.getConnectionFuture().get();
+
+        assertTrue(firstConnectionResult.isLeft());
+
+        final String actualConnectionId1 = firstConnectionResult.left().getCorrelationId();
 
         assertEquals(actualConnectionId1, connectionId1);
 
         assertTrue(connection.tryReconnect());
 
-        final String actualConnectionId2 = connection.getConnectionFuture().get();
+        final Either<TestRegistrationSuccess, TestRegistrationRejection> secondConnectionResult =
+                connection.getConnectionFuture().get();
+
+        assertTrue(secondConnectionResult.isLeft());
+
+        final String actualConnectionId2 = secondConnectionResult.left().getCorrelationId();
 
         assertEquals(actualConnectionId2, connectionId2);
     }
@@ -205,13 +257,17 @@ public class RegisteredRpcConnectionTest extends TestLogger {
 
     private static class TestRpcConnection
             extends RegisteredRpcConnection<
-                    UUID, TestRegistrationGateway, TestRegistrationSuccess> {
+                    UUID,
+                    TestRegistrationGateway,
+                    TestRegistrationSuccess,
+                    TestRegistrationRejection> {
 
         private final Object lock = new Object();
 
         private final RpcService rpcService;
 
-        private CompletableFuture<String> connectionFuture;
+        private CompletableFuture<Either<TestRegistrationSuccess, TestRegistrationRejection>>
+                connectionFuture;
 
         public TestRpcConnection(
                 String targetAddress,
@@ -231,7 +287,8 @@ public class RegisteredRpcConnectionTest extends TestLogger {
         protected RetryingRegistration<
                         UUID,
                         TestRegistrationGateway,
-                        RetryingRegistrationTest.TestRegistrationSuccess>
+                        RetryingRegistrationTest.TestRegistrationSuccess,
+                        RetryingRegistrationTest.TestRegistrationRejection>
                 generateRegistration() {
             return new RetryingRegistrationTest.TestRetryingRegistration(
                     rpcService, getTargetAddress(), getTargetLeaderId());
@@ -241,7 +298,14 @@ public class RegisteredRpcConnectionTest extends TestLogger {
         protected void onRegistrationSuccess(
                 RetryingRegistrationTest.TestRegistrationSuccess success) {
             synchronized (lock) {
-                connectionFuture.complete(success.getCorrelationId());
+                connectionFuture.complete(Either.Left(success));
+            }
+        }
+
+        @Override
+        protected void onRegistrationRejection(TestRegistrationRejection rejection) {
+            synchronized (lock) {
+                connectionFuture.complete(Either.Right(rejection));
             }
         }
 
@@ -261,7 +325,8 @@ public class RegisteredRpcConnectionTest extends TestLogger {
             return super.tryReconnect();
         }
 
-        public CompletableFuture<String> getConnectionFuture() {
+        public CompletableFuture<Either<TestRegistrationSuccess, TestRegistrationRejection>>
+                getConnectionFuture() {
             synchronized (lock) {
                 return connectionFuture;
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/TestRegistrationGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/TestRegistrationGateway.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,69 +18,13 @@
 
 package org.apache.flink.runtime.registration;
 
-import org.apache.flink.runtime.rpc.TestingGatewayBase;
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.runtime.rpc.RpcGateway;
 
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedBlockingQueue;
 
-/** Mock gateway for {@link RegistrationResponse}. */
-public class TestRegistrationGateway extends TestingGatewayBase {
+/** Testing interface for the {@link RetryingRegistrationTest}. */
+public interface TestRegistrationGateway extends RpcGateway {
 
-    private final BlockingQueue<RegistrationCall> invocations;
-
-    private final RegistrationResponse[] responses;
-
-    private int pos;
-
-    public TestRegistrationGateway(RegistrationResponse... responses) {
-        Preconditions.checkArgument(responses != null && responses.length > 0);
-
-        this.invocations = new LinkedBlockingQueue<>();
-        this.responses = responses;
-    }
-
-    // ------------------------------------------------------------------------
-
-    public CompletableFuture<RegistrationResponse> registrationCall(UUID leaderId, long timeout) {
-        invocations.add(new RegistrationCall(leaderId, timeout));
-
-        RegistrationResponse response = responses[pos];
-        if (pos < responses.length - 1) {
-            pos++;
-        }
-
-        // return a completed future (for a proper value), or one that never completes and will time
-        // out (for null)
-        return response != null
-                ? CompletableFuture.completedFuture(response)
-                : futureWithTimeout(timeout);
-    }
-
-    public BlockingQueue<RegistrationCall> getInvocations() {
-        return invocations;
-    }
-
-    // ------------------------------------------------------------------------
-
-    /** Invocation parameters. */
-    public static class RegistrationCall {
-        private final UUID leaderId;
-        private final long timeout;
-
-        public RegistrationCall(UUID leaderId, long timeout) {
-            this.leaderId = leaderId;
-            this.timeout = timeout;
-        }
-
-        public UUID leaderId() {
-            return leaderId;
-        }
-
-        public long timeout() {
-            return timeout;
-        }
-    }
+    CompletableFuture<RegistrationResponse> registrationCall(UUID leaderId, long timeout);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -244,7 +244,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
                         jobMasterGateway.getAddress(),
                         jobId,
                         TIMEOUT);
-        assertTrue(unMatchedLeaderFuture.get() instanceof RegistrationResponse.Decline);
+        assertTrue(unMatchedLeaderFuture.get() instanceof RegistrationResponse.Failure);
     }
 
     /** Test receive registration with invalid address from job master. */
@@ -262,7 +262,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
                         TIMEOUT);
         assertTrue(
                 invalidAddressFuture.get(5, TimeUnit.SECONDS)
-                        instanceof RegistrationResponse.Decline);
+                        instanceof RegistrationResponse.Failure);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -390,7 +390,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
                 registerTaskExecutor(rmGateway, invalidAddress);
         assertTrue(
                 invalidAddressFuture.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS)
-                        instanceof RegistrationResponse.Decline);
+                        instanceof RegistrationResponse.Failure);
     }
 
     private CompletableFuture<RegistrationResponse> registerTaskExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -689,7 +689,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     registerTaskExecutor(ResourceID.generate());
                             assertThat(
                                     registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    instanceOf(RegistrationResponse.Decline.class));
+                                    instanceOf(RegistrationResponse.Failure.class));
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -689,7 +689,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     registerTaskExecutor(ResourceID.generate());
                             assertThat(
                                     registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    instanceOf(RegistrationResponse.Failure.class));
+                                    instanceOf(RegistrationResponse.Rejection.class));
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -243,7 +243,7 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
             ResourceID jobManagerResourceId) {
         return new TestingJobMasterGatewayBuilder()
                 .setRegisterTaskManagerFunction(
-                        (s, location) ->
+                        (s, location, ignored) ->
                                 CompletableFuture.completedFuture(
                                         new JMTMRegistrationSuccess(jobManagerResourceId)))
                 .setOfferSlotsFunction(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -449,7 +449,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
         final TestingJobMasterGateway jobMasterGateway =
                 new TestingJobMasterGatewayBuilder()
                         .setRegisterTaskManagerFunction(
-                                (s, location) ->
+                                (s, location, ignored) ->
                                         CompletableFuture.completedFuture(
                                                 new JMTMRegistrationSuccess(ResourceID.generate())))
                         .setOfferSlotsFunction(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -72,7 +72,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.registration.RegistrationResponse;
-import org.apache.flink.runtime.registration.RegistrationResponse.Decline;
+import org.apache.flink.runtime.registration.RegistrationResponse.Failure;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
@@ -1353,7 +1353,9 @@ public class TaskExecutorTest extends TestLogger {
                         } else {
                             secondRegistration.trigger();
                             return CompletableFuture.completedFuture(
-                                    new Decline("Only the first registration should succeed."));
+                                    new Failure(
+                                            new FlinkException(
+                                                    "Only the first registration should succeed.")));
                         }
                     });
             rpc.registerGateway(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -305,7 +305,7 @@ public class TaskExecutorTest extends TestLogger {
         final TestingJobMasterGateway jobMasterGateway =
                 new TestingJobMasterGatewayBuilder()
                         .setRegisterTaskManagerFunction(
-                                (s, taskManagerUnresolvedLocation) -> {
+                                (s, taskManagerUnresolvedLocation, ignored) -> {
                                     registrationAttempts.countDown();
                                     return CompletableFuture.completedFuture(
                                             new JMTMRegistrationSuccess(jmResourceId));
@@ -1887,7 +1887,7 @@ public class TaskExecutorTest extends TestLogger {
                                         CompletableFuture.completedFuture(
                                                 new ArrayList<>(slotOffers)))
                         .setRegisterTaskManagerFunction(
-                                (ignoredA, ignoredB) ->
+                                (ignoredA, ignoredB, ignoredC) ->
                                         CompletableFuture.completedFuture(
                                                 new JMTMRegistrationSuccess(jobManagerResourceId)))
                         .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
@@ -80,6 +80,8 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 
     private CompletableFuture<Void> registrationSuccessFuture;
 
+    private CompletableFuture<Void> registrationRejectionFuture;
+
     @Test
     public void testResourceManagerRegistration() throws Exception {
         final TaskExecutorToResourceManagerConnection resourceManagerRegistration =
@@ -108,6 +110,21 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 
         resourceManagerRegistration.start();
         registrationSuccessFuture.get(TEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testResourceManagerRegistrationIsRejected() {
+        final TaskExecutorToResourceManagerConnection resourceManagerRegistration =
+                createTaskExecutorToResourceManagerConnection();
+
+        testingResourceManagerGateway.setRegisterTaskExecutorFunction(
+                taskExecutorRegistration -> {
+                    return CompletableFuture.completedFuture(
+                            new TaskExecutorRegistrationRejection("Foobar"));
+                });
+
+        resourceManagerRegistration.start();
+        registrationRejectionFuture.join();
     }
 
     private TaskExecutorToResourceManagerConnection
@@ -148,6 +165,7 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
         rpcService.registerGateway(RESOURCE_MANAGER_ADDRESS, testingResourceManagerGateway);
 
         registrationSuccessFuture = new CompletableFuture<>();
+        registrationRejectionFuture = new CompletableFuture<>();
     }
 
     @After
@@ -157,8 +175,9 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
 
     private class TestRegistrationConnectionListener<
                     T extends RegisteredRpcConnection<?, ?, S, ?>,
-                    S extends RegistrationResponse.Success>
-            implements RegistrationConnectionListener<T, S> {
+                    S extends RegistrationResponse.Success,
+                    R extends RegistrationResponse.Rejection>
+            implements RegistrationConnectionListener<T, S, R> {
 
         @Override
         public void onRegistrationSuccess(final T connection, final S success) {
@@ -168,6 +187,11 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
         @Override
         public void onRegistrationFailure(final Throwable failure) {
             registrationSuccessFuture.completeExceptionally(failure);
+        }
+
+        @Override
+        public void onRegistrationRejection(String targetAddress, R rejection) {
+            registrationRejectionFuture.complete(null);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorToResourceManagerConnectionTest.java
@@ -156,7 +156,7 @@ public class TaskExecutorToResourceManagerConnectionTest extends TestLogger {
     }
 
     private class TestRegistrationConnectionListener<
-                    T extends RegisteredRpcConnection<?, ?, S>,
+                    T extends RegisteredRpcConnection<?, ?, S, ?>,
                     S extends RegistrationResponse.Success>
             implements RegistrationConnectionListener<T, S> {
 


### PR DESCRIPTION
This PR introduces the notion of rejected registration attempts to the `RetryingRegistration` and `RegisteredRpcConnection`. This functionality is used to let the `JobManager` reject connection attempts from `TaskManagers` who think that the `JobManager` is responsible for another job. On the `TaskManager` side, a rejected connection attempt will clear all relevant job resources (slots, partitions) because the `TaskManager` no longer knows where the `JobManager` for the sought-after job is running.

The same functionality is used to reject `TaskManager` connections to the `ResourceManager` if the `TaskManager` is not known by the `ResourceManager`. If the `TaskManager` sees the connection rejection, then it will shut itself down. This gives a better behaviour compared to waiting for the max registration timeout to be fired.