### PR TITLE
[FLINK-21306] Ensure fatal errors always stop the JVM process

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -444,7 +444,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(exception);
         LOG.error("Fatal error occurred in the cluster entrypoint.", exception);
 
-        System.exit(RUNTIME_FAILURE_RETURN_CODE);
+        FlinkSecurityManager.forceProcessExit(RUNTIME_FAILURE_RETURN_CODE);
     }
 
     // --------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -332,7 +332,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
     }
 
     private void terminateJVM() {
-        System.exit(FAILURE_EXIT_CODE);
+        FlinkSecurityManager.forceProcessExit(FAILURE_EXIT_CODE);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/FatalExitExceptionHandler.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.util;
 
+import org.apache.flink.runtime.security.FlinkSecurityManager;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +45,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
                     t.getName(),
                     e);
         } finally {
-            System.exit(EXIT_CODE);
+            FlinkSecurityManager.forceProcessExit(EXIT_CODE);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -288,6 +288,15 @@ public abstract class TestJvmProcess {
         }
     }
 
+    public int exitCode() {
+        Process process = this.process;
+        if (process != null) {
+            return process.exitValue();
+        } else {
+            throw new IllegalStateException("process not started");
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // File based synchronization utilities
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/FlinkSecurityManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/FlinkSecurityManagerITCase.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.security.FlinkSecurityManager;
+import org.apache.flink.runtime.testutils.TestJvmProcess;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/** Integration tests for the {@link FlinkSecurityManager}. */
+public class FlinkSecurityManagerITCase extends TestLogger {
+
+    @Before
+    public void ensureSupportedOS() {
+        // based on the assumption in JvmExitOnFatalErrorTest, and manual testing on Mac, we do not
+        // support all platforms (in particular not Windows)
+        assumeTrue(OperatingSystem.isLinux() || OperatingSystem.isMac());
+    }
+
+    @Test
+    public void testForcedJVMExit() throws Exception {
+        final ForcedJVMExitProcess testProcess =
+                new ForcedJVMExitProcess(ForcedExitEntryPoint.class);
+
+        testProcess.startProcess();
+        try {
+            testProcess.waitFor();
+            assertThat(testProcess.exitCode(), is(222));
+        } finally {
+            testProcess.destroy();
+        }
+    }
+
+    @Test
+    public void testIgnoredJVMExit() throws Exception {
+        final ForcedJVMExitProcess testProcess =
+                new ForcedJVMExitProcess(IgnoredExitEntryPoint.class);
+
+        testProcess.startProcess();
+        try {
+            testProcess.waitFor();
+            assertThat(testProcess.exitCode(), is(0));
+        } finally {
+            testProcess.destroy();
+        }
+    }
+
+    private static final class ForcedJVMExitProcess extends TestJvmProcess {
+
+        private final Class<?> entryPointName;
+
+        private ForcedJVMExitProcess(Class<?> entryPointName) throws Exception {
+            this.entryPointName = entryPointName;
+        }
+
+        @Override
+        public String getName() {
+            return getEntryPointClassName();
+        }
+
+        @Override
+        public String[] getJvmArgs() {
+            return new String[0];
+        }
+
+        @Override
+        public String getEntryPointClassName() {
+            return entryPointName.getName();
+        }
+    }
+
+    public static final class ForcedExitEntryPoint {
+
+        public static void main(String[] args) throws Exception {
+            Configuration configuration = new Configuration();
+            // configure FlinkSecurityManager to intercept calls to System.exit().
+            configuration.set(
+                    ClusterOptions.INTERCEPT_USER_SYSTEM_EXIT,
+                    ClusterOptions.UserSystemExitMode.THROW);
+            FlinkSecurityManager.setFromConfiguration(configuration);
+
+            FlinkSecurityManager.forceProcessExit(222);
+
+            System.exit(0);
+        }
+    }
+
+    public static final class IgnoredExitEntryPoint {
+
+        public static void main(String[] args) throws Exception {
+            Configuration configuration = new Configuration();
+            // configure FlinkSecurityManager to intercept calls to System.exit().
+            configuration.set(
+                    ClusterOptions.INTERCEPT_USER_SYSTEM_EXIT,
+                    ClusterOptions.UserSystemExitMode.THROW);
+            FlinkSecurityManager.setFromConfiguration(configuration);
+
+            FlinkSecurityManager.monitorUserSystemExitForCurrentThread();
+            // expect this call to be ignored
+            try {
+                System.exit(123);
+            } catch (Throwable t) {
+                System.err.println(
+                        "Caught exception during system exit with message: " + t.getMessage());
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -68,6 +68,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.testutils.TestJvmProcess;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,7 +86,7 @@ import static org.mockito.Mockito.mock;
  * Test that verifies the behavior of blocking shutdown hooks and of the {@link
  * JvmShutdownSafeguard} that guards against it.
  */
-public class JvmExitOnFatalErrorTest {
+public class JvmExitOnFatalErrorTest extends TestLogger {
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 


### PR DESCRIPTION


## What is the purpose of the change

Make sure that the `FlinkSecurityManager` is not intercepting System.exit() calls from Flink's internal assertions (such as calls leading to the invocation of the `FatalExitExceptionHandler`).

## Brief change log

- Introduce FlinkSecurityManager. forceProcessExit, refactor security manager
- Replace relevant System.exit() calls
- At FSM IT case.

## Verifying this change

Existing and additional tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

