### PR TITLE
[FLINK-20955][connectors/hbase] HBase connector using new connector API

### DIFF
--- a/flink-connectors/flink-connector-hbase-unified/README.md
+++ b/flink-connectors/flink-connector-hbase-unified/README.md
@@ -1,0 +1,122 @@
+# Flink HBase Connector
+
+This module provides connectors that allow Flink to access [HBase](https://hbase.apache.org/) using [CDC](https://en.wikipedia.org/wiki/Change_data_capture). 
+It supports the new Source and Sink API specified in [FLIP-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface) and [FLIP-143](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API).
+
+## Installing HBase
+
+Follow the instructions from the [HBase Quick Start Guide](http://hbase.apache.org/book.html#quickstart) to install HBase.
+
+*Version Compatibility*: This module is compatible with Apache HBase *2.0.0+*.
+
+## HBase Configuration
+
+Connecting to HBase always requires a `Configuration` instance.
+If there is an HBase gateway on the same host as the Flink gateway where the application is started, this can be obtained by invoking `HBaseConfiguration.create()` as in the examples below.
+If that's not the case a configuration should be provided where the proper core-site, hdfs-site, and hbase-site are added as resources.
+
+The application needs the following permissions for HBase: 
+- Create/delete ZooKeeper paths
+- Register/unregister replication peers
+
+## DataStream API
+
+### Reading data from HBase
+
+To receive data from HBase, the connector makes use of the internal replication mechanism of HBase. 
+The connector registers at the HBase cluster as a *Replication Peer* and will receive all change events from HBase.
+
+For the replication to work, the HBase config needs to have replication enabled in the `hbase-site.xml` file.
+This needs be done only once per cluster:
+```xml
+<configuration>
+  <property>
+    <name>hbase.replication</name>
+    <value>true</value>
+  </property>
+  ...
+</configuration>
+```
+All incoming events to Flink will be processed as an `HBaseSourceEvent`. 
+You will need to specify a Deserializer which will transform each event from an `HBaseSourceEvent` to the desired DataStream type.
+
+```java
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+Configuration hbaseConfig = HBaseConfiguration.create();
+String tableName = "TestTable";
+
+HBaseSource<String> hbaseSource =
+    HBaseSource.builder()
+        .setTableName(tableName)
+        .setSourceDeserializer(new HBaseStringDeserializer())
+        .setHBaseConfiguration(hbaseConfig)
+        .build();
+
+DataStream<String> stream = env.fromSource(
+        hbaseSource,
+        WatermarkStrategy.noWatermarks(),
+        "HBaseSource");
+// ...
+```
+
+The Deserializer is created as follows:
+
+```java
+static class HBaseStringDeserializer implements HBaseSourceDeserializer<String> {
+    @Override
+    public String deserialize(HBaseSourceEvent event) {
+        return new String(event.getPayload(), HBaseEvent.DEFAULT_CHARSET);
+    }
+}
+```
+
+### Writing data to HBase
+To write data from Flink into HBase, you can use the `HBaseSink`.
+Similar to the `HBaseSource` you need to specify a Serializer which knows how to write your DataStream element into HBase.
+
+```java
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+Configuration hbaseConfig = HBaseConfiguration.create();
+String tableName = "TestTable";
+
+DataStream<Long> longStream = env.fromSequence(0, 100);
+
+HBaseSink<Long> hbaseSink =
+    HBaseSink.builder()
+        .setTableName(tableName)
+        .setSinkSerializer(new HBaseLongSerializer())
+        .setHBaseConfiguration(hbaseConfig)
+        .build();
+
+longStream.sinkTo(hbaseSink);
+// ...
+```
+An example Serializer is given below. You need to implement the following five methods, so the connector 
+knows how to save the data to HBase.
+```java
+static class HBaseLongSerializer implements HBaseSinkSerializer<Long> {
+    @Override
+    public HBaseEvent serialize(Long event) {
+        return HBaseEvent.putWith(                  // or deleteWith()                 
+                event.toString(),                   // rowId
+                "exampleColumnFamily",              // column family
+                "exampleQualifier",                 // qualifier
+                Bytes.toBytes(event.toString()));   // payload
+    }
+}
+```
+
+## Building the connector
+
+Note that the streaming connectors are not part of the binary distribution of Flink.
+You need to link them into your job jar for cluster execution.
+See how to link with them for cluster execution [here](https://ci.apache.org/projects/flink/flink-docs-stable/dev/project-configuration.html#adding-connector-and-library-dependencies).
+
+The connector can be built by using maven:
+
+```
+cd flink-connectors/flink-connector-hbase
+mvn clean install
+```

--- a/flink-connectors/flink-connector-hbase-unified/pom.xml
+++ b/flink-connectors/flink-connector-hbase-unified/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-connectors</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.13-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-connector-hbase-unified</artifactId>
+	<name>Flink : Connectors : HBase : Unified</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<hbase.version>2.3.4</hbase.version>
+	</properties>
+
+	<dependencies>
+
+
+		<!-- Add HBase 2.x as a dependency -->
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase-testing-util</artifactId>
+			<version>${hbase.version}</version>
+			<scope>test</scope>
+			<!-- Exclude forbidden dependencies -->
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase-common</artifactId>
+			<version>${hbase.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase-client</artifactId>
+			<version>${hbase.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase-server</artifactId>
+			<version>${hbase.version}</version>
+
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase-zookeeper</artifactId>
+			<version>${hbase.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hbase.thirdparty</groupId>
+			<artifactId>hbase-shaded-protobuf</artifactId>
+			<version>3.4.1</version>
+		</dependency>
+
+
+
+		<!-- streaming-java dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- For creating other sources for testing etc. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Flink connector base -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Hadoop dependencies bumped to 2.10 because compatibility with hbase (especially testcluster) -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<version>2.10.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs</artifactId>
+			<version>2.10.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.zookeeper</groupId>
+			<artifactId>zookeeper</artifactId>
+			<version>3.5.8</version>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-hbase-base_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/HBaseEvent.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/HBaseEvent.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase;
+
+import org.apache.flink.connector.hbase.sink.HBaseSinkSerializer;
+import org.apache.flink.connector.hbase.source.HBaseSource;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceEvent;
+
+import org.apache.hadoop.hbase.Cell;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * The base HBaseEvent which needs to be created in the {@link HBaseSinkSerializer} to write data to
+ * HBase. The subclass {@link HBaseSourceEvent} contains additional information and is used by the
+ * {@link HBaseSource} to represent an incoming event from HBase.
+ */
+public class HBaseEvent {
+
+    public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+    private final String rowId;
+    private final String columnFamily;
+    private final String qualifier;
+    private final byte[] payload;
+    private final Cell.Type type;
+
+    protected HBaseEvent(
+            Cell.Type type, String rowId, String columnFamily, String qualifier, byte[] payload) {
+        this.rowId = rowId;
+        this.columnFamily = columnFamily;
+        this.qualifier = qualifier;
+        this.payload = payload;
+        this.type = type;
+    }
+
+    public static HBaseEvent deleteWith(String rowId, String columnFamily, String qualifier) {
+        return new HBaseEvent(Cell.Type.Delete, rowId, columnFamily, qualifier, null);
+    }
+
+    public static HBaseEvent putWith(
+            String rowId, String columnFamily, String qualifier, byte[] payload) {
+        return new HBaseEvent(Cell.Type.Put, rowId, columnFamily, qualifier, payload);
+    }
+
+    @Override
+    public String toString() {
+        return type.name()
+                + " "
+                + rowId
+                + " "
+                + columnFamily
+                + " "
+                + qualifier
+                + " "
+                + new String(payload);
+    }
+
+    public Cell.Type getType() {
+        return type;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    public String getRowId() {
+        return rowId;
+    }
+
+    public String getColumnFamily() {
+        return columnFamily;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public byte[] getRowIdBytes() {
+        return rowId.getBytes(DEFAULT_CHARSET);
+    }
+
+    public byte[] getColumnFamilyBytes() {
+        return columnFamily.getBytes(DEFAULT_CHARSET);
+    }
+
+    public byte[] getQualifierBytes() {
+        return qualifier.getBytes(DEFAULT_CHARSET);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HBaseEvent that = (HBaseEvent) o;
+        return rowId.equals(that.rowId)
+                && columnFamily.equals(that.columnFamily)
+                && qualifier.equals(that.qualifier)
+                && Arrays.equals(payload, that.payload)
+                && type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(rowId, columnFamily, qualifier, type);
+        result = 31 * result + Arrays.hashCode(payload);
+        return result;
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSink.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSink.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.api.connector.sink.Committer;
+import org.apache.flink.api.connector.sink.GlobalCommitter;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.SinkWriter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.sink.writer.HBaseWriter;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.apache.hadoop.hbase.client.Mutation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A Sink Connector for HBase. Please use an {@link HBaseSinkBuilder} to construct a {@link
+ * HBaseSink}. As HBase does not support transactions, this sink does not guarantee exactly-once,
+ * but at-least-once.
+ *
+ * <p>The following example shows how to create an HBaseSink that writes Long values to HBase.
+ *
+ * <pre>{@code
+ * HBaseSink<Long> hbaseSink =
+ *      HBaseSink.builder()
+ *          .setTableName(tableName)
+ *          .setSinkSerializer(new HBaseLongSerializer())
+ *          .setHBaseConfiguration(hbaseConfig)
+ *          .build();
+ * }</pre>
+ *
+ * <p>Here is an example for the Serializer:
+ *
+ * <pre>{@code
+ * static class HBaseLongSerializer implements HBaseSinkSerializer<Long> {
+ *     @Override
+ *     public HBaseEvent serialize(Long event) {
+ *         return HBaseEvent.putWith(                  // or deleteWith()
+ *                 event.toString(),                   // rowId
+ *                 "exampleColumnFamily",              // column family
+ *                 "exampleQualifier",                 // qualifier
+ *                 Bytes.toBytes(event.toString()));   // payload
+ *     }
+ * }
+ * }</pre>
+ *
+ * @see HBaseSinkBuilder HBaseSinkBuilder for more details on creation
+ * @see HBaseSinkSerializer HBaseSinkSerializer for more details on serialization
+ */
+public class HBaseSink<IN> implements Sink<IN, Void, Mutation, Void> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSink.class);
+
+    private final HBaseSinkSerializer<IN> sinkSerializer;
+    private final byte[] serializedHBaseConfig;
+    private final Configuration sinkConfiguration;
+
+    HBaseSink(
+            HBaseSinkSerializer<IN> sinkSerializer,
+            org.apache.hadoop.conf.Configuration hbaseConfiguration,
+            Configuration sinkConfiguration) {
+        this.sinkSerializer = sinkSerializer;
+        this.serializedHBaseConfig =
+                HBaseConfigurationUtil.serializeConfiguration(hbaseConfiguration);
+        this.sinkConfiguration = sinkConfiguration;
+        LOG.debug("constructed sink");
+    }
+
+    public static <IN> HBaseSinkBuilder<IN> builder() {
+        return new HBaseSinkBuilder<>();
+    }
+
+    @Override
+    public SinkWriter<IN, Void, Mutation> createWriter(InitContext context, List<Mutation> states) {
+        return new HBaseWriter<>(
+                context, states, sinkSerializer, serializedHBaseConfig, sinkConfiguration);
+    }
+
+    @Override
+    public Optional<Committer<Void>> createCommitter() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<GlobalCommitter<Void, Void>> createGlobalCommitter() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<SimpleVersionedSerializer<Void>> getCommittableSerializer() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<SimpleVersionedSerializer<Void>> getGlobalCommittableSerializer() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<SimpleVersionedSerializer<Mutation>> getWriterStateSerializer() {
+        return Optional.of(new HBaseSinkMutationSerializer());
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkBuilder.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkBuilder.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The builder class to create an {@link HBaseSink}. The following example shows how to create an
+ * HBaseSink that writes Long values to HBase.
+ *
+ * <pre>{@code
+ * HBaseSink<Long> hbaseSink = HBaseSink.builder()
+ *          .setTableName(tableName)
+ *          .setSinkSerializer(new HBaseLongSerializer())
+ *          .setHBaseConfiguration(hbaseConfig)
+ *          .build();
+ * }</pre>
+ *
+ * <p>Here is an example for the Serializer:
+ *
+ * <pre>{@code
+ * static class HBaseLongSerializer implements HBaseSinkSerializer<Long> {
+ *     @Override
+ *     public HBaseEvent serialize(Long event) {
+ *         return HBaseEvent.putWith(                  // or deleteWith()
+ *                 event.toString(),                   // rowId
+ *                 "exampleColumnFamily",              // column family
+ *                 "exampleQualifier",                 // qualifier
+ *                 Bytes.toBytes(event.toString()));   // payload
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>A SerializationSchema is always required, as well as a table name to write to and an
+ * HBaseConfiguration.
+ *
+ * <p>By default each HBaseWriter has a queue limit of 1000 entries used for batching. This can be
+ * changed with {@link #setQueueLimit(int)}. The maximum allowed latency of an event can be set by
+ * {@link #setMaxLatencyMs(int)}. After the specified elements will be sent to HBase no matter how
+ * many elements are currently in the batching queue.
+ */
+public class HBaseSinkBuilder<IN> {
+
+    private static final ConfigOption<?>[] REQUIRED_CONFIGS = {HBaseSinkOptions.TABLE_NAME};
+    private final Configuration sinkConfiguration;
+    private org.apache.hadoop.conf.Configuration hbaseConfiguration;
+    private HBaseSinkSerializer<IN> sinkSerializer;
+
+    protected HBaseSinkBuilder() {
+        this.sinkSerializer = null;
+        this.hbaseConfiguration = null;
+        this.sinkConfiguration = new Configuration();
+    }
+
+    public HBaseSinkBuilder<IN> setTableName(String tableName) {
+        sinkConfiguration.setString(HBaseSinkOptions.TABLE_NAME, tableName);
+        return this;
+    }
+
+    public <T extends IN> HBaseSinkBuilder<T> setSinkSerializer(
+            HBaseSinkSerializer<T> sinkSerializer) {
+        final HBaseSinkBuilder<T> sinkBuilder = (HBaseSinkBuilder<T>) this;
+        sinkBuilder.sinkSerializer = sinkSerializer;
+        return sinkBuilder;
+    }
+
+    public HBaseSinkBuilder<IN> setHBaseConfiguration(
+            org.apache.hadoop.conf.Configuration hbaseConfiguration) {
+        this.hbaseConfiguration = hbaseConfiguration;
+        return this;
+    }
+
+    public HBaseSinkBuilder<IN> setQueueLimit(int queueLimit) {
+        sinkConfiguration.setInteger(HBaseSinkOptions.QUEUE_LIMIT, queueLimit);
+        return this;
+    }
+
+    public HBaseSinkBuilder<IN> setMaxLatencyMs(int maxLatencyMs) {
+        sinkConfiguration.setInteger(HBaseSinkOptions.MAX_LATENCY, maxLatencyMs);
+        return this;
+    }
+
+    public HBaseSink<IN> build() {
+        sanityCheck();
+        return new HBaseSink<>(sinkSerializer, hbaseConfiguration, sinkConfiguration);
+    }
+
+    private void sanityCheck() {
+        for (ConfigOption<?> requiredConfig : REQUIRED_CONFIGS) {
+            checkNotNull(
+                    sinkConfiguration.get(requiredConfig),
+                    String.format("Config option %s is required but not provided", requiredConfig));
+        }
+
+        checkNotNull(sinkSerializer, "No sink serializer was specified.");
+        checkNotNull(hbaseConfiguration, "No hbase configuration was specified.");
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkMutationSerializer.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkMutationSerializer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.hbase.sink.writer.HBaseWriter;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.protobuf.generated.ClientProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * This class serializes {@link Mutation} and is used to serialize the state of the {@link
+ * HBaseWriter}.
+ */
+@Internal
+class HBaseSinkMutationSerializer implements SimpleVersionedSerializer<Mutation> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSinkMutationSerializer.class);
+
+    private static final int VERSION = 1;
+
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public byte[] serialize(Mutation mutation) throws IOException {
+        LOG.debug("serializing mutation {}", mutation);
+        ClientProtos.MutationProto.MutationType type;
+
+        if (mutation instanceof Put) {
+            type = ClientProtos.MutationProto.MutationType.PUT;
+        } else if (mutation instanceof Delete) {
+            type = ClientProtos.MutationProto.MutationType.DELETE;
+        } else {
+            throw new IllegalArgumentException("Only Put and Delete are supported");
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            ProtobufUtil.toMutation(type, mutation).writeDelimitedTo(out);
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public Mutation deserialize(int version, byte[] serialized) throws IOException {
+        LOG.debug("deserializing mutation");
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            ClientProtos.MutationProto proto = ClientProtos.MutationProto.parseDelimitedFrom(in);
+            return ProtobufUtil.toMutation(proto);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkOptions.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkOptions.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/** HBaseSinkOptions contains configuration options used for building an {@link HBaseSink}. */
+public class HBaseSinkOptions {
+
+    public static final ConfigOption<String> TABLE_NAME =
+            ConfigOptions.key("table_name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The table in which the sink will store data.");
+
+    public static final ConfigOption<Integer> QUEUE_LIMIT =
+            ConfigOptions.key("queue.limit")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("The maximum buffer size before sending data to HBase");
+
+    public static final ConfigOption<Integer> MAX_LATENCY =
+            ConfigOptions.key("buffer.timeout.ms")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            "The maximum time an element stays in the queue before being flushed.");
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkSerializer.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.connector.hbase.HBaseEvent;
+
+import java.io.Serializable;
+
+/**
+ * The serialization interface that needs to be implemented for constructing an {@link HBaseSink}.
+ *
+ * <p>A minimal implementation can be seen in the following example.
+ *
+ * <pre>{@code
+ * static class HBaseLongSerializer implements HBaseSinkSerializer<Long> {
+ *     @Override
+ *     public HBaseEvent serialize(Long event) {
+ *         return HBaseEvent.putWith(                  // or deleteWith()
+ *                 event.toString(),                   // rowId
+ *                 "exampleColumnFamily",              // column family
+ *                 "exampleQualifier",                 // qualifier
+ *                 Bytes.toBytes(event.toString()));   // payload
+ *     }
+ * }
+ * }</pre>
+ */
+@FunctionalInterface
+public interface HBaseSinkSerializer<T> extends Serializable {
+    HBaseEvent serialize(T event);
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/writer/HBaseWriter.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/sink/writer/HBaseWriter.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink.writer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink.SinkWriter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.HBaseEvent;
+import org.apache.flink.connector.hbase.sink.HBaseSinkOptions;
+import org.apache.flink.connector.hbase.sink.HBaseSinkSerializer;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
+
+import org.apache.flink.shaded.curator4.org.apache.curator.shaded.com.google.common.io.Closer;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ArrayBlockingQueue;
+
+/**
+ * The HBaseWriter is responsible for writing incoming events to HBase.
+ *
+ * <p>Stored events will be flushed to HBase eiter if the {@link #queueLimit} is reached or if the
+ * {@link #maxLatencyMs} has elapsed.
+ */
+@Internal
+public class HBaseWriter<IN> implements SinkWriter<IN, Void, Mutation> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseWriter.class);
+
+    private final int queueLimit;
+    private final int maxLatencyMs;
+    private final HBaseSinkSerializer<IN> sinkSerializer;
+    private final ArrayBlockingQueue<Mutation> pendingMutations;
+    private final Connection connection;
+    private final Table table;
+    private volatile long lastFlushTimeStamp = 0;
+    private TimerTask batchSendTimer;
+
+    public HBaseWriter(
+            Sink.InitContext context,
+            List<Mutation> states,
+            HBaseSinkSerializer<IN> sinkSerializer,
+            byte[] serializedHBaseConfig,
+            Configuration sinkConfiguration) {
+        this.sinkSerializer = sinkSerializer;
+        this.queueLimit = sinkConfiguration.get(HBaseSinkOptions.QUEUE_LIMIT);
+        this.maxLatencyMs = sinkConfiguration.get(HBaseSinkOptions.MAX_LATENCY);
+        String tableName = sinkConfiguration.get(HBaseSinkOptions.TABLE_NAME);
+
+        // Queue limit is multiplied by 2, to reduce the probability of blocking while committing
+        this.pendingMutations = new ArrayBlockingQueue<>(2 * queueLimit);
+        pendingMutations.addAll(states);
+
+        org.apache.hadoop.conf.Configuration hbaseConfiguration =
+                HBaseConfigurationUtil.deserializeConfiguration(serializedHBaseConfig, null);
+        try {
+            connection = ConnectionFactory.createConnection(hbaseConfiguration);
+            table = connection.getTable(TableName.valueOf(tableName));
+        } catch (IOException e) {
+            throw new RuntimeException("Connection to HBase couldn't be established", e);
+        }
+
+        startBatchSendTimer();
+        LOG.debug("started sink writer for table {}", tableName);
+    }
+
+    private void startBatchSendTimer() {
+        batchSendTimer =
+                new TimerTask() {
+                    @Override
+                    public void run() {
+                        long diff = System.currentTimeMillis() - lastFlushTimeStamp;
+                        if (diff > maxLatencyMs) {
+                            LOG.debug("Time based flushing of mutations");
+                            flushBuffer();
+                        }
+                    }
+                };
+        new Timer().scheduleAtFixedRate(batchSendTimer, 0, maxLatencyMs / 2);
+    }
+
+    private void flushBuffer() {
+        lastFlushTimeStamp = System.currentTimeMillis();
+        if (pendingMutations.size() == 0) {
+            return;
+        }
+        try {
+            ArrayList<Mutation> batch = new ArrayList<>();
+            pendingMutations.drainTo(batch);
+            table.batch(batch, null);
+            pendingMutations.clear();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed storing batch data in HBase", e);
+        }
+    }
+
+    @Override
+    public void write(IN element, Context context) {
+        HBaseEvent event = sinkSerializer.serialize(element);
+        if (event.getType() == Cell.Type.Put) {
+            Put put = new Put(event.getRowIdBytes());
+            put.addColumn(
+                    event.getColumnFamilyBytes(), event.getQualifierBytes(), event.getPayload());
+            pendingMutations.add(put);
+        } else if (event.getType() == Cell.Type.Delete) {
+            Delete delete = new Delete(event.getRowIdBytes());
+            delete.addColumn(event.getColumnFamilyBytes(), event.getQualifierBytes());
+            pendingMutations.add(delete);
+        } else {
+            throw new UnsupportedOperationException("event type not supported");
+        }
+
+        if (pendingMutations.size() >= queueLimit) {
+            LOG.debug("Capacity based flushing of mutations");
+            flushBuffer();
+        }
+    }
+
+    @Override
+    public List<Void> prepareCommit(boolean flush) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Mutation> snapshotState() {
+        ArrayList<Mutation> snapshot = new ArrayList<>();
+        pendingMutations.drainTo(snapshot);
+        LOG.debug("Snapshotting state with {} elements", snapshot.size());
+        return snapshot;
+    }
+
+    @Override
+    public void close() throws Exception {
+        try (Closer closer = Closer.create()) {
+            closer.register(connection);
+            closer.register(table);
+            closer.register(this::flushBuffer);
+            closer.register(batchSendTimer::cancel);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/HBaseSource.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/HBaseSource.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.source.enumerator.HBaseSourceEnumeratorCheckpointSerializer;
+import org.apache.flink.connector.hbase.source.enumerator.HBaseSplitEnumerator;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceDeserializer;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceReader;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplit;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplitSerializer;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+/**
+ * A source connector for HBase. Please use an {@link HBaseSourceBuilder} to construct an {@link
+ * HBaseSource}. The following example shows how to create a HBaseSource that reads String values
+ * from each cell.
+ *
+ * <pre>{@code
+ * HBaseSource<String> source =
+ *     HBaseSource.builder()
+ *         .setSourceDeserializer(new HBaseStringDeserializer())
+ *         .setTableName("test-table")
+ *         .setHBaseConfiguration(new HBaseTestClusterUtil().getConfig())
+ *         .build();
+ *
+ * static class HBaseStringDeserializer implements HBaseSourceDeserializer<String> {
+ *     @Override
+ *     public String deserialize(HBaseSourceEvent event) {
+ *         return new String(event.getPayload(), HBaseEvent.DEFAULT_CHARSET);
+ *     }
+ * }
+ * }</pre>
+ *
+ * @see HBaseSourceBuilder HBaseSourceBuilder for more details.
+ */
+public class HBaseSource<T> implements Source<T, HBaseSourceSplit, Collection<HBaseSourceSplit>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSource.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final HBaseSourceDeserializer<T> sourceDeserializer;
+    private final byte[] serializedHBaseConfig;
+    private final Configuration sourceConfiguration;
+
+    HBaseSource(
+            HBaseSourceDeserializer<T> sourceDeserializer,
+            org.apache.hadoop.conf.Configuration hbaseConfiguration,
+            Configuration sourceConfiguration) {
+        this.serializedHBaseConfig =
+                HBaseConfigurationUtil.serializeConfiguration(hbaseConfiguration);
+        this.sourceDeserializer = sourceDeserializer;
+        this.sourceConfiguration = sourceConfiguration;
+    }
+
+    public static <IN> HBaseSourceBuilder<IN> builder() {
+        return new HBaseSourceBuilder<>();
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SourceReader<T, HBaseSourceSplit> createReader(SourceReaderContext readerContext) {
+        LOG.debug("creating reader");
+        return new HBaseSourceReader<>(
+                serializedHBaseConfig, sourceDeserializer, sourceConfiguration, readerContext);
+    }
+
+    @Override
+    public SplitEnumerator<HBaseSourceSplit, Collection<HBaseSourceSplit>> restoreEnumerator(
+            SplitEnumeratorContext<HBaseSourceSplit> enumContext,
+            Collection<HBaseSourceSplit> checkpoint) {
+        LOG.debug("restoring enumerator with {} splits", checkpoint.size());
+
+        HBaseSplitEnumerator enumerator =
+                new HBaseSplitEnumerator(enumContext, serializedHBaseConfig, sourceConfiguration);
+        enumerator.addSplits(checkpoint);
+        return enumerator;
+    }
+
+    @Override
+    public SplitEnumerator<HBaseSourceSplit, Collection<HBaseSourceSplit>> createEnumerator(
+            SplitEnumeratorContext<HBaseSourceSplit> enumContext) {
+        LOG.debug("creating enumerator");
+        return new HBaseSplitEnumerator(enumContext, serializedHBaseConfig, sourceConfiguration);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<HBaseSourceSplit> getSplitSerializer() {
+        LOG.debug("getSplitSerializer");
+        return new HBaseSourceSplitSerializer();
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Collection<HBaseSourceSplit>>
+            getEnumeratorCheckpointSerializer() {
+        LOG.debug("getEnumeratorCheckpointSerializer");
+        return new HBaseSourceEnumeratorCheckpointSerializer();
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/HBaseSourceBuilder.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/HBaseSourceBuilder.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.source.hbaseendpoint.HBaseEndpoint;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceDeserializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The builder class to create an {@link HBaseSource}.
+ *
+ * <p>The following example shows a minimum setup to create an {@link HBaseSource} that reads String
+ * values from each cell.
+ *
+ * <pre>{@code
+ * HBaseSource<String> source = HBaseSource.builder()
+ *     .setSourceDeserializer(new HBaseStringDeserializer())
+ *     .setTableName("test-table")
+ *     .setHBaseConfiguration(new HBaseTestClusterUtil().getConfig())
+ *     .build();
+ *
+ * static class HBaseStringDeserializer implements HBaseSourceDeserializer<String> {
+ *     @Override
+ *     public String deserialize(HBaseSourceEvent event) {
+ *         return new String(event.getPayload(), HBaseEvent.DEFAULT_CHARSET);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>A {@link HBaseSourceDeserializer} is always required to be set, as well as a table name to
+ * read from and a {@link org.apache.hadoop.conf.Configuration} for HBase.
+ *
+ * <p>By default each {@link HBaseEndpoint} has a queue capacity of 1000 entries for WALedits. This
+ * can be changed with {@link #setQueueCapacity(int queueSize)}. The hostname of the created RPC
+ * Servers can be changed with {@link #setHostName(String hostname)}.
+ *
+ * @see HBaseSourceOptions HBaseSourceOptions
+ */
+public class HBaseSourceBuilder<IN> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSourceBuilder.class);
+
+    private static final ConfigOption<?>[] REQUIRED_CONFIGS = {HBaseSourceOptions.TABLE_NAME};
+    private final Configuration sourceConfiguration;
+    private org.apache.hadoop.conf.Configuration hbaseConfiguration;
+    private HBaseSourceDeserializer<IN> sourceDeserializer;
+
+    protected HBaseSourceBuilder() {
+        this.sourceDeserializer = null;
+        this.hbaseConfiguration = null;
+        this.sourceConfiguration = new Configuration();
+    }
+
+    /**
+     * Sets the table name from which changes will be processed.
+     *
+     * @param tableName the HBase table name.
+     * @return this HBaseSourceBuilder.
+     */
+    public HBaseSourceBuilder<IN> setTableName(String tableName) {
+        sourceConfiguration.setString(HBaseSourceOptions.TABLE_NAME, tableName);
+        return this;
+    }
+
+    /**
+     * Sets the Deserializer, that will be used to deserialize cell entries in HBase.
+     *
+     * @param sourceDeserializer the HBase Source Deserializer.
+     * @return this HBaseSourceBuilder.
+     */
+    public <T> HBaseSourceBuilder<T> setSourceDeserializer(
+            HBaseSourceDeserializer<T> sourceDeserializer) {
+        final HBaseSourceBuilder<T> sourceBuilder = (HBaseSourceBuilder<T>) this;
+        sourceBuilder.sourceDeserializer = sourceDeserializer;
+        return sourceBuilder;
+    }
+
+    /**
+     * Sets the HBaseConfiguration.
+     *
+     * @param hbaseConfiguration the HBaseConfiguration.
+     * @return this HBaseSourceBuilder.
+     */
+    public HBaseSourceBuilder<IN> setHBaseConfiguration(
+            org.apache.hadoop.conf.Configuration hbaseConfiguration) {
+        this.hbaseConfiguration = hbaseConfiguration;
+        return this;
+    }
+
+    /**
+     * Sets the queue capacity for incoming WALedits in the HBaseEndpoint.
+     *
+     * @param queueCapacity integer value of the queue capacity.
+     * @return this KafkaSourceBuilder.
+     */
+    public HBaseSourceBuilder<IN> setQueueCapacity(int queueCapacity) {
+        sourceConfiguration.setInteger(HBaseSourceOptions.ENDPOINT_QUEUE_CAPACITY, queueCapacity);
+        return this;
+    }
+
+    /**
+     * Sets the hostname of the RPC Server in the HBaseEndpoint.
+     *
+     * @param hostName the hostname String.
+     * @return this KafkaSourceBuilder.
+     */
+    public HBaseSourceBuilder<IN> setHostName(String hostName) {
+        sourceConfiguration.setString(HBaseSourceOptions.HOST_NAME, hostName);
+        return this;
+    }
+
+    public HBaseSource<IN> build() {
+        sanityCheck();
+        LOG.debug("constructing source with config: {}", sourceConfiguration.toString());
+        return new HBaseSource<>(sourceDeserializer, hbaseConfiguration, sourceConfiguration);
+    }
+
+    private void sanityCheck() {
+        for (ConfigOption<?> requiredConfig : REQUIRED_CONFIGS) {
+            checkNotNull(
+                    sourceConfiguration.get(requiredConfig),
+                    String.format("Config option %s is required but not provided", requiredConfig));
+        }
+
+        checkNotNull(sourceDeserializer, "No source deserializer was specified.");
+        checkNotNull(hbaseConfiguration, "No hbase configuration was specified.");
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/HBaseSourceOptions.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/HBaseSourceOptions.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/** Configuration options for the {@link HBaseSourceBuilder}. */
+public class HBaseSourceOptions {
+
+    public static final ConfigOption<String> TABLE_NAME =
+            ConfigOptions.key("table_name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The table from which changes will be received");
+
+    public static final ConfigOption<Integer> ENDPOINT_QUEUE_CAPACITY =
+            ConfigOptions.key("endpoint.queue.capacity")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("The maximum queue size in the HBase endpoint");
+
+    public static final ConfigOption<String> HOST_NAME =
+            ConfigOptions.key("endpoint.hostname")
+                    .stringType()
+                    .defaultValue("localhost")
+                    .withDescription(
+                            "The hostname of the RPC server in the HBaseEndpoint receiving events from HBase");
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/enumerator/HBaseSourceEnumeratorCheckpointSerializer.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/enumerator/HBaseSourceEnumeratorCheckpointSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.hbase.source.HBaseSource;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplit;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** Checkpoint serializer for {@link HBaseSource}. (De-)Serializes the collection of splits. */
+@Internal
+public class HBaseSourceEnumeratorCheckpointSerializer
+        implements SimpleVersionedSerializer<Collection<HBaseSourceSplit>> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HBaseSourceEnumeratorCheckpointSerializer.class);
+
+    private final HBaseSourceSplitSerializer splitSerializer = new HBaseSourceSplitSerializer();
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public byte[] serialize(Collection<HBaseSourceSplit> checkpointState) throws IOException {
+        LOG.debug("serializing checkpoint state with {} splits", checkpointState.size());
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeInt(checkpointState.size());
+            for (HBaseSourceSplit split : checkpointState) {
+                byte[] serializedSplit = splitSerializer.serialize(split);
+                out.write(serializedSplit.length);
+                out.write(serializedSplit);
+            }
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public Collection<HBaseSourceSplit> deserialize(int version, byte[] serialized)
+            throws IOException {
+        LOG.debug("deserializing checkpoint state");
+        List<HBaseSourceSplit> checkPointState = new ArrayList<>();
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            int numSplits = in.readInt();
+            for (int i = 0; i < numSplits; i++) {
+                int splitSize = in.readInt();
+                byte[] serializedSplit = new byte[splitSize];
+                in.read(serializedSplit);
+                HBaseSourceSplit split =
+                        splitSerializer.deserialize(splitSerializer.getVersion(), serializedSplit);
+                checkPointState.add(split);
+            }
+        }
+        return checkPointState;
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/enumerator/HBaseSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/enumerator/HBaseSplitEnumerator.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.source.HBaseSourceOptions;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplit;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * The SourceEnumerator is responsible for work discovery and assignment of splits. The
+ * HBaseSourceEnumerator does the following:
+ *
+ * <ol>
+ *   <li>Connect to HBase to discover all column families of the table that is being watched.
+ *   <li>Equally distribute column families to HBaseSourceSplits depending on the parallelism. One
+ *       {@link HBaseSourceSplit} will be created per parallel reader. Each {@link HBaseSourceSplit}
+ *       can cover multiple column families.
+ * </ol>
+ */
+@Internal
+public class HBaseSplitEnumerator
+        implements SplitEnumerator<HBaseSourceSplit, Collection<HBaseSourceSplit>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSplitEnumerator.class);
+
+    private final SplitEnumeratorContext<HBaseSourceSplit> context;
+    private final Queue<HBaseSourceSplit> remainingSplits;
+    private final String table;
+    private final byte[] serializedHBaseConfig;
+    private final String host;
+
+    public HBaseSplitEnumerator(
+            SplitEnumeratorContext<HBaseSourceSplit> context,
+            byte[] serializedHBaseConfig,
+            Configuration sourceConfiguration) {
+        this.context = context;
+        this.remainingSplits = new ArrayDeque<>();
+        this.host = sourceConfiguration.get(HBaseSourceOptions.HOST_NAME);
+        this.table = sourceConfiguration.get(HBaseSourceOptions.TABLE_NAME);
+        this.serializedHBaseConfig = serializedHBaseConfig;
+        LOG.debug("Constructed with {} remaining splits", remainingSplits.size());
+    }
+
+    @Override
+    public void start() {
+        org.apache.hadoop.conf.Configuration hbaseConfiguration =
+                HBaseConfigurationUtil.deserializeConfiguration(this.serializedHBaseConfig, null);
+        try (Connection connection = ConnectionFactory.createConnection(hbaseConfiguration);
+                Admin admin = connection.getAdmin()) {
+            ColumnFamilyDescriptor[] colFamDes =
+                    admin.getDescriptor(TableName.valueOf(this.table)).getColumnFamilies();
+            List<HBaseSourceSplit> splits = new ArrayList<>();
+            List<ArrayList<String>> parallelInstances =
+                    new ArrayList<>(context.currentParallelism());
+
+            for (int i = 0; i < context.currentParallelism(); i++) {
+                parallelInstances.add(new ArrayList<>());
+            }
+            int index = 0;
+            for (ColumnFamilyDescriptor colFamDe : colFamDes) {
+                parallelInstances.get(index).add(colFamDe.getNameAsString());
+                index = (index + 1) % parallelInstances.size();
+            }
+
+            parallelInstances.forEach(
+                    (list) -> {
+                        if (!list.isEmpty()) {
+                            splits.add(new HBaseSourceSplit(list.get(0), host, list));
+                        }
+                    });
+            addSplits(splits);
+        } catch (IOException e) {
+            throw new RuntimeException("could not start HBaseSplitEnumerator", e);
+        }
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        final HBaseSourceSplit nextSplit = remainingSplits.poll();
+        if (nextSplit != null) {
+            context.assignSplit(nextSplit, subtaskId);
+        } else {
+            context.signalNoMoreSplits(subtaskId);
+        }
+    }
+
+    @Override
+    public void addSplitsBack(List<HBaseSourceSplit> splits, int subtaskId) {
+        remainingSplits.addAll(splits);
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        LOG.debug("adding reader with id {}", subtaskId);
+        HBaseSourceSplit nextSplit = remainingSplits.poll();
+        if (nextSplit != null) {
+            context.assignSplit(nextSplit, subtaskId);
+        } else {
+            context.signalNoMoreSplits(subtaskId);
+        }
+    }
+
+    @Override
+    public Collection<HBaseSourceSplit> snapshotState() {
+        return remainingSplits;
+    }
+
+    public void addSplits(Collection<HBaseSourceSplit> splits) {
+        remainingSplits.addAll(splits);
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/hbaseendpoint/EmptyHBaseServer.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/hbaseendpoint/EmptyHBaseServer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.hbaseendpoint;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ChoreService;
+import org.apache.hadoop.hbase.CoordinatedStateManager;
+import org.apache.hadoop.hbase.Server;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.ClusterConnection;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.ipc.RpcScheduler;
+import org.apache.hadoop.hbase.ipc.RpcServer;
+import org.apache.hadoop.hbase.ipc.RpcServerFactory;
+import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * Minimal implementation of {@link Server} to enable the creation of {@link RpcServer} via {@link
+ * RpcServerFactory#createRpcServer(Server, String, List, InetSocketAddress, Configuration,
+ * RpcScheduler)}.
+ */
+@Internal
+public class EmptyHBaseServer implements Server {
+
+    private final Configuration configuration;
+
+    public EmptyHBaseServer(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void abort(String why, Throwable e) {
+        throw new UnsupportedOperationException(
+                "Operation \"abort\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public boolean isAborted() {
+        throw new UnsupportedOperationException(
+                "Operation \"isAborted\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public void stop(String why) {
+        throw new UnsupportedOperationException(
+                "Operation \"stop\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public boolean isStopped() {
+        throw new UnsupportedOperationException(
+                "Operation \"isStopped\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public ZKWatcher getZooKeeper() {
+        throw new UnsupportedOperationException(
+                "Operation \"getZooKeeper\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public Connection getConnection() {
+        throw new UnsupportedOperationException(
+                "Operation \"getConnection\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public Connection createConnection(Configuration conf) {
+        throw new UnsupportedOperationException(
+                "Operation \"createConnection\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public ClusterConnection getClusterConnection() {
+        throw new UnsupportedOperationException(
+                "Operation \"getClusterConnection\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public ServerName getServerName() {
+        throw new UnsupportedOperationException(
+                "Operation \"getServerName\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public CoordinatedStateManager getCoordinatedStateManager() {
+        throw new UnsupportedOperationException(
+                "Operation \"getCoordinatedStateManager\" not implemented in class " + getClass());
+    }
+
+    @Override
+    public ChoreService getChoreService() {
+        throw new UnsupportedOperationException(
+                "Operation \"getChoreService\" not implemented in class " + getClass());
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/hbaseendpoint/HBaseEndpoint.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/hbaseendpoint/HBaseEndpoint.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.hbaseendpoint;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.hbase.source.HBaseSourceOptions;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceEvent;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellScanner;
+import org.apache.hadoop.hbase.Server;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.ipc.FifoRpcScheduler;
+import org.apache.hadoop.hbase.ipc.HBaseRpcController;
+import org.apache.hadoop.hbase.ipc.RpcServer;
+import org.apache.hadoop.hbase.ipc.RpcServerFactory;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.AdminService.BlockingInterface;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.zookeeper.RecoverableZooKeeper;
+import org.apache.hadoop.hbase.zookeeper.ZKUtil;
+import org.apache.hbase.thirdparty.com.google.protobuf.RpcController;
+import org.apache.hbase.thirdparty.com.google.protobuf.ServiceException;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Endpoint for HBase CDC via HBase replication. Runs an rpc server that is registered as
+ * replication peer at HBase. A table is specified in the constructor, and the column families to
+ * replicate are specified when the replication is started with {@link #startReplication}. The
+ * incoming WAL edits are internally buffered and can be retrieved with {@link #getAll}.
+ */
+@Internal
+public class HBaseEndpoint implements ReplicationTargetInterface {
+
+    private static final AdminProtos.ReplicateWALEntryResponse REPLICATE_WAL_ENTRY_RESPONSE =
+            AdminProtos.ReplicateWALEntryResponse.newBuilder().build();
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseEndpoint.class);
+    private final String clusterKey;
+    /**
+     * The id under which the replication target is made known to the source cluster. Using the same
+     * id as a previous consumer - that has not been unregistered - prevents that already
+     * acknowledged events are sent again.
+     */
+    private final String replicationPeerId;
+
+    private final org.apache.hadoop.conf.Configuration hbaseConf;
+    private final RecoverableZooKeeper zooKeeper;
+    private final RpcServer rpcServer;
+    private final FutureCompletingBlockingQueue<HBaseSourceEvent> walEdits;
+    private final String hostName;
+    private final String tableName;
+    private boolean isRunning = false;
+
+    public HBaseEndpoint(
+            org.apache.hadoop.conf.Configuration hbaseConf, Configuration sourceConfiguration)
+            throws IOException, InterruptedException {
+        this.hbaseConf = hbaseConf;
+        this.replicationPeerId = UUID.randomUUID().toString().substring(0, 5);
+        this.clusterKey = replicationPeerId + "_clusterKey";
+        this.hostName = sourceConfiguration.get(HBaseSourceOptions.HOST_NAME);
+        this.tableName = sourceConfiguration.get(HBaseSourceOptions.TABLE_NAME);
+        int queueCapacity = sourceConfiguration.get(HBaseSourceOptions.ENDPOINT_QUEUE_CAPACITY);
+        this.walEdits = new FutureCompletingBlockingQueue<>(queueCapacity);
+
+        // Setup
+        rpcServer = createServer();
+        zooKeeper = connectToZooKeeper();
+        registerAtZooKeeper();
+    }
+
+    private RecoverableZooKeeper connectToZooKeeper() throws IOException {
+        // Using private ZKUtil and RecoverableZooKeeper here, because the stability is so much
+        // improved
+        RecoverableZooKeeper zooKeeper =
+                ZKUtil.connect(hbaseConf, getZookeeperClientAddress(), null);
+        LOG.debug("Connected to Zookeeper");
+        return zooKeeper;
+    }
+
+    private RpcServer createServer() throws IOException {
+        Server server = new EmptyHBaseServer(hbaseConf);
+        InetSocketAddress initialIsa = new InetSocketAddress(hostName, 0);
+        String name = "regionserver/" + initialIsa.toString();
+
+        RpcServer.BlockingServiceAndInterface bsai =
+                new RpcServer.BlockingServiceAndInterface(
+                        AdminProtos.AdminService.newReflectiveBlockingService(this),
+                        BlockingInterface.class);
+        RpcServer rpcServer =
+                RpcServerFactory.createRpcServer(
+                        server,
+                        name,
+                        Arrays.asList(bsai),
+                        initialIsa,
+                        hbaseConf,
+                        new FifoRpcScheduler(
+                                hbaseConf,
+                                hbaseConf.getInt("hbase.regionserver.handler.count", 10)));
+
+        rpcServer.start();
+        LOG.debug("Started rpc server at {}", initialIsa);
+        return rpcServer;
+    }
+
+    private void registerAtZooKeeper() throws InterruptedException {
+        createZKPath(getZookeeperRootNode() + "/" + clusterKey, null, CreateMode.PERSISTENT);
+        createZKPath(
+                getZookeeperRootNode() + "/" + clusterKey + "/rs", null, CreateMode.PERSISTENT);
+
+        UUID uuid = UUID.nameUUIDFromBytes(Bytes.toBytes(clusterKey));
+        createZKPath(
+                getZookeeperRootNode() + "/" + clusterKey + "/hbaseid",
+                Bytes.toBytes(uuid.toString()),
+                CreateMode.PERSISTENT);
+
+        ServerName serverName =
+                ServerName.valueOf(
+                        hostName,
+                        rpcServer.getListenerAddress().getPort(),
+                        System.currentTimeMillis());
+        createZKPath(
+                getZookeeperRootNode() + "/" + clusterKey + "/rs/" + serverName.getServerName(),
+                null,
+                CreateMode.EPHEMERAL);
+
+        LOG.debug("Registered rpc server node at zookeeper");
+    }
+
+    /**
+     * Blocks as long as the queue is empty. If the queue isn't empty it will try and get as many
+     * elements as possible from the queue. It is not guaranteed that at least one element is in the
+     * returned list.
+     *
+     * @return a list of {@link HBaseSourceEvent}.
+     */
+    public List<HBaseSourceEvent> getAll() {
+        if (!isRunning) {
+            // Protects from infinite waiting
+            throw new RuntimeException("Consumer is not running");
+        }
+        List<HBaseSourceEvent> elements = new ArrayList<>();
+        HBaseSourceEvent event;
+
+        try {
+            walEdits.getAvailabilityFuture().get();
+            while ((event = walEdits.poll()) != null) {
+                elements.add(event);
+            }
+            return elements;
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Can't retrieve elements from queue", e);
+        }
+    }
+
+    public void wakeup() {
+        walEdits.notifyAvailable();
+    }
+
+    public void close() throws InterruptedException {
+        isRunning = false;
+
+        try (Connection connection = ConnectionFactory.createConnection(hbaseConf);
+                Admin admin = connection.getAdmin()) {
+            admin.removeReplicationPeer(replicationPeerId);
+        } catch (IOException e) {
+            LOG.error(
+                    "Error unregistering HBase endpoint replication peer. Will proceed with shutdown, but source cluster might be dirty.",
+                    e);
+        }
+
+        try {
+            org.apache.zookeeper.ZKUtil.deleteRecursive(
+                    zooKeeper.getZooKeeper(), getZookeeperRootNode() + "/" + clusterKey);
+        } catch (KeeperException e) {
+            LOG.error(
+                    "Error unregistering up HBase endpoint from zookeeper. Will proceed with shutdown, but source cluster might be dirty.",
+                    e);
+        }
+
+        try {
+            zooKeeper.close();
+            LOG.debug("Closed connection to ZooKeeper");
+        } finally {
+            rpcServer.stop();
+            LOG.debug("Closed HBase replication target rpc server");
+        }
+    }
+
+    public void startReplication(List<String> columnFamilies) throws IOException {
+        if (isRunning) {
+            throw new RuntimeException("HBase replication endpoint is already running");
+        }
+        try (Connection connection = ConnectionFactory.createConnection(hbaseConf);
+                Admin admin = connection.getAdmin()) {
+
+            ReplicationPeerConfig peerConfig = createPeerConfig(this.tableName, columnFamilies);
+            if (admin.listReplicationPeers().stream()
+                    .map(ReplicationPeerDescription::getPeerId)
+                    .anyMatch(replicationPeerId::equals)) {
+                admin.updateReplicationPeerConfig(replicationPeerId, peerConfig);
+            } else {
+                admin.addReplicationPeer(replicationPeerId, peerConfig);
+            }
+            isRunning = true;
+        }
+    }
+
+    @Override
+    public AdminProtos.ReplicateWALEntryResponse replicateWALEntry(
+            RpcController controller, AdminProtos.ReplicateWALEntryRequest request)
+            throws ServiceException {
+        List<AdminProtos.WALEntry> entries = request.getEntryList();
+        CellScanner cellScanner = ((HBaseRpcController) controller).cellScanner();
+
+        try {
+            for (final AdminProtos.WALEntry entry : entries) {
+                final String table =
+                        TableName.valueOf(entry.getKey().getTableName().toByteArray()).toString();
+                final int count = entry.getAssociatedCellCount();
+                for (int i = 0; i < count; i++) {
+                    if (!cellScanner.advance()) {
+                        throw new ArrayIndexOutOfBoundsException(
+                                "Expected WAL entry to have "
+                                        + count
+                                        + "elements, but cell scanner did not have cell for index"
+                                        + i);
+                    }
+
+                    Cell cell = cellScanner.current();
+                    HBaseSourceEvent event = HBaseSourceEvent.fromCell(table, cell, i);
+                    walEdits.put(0, event);
+                }
+            }
+        } catch (Exception e) {
+            throw new ServiceException("Could not replicate WAL entry in HBase endpoint", e);
+        }
+
+        return REPLICATE_WAL_ENTRY_RESPONSE;
+    }
+
+    private ReplicationPeerConfig createPeerConfig(String table, List<String> columnFamilies) {
+        Map<TableName, List<String>> tableColumnFamiliesMap = new HashMap<>();
+        tableColumnFamiliesMap.put(TableName.valueOf(table), columnFamilies);
+        return ReplicationPeerConfig.newBuilder()
+                .setClusterKey(
+                        getZookeeperClientAddress()
+                                + ":"
+                                + getZookeeperRootNode()
+                                + "/"
+                                + clusterKey)
+                .setReplicateAllUserTables(false)
+                .setTableCFsMap(tableColumnFamiliesMap)
+                .build();
+    }
+
+    private String getZookeeperClientAddress() {
+        return hbaseConf.get("hbase.zookeeper.quorum")
+                + ":"
+                + hbaseConf.get("hbase.zookeeper.property.clientPort");
+    }
+
+    private String getZookeeperRootNode() {
+        return hbaseConf.get("zookeeper.znode.parent", "/hbase");
+    }
+
+    private void createZKPath(final String path, byte[] data, CreateMode createMode)
+            throws InterruptedException {
+        try {
+            if (zooKeeper.exists(path, false) == null) {
+                zooKeeper.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, createMode);
+            }
+        } catch (KeeperException e) {
+            throw new RuntimeException("Error creating ZK path in HBase replication endpoint", e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/hbaseendpoint/ReplicationTargetInterface.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/hbaseendpoint/ReplicationTargetInterface.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.hbaseendpoint;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos;
+import org.apache.hbase.thirdparty.com.google.protobuf.RpcController;
+
+/**
+ * Reduces {@link AdminProtos.AdminService.BlockingInterface} to interface necessary for WAL
+ * replication ({@link AdminProtos.AdminService.BlockingInterface#replicateWALEntry(RpcController,
+ * AdminProtos.ReplicateWALEntryRequest)}) to keep implementing class small.
+ */
+@Internal
+public interface ReplicationTargetInterface extends AdminProtos.AdminService.BlockingInterface {
+
+    @Override
+    default AdminProtos.ClearCompactionQueuesResponse clearCompactionQueues(
+            RpcController arg0, AdminProtos.ClearCompactionQueuesRequest arg1) {
+        throw new UnsupportedOperationException(
+                "Operation \"clearCompactionQueues\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.GetRegionInfoResponse getRegionInfo(
+            RpcController controller, AdminProtos.GetRegionInfoRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getRegionInfo\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.GetStoreFileResponse getStoreFile(
+            RpcController controller, AdminProtos.GetStoreFileRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getStoreFile\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.GetOnlineRegionResponse getOnlineRegion(
+            RpcController controller, AdminProtos.GetOnlineRegionRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getOnlineRegion\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.OpenRegionResponse openRegion(
+            RpcController controller, AdminProtos.OpenRegionRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"openRegion\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.WarmupRegionResponse warmupRegion(
+            RpcController controller, AdminProtos.WarmupRegionRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"warmupRegion\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.CloseRegionResponse closeRegion(
+            RpcController controller, AdminProtos.CloseRegionRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"closeRegion\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.FlushRegionResponse flushRegion(
+            RpcController controller, AdminProtos.FlushRegionRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"flushRegion\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.CompactionSwitchResponse compactionSwitch(
+            RpcController controller, AdminProtos.CompactionSwitchRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"compactionSwitch\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.CompactRegionResponse compactRegion(
+            RpcController controller, AdminProtos.CompactRegionRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"compactRegion\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.ReplicateWALEntryResponse replay(
+            RpcController controller, AdminProtos.ReplicateWALEntryRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"replay\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.RollWALWriterResponse rollWALWriter(
+            RpcController controller, AdminProtos.RollWALWriterRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"rollWALWriter\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.GetServerInfoResponse getServerInfo(
+            RpcController controller, AdminProtos.GetServerInfoRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getServerInfo\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.StopServerResponse stopServer(
+            RpcController controller, AdminProtos.StopServerRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"stopServer\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.UpdateFavoredNodesResponse updateFavoredNodes(
+            RpcController controller, AdminProtos.UpdateFavoredNodesRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"updateFavoredNodes\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.UpdateConfigurationResponse updateConfiguration(
+            RpcController controller, AdminProtos.UpdateConfigurationRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"updateConfiguration\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.GetRegionLoadResponse getRegionLoad(
+            RpcController controller, AdminProtos.GetRegionLoadRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getRegionLoad\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.ClearRegionBlockCacheResponse clearRegionBlockCache(
+            RpcController controller, AdminProtos.ClearRegionBlockCacheRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"clearRegionBlockCache\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.ExecuteProceduresResponse executeProcedures(
+            RpcController controller, AdminProtos.ExecuteProceduresRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"executeProcedures\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default QuotaProtos.GetSpaceQuotaSnapshotsResponse getSpaceQuotaSnapshots(
+            RpcController arg0, QuotaProtos.GetSpaceQuotaSnapshotsRequest arg1) {
+        throw new UnsupportedOperationException(
+                "Operation \"getSpaceQuotaSnapshots\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.SlowLogResponses getSlowLogResponses(
+            RpcController controller, AdminProtos.SlowLogResponseRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getSlowLogResponses\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.SlowLogResponses getLargeLogResponses(
+            RpcController controller, AdminProtos.SlowLogResponseRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"getLargeLogResponses\" not implemented in class " + getClass());
+    }
+
+    @Override
+    default AdminProtos.ClearSlowLogResponses clearSlowLogsResponses(
+            RpcController controller, AdminProtos.ClearSlowLogResponseRequest request) {
+        throw new UnsupportedOperationException(
+                "Operation \"clearSlowLogsResponses\" not implemented in class " + getClass());
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseRecordEmitter.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseRecordEmitter.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplitState;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link HBaseSourceReader}. It updates the {@link
+ * HBaseSourceSplitState} and deserializes the record before emitting it.
+ */
+@Internal
+public class HBaseRecordEmitter<T>
+        implements RecordEmitter<HBaseSourceEvent, T, HBaseSourceSplitState> {
+
+    private final HBaseSourceDeserializer<T> sourceDeserializer;
+
+    public HBaseRecordEmitter(HBaseSourceDeserializer<T> sourceDeserializer) {
+        this.sourceDeserializer = sourceDeserializer;
+    }
+
+    @Override
+    public void emitRecord(
+            HBaseSourceEvent event, SourceOutput<T> output, HBaseSourceSplitState splitState)
+            throws Exception {
+        if (!splitState.isAlreadyProcessedEvent(event)) {
+            splitState.notifyEmittedEvent(event);
+            T deserializedPayload = sourceDeserializer.deserialize(event);
+            output.collect(deserializedPayload, event.getTimestamp());
+        } else {
+            // Ignore event, was already processed
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceDeserializer.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceDeserializer.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.reader;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.connector.hbase.source.HBaseSource;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * The deserialization interface that needs to be implemented for constructing an {@link
+ * HBaseSource}.
+ *
+ * <p>A minimal implementation can be seen in the following example.
+ *
+ * <pre>{@code
+ * static class HBaseStringDeserializer implements HBaseSourceDeserializer<String> {
+ *     @Override
+ *     public String deserialize(HBaseSourceEvent event) {
+ *         return new String(event.getPayload(), HBaseEvent.DEFAULT_CHARSET);
+ *     }
+ * }
+ * }</pre>
+ *
+ * {@link #getProducedType()} should be overridden if the type information cannot be extracted this
+ * way.
+ */
+@FunctionalInterface
+public interface HBaseSourceDeserializer<T> extends Serializable, ResultTypeQueryable<T> {
+
+    /**
+     * This method wraps a {@link DeserializationSchema} in an HBaseSourceDeserializer. It will only
+     * have access to the payload of the {@link HBaseSourceEvent}.
+     */
+    static <T> HBaseSourceDeserializer<T> valueOnly(
+            DeserializationSchema<T> deserializationSchema) {
+        return new HBaseSourceDeserializerWrapper<>(deserializationSchema);
+    }
+
+    T deserialize(HBaseSourceEvent event) throws IOException;
+
+    @Override
+    default TypeInformation<T> getProducedType() {
+        return TypeExtractor.createTypeInfo(
+                HBaseSourceDeserializer.class, getClass(), 0, null, null);
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceDeserializerWrapper.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceDeserializerWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.hbase.source.HBaseSource;
+
+import java.io.IOException;
+
+/**
+ * This class wraps a {@link DeserializationSchema} so it can be used in an {@link HBaseSource} as a
+ * {@link HBaseSourceDeserializer}.
+ *
+ * @see HBaseSourceDeserializer#valueOnly(DeserializationSchema) valueOnly(DeserializationSchema).
+ */
+@Internal
+class HBaseSourceDeserializerWrapper<T> implements HBaseSourceDeserializer<T> {
+    private final DeserializationSchema<T> deserializationSchema;
+
+    HBaseSourceDeserializerWrapper(DeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+    }
+
+    @Override
+    public T deserialize(HBaseSourceEvent event) throws IOException {
+        return deserializationSchema.deserialize(event.getPayload());
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceEvent.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceEvent.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.reader;
+
+import org.apache.flink.connector.hbase.HBaseEvent;
+
+import org.apache.hadoop.hbase.Cell;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** The HBaseSourceEvent is used to represent incoming events from HBase. */
+public class HBaseSourceEvent extends HBaseEvent {
+
+    private final String table;
+    private final long timestamp;
+    /** Index of operation inside one wal entry. */
+    private final int index;
+
+    public HBaseSourceEvent(
+            Cell.Type type,
+            String rowId,
+            String table,
+            String columnFamily,
+            String qualifier,
+            byte[] payload,
+            long timestamp,
+            int index) {
+        super(type, rowId, columnFamily, qualifier, payload);
+        this.table = table;
+        this.timestamp = timestamp;
+        this.index = index;
+    }
+
+    public static HBaseSourceEvent fromCell(String table, Cell cell, int index) {
+        final String row = new String(cell.getRowArray(), DEFAULT_CHARSET);
+        final String columnFamily = new String(cell.getFamilyArray(), DEFAULT_CHARSET);
+        final String qualifier = new String(cell.getQualifierArray(), DEFAULT_CHARSET);
+        final byte[] payload = Arrays.copyOf(cell.getValueArray(), cell.getValueLength());
+        final long timestamp = cell.getTimestamp();
+        final Cell.Type type = cell.getType();
+        return new HBaseSourceEvent(
+                type, row, table, columnFamily, qualifier, payload, timestamp, index);
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    @Override
+    public String toString() {
+        return table + " " + super.toString() + " " + timestamp + " " + index;
+    }
+
+    public boolean isLaterThan(long timestamp, int index) {
+        return timestamp < this.getTimestamp()
+                || (timestamp == this.getTimestamp() && index < this.getIndex());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        HBaseSourceEvent that = (HBaseSourceEvent) o;
+        return timestamp == that.timestamp && index == that.index && table.equals(that.table);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), table, timestamp, index);
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceReader.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceReader.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplit;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplitState;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/** The source reader for Hbase. */
+@Internal
+public class HBaseSourceReader<T>
+        extends SingleThreadMultiplexSourceReaderBase<
+                HBaseSourceEvent, T, HBaseSourceSplit, HBaseSourceSplitState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSourceReader.class);
+
+    public HBaseSourceReader(
+            byte[] serializedHBaseConfig,
+            HBaseSourceDeserializer<T> sourceDeserializer,
+            Configuration sourceConfiguration,
+            SourceReaderContext context) {
+        super(
+                () -> new HBaseSourceSplitReader(serializedHBaseConfig, sourceConfiguration),
+                new HBaseRecordEmitter<>(sourceDeserializer),
+                sourceConfiguration,
+                context);
+        LOG.debug("constructing Source Reader with config: {}", sourceConfiguration.toString());
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, HBaseSourceSplitState> finishedSplitIds) {
+        LOG.debug("finished {} split(s)", finishedSplitIds.entrySet().size());
+        context.sendSplitRequest();
+    }
+
+    @Override
+    protected HBaseSourceSplitState initializedState(HBaseSourceSplit split) {
+        LOG.debug("initialized state for split {}", split.splitId());
+        return new HBaseSourceSplitState(split);
+    }
+
+    @Override
+    protected HBaseSourceSplit toSplitType(String splitId, HBaseSourceSplitState splitState) {
+        return splitState.toSplit();
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceSplitReader.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/reader/HBaseSourceSplitReader.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.hbase.source.hbaseendpoint.HBaseEndpoint;
+import org.apache.flink.connector.hbase.source.split.HBaseSourceSplit;
+import org.apache.flink.connector.hbase.util.HBaseConfigurationUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+
+/** A {@link SplitReader} implementation for HBase. */
+@Internal
+public class HBaseSourceSplitReader implements SplitReader<HBaseSourceEvent, HBaseSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSourceSplitReader.class);
+
+    private final Queue<HBaseSourceSplit> splits;
+    private final HBaseEndpoint hbaseEndpoint;
+
+    @Nullable private String currentSplitId;
+
+    public HBaseSourceSplitReader(byte[] serializedConfig, Configuration sourceConfiguration) {
+        LOG.debug("constructing Split Reader");
+        try {
+            this.hbaseEndpoint =
+                    new HBaseEndpoint(
+                            HBaseConfigurationUtil.deserializeConfiguration(serializedConfig, null),
+                            sourceConfiguration);
+        } catch (Exception e) {
+            throw new RuntimeException("failed HBase consumer", e);
+        }
+        this.splits = new ArrayDeque<>();
+    }
+
+    @Override
+    public RecordsWithSplitIds<HBaseSourceEvent> fetch() throws IOException {
+        if (currentSplitId == null) {
+            HBaseSourceSplit nextSplit = splits.poll();
+            if (nextSplit != null) {
+                currentSplitId = nextSplit.splitId();
+            } else {
+                throw new IOException("No split remaining");
+            }
+        }
+        List<HBaseSourceEvent> records = hbaseEndpoint.getAll();
+        LOG.debug("{} records in the queue", records.size());
+        return new HBaseSplitRecords<>(currentSplitId, records.iterator());
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<HBaseSourceSplit> splitsChanges) {
+        LOG.debug("handle splits change {}", splitsChanges);
+        if (splitsChanges instanceof SplitsAddition) {
+            HBaseSourceSplit split = splitsChanges.splits().get(0);
+            try {
+                this.hbaseEndpoint.startReplication(split.getColumnFamilies());
+            } catch (Exception e) {
+                throw new RuntimeException("failed HBase consumer", e);
+            }
+            splits.addAll(splitsChanges.splits());
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported splits change type "
+                            + splitsChanges.getClass().getSimpleName()
+                            + " in "
+                            + this.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public void wakeUp() {
+        LOG.debug("waking up HBaseEndpoint");
+        hbaseEndpoint.wakeup();
+    }
+
+    @Override
+    public void close() throws Exception {
+        hbaseEndpoint.close();
+    }
+
+    private static class HBaseSplitRecords<T> implements RecordsWithSplitIds<T> {
+        private Iterator<T> recordsForSplit;
+        private String splitId;
+
+        HBaseSplitRecords(String splitId, Iterator<T> recordsForSplit) {
+            this.splitId = splitId;
+            this.recordsForSplit = recordsForSplit;
+        }
+
+        @Nullable
+        @Override
+        public String nextSplit() {
+            final String nextSplit = this.splitId;
+            this.splitId = null;
+            this.recordsForSplit = nextSplit != null ? this.recordsForSplit : null;
+
+            return nextSplit;
+        }
+
+        @Nullable
+        @Override
+        public T nextRecordFromSplit() {
+            if (recordsForSplit != null && recordsForSplit.hasNext()) {
+                return recordsForSplit.next();
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public Set<String> finishedSplits() {
+            return Collections.emptySet();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/split/HBaseSourceSplit.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/split/HBaseSourceSplit.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceSplitReader;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * An HBaseSourceSplit contains all necessary information a {@link HBaseSourceSplitReader} needs to
+ * read from HBase.
+ */
+@Internal
+public class HBaseSourceSplit implements SourceSplit, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String id;
+
+    private final String host;
+
+    private final List<String> columnFamilies;
+
+    private final Tuple2<Long, Integer> firstEventStamp;
+
+    public HBaseSourceSplit(String id, String host, List<String> columnFamilies) {
+        this(id, host, columnFamilies, Tuple2.of(-1L, -1));
+    }
+
+    public HBaseSourceSplit(
+            String id,
+            String host,
+            List<String> columnFamilies,
+            Tuple2<Long, Integer> firstEventStamp) {
+        this.id = id;
+        this.host = host;
+        this.columnFamilies = columnFamilies;
+        this.firstEventStamp = firstEventStamp;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public List<String> getColumnFamilies() {
+        return columnFamilies;
+    }
+
+    @Override
+    public String splitId() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("HBaseSourceSplit: %s ", getHost());
+    }
+
+    public Tuple2<Long, Integer> getFirstEventStamp() {
+        return firstEventStamp;
+    }
+
+    public HBaseSourceSplit withStamp(long lastTimeStamp, int lastIndex) {
+        return new HBaseSourceSplit(id, host, columnFamilies, Tuple2.of(lastTimeStamp, lastIndex));
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/split/HBaseSourceSplitSerializer.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/split/HBaseSourceSplitSerializer.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+
+/** A serializer for {@link HBaseSourceSplit}. */
+@Internal
+public class HBaseSourceSplitSerializer implements SimpleVersionedSerializer<HBaseSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseSourceSplitSerializer.class);
+
+    private static final int VERSION = 1;
+
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public byte[] serialize(HBaseSourceSplit split) throws IOException {
+        LOG.debug("serializing split {}", split.splitId());
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeUTF(split.splitId());
+            out.writeUTF(split.getHost());
+            out.writeInt(split.getColumnFamilies().size());
+            for (String columnFamily : split.getColumnFamilies()) {
+                out.writeUTF(columnFamily);
+            }
+            out.writeLong(split.getFirstEventStamp().f0);
+            out.writeInt(split.getFirstEventStamp().f1);
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public HBaseSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+        LOG.debug("deserializing split");
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            String id = in.readUTF();
+            String host = in.readUTF();
+            ArrayList<String> columnFamilies = new ArrayList<>();
+            int numberOfColumnFamilies = in.readInt();
+            for (int i = 0; i < numberOfColumnFamilies; i++) {
+                columnFamilies.add(in.readUTF());
+            }
+
+            long firstTimestamp = in.readLong();
+            int firstIndex = in.readInt();
+            return new HBaseSourceSplit(
+                    id, host, columnFamilies, Tuple2.of(firstTimestamp, firstIndex));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/split/HBaseSourceSplitState.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/main/java/org/apache/flink/connector/hbase/source/split/HBaseSourceSplitState.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.hbase.HBaseEvent;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceEvent;
+
+/**
+ * Contains the state of an {@link HBaseSourceSplit}. It tracks the timestamp of the last emitted
+ * event to ensure no duplicates appear on recovery.
+ */
+@Internal
+public class HBaseSourceSplitState {
+    private final HBaseSourceSplit split;
+
+    private long lastTimeStamp = -1;
+    private int lastIndex = -1;
+
+    public HBaseSourceSplitState(HBaseSourceSplit split) {
+        this.split = split;
+        this.lastTimeStamp = this.split.getFirstEventStamp().f0;
+        this.lastIndex = this.split.getFirstEventStamp().f1;
+    }
+
+    public HBaseSourceSplit toSplit() {
+        return split.withStamp(lastTimeStamp, lastIndex);
+    }
+
+    /**
+     * Update the state of which element was emitted last.
+     *
+     * @param event An {@link HBaseEvent} that has been emitted by the {@link
+     *     org.apache.flink.connector.hbase.source.reader.HBaseRecordEmitter}
+     */
+    public void notifyEmittedEvent(HBaseSourceEvent event) {
+        lastTimeStamp = event.getTimestamp();
+        lastIndex = event.getIndex();
+    }
+
+    public boolean isAlreadyProcessedEvent(HBaseSourceEvent event) {
+        return !event.isLaterThan(lastTimeStamp, lastIndex);
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/sink/HBaseSinkTests.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/sink/HBaseSinkTests.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.connector.hbase.HBaseEvent;
+import org.apache.flink.connector.hbase.testutil.HBaseTestCluster;
+import org.apache.flink.connector.hbase.testutil.TestsWithTestHBaseCluster;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Test for {@link org.apache.flink.connector.hbase.sink.HBaseSink}. */
+public class HBaseSinkTests extends TestsWithTestHBaseCluster {
+
+    @Test
+    public void testSinkPut() throws Exception {
+        cluster.makeTable(baseTableName);
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration hbaseConfiguration = cluster.getConfig();
+
+        int start = 1;
+        int end = 10;
+
+        DataStream<Long> numberStream = env.fromSequence(start, end);
+
+        final HBaseSink<Long> hbaseSink =
+                HBaseSink.builder()
+                        .setTableName(baseTableName)
+                        .setSinkSerializer(new HBasePutLongSerializer())
+                        .setHBaseConfiguration(hbaseConfiguration)
+                        .build();
+        numberStream.sinkTo(hbaseSink);
+        env.execute();
+
+        long[] expected = LongStream.rangeClosed(start, end).toArray();
+        long[] actual = new long[end - start + 1];
+
+        try (Connection connection = ConnectionFactory.createConnection(hbaseConfiguration)) {
+            Table table = connection.getTable(TableName.valueOf(baseTableName));
+            for (int i = start; i <= end; i++) {
+                Get get = new Get(Bytes.toBytes(String.valueOf(i)));
+                Result r = table.get(get);
+                byte[] value =
+                        r.getValue(
+                                HBaseTestCluster.DEFAULT_COLUMN_FAMILY.getBytes(),
+                                HBaseTestCluster.DEFAULT_QUALIFIER.getBytes());
+                long l = Long.parseLong(new String(value));
+                actual[i - start] = l;
+            }
+        }
+
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testSinkDelete() throws Exception {
+        cluster.makeTable(baseTableName);
+        List<String> rows = new ArrayList<>();
+        String rowId;
+
+        for (int i = 0; i < 10; i++) {
+            rowId = cluster.put(baseTableName, String.valueOf(i));
+            rows.add(rowId);
+        }
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration hbaseConfiguration = cluster.getConfig();
+
+        DataStream<String> numberStream = env.fromCollection(rows);
+
+        final HBaseSink<String> hbaseSink =
+                HBaseSink.builder()
+                        .setTableName(baseTableName)
+                        .setSinkSerializer(new HBaseDeleteStringSerializer())
+                        .setHBaseConfiguration(hbaseConfiguration)
+                        .build();
+
+        numberStream.sinkTo(hbaseSink);
+        env.execute();
+
+        try (Connection connection = ConnectionFactory.createConnection(hbaseConfiguration)) {
+            Table table = connection.getTable(TableName.valueOf(baseTableName));
+            for (String row : rows) {
+                Get get = new Get(Bytes.toBytes(row));
+                Result r = table.get(get);
+                assertTrue(r.isEmpty());
+            }
+        }
+    }
+
+    private static class HBasePutLongSerializer implements HBaseSinkSerializer<Long> {
+        @Override
+        public HBaseEvent serialize(Long event) {
+            return HBaseEvent.putWith(
+                    event.toString(),
+                    HBaseTestCluster.DEFAULT_COLUMN_FAMILY,
+                    HBaseTestCluster.DEFAULT_QUALIFIER,
+                    Bytes.toBytes(event.toString()));
+        }
+    }
+
+    private static class HBaseDeleteStringSerializer implements HBaseSinkSerializer<String> {
+        @Override
+        public HBaseEvent serialize(String event) {
+            return HBaseEvent.deleteWith(
+                    event,
+                    HBaseTestCluster.DEFAULT_COLUMN_FAMILY,
+                    HBaseTestCluster.DEFAULT_QUALIFIER);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/source/HBaseSourceITCase.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/source/HBaseSourceITCase.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.connector.hbase.HBaseEvent;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceDeserializer;
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceEvent;
+import org.apache.flink.connector.hbase.testutil.FailureSink;
+import org.apache.flink.connector.hbase.testutil.FileSignal;
+import org.apache.flink.connector.hbase.testutil.HBaseTestCluster;
+import org.apache.flink.connector.hbase.testutil.TestsWithTestHBaseCluster;
+import org.apache.flink.connector.hbase.testutil.Util;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.function.RunnableWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.internal.ArrayComparisonFailure;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/** Tests the most basic use cases of the source with a mocked HBase system. */
+public class HBaseSourceITCase extends TestsWithTestHBaseCluster {
+
+    @Rule
+    public final MiniClusterWithClientResource miniClusterResource =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(8)
+                            .build());
+
+    private DataStream<String> streamFromHBaseSource(
+            StreamExecutionEnvironment environment, String tableName) {
+        return streamFromHBaseSource(environment, tableName, 1);
+    }
+
+    private DataStream<String> streamFromHBaseSource(
+            StreamExecutionEnvironment environment, String tableName, int parallelism) {
+        HBaseStringDeserializationScheme deserializationScheme =
+                new HBaseStringDeserializationScheme();
+        HBaseSource<String> source =
+                HBaseSource.builder()
+                        .setTableName(tableName)
+                        .setSourceDeserializer(deserializationScheme)
+                        .setHBaseConfiguration(cluster.getConfig())
+                        .build();
+        environment.setParallelism(parallelism);
+        DataStream<String> stream =
+                environment.fromSource(
+                        source,
+                        WatermarkStrategy.noWatermarks(),
+                        "hbaseSourceITCase",
+                        deserializationScheme.getProducedType());
+        return stream;
+    }
+
+    private static <T> void expectFirstValuesToBe(
+            DataStream<T> stream, T[] expectedValues, String message) {
+
+        List<T> collectedValues = new ArrayList<>();
+        stream.flatMap(
+                new RichFlatMapFunction<T, Object>() {
+
+                    @Override
+                    public void flatMap(T value, Collector<Object> out) {
+                        LOG.info("Test collected: {}", value);
+                        collectedValues.add(value);
+                        if (collectedValues.size() == expectedValues.length) {
+                            assertArrayEquals(message, expectedValues, collectedValues.toArray());
+                            throw new SuccessException();
+                        }
+                    }
+                });
+    }
+
+    private void doAndWaitForSuccess(
+            StreamExecutionEnvironment env, RunnableWithException action, int timeout) {
+        try {
+            JobClient jobClient = env.executeAsync();
+            Util.waitForClusterStart(miniClusterResource.getMiniCluster());
+
+            action.run();
+            jobClient.getJobExecutionResult().get(timeout, TimeUnit.SECONDS);
+            jobClient.cancel();
+            throw new RuntimeException("Waiting for the correct data timed out");
+        } catch (Exception exception) {
+            if (!causedBySuccess(exception)) {
+                throw new RuntimeException("Test failed", exception);
+            } else {
+                // Normal termination
+            }
+        }
+    }
+
+    private void waitUntilNReplicationPeers(int n)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        CompletableFuture.runAsync(
+                        ThrowingRunnable.unchecked(
+                                () -> {
+                                    while (cluster.getReplicationPeers().size() != n) {
+                                        sleep(1000);
+                                    }
+                                }))
+                .get(90, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testBasicPut() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        DataStream<String> stream = streamFromHBaseSource(env, baseTableName);
+        cluster.makeTable(baseTableName, DEFAULT_COLUMNFAMILY_COUNT);
+        String[] expectedValues = uniqueValues(2 * DEFAULT_COLUMNFAMILY_COUNT);
+
+        expectFirstValuesToBe(
+                stream,
+                expectedValues,
+                "HBase source did not produce the right values after a basic put operation");
+        doAndWaitForSuccess(
+                env,
+                () -> cluster.put(baseTableName, DEFAULT_COLUMNFAMILY_COUNT, expectedValues),
+                120);
+    }
+
+    @Test
+    public void testOnlyReplicateSpecifiedTable() throws Exception {
+        String secondTable = baseTableName + "-table2";
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        DataStream<String> stream = streamFromHBaseSource(env, baseTableName);
+        cluster.makeTable(baseTableName, DEFAULT_COLUMNFAMILY_COUNT);
+        cluster.makeTable(secondTable, DEFAULT_COLUMNFAMILY_COUNT);
+        String[] expectedValues = uniqueValues(DEFAULT_COLUMNFAMILY_COUNT);
+
+        expectFirstValuesToBe(
+                stream,
+                expectedValues,
+                "HBase source did not produce the values of the correct table");
+        doAndWaitForSuccess(
+                env,
+                () -> {
+                    cluster.put(
+                            secondTable,
+                            DEFAULT_COLUMNFAMILY_COUNT,
+                            uniqueValues(DEFAULT_COLUMNFAMILY_COUNT));
+                    sleep(2000);
+                    cluster.put(baseTableName, DEFAULT_COLUMNFAMILY_COUNT, expectedValues);
+                },
+                180);
+    }
+
+    @Test
+    public void testRecordsAreProducedExactlyOnceWithCheckpoints() throws Exception {
+        final String collectedValueSignal = "collectedValue";
+        final FileSignal testOracle = this.testOracle;
+        String[] expectedValues = uniqueValues(20);
+        cluster.makeTable(baseTableName);
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(2000);
+        env.getCheckpointConfig().setCheckpointingMode(CheckpointingMode.EXACTLY_ONCE);
+        DataStream<String> stream = streamFromHBaseSource(env, baseTableName);
+        stream.addSink(
+                new FailureSink<String>(3500) {
+
+                    private void checkForSuccess() {
+                        List<String> checkpointed = getCheckpointedValues();
+                        LOG.info(
+                                "\n\tUncheckpointed: {}\n\tCheckpointed: {}",
+                                unCheckpointedValues,
+                                checkpointed);
+                        if (checkpointed.size() == expectedValues.length) {
+                            try {
+                                assertArrayEquals(
+                                        "Wrong values were produced.",
+                                        expectedValues,
+                                        checkpointed.toArray());
+                                testOracle.signalSuccess();
+                            } catch (ArrayComparisonFailure e) {
+                                LOG.error("Comparison failed", e);
+                                testOracle.signalFailure();
+                                throw e;
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void collectValue(String value) {
+
+                        if (getCheckpointedValues().contains(value)) {
+                            LOG.error("Unique value {} was not seen only once", value);
+                            testOracle.signalFailure();
+                            throw new RuntimeException(
+                                    "Unique value " + value + " was not seen only once");
+                        }
+                        checkForSuccess();
+                        testOracle.signal(collectedValueSignal + value);
+                    }
+
+                    @Override
+                    public void checkpoint() {
+                        checkForSuccess();
+                    }
+                });
+
+        JobClient jobClient = env.executeAsync();
+        Util.waitForClusterStart(miniClusterResource.getMiniCluster());
+        try {
+            Thread.sleep(8000);
+            int putsPerPackage = 5;
+            for (int i = 0; i < expectedValues.length; i += putsPerPackage) {
+                LOG.info("Sending next package ...");
+                CompletableFuture<String>[] signalsToWait = new CompletableFuture[putsPerPackage];
+                for (int j = i; j < expectedValues.length && j < i + putsPerPackage; j++) {
+                    cluster.put(baseTableName, expectedValues[j]);
+                    signalsToWait[j - i] =
+                            testOracle.awaitSignal(collectedValueSignal + expectedValues[j]);
+                }
+
+                // Assert that values have actually been sent over so there was an opportunity to
+                // checkpoint them
+                testOracle.awaitThrowOnFailure(
+                        CompletableFuture.allOf(signalsToWait),
+                        240,
+                        TimeUnit.SECONDS,
+                        "Failure occurred while waiting for package to be collected");
+
+                Thread.sleep(3000);
+                LOG.info("Consuming collection signal");
+            }
+            LOG.info("Finished sending packages, awaiting success ...");
+            testOracle.awaitSuccess(120, TimeUnit.SECONDS);
+            LOG.info("Received success, ending test ...");
+        } finally {
+            LOG.info("Cancelling job client");
+            jobClient.cancel();
+        }
+        LOG.info("End of test method reached");
+    }
+
+    @Test
+    public void testMultipleSplitReadersAreCreated() throws Exception {
+        int parallelism = 4;
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        streamFromHBaseSource(env, baseTableName, parallelism).print();
+        cluster.makeTable(baseTableName, parallelism);
+        JobClient jobClient = env.executeAsync();
+        waitUntilNReplicationPeers(parallelism);
+        jobClient.cancel();
+    }
+
+    @Test
+    public void testBasicPutWhenMoreColumnFamiliesThanThreads() throws Exception {
+        int parallelism = 1;
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        DataStream<String> stream = streamFromHBaseSource(env, baseTableName, parallelism);
+
+        String[] expectedValues = new String[] {"foo", "bar", "baz", "boo"};
+        assert expectedValues.length > parallelism;
+        cluster.makeTable(baseTableName, expectedValues.length);
+        Put put = new Put("rowkey".getBytes());
+        for (int i = 0; i < expectedValues.length; i++) {
+            put.addColumn(
+                    (HBaseTestCluster.COLUMN_FAMILY_BASE + i).getBytes(),
+                    expectedValues[i].getBytes(),
+                    expectedValues[i].getBytes());
+        }
+        cluster.commitPut(baseTableName, put);
+
+        expectFirstValuesToBe(
+                stream,
+                expectedValues,
+                "HBase source did not produce the right values after a multi-column-family put");
+        doAndWaitForSuccess(env, () -> {}, 120);
+    }
+
+    /** Simple Deserialization Scheme to get event payloads as String. */
+    public static class HBaseStringDeserializationScheme
+            implements HBaseSourceDeserializer<String> {
+        @Override
+        public String deserialize(HBaseSourceEvent event) {
+            return new String(event.getPayload(), HBaseEvent.DEFAULT_CHARSET);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/source/hbaseendpoint/HBaseEndpointTest.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/source/hbaseendpoint/HBaseEndpointTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.source.hbaseendpoint;
+
+import org.apache.flink.connector.hbase.source.reader.HBaseSourceEvent;
+import org.apache.flink.connector.hbase.testutil.HBaseTestCluster;
+import org.apache.flink.connector.hbase.testutil.TestsWithTestHBaseCluster;
+
+import org.apache.hadoop.hbase.Cell;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link HBaseEndpoint}. */
+public class HBaseEndpointTest extends TestsWithTestHBaseCluster {
+
+    @Test
+    public void testSetup() throws Exception {
+        new HBaseEndpoint(cluster.getConfig(), cluster.getConfigurationForTable(baseTableName))
+                .startReplication(
+                        Collections.singletonList(HBaseTestCluster.DEFAULT_COLUMN_FAMILY));
+    }
+
+    @Test
+    public void testPutCreatesEvent() throws Exception {
+        cluster.makeTable(baseTableName);
+        HBaseEndpoint consumer =
+                new HBaseEndpoint(
+                        cluster.getConfig(), cluster.getConfigurationForTable(baseTableName));
+        consumer.startReplication(
+                Collections.singletonList(HBaseTestCluster.DEFAULT_COLUMN_FAMILY));
+        cluster.put(baseTableName, "foobar");
+        List<HBaseSourceEvent> result =
+                CompletableFuture.supplyAsync(consumer::getAll).get(30, TimeUnit.SECONDS);
+        assertNotNull(result.get(0));
+        assertEquals(Cell.Type.Put, result.get(0).getType());
+    }
+
+    @Test
+    public void testDeleteCreatesEvent() throws Exception {
+        cluster.makeTable(baseTableName);
+        HBaseEndpoint consumer =
+                new HBaseEndpoint(
+                        cluster.getConfig(), cluster.getConfigurationForTable(baseTableName));
+        consumer.startReplication(
+                Collections.singletonList(HBaseTestCluster.DEFAULT_COLUMN_FAMILY));
+
+        String rowKey = cluster.put(baseTableName, "foobar");
+        cluster.delete(
+                baseTableName,
+                rowKey,
+                HBaseTestCluster.DEFAULT_COLUMN_FAMILY,
+                HBaseTestCluster.DEFAULT_QUALIFIER);
+
+        List<HBaseSourceEvent> results = new ArrayList<>();
+        while (results.size() < 2) {
+            results.addAll(
+                    CompletableFuture.supplyAsync(consumer::getAll).get(30, TimeUnit.SECONDS));
+        }
+
+        assertNotNull(results.get(1));
+        assertEquals(Cell.Type.Delete, results.get(1).getType());
+    }
+
+    @Test
+    public void testTimestampsAndIndicesDefineStrictOrder() throws Exception {
+        HBaseEndpoint consumer =
+                new HBaseEndpoint(
+                        cluster.getConfig(), cluster.getConfigurationForTable(baseTableName));
+        consumer.startReplication(
+                Collections.singletonList(HBaseTestCluster.DEFAULT_COLUMN_FAMILY));
+        cluster.makeTable(baseTableName);
+
+        int numPuts = 3;
+        int putSize = 2 * DEFAULT_COLUMNFAMILY_COUNT;
+        for (int i = 0; i < numPuts; i++) {
+            cluster.put(baseTableName, 1, uniqueValues(putSize));
+        }
+
+        long lastTimeStamp = -1;
+        int lastIndex = -1;
+
+        List<HBaseSourceEvent> events = new ArrayList<>();
+        while (events.size() < numPuts * putSize) {
+            events.addAll(
+                    CompletableFuture.supplyAsync(consumer::getAll).get(30, TimeUnit.SECONDS));
+        }
+
+        for (int i = 0; i < numPuts * putSize; i++) {
+            HBaseSourceEvent nextEvent = events.get(i);
+            assertTrue(
+                    "Events were not collected with strictly ordered, unique timestamp x index",
+                    nextEvent.isLaterThan(lastTimeStamp, lastIndex));
+            lastTimeStamp = nextEvent.getTimestamp();
+            lastIndex = nextEvent.getIndex();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/FailureSink.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/FailureSink.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.testutil;
+
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Utility sink for testing checkpointing. Throws exception after at least one value has been
+ * processed and one checkpoint has been completed. Provides callbacks for value collection and
+ * checkpointing.
+ */
+public abstract class FailureSink<T> extends RichSinkFunction<T>
+        implements CheckpointedFunction, CheckpointListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FailureSink.class);
+
+    private final long activateAfter;
+    private boolean active = false;
+    private boolean completedAtLeastOneCheckpoint = false;
+    private boolean hasSeenAtLeastOneInput = false;
+
+    protected final List<T> unCheckpointedValues = new ArrayList<>();
+    protected transient ListState<T> checkpointedValues;
+
+    public FailureSink(long activateAfter) {
+        this.activateAfter = activateAfter;
+    }
+
+    public void collectValue(T value) throws Exception {}
+
+    public void checkpoint() throws Exception {}
+
+    public List<T> getCheckpointedValues() {
+        try {
+            List<T> checkpointed = new ArrayList<>();
+            checkpointedValues.get().forEach(checkpointed::add);
+            return checkpointed;
+        } catch (Exception e) {
+            LOG.error("Could not retrieve checkpointed values", e);
+            return null;
+        }
+    }
+
+    @Override
+    public void invoke(T value, Context context) throws Exception {
+        LOG.info("FailureSink has been invoked with value {} is active={}", value, active);
+        unCheckpointedValues.add(value);
+        collectValue(value);
+        hasSeenAtLeastOneInput = true;
+        throwFailureIfActive();
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        LOG.info(
+                "FailureSink.notifyCheckpointComplete has been called with checkpointId={} is active{}",
+                checkpointId,
+                active);
+        completedAtLeastOneCheckpoint = true;
+        throwFailureIfActive();
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        LOG.info("FailureSink.snapshotState has been called");
+        checkpointedValues.addAll(unCheckpointedValues);
+        unCheckpointedValues.clear();
+        checkpoint();
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        LOG.info("FailureSink.initializeState has been called");
+
+        completedAtLeastOneCheckpoint = false;
+        hasSeenAtLeastOneInput = false;
+
+        ListStateDescriptor<T> descriptor =
+                new ListStateDescriptor<>("checkpointed", getTypeInfo());
+
+        checkpointedValues = context.getOperatorStateStore().getListState(descriptor);
+
+        new Timer().schedule(activation(), activateAfter);
+    }
+
+    private TimerTask activation() {
+        return new TimerTask() {
+            @Override
+            public void run() {
+                if (completedAtLeastOneCheckpoint && hasSeenAtLeastOneInput) {
+                    active = true;
+                    LOG.info("FailureSink activated");
+                } else {
+                    new Timer().schedule(activation(), activateAfter / 2);
+                }
+            }
+        };
+    }
+
+    private void throwFailureIfActive() {
+        if (active) {
+            LOG.info("FailureSink triggered");
+            throw new RuntimeException("Failure Sink throws error");
+        }
+    }
+
+    private TypeInformation<T> getTypeInfo() {
+        return TypeExtractor.createTypeInfo(FailureSink.class, getClass(), 0, null, null);
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/FileSignal.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/FileSignal.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.testutil;
+
+import org.apache.flink.util.FileUtils;
+
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Utility class to signal events of tests such as success or failure. Allows to get signals out of
+ * flink without using web sockets or success exceptions or similar.
+ */
+public class FileSignal extends ExternalResource implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileSignal.class);
+
+    private static final long POLL_INTERVAL = 100; // ms
+    private static final String SUCCESS_SIGNAL = "success";
+    private static final String FAILURE_SIGNAL = "failure";
+
+    private final File signalFolder = new File("signal" + UUID.randomUUID());
+
+    public void signal(String signalName) {
+        File signalFile = signalFile(signalName);
+        try {
+            signalFile.createNewFile();
+            LOG.debug("Created signal file at " + signalFile.getAbsolutePath());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create signal file " + signalName, e);
+        }
+    }
+
+    public void signalSuccess() {
+        signal(SUCCESS_SIGNAL);
+    }
+
+    public void signalFailure() {
+        signal(FAILURE_SIGNAL);
+    }
+
+    public CompletableFuture<String> awaitSignal(String signalName) {
+        File signalFile = signalFile(signalName);
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    while (!signalFile.exists()) {
+                        try {
+                            Thread.sleep(POLL_INTERVAL);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(
+                                    "Waiting for signal " + signalName + "was interrupted.", e);
+                        }
+                    }
+                    cleanupSignal(signalName);
+                    return signalName;
+                });
+    }
+
+    public void awaitSignalThrowOnFailure(String signalName, long timeout, TimeUnit timeUnit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        awaitThrowOnFailure(
+                awaitSignal(signalName),
+                timeout,
+                timeUnit,
+                "Waiting for signal " + signalName + " yielded failure");
+    }
+
+    public void awaitThrowOnFailure(
+            CompletableFuture<?> toAwait, long timeout, TimeUnit timeUnit, String errorMsg)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        Object result =
+                CompletableFuture.anyOf(toAwait, awaitSignal(FAILURE_SIGNAL))
+                        .get(timeout, timeUnit);
+        if (FAILURE_SIGNAL.equals(result)) {
+            throw new RuntimeException(errorMsg);
+        }
+    }
+
+    public void awaitSuccess(long timeout, TimeUnit timeUnit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        awaitSignalThrowOnFailure(SUCCESS_SIGNAL, timeout, timeUnit);
+    }
+
+    public void makeFolder() {
+        assert signalFolder.mkdirs();
+        LOG.info("Created signal folder");
+    }
+
+    public void cleanupSignal(String signalName) {
+        File signalFile = signalFile(signalName);
+        signalFile.delete();
+    }
+
+    public void cleanupFolder() throws IOException {
+        FileUtils.deleteDirectory(signalFolder);
+        LOG.info("Deleted signal folder");
+    }
+
+    private File signalFile(String signalName) {
+        return signalFolder.toPath().resolve(signalName + ".signal").toFile();
+    }
+
+    @Override
+    protected void before() {
+        makeFolder();
+    }
+
+    @Override
+    protected void after() {
+        try {
+            cleanupFolder();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not clean up signal folder", e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/HBaseTestCluster.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/HBaseTestCluster.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.testutil;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.hbase.source.HBaseSourceOptions;
+
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.StartMiniClusterOption;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hbase.thirdparty.com.google.common.io.Closer;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/** Provides static access to a {@link MiniHBaseCluster} for testing. */
+public class HBaseTestCluster extends ExternalResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseTestCluster.class);
+
+    public static final String COLUMN_FAMILY_BASE = "info";
+    public static final String DEFAULT_COLUMN_FAMILY = COLUMN_FAMILY_BASE + 0;
+    public static final String QUALIFIER_BASE = "qualifier";
+    public static final String DEFAULT_QUALIFIER = QUALIFIER_BASE + 0;
+
+    private MiniHBaseCluster cluster;
+    private org.apache.hadoop.conf.Configuration hbaseConf;
+    private String testFolder;
+
+    public HBaseTestCluster() {}
+
+    /*
+     * How to use it
+     */
+    public static void main(String[] args) throws Exception {
+        HBaseTestCluster hbaseTestCluster = new HBaseTestCluster();
+        hbaseTestCluster.startCluster();
+        hbaseTestCluster.makeTable("tableName");
+        // ...
+        hbaseTestCluster.shutdownCluster();
+    }
+
+    public void startCluster() throws IOException, InterruptedException, ExecutionException {
+        LOG.info("Starting HBase test cluster ...");
+        testFolder = Files.createTempDirectory(null).toString();
+
+        // Fallback for windows users with space in user name, will not work if path contains space.
+        if (testFolder.contains(" ")) {
+            testFolder = "/flink-hbase-test-data/";
+        }
+        UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("tempusername"));
+
+        hbaseConf = HBaseConfiguration.create();
+        hbaseConf.setInt("replication.stats.thread.period.seconds", 5);
+        hbaseConf.setLong("replication.sleep.before.failover", 2000);
+        hbaseConf.setInt("replication.source.maxretriesmultiplier", 10);
+        hbaseConf.setBoolean("hbase.replication", true);
+
+        System.setProperty(HBaseTestingUtility.BASE_TEST_DIRECTORY_KEY, testFolder);
+
+        HBaseTestingUtility utility = new HBaseTestingUtility(hbaseConf);
+        LOG.info("Testfolder: {}", utility.getDataTestDir().toString());
+        try {
+            cluster =
+                    utility.startMiniCluster(
+                            StartMiniClusterOption.builder().numRegionServers(3).build());
+            int numRegionServers = utility.getHBaseCluster().getRegionServerThreads().size();
+            LOG.info("Number of region servers: {}", numRegionServers);
+            LOG.info(
+                    "ZooKeeper client address: {}:{}",
+                    hbaseConf.get("hbase.zookeeper.quorum"),
+                    hbaseConf.get("hbase.zookeeper.property.clientPort"));
+            LOG.info(
+                    "Master port={}, web UI at port={}",
+                    hbaseConf.get("hbase.master.port"),
+                    hbaseConf.get("hbase.master.info.port"));
+
+            cluster.waitForActiveAndReadyMaster(30 * 1000);
+            HBaseAdmin.available(hbaseConf);
+            LOG.info("HBase test cluster up and running ...");
+
+        } catch (Exception e) {
+            throw new RuntimeException("Could not start HBase test mini cluster", e);
+        }
+
+        assert canConnectToCluster();
+    }
+
+    public void shutdownCluster() {
+        LOG.info("Shutting down HBase test cluster");
+        try {
+            try (Closer closer = Closer.create()) {
+                // Is executed in reverse order!
+                closer.register(Paths.get(testFolder).toFile()::delete);
+                closer.register(this::waitForShutDown);
+                closer.register(cluster::shutdown);
+                closer.register(this::clearReplicationPeers);
+                closer.register(this::clearTables);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Failed to shut down HBase test cluster correctly. Future program state might be compromised.",
+                    e);
+        }
+        LOG.info("HBase test cluster shut down");
+    }
+
+    public void waitForShutDown() {
+        try {
+            CompletableFuture.runAsync(cluster::waitUntilShutDown).get(20, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.error("Interrupted while waiting for HBase test cluster to shut down", e);
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+            LOG.error("Exception while waiting for HBase test cluster to shut down", e);
+        } catch (TimeoutException e) {
+            e.printStackTrace();
+            LOG.error("Waiting for HBase test cluster to shut down timed out", e);
+        }
+    }
+
+    public boolean canConnectToCluster() throws InterruptedException, ExecutionException {
+        try {
+            return CompletableFuture.supplyAsync(
+                            () -> {
+                                try (Connection connection =
+                                        ConnectionFactory.createConnection(getConfig())) {
+                                    return true;
+                                } catch (IOException e) {
+                                    LOG.error("Error trying to connect to cluster", e);
+                                    return false;
+                                }
+                            })
+                    .get(10, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            LOG.error("Trying to connect to HBase test cluster timed out", e);
+            return false;
+        }
+    }
+
+    public void clearTables() throws IOException {
+        try (Admin admin = ConnectionFactory.createConnection(getConfig()).getAdmin()) {
+            for (TableDescriptor table : admin.listTableDescriptors()) {
+                admin.disableTable(table.getTableName());
+                admin.deleteTable(table.getTableName());
+            }
+        } catch (IOException e) {
+            throw new IOException("Could not clear test cluster tables", e);
+        }
+    }
+
+    public void clearReplicationPeers() throws IOException {
+        try (Admin admin = ConnectionFactory.createConnection(getConfig()).getAdmin()) {
+            StringBuilder logMessage = new StringBuilder("Clearing existing replication peers:");
+            try (Closer closer = Closer.create()) {
+                for (ReplicationPeerDescription desc : admin.listReplicationPeers()) {
+                    logMessage.append("\n\t").append(desc.getPeerId()).append(" | ").append(desc);
+                    closer.register(() -> admin.removeReplicationPeer(desc.getPeerId()));
+                }
+                LOG.info(logMessage.toString());
+            }
+        } catch (IOException e) {
+            throw new IOException("Could not clear test cluster replication peers", e);
+        }
+    }
+
+    public List<ReplicationPeerDescription> getReplicationPeers() throws IOException {
+        try (Admin admin = ConnectionFactory.createConnection(getConfig()).getAdmin()) {
+            return admin.listReplicationPeers();
+        } catch (IOException e) {
+            throw new IOException("Error retrieving replication peers", e);
+        }
+    }
+
+    public void makeTable(String tableName) throws IOException {
+        makeTable(tableName, 1);
+    }
+
+    /**
+     * Creates a table for given name with given number of column families. Column family names
+     * start with {@link HBaseTestCluster#COLUMN_FAMILY_BASE} and are indexed, if more than one is
+     * requested
+     */
+    public void makeTable(String tableName, int numColumnFamilies) throws IOException {
+        assert numColumnFamilies >= 1;
+        try (Admin admin = ConnectionFactory.createConnection(getConfig()).getAdmin()) {
+            TableName tableNameObj = TableName.valueOf(tableName);
+            if (!admin.tableExists(tableNameObj)) {
+                TableDescriptorBuilder tableBuilder =
+                        TableDescriptorBuilder.newBuilder(tableNameObj);
+                for (int i = 0; i < numColumnFamilies; i++) {
+                    ColumnFamilyDescriptorBuilder columnFamilyBuilder =
+                            ColumnFamilyDescriptorBuilder.newBuilder(
+                                    Bytes.toBytes(COLUMN_FAMILY_BASE + i));
+                    columnFamilyBuilder.setScope(1);
+                    tableBuilder.setColumnFamily(columnFamilyBuilder.build());
+                }
+                admin.createTable(tableBuilder.build());
+            }
+        } catch (IOException e) {
+            throw new IOException("Could not create test cluster table", e);
+        }
+    }
+
+    public void commitPut(String tableName, Put put) throws IOException {
+        try (Table htable =
+                ConnectionFactory.createConnection(getConfig())
+                        .getTable(TableName.valueOf(tableName))) {
+            htable.put(put);
+            LOG.info("Commited put to row {}", Bytes.toString(put.getRow()));
+        } catch (IOException e) {
+            throw new IOException("Could not commit put to test cluster", e);
+        }
+    }
+
+    public String put(String tableName, String value) throws IOException {
+        return put(tableName, 1, value);
+    }
+
+    public void delete(String tableName, String rowKey, String columnFamily, String qualifier)
+            throws IOException {
+        try (Table htable =
+                ConnectionFactory.createConnection(getConfig())
+                        .getTable(TableName.valueOf(tableName))) {
+            Delete delete = new Delete(rowKey.getBytes());
+            delete.addColumn(columnFamily.getBytes(), qualifier.getBytes());
+            htable.delete(delete);
+            LOG.info("Deleted row {}", rowKey);
+        } catch (IOException e) {
+            throw new IOException("Could not delete row in test cluster", e);
+        }
+    }
+
+    public String put(String tableName, int numColumnFamilies, String... values)
+            throws IOException {
+        assert numColumnFamilies >= 1;
+        assert values.length >= numColumnFamilies;
+        try (Table htable =
+                ConnectionFactory.createConnection(getConfig())
+                        .getTable(TableName.valueOf(tableName))) {
+
+            String rowKey = UUID.randomUUID().toString();
+            Put put = new Put(rowKey.getBytes());
+            int index = 0;
+            for (int columnFamily = 0; columnFamily < numColumnFamilies; columnFamily++) {
+                int columnQualifier = 0;
+                for (;
+                        index + columnQualifier
+                                < values.length * (columnFamily + 1) / numColumnFamilies;
+                        columnQualifier++) {
+                    put.addColumn(
+                            (COLUMN_FAMILY_BASE + columnFamily).getBytes(),
+                            (QUALIFIER_BASE + columnQualifier).getBytes(),
+                            values[index + columnQualifier].getBytes());
+                }
+                index += columnQualifier;
+            }
+            htable.put(put);
+            LOG.info("Added row " + rowKey);
+            return rowKey;
+        } catch (IOException e) {
+            throw new IOException("Could not put to test cluster", e);
+        }
+    }
+
+    public org.apache.hadoop.conf.Configuration getConfig() {
+        return hbaseConf;
+    }
+
+    public Configuration getConfigurationForTable(String tableName) {
+        Configuration config = new Configuration();
+        config.setString(HBaseSourceOptions.TABLE_NAME, tableName);
+        return config;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        startCluster();
+    }
+
+    @Override
+    protected void after() {
+        shutdownCluster();
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/TestsWithTestHBaseCluster.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/TestsWithTestHBaseCluster.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.testutil;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.UUID;
+
+/** Abstract test class that provides that {@link HBaseTestCluster} is up and running. */
+public abstract class TestsWithTestHBaseCluster {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(TestsWithTestHBaseCluster.class);
+    public static final int DEFAULT_COLUMNFAMILY_COUNT = 4;
+
+    @Rule public FileSignal testOracle = new FileSignal();
+    @Rule public HBaseTestCluster cluster = new HBaseTestCluster();
+
+    /** Shadowed from org.apache.flink.test.util.SuccessException. */
+    public static class SuccessException extends RuntimeException {}
+
+    /**
+     * Unique table name provided for each test; can be used to minimize interference between tests
+     * on the same cluster.
+     */
+    protected String baseTableName;
+
+    @Before
+    public void determineBaseTableName() {
+        baseTableName =
+                String.format(
+                        "%s-table-%s", getClass().getSimpleName().toLowerCase(), UUID.randomUUID());
+    }
+
+    protected static boolean causedBySuccess(Exception exception) {
+        for (Throwable e = exception; e != null; e = e.getCause()) {
+            if (e instanceof SuccessException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected static String[] uniqueValues(int count) {
+        String[] values = new String[count];
+        for (int i = 0; i < count; i++) {
+            values[i] = UUID.randomUUID().toString();
+        }
+        return values;
+    }
+
+    protected static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Waiting was interrupted", e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/Util.java
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/java/org/apache/flink/connector/hbase/testutil/Util.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.testutil;
+
+import org.apache.flink.runtime.minicluster.MiniCluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Provides utility for testing with flink miniclusters. */
+public class Util {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+
+    public static void waitForClusterStart(MiniCluster miniCluster) throws InterruptedException {
+        LOG.info("Started flink minicluster execution ...");
+
+        while (!miniCluster.isRunning()) {
+            Thread.sleep(100);
+        }
+
+        LOG.info("Flink minicluster is running");
+    }
+}

--- a/flink-connectors/flink-connector-hbase-unified/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-hbase-unified/src/test/resources/log4j2-test.properties
@@ -1,0 +1,32 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+# Set logging level of test classes and tested classes
+logger.hbase.name = org.apache.flink.connector.hbase
+logger.hbase.level = ALL
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -45,6 +45,7 @@ under the License.
 		<module>flink-connector-hbase-base</module>
 		<module>flink-connector-hbase-1.4</module>
 		<module>flink-connector-hbase-2.2</module>
+		<module>flink-connector-hbase-unified</module>
 		<module>flink-connector-hive</module>
 		<module>flink-connector-jdbc</module>
 		<module>flink-connector-rabbitmq</module>

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -87,6 +87,7 @@ flink-formats/flink-orc-nohive,\
 flink-connectors/flink-connector-hbase-base,\
 flink-connectors/flink-connector-hbase-1.4,\
 flink-connectors/flink-connector-hbase-2.2,\
+flink-connectors/flink-connector-hbase-unified,\
 flink-connectors/flink-hcatalog,\
 flink-connectors/flink-hadoop-compatibility,\
 flink-connectors,\


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds an HBase connector implementation conforming to the new Connector’s API’s described in [FLIP-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface) and [FLIP-143](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API). It includes both source and sink.

## Brief change log

- The HBase source uses the replication mechanism of HBase to receive changes 
- The HBase Sink uses the HBase API to enter data into HBase.
- Sink and Source use user-specified Serializer and Deserializer to put/get elements to/from HBase.


## Verifying this change

This change added tests and can be verified as follows:

All changes are within the `flink-connectors/flink-connector-hbase/` module. 
Added Unit and Integration Tests under `org.apache.flink.connector.hbase.source` and `org.apache.flink.connector.hbase.sink` package in the test directory.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)