### PR TITLE
[FLINK-21665][Table] Support [IF NOT EXISTS] and [COMMENT] for create catalog statement

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -310,7 +310,9 @@ public class CliClientTest extends TestLogger {
                 new TestingExecutorBuilder()
                         .setExecuteSqlConsumer((s, s2) -> TestTableResult.TABLE_RESULT_OK)
                         .build();
-        testExecuteSql(executor, "create catalog c1 with('type'='generic_in_memory');");
+        testExecuteSql(
+                executor,
+                "create catalog if not exists c1 comment 'c1_comment' with('type'='generic_in_memory');");
         assertThat(executor.getNumExecuteSqlCalls(), is(1));
     }
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -172,9 +172,9 @@ public class SqlCommandParserTest {
                                 .cannotParseComment(),
                         // create catalog xx
                         TestItem.validSql(
-                                "create CATALOG c1 with('type'='generic_in_memory')",
+                                "create CATALOG if not exists c1 comment 'c1_comment' with('type'='generic_in_memory')",
                                 SqlCommand.CREATE_CATALOG,
-                                "create CATALOG c1 with('type'='generic_in_memory')"),
+                                "create CATALOG if not exists c1 comment 'c1_comment' with('type'='generic_in_memory')"),
                         TestItem.validSql(
                                 "create CATALOG c1 WITH ('type'='simple-catalog', 'default-database'='db1')",
                                 SqlCommand.CREATE_CATALOG,

--- a/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
@@ -1108,26 +1108,41 @@ SqlUseCatalog SqlUseCatalog() :
 
 /**
 * Parses a create catalog statement.
-* CREATE CATALOG catalog_name [WITH (property_name=property_value, ...)];
+* <pre>CREATE CATALOG catalog_name
+*       [COMMENT catalog_comment]
+*       [WITH (property_name=property_value, ...)].</pre>
 */
 SqlCreate SqlCreateCatalog(Span s, boolean replace) :
 {
     SqlParserPos startPos;
     SqlIdentifier catalogName;
+    SqlCharStringLiteral comment = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
+    boolean ifNotExists = false;
 }
 {
     <CATALOG> { startPos = getPos(); }
+
+    [ <IF> <NOT> <EXISTS> { ifNotExists = true; } ]
+
     catalogName = SimpleIdentifier()
+    [ <COMMENT> <QUOTED_STRING>
+        {
+            String p = SqlParserUtil.parseString(token.image);
+            comment = SqlLiteral.createCharString(p, getPos());
+        }
+    ]
     [
         <WITH>
         propertyList = TableProperties()
     ]
-    {
-        return new SqlCreateCatalog(startPos.plus(getPos()),
-            catalogName,
-            propertyList);
-    }
+
+    { return new SqlCreateCatalog(startPos.plus(getPos()),
+                    catalogName,
+                    propertyList,
+                    comment,
+                    ifNotExists); }
+
 }
 
 // make sure a feature only applies to table, not partitions

--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -256,9 +256,21 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
 
     @Test
     public void testCreateCatalog() {
-        sql("create catalog cat").ok("CREATE CATALOG `CAT`");
-        sql("create catalog cat with ('k1'='v1')")
-                .ok("CREATE CATALOG `CAT` WITH (\n" + "  'k1' = 'v1'\n" + ")");
+        sql("create catalog c1").ok("CREATE CATALOG `C1`");
+        sql("create catalog if not exists c1").ok("CREATE CATALOG IF NOT EXISTS `C1`");
+        final String sql = "create catalog c1 comment 'test create catalog'";
+        final String expected = "CREATE CATALOG `C1`\n" + "COMMENT 'test create catalog'";
+        sql(sql).ok(expected);
+        final String sql1 =
+                "create catalog c1 comment 'test create catalog'"
+                        + "with ( 'key1' = 'value1', 'key2.a' = 'value2.a')";
+        final String expected1 =
+                "CREATE CATALOG `C1`\n"
+                        + "COMMENT 'test create catalog' WITH (\n"
+                        + "  'key1' = 'value1',\n"
+                        + "  'key2.a' = 'value2.a'\n"
+                        + ")";
+        sql(sql1).ok(expected1);
     }
 
     @Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -73,17 +73,21 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Test
     public void testCreateCatalog() {
-        sql("create catalog c1\n"
-                        + " WITH (\n"
-                        + "  'key1'='value1',\n"
-                        + "  'key2'='value2'\n"
-                        + " )\n")
-                .ok(
-                        "CREATE CATALOG `C1` "
-                                + "WITH (\n"
-                                + "  'key1' = 'value1',\n"
-                                + "  'key2' = 'value2'\n"
-                                + ")");
+        sql("create catalog c1").ok("CREATE CATALOG `C1`");
+        sql("create catalog if not exists c1").ok("CREATE CATALOG IF NOT EXISTS `C1`");
+        final String sql = "create catalog c1 comment 'test create catalog'";
+        final String expected = "CREATE CATALOG `C1`\n" + "COMMENT 'test create catalog'";
+        sql(sql).ok(expected);
+        final String sql1 =
+                "create catalog c1 comment 'test create catalog'"
+                        + "with ( 'key1' = 'value1', 'key2.a' = 'value2.a')";
+        final String expected1 =
+                "CREATE CATALOG `C1`\n"
+                        + "COMMENT 'test create catalog' WITH (\n"
+                        + "  'key1' = 'value1',\n"
+                        + "  'key2.a' = 'value2.a'\n"
+                        + ")";
+        sql(sql1).ok(expected1);
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogOperation.java
@@ -33,8 +33,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CreateCatalogOperation implements CreateOperation {
     private final String catalogName;
     private final Map<String, String> properties;
-    @Nullable private final boolean ignoreIfExists;
-    private final String comment;
+    private final boolean ignoreIfExists;
+    @Nullable private final String comment;
 
     public CreateCatalogOperation(
             String catalogName,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogOperation.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.operations.ddl;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.OperationUtils;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -31,10 +33,18 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CreateCatalogOperation implements CreateOperation {
     private final String catalogName;
     private final Map<String, String> properties;
+    @Nullable private final boolean ignoreIfExists;
+    private final String comment;
 
-    public CreateCatalogOperation(String catalogName, Map<String, String> properties) {
+    public CreateCatalogOperation(
+            String catalogName,
+            Map<String, String> properties,
+            boolean ignoreIfExists,
+            String comment) {
         this.catalogName = checkNotNull(catalogName);
         this.properties = checkNotNull(properties);
+        this.ignoreIfExists = ignoreIfExists;
+        this.comment = comment;
     }
 
     public String getCatalogName() {
@@ -45,11 +55,20 @@ public class CreateCatalogOperation implements CreateOperation {
         return Collections.unmodifiableMap(properties);
     }
 
+    public boolean isIgnoreIfExists() {
+        return ignoreIfExists;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
     @Override
     public String asSummaryString() {
         Map<String, Object> params = new LinkedHashMap<>();
         params.put("catalogName", catalogName);
         params.put("properties", properties);
+        params.put("ignoreIfExists", ignoreIfExists);
 
         return OperationUtils.formatWithChildren(
                 "CREATE CATALOG", params, Collections.emptyList(), Operation::asSummaryString);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -608,8 +608,13 @@ public class SqlToOperationConverter {
                                 properties.put(
                                         ((SqlTableOption) p).getKeyString(),
                                         ((SqlTableOption) p).getValueString()));
-
-        return new CreateCatalogOperation(catalogName, properties);
+        boolean ignoreIfExists = sqlCreateCatalog.isIfNotExists();
+        String catalogComment =
+                sqlCreateCatalog
+                        .getComment()
+                        .map(comment -> comment.getNlsString().getValue())
+                        .orElse(null);
+        return new CreateCatalogOperation(catalogName, properties, ignoreIfExists, catalogComment);
     }
 
     /** Convert DROP CATALOG statement. */

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -413,8 +413,14 @@ class TableEnvironmentTest {
 
   @Test
   def testExecuteSqlWithCreateUseDropCatalog(): Unit = {
-    val tableResult1 = tableEnv.executeSql(
-      "CREATE CATALOG my_catalog WITH('type'='generic_in_memory')")
+    val createCatalogStmt =
+      """
+        |CREATE CATALOG IF NOT EXISTS my_catalog
+        |COMMENT 'my_catalog_comment' WITH (
+        |  'type'='generic_in_memory'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createCatalogStmt)
     assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
     assertTrue(tableEnv.getCatalog("my_catalog").isPresent)
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports create catalog by CREATE CATALOG catalog_name [COMMENT catalog_comment]  [WITH (property_name=property_value, ...)] syntax.


## Brief change log

  - Support syntax in flink and hive parser;
  - Support syntax in TableEnvironment.


## Verifying this change

  - Added tests in [SqlCommandParserTest, TableEnvironmentTest, CliClientTest, FlinkSqlParserImplTest, FlinkHiveSqlParserImplTest] to verify syntax support.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs