### PR TITLE
[FLINK-21668][table] Change tableName to databaseName

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
@@ -56,7 +56,7 @@ public class SqlCreateDatabase extends SqlCreate {
             SqlCharStringLiteral comment,
             boolean ifNotExists) {
         super(OPERATOR, pos, false, ifNotExists);
-        this.databaseName = requireNonNull(databaseName, "tableName should not be null");
+        this.databaseName = requireNonNull(databaseName, "databaseName should not be null");
         this.propertyList = requireNonNull(propertyList, "propertyList should not be null");
         this.comment = comment;
     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixed a writing error in org.apache.flink.sql.parser.ddl.SqlCreateDatabase: change tableName to databaseName.


## Brief change log

  - Change tableName to databaseName in org.apache.flink.sql.parser.ddl.SqlCreateDatabase.


## Verifying this change

  - It is just a writing error, we needn't verify.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs

