### PR TITLE
[FLINK-21736][state] Introduce state scope latency tracking metrics

### DIFF
--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -307,6 +307,10 @@ Please refer to the [Debugging Classloading Docs]({{< ref "docs/ops/debugging/de
 
 {{< generated/expert_state_backends_section >}}
 
+### State Backends Latency Tracking Options
+
+{{< generated/state_backend_latency_tracking_section >}}
+
 ### Advanced RocksDB State Backends Options
 
 Advanced options to tune RocksDB and RocksDB checkpoints.

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -307,6 +307,10 @@ Please refer to the [Debugging Classloading Docs]({{< ref "docs/ops/debugging/de
 
 {{< generated/expert_state_backends_section >}}
 
+### State Backends Latency Tracking Options
+
+{{< generated/state_backend_latency_tracking_section >}}
+
 ### Advanced RocksDB State Backends Options
 
 Advanced options to tune RocksDB and RocksDB checkpoints.

--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -9,12 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>state.backend</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <span markdown="span">`StateBackendFactory`</span>. If a factory is specified it is instantiated via its zero argument constructor and its <span markdown="span">`StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)`</span> method is called.<br />Recognized shortcut names are 'hashmap' and 'rocksdb'.</td>
-        </tr>
-        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/state_backend_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_backend_configuration.html
@@ -1,0 +1,18 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>state.backend</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <span markdown="span">`StateBackendFactory`</span>. If a factory is specified it is instantiated via its zero argument constructor and its <span markdown="span">`StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)`</span> method is called.<br />Recognized shortcut names are 'hashmap' and 'rocksdb'.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/state_backend_latency_tracking_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_latency_tracking_section.html
@@ -9,12 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>state.backend</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <span markdown="span">`StateBackendFactory`</span>. If a factory is specified it is instantiated via its zero argument constructor and its <span markdown="span">`StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)`</span> method is called.<br />Recognized shortcut names are 'hashmap' and 'rocksdb'.</td>
-        </tr>
-        <tr>
             <td><h5>state.backend.latency-track.history-size</h5></td>
             <td style="word-wrap: break-word;">128</td>
             <td>Integer</td>

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/Documentation.java
@@ -74,6 +74,9 @@ public final class Documentation {
 
         public static final String STATE_BACKEND_ROCKSDB = "state_backend_rocksdb";
 
+        public static final String STATE_BACKEND_LATENCY_TRACKING =
+                "state_backend_latency_tracking";
+
         public static final String EXPERT_CLASS_LOADING = "expert_class_loading";
         public static final String EXPERT_DEBUGGING_AND_TUNING = "expert_debugging_and_tuning";
         public static final String EXPERT_SCHEDULING = "expert_scheduling";

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.description.TextElement;
 public class CheckpointingOptions {
 
     // ------------------------------------------------------------------------
-    //  general checkpoint and state backend options
+    //  general checkpoint options
     // ------------------------------------------------------------------------
 
     /**
@@ -39,8 +39,12 @@ public class CheckpointingOptions {
      * StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)} method is called.
      *
      * <p>Recognized shortcut names are 'hashmap' and 'rocksdb'.
+     *
+     * @deprecated Use {@link StateBackendOptions#STATE_BACKEND}.
      */
-    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS, position = 1)
+    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
+    @Deprecated
     public static final ConfigOption<String> STATE_BACKEND =
             ConfigOptions.key("state.backend")
                     .stringType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
+
+/** A collection of all configuration options that relate to state backend. */
+public class StateBackendOptions {
+
+    // ------------------------------------------------------------------------
+    //  general state backend options
+    // ------------------------------------------------------------------------
+
+    /**
+     * The checkpoint storage used to store operator state locally within the cluster during
+     * execution.
+     *
+     * <p>The implementation can be specified either via their shortcut name, or via the class name
+     * of a {@code StateBackendFactory}. If a StateBackendFactory class name is specified, the
+     * factory is instantiated (via its zero-argument constructor) and its {@code
+     * StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)} method is called.
+     *
+     * <p>Recognized shortcut names are 'hashmap' and 'rocksdb'.
+     */
+    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS, position = 1)
+    public static final ConfigOption<String> STATE_BACKEND =
+            ConfigOptions.key("state.backend")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text("The state backend to be used to store state.")
+                                    .linebreak()
+                                    .text(
+                                            "The implementation can be specified either via their shortcut "
+                                                    + " name, or via the class name of a %s. "
+                                                    + "If a factory is specified it is instantiated via its "
+                                                    + "zero argument constructor and its %s "
+                                                    + "method is called.",
+                                            TextElement.code("StateBackendFactory"),
+                                            TextElement.code(
+                                                    "StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)"))
+                                    .linebreak()
+                                    .text("Recognized shortcut names are 'hashmap' and 'rocksdb'.")
+                                    .build());
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
@@ -61,4 +61,31 @@ public class StateBackendOptions {
                                     .linebreak()
                                     .text("Recognized shortcut names are 'hashmap' and 'rocksdb'.")
                                     .build());
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    public static final ConfigOption<Boolean> LATENCY_TRACK_ENABLED =
+            ConfigOptions.key("state.backend.latency-track.keyed-state-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to track latency of keyed state operations, e.g value state put/get/clear.");
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    public static final ConfigOption<Integer> LATENCY_TRACK_SAMPLE_INTERVAL =
+            ConfigOptions.key("state.backend.latency-track.sample-interval")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription(
+                            String.format(
+                                    "The sample interval of latency track once '%s' is enabled. "
+                                            + "The default value is 100, which means we would track the latency every 100 access requests.",
+                                    LATENCY_TRACK_ENABLED.key()));
+
+    @Documentation.Section(Documentation.Sections.STATE_BACKEND_LATENCY_TRACKING)
+    public static final ConfigOption<Integer> LATENCY_TRACK_HISTORY_SIZE =
+            ConfigOptions.key("state.backend.latency-track.history-size")
+                    .intType()
+                    .defaultValue(128)
+                    .withDescription(
+                            "Defines the number of measured latencies to maintain at each state access operation.");
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import org.junit.Test;
@@ -292,6 +293,7 @@ public class KvStateRequestSerializerTest {
                                 keyGroupRange,
                                 executionConfig,
                                 TtlTimeProvider.DEFAULT,
+                                LatencyTrackingStateConfig.disabled(),
                                 Collections.emptyList(),
                                 AbstractStateBackend.getCompressionDecorator(executionConfig),
                                 TestLocalRecoveryConfig.disabled(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -297,7 +297,7 @@ public abstract class AbstractKeyedStateBackend<K>
                 stateDescriptor.initializeSerializerUnlessSet(executionConfig);
             }
             kvState =
-                    LatencyTrackingStateFactory.trackLatencyIfEnabled(
+                    LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
                             TtlStateFactory.createStateAndWrapWithTtlIfEnabled(
                                     namespaceSerializer, stateDescriptor, this, ttlTimeProvider),
                             stateDescriptor,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackendBuilder.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import org.slf4j.Logger;
@@ -43,6 +44,7 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
     protected final KeyGroupRange keyGroupRange;
     protected final ExecutionConfig executionConfig;
     protected final TtlTimeProvider ttlTimeProvider;
+    protected final LatencyTrackingStateConfig latencyTrackingStateConfig;
     protected final StreamCompressionDecorator keyGroupCompressionDecorator;
     protected final Collection<KeyedStateHandle> restoreStateHandles;
     protected final CloseableRegistry cancelStreamRegistry;
@@ -55,6 +57,7 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
             KeyGroupRange keyGroupRange,
             ExecutionConfig executionConfig,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             StreamCompressionDecorator keyGroupCompressionDecorator,
             CloseableRegistry cancelStreamRegistry) {
@@ -66,6 +69,7 @@ public abstract class AbstractKeyedStateBackendBuilder<K>
         this.keyGroupRange = keyGroupRange;
         this.executionConfig = executionConfig;
         this.ttlTimeProvider = ttlTimeProvider;
+        this.latencyTrackingStateConfig = latencyTrackingStateConfig;
         this.keyGroupCompressionDecorator = keyGroupCompressionDecorator;
         this.restoreStateHandles = stateHandles;
         this.cancelStreamRegistry = cancelStreamRegistry;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
@@ -52,6 +53,9 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
             return UncompressedStreamCompressionDecorator.INSTANCE;
         }
     }
+
+    protected LatencyTrackingStateConfig.Builder latencyTrackingConfigBuilder =
+            LatencyTrackingStateConfig.newBuilder();
 
     // ------------------------------------------------------------------------
     //  State Backend - State-Holding Backends

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackendFactory;
@@ -79,7 +80,7 @@ public class StateBackendLoader {
 
     /**
      * Loads the unwrapped state backend from the configuration, from the parameter 'state.backend',
-     * as defined in {@link CheckpointingOptions#STATE_BACKEND}.
+     * as defined in {@link StateBackendOptions#STATE_BACKEND}.
      *
      * <p>The state backends can be specified either via their shortcut name, or via the class name
      * of a {@link StateBackendFactory}. If a StateBackendFactory class name is specified, the
@@ -109,7 +110,7 @@ public class StateBackendLoader {
         checkNotNull(config, "config");
         checkNotNull(classLoader, "classLoader");
 
-        final String backendName = config.get(CheckpointingOptions.STATE_BACKEND);
+        final String backendName = config.get(StateBackendOptions.STATE_BACKEND);
         if (backendName == null) {
             return null;
         }
@@ -175,7 +176,7 @@ public class StateBackendLoader {
                 } catch (ClassCastException | InstantiationException | IllegalAccessException e) {
                     throw new DynamicCodeLoadingException(
                             "The class configured under '"
-                                    + CheckpointingOptions.STATE_BACKEND.key()
+                                    + StateBackendOptions.STATE_BACKEND.key()
                                     + "' is not a valid state backend factory ("
                                     + backendName
                                     + ')',

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.state.StateSnapshotRestore;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.StateSnapshotTransformers;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.StateMigrationException;
@@ -117,6 +118,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             ClassLoader userCodeClassLoader,
             ExecutionConfig executionConfig,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             CloseableRegistry cancelStreamRegistry,
             StreamCompressionDecorator keyGroupCompressionDecorator,
             Map<String, StateTable<K, ?, ?>> registeredKVStates,
@@ -133,6 +135,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                 userCodeClassLoader,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 cancelStreamRegistry,
                 keyGroupCompressionDecorator,
                 keyContext);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendBuilder.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.RestoreOperation;
 import org.apache.flink.runtime.state.SavepointKeyedStateHandle;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
@@ -63,6 +64,7 @@ public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
             KeyGroupRange keyGroupRange,
             ExecutionConfig executionConfig,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             StreamCompressionDecorator keyGroupCompressionDecorator,
             LocalRecoveryConfig localRecoveryConfig,
@@ -77,6 +79,7 @@ public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 keyGroupRange,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 stateHandles,
                 keyGroupCompressionDecorator,
                 cancelStreamRegistry);
@@ -112,6 +115,7 @@ public class HeapKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 userCodeClassLoader,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 cancelStreamRegistryForBackend,
                 keyGroupCompressionDecorator,
                 registeredKVStates,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.filesystem.AbstractFileStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.TernaryBoolean;
 
@@ -257,6 +258,10 @@ public class MemoryStateBackend extends AbstractFileStateBackend
         super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
 
         this.maxStateSize = original.maxStateSize;
+
+        // configure latency tracking
+        latencyTrackingConfigBuilder =
+                original.latencyTrackingConfigBuilder.configure(configuration);
     }
 
     // ------------------------------------------------------------------------
@@ -347,6 +352,8 @@ public class MemoryStateBackend extends AbstractFileStateBackend
         TaskStateManager taskStateManager = env.getTaskStateManager();
         HeapPriorityQueueSetFactory priorityQueueSetFactory =
                 new HeapPriorityQueueSetFactory(keyGroupRange, numberOfKeyGroups, 128);
+        LatencyTrackingStateConfig latencyTrackingStateConfig =
+                latencyTrackingConfigBuilder.setMetricGroup(metricGroup).build();
         return new HeapKeyedStateBackendBuilder<>(
                         kvStateRegistry,
                         keySerializer,
@@ -355,6 +362,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend
                         keyGroupRange,
                         env.getExecutionConfig(),
                         ttlTimeProvider,
+                        latencyTrackingStateConfig,
                         stateHandles,
                         AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
                         taskStateManager.createLocalRecoveryConfig(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/AbstractLatencyTrackState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/AbstractLatencyTrackState.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.util.function.SupplierWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * Abstract implementation of latency tracking state.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <V> Type of the user entry value of state
+ * @param <S> Type of the internal kv state
+ * @param <LSM> Type of the latency tracking state metrics
+ */
+class AbstractLatencyTrackState<
+                K, N, V, S extends InternalKvState<K, N, V>, LSM extends StateLatencyMetricBase>
+        implements InternalKvState<K, N, V> {
+
+    protected S original;
+    protected LSM latencyTrackingStateMetric;
+
+    AbstractLatencyTrackState(S original, LSM latencyTrackingStateMetric) {
+        this.original = original;
+        this.latencyTrackingStateMetric = latencyTrackingStateMetric;
+    }
+
+    @Override
+    public TypeSerializer<K> getKeySerializer() {
+        return original.getKeySerializer();
+    }
+
+    @Override
+    public TypeSerializer<N> getNamespaceSerializer() {
+        return original.getNamespaceSerializer();
+    }
+
+    @Override
+    public TypeSerializer<V> getValueSerializer() {
+        return original.getValueSerializer();
+    }
+
+    @Override
+    public void setCurrentNamespace(N namespace) {
+        original.setCurrentNamespace(namespace);
+    }
+
+    @Override
+    public byte[] getSerializedValue(
+            byte[] serializedKeyAndNamespace,
+            TypeSerializer<K> safeKeySerializer,
+            TypeSerializer<N> safeNamespaceSerializer,
+            TypeSerializer<V> safeValueSerializer)
+            throws Exception {
+        return original.getSerializedValue(
+                serializedKeyAndNamespace,
+                safeKeySerializer,
+                safeNamespaceSerializer,
+                safeValueSerializer);
+    }
+
+    @Override
+    public StateIncrementalVisitor<K, N, V> getStateIncrementalVisitor(
+            int recommendedMaxNumberOfReturnedRecords) {
+        return original.getStateIncrementalVisitor(recommendedMaxNumberOfReturnedRecords);
+    }
+
+    @Override
+    public void clear() {
+        if (latencyTrackingStateMetric.trackLatencyOnClear()) {
+            trackLatency(original::clear, StateLatencyMetricBase.STATE_CLEAR_LATENCY);
+        } else {
+            original.clear();
+        }
+    }
+
+    protected <T> T trackLatency(Supplier<T> supplier, String latencyLabel) {
+        long startTime = System.nanoTime();
+        T result = supplier.get();
+        long latency = System.nanoTime() - startTime;
+        latencyTrackingStateMetric.updateLatency(latencyLabel, latency);
+        return result;
+    }
+
+    protected <T> T trackLatencyWithIOException(
+            SupplierWithException<T, IOException> supplier, String latencyLabel)
+            throws IOException {
+        long startTime = System.nanoTime();
+        T result = supplier.get();
+        long latency = System.nanoTime() - startTime;
+        latencyTrackingStateMetric.updateLatency(latencyLabel, latency);
+        return result;
+    }
+
+    protected void trackLatencyWithIOException(
+            ThrowingRunnable<IOException> runnable, String latencyLabel) throws IOException {
+        long startTime = System.nanoTime();
+        runnable.run();
+        long latency = System.nanoTime() - startTime;
+        latencyTrackingStateMetric.updateLatency(latencyLabel, latency);
+    }
+
+    protected <T> T trackLatencyWithException(
+            SupplierWithException<T, Exception> supplier, String latencyLabel) throws Exception {
+        long startTime = System.nanoTime();
+        T result = supplier.get();
+        long latency = System.nanoTime() - startTime;
+        latencyTrackingStateMetric.updateLatency(latencyLabel, latency);
+        return result;
+    }
+
+    protected void trackLatencyWithException(
+            ThrowingRunnable<Exception> runnable, String latencyLabel) throws Exception {
+        long startTime = System.nanoTime();
+        runnable.run();
+        long latency = System.nanoTime() - startTime;
+        latencyTrackingStateMetric.updateLatency(latencyLabel, latency);
+    }
+
+    protected void trackLatency(Runnable runnable, String latencyLabel) {
+        long startTime = System.nanoTime();
+        runnable.run();
+        long latency = System.nanoTime() - startTime;
+        latencyTrackingStateMetric.updateLatency(latencyLabel, latency);
+    }
+
+    @VisibleForTesting
+    LSM getLatencyTrackingStateMetric() {
+        return latencyTrackingStateMetric;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingAggregatingState.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+
+import java.util.Collection;
+
+/**
+ * This class wraps aggregating state with latency tracking logic.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <IN> Type of the value added to the state
+ * @param <ACC> The type of the accumulator (intermediate aggregate state).
+ * @param <OUT> Type of the value extracted from the state
+ */
+class LatencyTrackingAggregatingState<K, N, IN, ACC, OUT>
+        extends AbstractLatencyTrackState<
+                K,
+                N,
+                ACC,
+                InternalAggregatingState<K, N, IN, ACC, OUT>,
+                LatencyTrackingAggregatingState.AggregatingStateLatencyMetrics>
+        implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+
+    LatencyTrackingAggregatingState(
+            String stateName,
+            InternalAggregatingState<K, N, IN, ACC, OUT> original,
+            LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        super(
+                original,
+                new AggregatingStateLatencyMetrics(
+                        stateName,
+                        latencyTrackingStateConfig.getMetricGroup(),
+                        latencyTrackingStateConfig.getSampleInterval(),
+                        latencyTrackingStateConfig.getHistorySize()));
+    }
+
+    @Override
+    public OUT get() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnGet()) {
+            return trackLatencyWithException(
+                    () -> original.get(),
+                    AggregatingStateLatencyMetrics.AGGREGATING_STATE_GET_LATENCY);
+        } else {
+            return original.get();
+        }
+    }
+
+    @Override
+    public void add(IN value) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnAdd()) {
+            trackLatencyWithException(
+                    () -> original.add(value),
+                    AggregatingStateLatencyMetrics.AGGREGATING_STATE_ADD_LATENCY);
+        } else {
+            original.add(value);
+        }
+    }
+
+    @Override
+    public ACC getInternal() throws Exception {
+        return original.getInternal();
+    }
+
+    @Override
+    public void updateInternal(ACC valueToStore) throws Exception {
+        original.updateInternal(valueToStore);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnMergeNamespace()) {
+            trackLatencyWithException(
+                    () -> original.mergeNamespaces(target, sources),
+                    AggregatingStateLatencyMetrics.AGGREGATING_STATE_MERGE_NAMESPACES_LATENCY);
+        } else {
+            original.mergeNamespaces(target, sources);
+        }
+    }
+
+    static class AggregatingStateLatencyMetrics extends StateLatencyMetricBase {
+        private static final String AGGREGATING_STATE_GET_LATENCY = "aggregatingStateGetLatency";
+        private static final String AGGREGATING_STATE_ADD_LATENCY = "aggregatingStateAddLatency";
+        private static final String AGGREGATING_STATE_MERGE_NAMESPACES_LATENCY =
+                "aggregatingStateMergeNamespacesLatency";
+
+        private int getCount = 0;
+        private int addCount = 0;
+        private int mergeNamespaceCount = 0;
+
+        private AggregatingStateLatencyMetrics(
+                String stateName, MetricGroup metricGroup, int sampleInterval, int historySize) {
+            super(stateName, metricGroup, sampleInterval, historySize);
+        }
+
+        int getGetCount() {
+            return getCount;
+        }
+
+        int getAddCount() {
+            return addCount;
+        }
+
+        int getMergeNamespaceCount() {
+            return mergeNamespaceCount;
+        }
+
+        private boolean trackLatencyOnGet() {
+            getCount = loopUpdateCounter(getCount);
+            return getCount == 1;
+        }
+
+        private boolean trackLatencyOnAdd() {
+            addCount = loopUpdateCounter(addCount);
+            return addCount == 1;
+        }
+
+        private boolean trackLatencyOnMergeNamespace() {
+            mergeNamespaceCount = loopUpdateCounter(mergeNamespaceCount);
+            return mergeNamespaceCount == 1;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingListState.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This class wraps list state with latency tracking logic.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <T> Type of the user entry value of state
+ */
+class LatencyTrackingListState<K, N, T>
+        extends AbstractLatencyTrackState<
+                K,
+                N,
+                List<T>,
+                InternalListState<K, N, T>,
+                LatencyTrackingListState.ListStateLatencyMetrics>
+        implements InternalListState<K, N, T> {
+
+    LatencyTrackingListState(
+            String stateName,
+            InternalListState<K, N, T> original,
+            LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        super(
+                original,
+                new ListStateLatencyMetrics(
+                        stateName,
+                        latencyTrackingStateConfig.getMetricGroup(),
+                        latencyTrackingStateConfig.getSampleInterval(),
+                        latencyTrackingStateConfig.getHistorySize()));
+    }
+
+    @Override
+    public Iterable<T> get() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnGet()) {
+            return trackLatencyWithException(
+                    () -> original.get(), ListStateLatencyMetrics.LIST_STATE_GET_LATENCY);
+        } else {
+            return original.get();
+        }
+    }
+
+    @Override
+    public void add(T value) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnAdd()) {
+            trackLatencyWithException(
+                    () -> original.add(value), ListStateLatencyMetrics.LIST_STATE_ADD_LATENCY);
+        } else {
+            original.add(value);
+        }
+    }
+
+    @Override
+    public List<T> getInternal() throws Exception {
+        return original.getInternal();
+    }
+
+    @Override
+    public void updateInternal(List<T> valueToStore) throws Exception {
+        original.updateInternal(valueToStore);
+    }
+
+    @Override
+    public void update(List<T> values) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnUpdate()) {
+            trackLatencyWithException(
+                    () -> original.update(values),
+                    ListStateLatencyMetrics.LIST_STATE_UPDATE_LATENCY);
+        } else {
+            original.update(values);
+        }
+    }
+
+    @Override
+    public void addAll(List<T> values) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnAddAll()) {
+            trackLatencyWithException(
+                    () -> original.addAll(values),
+                    ListStateLatencyMetrics.LIST_STATE_ADD_ALL_LATENCY);
+        } else {
+            original.addAll(values);
+        }
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnMergeNamespace()) {
+            trackLatencyWithException(
+                    () -> original.mergeNamespaces(target, sources),
+                    ListStateLatencyMetrics.LIST_STATE_MERGE_NAMESPACES_LATENCY);
+        } else {
+            original.mergeNamespaces(target, sources);
+        }
+    }
+
+    static class ListStateLatencyMetrics extends StateLatencyMetricBase {
+        private static final String LIST_STATE_GET_LATENCY = "listStateGetLatency";
+        private static final String LIST_STATE_ADD_LATENCY = "listStateAddLatency";
+        private static final String LIST_STATE_ADD_ALL_LATENCY = "listStateAddAllLatency";
+        private static final String LIST_STATE_UPDATE_LATENCY = "listStateUpdateLatency";
+        private static final String LIST_STATE_MERGE_NAMESPACES_LATENCY =
+                "listStateMergeNamespacesLatency";
+
+        private int getCount = 0;
+        private int addCount = 0;
+        private int addAllCount = 0;
+        private int updateCount = 0;
+        private int mergeNamespaceCount = 0;
+
+        private ListStateLatencyMetrics(
+                String stateName, MetricGroup metricGroup, int sampleInterval, int historySize) {
+            super(stateName, metricGroup, sampleInterval, historySize);
+        }
+
+        int getGetCount() {
+            return getCount;
+        }
+
+        int getAddCount() {
+            return addCount;
+        }
+
+        int getAddAllCount() {
+            return addAllCount;
+        }
+
+        int getUpdateCount() {
+            return updateCount;
+        }
+
+        int getMergeNamespaceCount() {
+            return mergeNamespaceCount;
+        }
+
+        private boolean trackLatencyOnGet() {
+            getCount = loopUpdateCounter(getCount);
+            return getCount == 1;
+        }
+
+        private boolean trackLatencyOnAdd() {
+            addCount = loopUpdateCounter(addCount);
+            return addCount == 1;
+        }
+
+        private boolean trackLatencyOnAddAll() {
+            addAllCount = loopUpdateCounter(addAllCount);
+            return addAllCount == 1;
+        }
+
+        private boolean trackLatencyOnUpdate() {
+            updateCount = loopUpdateCounter(updateCount);
+            return updateCount == 1;
+        }
+
+        private boolean trackLatencyOnMergeNamespace() {
+            mergeNamespaceCount = loopUpdateCounter(mergeNamespaceCount);
+            return mergeNamespaceCount == 1;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingMapState.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * This class wraps map state with latency tracking logic.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <UK> Type of the user entry key of state
+ * @param <UV> Type of the user entry value of state
+ */
+class LatencyTrackingMapState<K, N, UK, UV>
+        extends AbstractLatencyTrackState<
+                K,
+                N,
+                Map<UK, UV>,
+                InternalMapState<K, N, UK, UV>,
+                LatencyTrackingMapState.MapStateLatencyMetrics>
+        implements InternalMapState<K, N, UK, UV> {
+    LatencyTrackingMapState(
+            String stateName,
+            InternalMapState<K, N, UK, UV> original,
+            LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        super(
+                original,
+                new MapStateLatencyMetrics(
+                        stateName,
+                        latencyTrackingStateConfig.getMetricGroup(),
+                        latencyTrackingStateConfig.getSampleInterval(),
+                        latencyTrackingStateConfig.getHistorySize()));
+    }
+
+    @Override
+    public UV get(UK key) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnGet()) {
+            return trackLatencyWithException(
+                    () -> original.get(key), MapStateLatencyMetrics.MAP_STATE_GET_LATENCY);
+        } else {
+            return original.get(key);
+        }
+    }
+
+    @Override
+    public void put(UK key, UV value) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnPut()) {
+            trackLatencyWithException(
+                    () -> original.put(key, value), MapStateLatencyMetrics.MAP_STATE_PUT_LATENCY);
+        } else {
+            original.put(key, value);
+        }
+    }
+
+    @Override
+    public void putAll(Map<UK, UV> map) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnPutAll()) {
+            trackLatencyWithException(
+                    () -> original.putAll(map), MapStateLatencyMetrics.MAP_STATE_PUT_ALL_LATENCY);
+        } else {
+            original.putAll(map);
+        }
+    }
+
+    @Override
+    public void remove(UK key) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnRemove()) {
+            trackLatencyWithException(
+                    () -> original.remove(key), MapStateLatencyMetrics.MAP_STATE_REMOVE_LATENCY);
+        } else {
+            original.remove(key);
+        }
+    }
+
+    @Override
+    public boolean contains(UK key) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnContains()) {
+            return trackLatencyWithException(
+                    () -> original.contains(key),
+                    MapStateLatencyMetrics.MAP_STATE_CONTAINS_LATENCY);
+        } else {
+            return original.contains(key);
+        }
+    }
+
+    @Override
+    public Iterable<Map.Entry<UK, UV>> entries() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnEntriesInit()) {
+            return trackLatencyWithException(
+                    () -> new IterableWrapper<>(original.entries()),
+                    MapStateLatencyMetrics.MAP_STATE_ENTRIES_INIT_LATENCY);
+        } else {
+            return new IterableWrapper<>(original.entries());
+        }
+    }
+
+    @Override
+    public Iterable<UK> keys() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnKeysInit()) {
+            return trackLatencyWithException(
+                    () -> new IterableWrapper<>(original.keys()),
+                    MapStateLatencyMetrics.MAP_STATE_KEYS_INIT_LATENCY);
+        } else {
+            return new IterableWrapper<>(original.keys());
+        }
+    }
+
+    @Override
+    public Iterable<UV> values() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnValuesInit()) {
+            return trackLatencyWithException(
+                    () -> new IterableWrapper<>(original.values()),
+                    MapStateLatencyMetrics.MAP_STATE_VALUES_INIT_LATENCY);
+        } else {
+            return new IterableWrapper<>(original.values());
+        }
+    }
+
+    @Override
+    public Iterator<Map.Entry<UK, UV>> iterator() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnIteratorInit()) {
+            return trackLatencyWithException(
+                    () -> new IteratorWrapper<>(original.iterator()),
+                    MapStateLatencyMetrics.MAP_STATE_ITERATOR_INIT_LATENCY);
+        } else {
+            return new IteratorWrapper<>(original.iterator());
+        }
+    }
+
+    @Override
+    public boolean isEmpty() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnIsEmpty()) {
+            return trackLatencyWithException(
+                    () -> original.isEmpty(), MapStateLatencyMetrics.MAP_STATE_IS_EMPTY_LATENCY);
+        } else {
+            return original.isEmpty();
+        }
+    }
+
+    private class IterableWrapper<E> implements Iterable<E> {
+        private final Iterable<E> iterable;
+
+        IterableWrapper(Iterable<E> iterable) {
+            this.iterable = iterable;
+        }
+
+        @Override
+        public Iterator<E> iterator() {
+            return new IteratorWrapper<>(iterable.iterator());
+        }
+    }
+
+    private class IteratorWrapper<E> implements Iterator<E> {
+        private final Iterator<E> iterator;
+
+        IteratorWrapper(Iterator<E> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (latencyTrackingStateMetric.trackLatencyOnIteratorHasNext()) {
+                return trackLatency(
+                        iterator::hasNext,
+                        MapStateLatencyMetrics.MAP_STATE_ITERATOR_HAS_NEXT_LATENCY);
+            } else {
+                return iterator.hasNext();
+            }
+        }
+
+        @Override
+        public E next() {
+            if (latencyTrackingStateMetric.trackLatencyOnIteratorNext()) {
+                return trackLatency(
+                        iterator::next, MapStateLatencyMetrics.MAP_STATE_ITERATOR_NEXT_LATENCY);
+            } else {
+                return iterator.next();
+            }
+        }
+
+        @Override
+        public void remove() {
+            if (latencyTrackingStateMetric.trackLatencyOnIteratorRemove()) {
+                trackLatency(
+                        iterator::remove, MapStateLatencyMetrics.MAP_STATE_ITERATOR_REMOVE_LATENCY);
+            } else {
+                iterator.remove();
+            }
+        }
+    }
+
+    static class MapStateLatencyMetrics extends StateLatencyMetricBase {
+        private static final String MAP_STATE_GET_LATENCY = "mapStateGetLatency";
+        private static final String MAP_STATE_PUT_LATENCY = "mapStatePutLatency";
+        private static final String MAP_STATE_PUT_ALL_LATENCY = "mapStatePutAllLatency";
+        private static final String MAP_STATE_REMOVE_LATENCY = "mapStateRemoveLatency";
+        private static final String MAP_STATE_CONTAINS_LATENCY = "mapStateContainsAllLatency";
+        private static final String MAP_STATE_ENTRIES_INIT_LATENCY = "mapStateEntriesInitLatency";
+        private static final String MAP_STATE_KEYS_INIT_LATENCY = "mapStateKeysInitLatency";
+        private static final String MAP_STATE_VALUES_INIT_LATENCY = "mapStateValuesInitLatency";
+        private static final String MAP_STATE_ITERATOR_INIT_LATENCY = "mapStateIteratorInitLatency";
+        private static final String MAP_STATE_IS_EMPTY_LATENCY = "mapStateIsEmptyLatency";
+        private static final String MAP_STATE_ITERATOR_HAS_NEXT_LATENCY =
+                "mapStateIteratorHasNextLatency";
+        private static final String MAP_STATE_ITERATOR_NEXT_LATENCY = "mapStateIteratorNextLatency";
+        private static final String MAP_STATE_ITERATOR_REMOVE_LATENCY =
+                "mapStateIteratorRemoveLatency";
+
+        private int getCount = 0;
+        private int iteratorRemoveCount = 0;
+        private int putCount = 0;
+        private int putAllCount = 0;
+        private int removeCount = 0;
+        private int containsCount = 0;
+        private int entriesInitCount = 0;
+        private int keysInitCount = 0;
+        private int valuesInitCount = 0;
+        private int isEmptyCount = 0;
+        private int iteratorInitCount = 0;
+        private int iteratorHasNextCount = 0;
+        private int iteratorNextCount = 0;
+
+        private MapStateLatencyMetrics(
+                String stateName, MetricGroup metricGroup, int sampleInterval, int historySize) {
+            super(stateName, metricGroup, sampleInterval, historySize);
+        }
+
+        int getGetCount() {
+            return getCount;
+        }
+
+        int getIteratorRemoveCount() {
+            return iteratorRemoveCount;
+        }
+
+        int getPutCount() {
+            return putCount;
+        }
+
+        int getPutAllCount() {
+            return putAllCount;
+        }
+
+        int getRemoveCount() {
+            return removeCount;
+        }
+
+        int getContainsCount() {
+            return containsCount;
+        }
+
+        int getEntriesInitCount() {
+            return entriesInitCount;
+        }
+
+        int getKeysInitCount() {
+            return keysInitCount;
+        }
+
+        int getValuesInitCount() {
+            return valuesInitCount;
+        }
+
+        int getIsEmptyCount() {
+            return isEmptyCount;
+        }
+
+        int getIteratorInitCount() {
+            return iteratorInitCount;
+        }
+
+        int getIteratorHasNextCount() {
+            return iteratorHasNextCount;
+        }
+
+        @VisibleForTesting
+        void resetIteratorHasNextCount() {
+            iteratorHasNextCount = 0;
+        }
+
+        int getIteratorNextCount() {
+            return iteratorNextCount;
+        }
+
+        private boolean trackLatencyOnGet() {
+            getCount = loopUpdateCounter(getCount);
+            return getCount == 1;
+        }
+
+        private boolean trackLatencyOnPut() {
+            putCount = loopUpdateCounter(putCount);
+            return putCount == 1;
+        }
+
+        private boolean trackLatencyOnPutAll() {
+            putAllCount = loopUpdateCounter(putAllCount);
+            return putAllCount == 1;
+        }
+
+        private boolean trackLatencyOnRemove() {
+            removeCount = loopUpdateCounter(removeCount);
+            return removeCount == 1;
+        }
+
+        private boolean trackLatencyOnContains() {
+            containsCount = loopUpdateCounter(containsCount);
+            return containsCount == 1;
+        }
+
+        private boolean trackLatencyOnEntriesInit() {
+            entriesInitCount = loopUpdateCounter(entriesInitCount);
+            return entriesInitCount == 1;
+        }
+
+        private boolean trackLatencyOnKeysInit() {
+            keysInitCount = loopUpdateCounter(keysInitCount);
+            return keysInitCount == 1;
+        }
+
+        private boolean trackLatencyOnValuesInit() {
+            valuesInitCount = loopUpdateCounter(valuesInitCount);
+            return valuesInitCount == 1;
+        }
+
+        private boolean trackLatencyOnIteratorInit() {
+            iteratorInitCount = loopUpdateCounter(iteratorInitCount);
+            return iteratorInitCount == 1;
+        }
+
+        private boolean trackLatencyOnIsEmpty() {
+            isEmptyCount = loopUpdateCounter(isEmptyCount);
+            return isEmptyCount == 1;
+        }
+
+        private boolean trackLatencyOnIteratorHasNext() {
+            iteratorHasNextCount = loopUpdateCounter(iteratorHasNextCount);
+            return iteratorHasNextCount == 1;
+        }
+
+        private boolean trackLatencyOnIteratorNext() {
+            iteratorNextCount = loopUpdateCounter(iteratorNextCount);
+            return iteratorNextCount == 1;
+        }
+
+        private boolean trackLatencyOnIteratorRemove() {
+            iteratorRemoveCount = loopUpdateCounter(iteratorRemoveCount);
+            return iteratorRemoveCount == 1;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingReducingState.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+
+import java.util.Collection;
+
+/**
+ * This class wraps reducing state with latency tracking logic.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <T> Type of the user value of state
+ */
+class LatencyTrackingReducingState<K, N, T>
+        extends AbstractLatencyTrackState<
+                K,
+                N,
+                T,
+                InternalReducingState<K, N, T>,
+                LatencyTrackingReducingState.ReducingStateLatencyMetrics>
+        implements InternalReducingState<K, N, T> {
+
+    LatencyTrackingReducingState(
+            String stateName,
+            InternalReducingState<K, N, T> original,
+            LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        super(
+                original,
+                new ReducingStateLatencyMetrics(
+                        stateName,
+                        latencyTrackingStateConfig.getMetricGroup(),
+                        latencyTrackingStateConfig.getSampleInterval(),
+                        latencyTrackingStateConfig.getHistorySize()));
+    }
+
+    @Override
+    public T get() throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnGet()) {
+            return trackLatencyWithException(
+                    () -> original.get(), ReducingStateLatencyMetrics.REDUCING_STATE_GET_LATENCY);
+        } else {
+            return original.get();
+        }
+    }
+
+    @Override
+    public void add(T value) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnAdd()) {
+            trackLatencyWithException(
+                    () -> original.add(value),
+                    ReducingStateLatencyMetrics.REDUCING_STATE_ADD_LATENCY);
+        } else {
+            original.add(value);
+        }
+    }
+
+    @Override
+    public T getInternal() throws Exception {
+        return original.getInternal();
+    }
+
+    @Override
+    public void updateInternal(T valueToStore) throws Exception {
+        original.updateInternal(valueToStore);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+        if (latencyTrackingStateMetric.trackLatencyOnMergeNamespace()) {
+            trackLatencyWithException(
+                    () -> original.mergeNamespaces(target, sources),
+                    ReducingStateLatencyMetrics.REDUCING_STATE_MERGE_NAMESPACES_LATENCY);
+        } else {
+            original.mergeNamespaces(target, sources);
+        }
+    }
+
+    protected static class ReducingStateLatencyMetrics extends StateLatencyMetricBase {
+        private static final String REDUCING_STATE_GET_LATENCY = "reducingStateGetLatency";
+        private static final String REDUCING_STATE_ADD_LATENCY = "reducingStateAddLatency";
+        private static final String REDUCING_STATE_MERGE_NAMESPACES_LATENCY =
+                "reducingStateMergeNamespacesLatency";
+
+        private int getCount = 0;
+        private int addCount = 0;
+        private int mergeNamespaceCount = 0;
+
+        ReducingStateLatencyMetrics(
+                String stateName, MetricGroup metricGroup, int sampleInterval, int historySize) {
+            super(stateName, metricGroup, sampleInterval, historySize);
+        }
+
+        int getGetCount() {
+            return getCount;
+        }
+
+        int getAddCount() {
+            return addCount;
+        }
+
+        int getMergeNamespaceCount() {
+            return mergeNamespaceCount;
+        }
+
+        private boolean trackLatencyOnGet() {
+            getCount = loopUpdateCounter(getCount);
+            return getCount == 1;
+        }
+
+        private boolean trackLatencyOnAdd() {
+            addCount = loopUpdateCounter(addCount);
+            return addCount == 1;
+        }
+
+        private boolean trackLatencyOnMergeNamespace() {
+            mergeNamespaceCount = loopUpdateCounter(mergeNamespaceCount);
+            return mergeNamespaceCount == 1;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfig.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/** Config to create latency tracking state metric. */
+@Internal
+public class LatencyTrackingStateConfig {
+
+    private final MetricGroup metricGroup;
+
+    private final boolean enabled;
+    private final int sampleInterval;
+    private final int historySize;
+
+    LatencyTrackingStateConfig(
+            MetricGroup metricGroup, boolean enabled, int sampleInterval, int historySize) {
+        if (enabled) {
+            Preconditions.checkNotNull(
+                    metricGroup, "Metric group cannot be null if latency tracking is enabled.");
+            Preconditions.checkArgument(sampleInterval >= 1);
+        }
+        this.metricGroup = metricGroup;
+        this.enabled = enabled;
+        this.sampleInterval = sampleInterval;
+        this.historySize = historySize;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public MetricGroup getMetricGroup() {
+        return metricGroup;
+    }
+
+    public int getHistorySize() {
+        return historySize;
+    }
+
+    public int getSampleInterval() {
+        return sampleInterval;
+    }
+
+    public static LatencyTrackingStateConfig disabled() {
+        return newBuilder().setEnabled(false).build();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private boolean enabled = StateBackendOptions.LATENCY_TRACK_ENABLED.defaultValue();
+        private int sampleInterval =
+                StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue();
+        private int historySize = StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue();
+        private MetricGroup metricGroup;
+
+        public Builder setEnabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder setSampleInterval(int sampleInterval) {
+            this.sampleInterval = sampleInterval;
+            return this;
+        }
+
+        public Builder setHistorySize(int historySize) {
+            this.historySize = historySize;
+            return this;
+        }
+
+        public Builder setMetricGroup(MetricGroup metricGroup) {
+            this.metricGroup = metricGroup;
+            return this;
+        }
+
+        public Builder configure(ReadableConfig config) {
+            this.setEnabled(config.get(StateBackendOptions.LATENCY_TRACK_ENABLED))
+                    .setSampleInterval(
+                            config.get(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL))
+                    .setHistorySize(config.get(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE));
+            return this;
+        }
+
+        public LatencyTrackingStateConfig build() {
+            return new LatencyTrackingStateConfig(
+                    metricGroup, enabled, sampleInterval, historySize);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateFactory.java
@@ -20,16 +20,130 @@ package org.apache.flink.runtime.state.metrics;
 
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** Factory to create {@link AbstractLatencyTrackState}. */
-public class LatencyTrackingStateFactory {
+public class LatencyTrackingStateFactory<
+        K, N, V, S extends State, IS extends InternalKvState<K, N, ?>> {
 
-    @SuppressWarnings("unchecked")
-    public static <K, N, S extends State, V> InternalKvState<K, ?, ?> trackLatencyIfEnabled(
-            InternalKvState<K, ?, ?> kvState,
+    private final InternalKvState<K, N, ?> kvState;
+    private final StateDescriptor<S, V> stateDescriptor;
+    private final LatencyTrackingStateConfig latencyTrackingStateConfig;
+    private final Map<StateDescriptor.Type, SupplierWithException<IS, Exception>> stateFactories;
+
+    private LatencyTrackingStateFactory(
+            InternalKvState<K, N, ?> kvState,
             StateDescriptor<S, V> stateDescriptor,
             LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        this.kvState = kvState;
+        this.stateDescriptor = stateDescriptor;
+        this.latencyTrackingStateConfig = latencyTrackingStateConfig;
+        this.stateFactories = createStateFactories();
+    }
+
+    /** Create latency tracking state if enabled. */
+    public static <K, N, V, S extends State>
+            InternalKvState<K, N, ?> createStateAndWrapWithLatencyTrackingIfEnabled(
+                    InternalKvState<K, N, ?> kvState,
+                    StateDescriptor<S, V> stateDescriptor,
+                    LatencyTrackingStateConfig latencyTrackingStateConfig)
+                    throws Exception {
+        if (latencyTrackingStateConfig.isEnabled()) {
+            return new LatencyTrackingStateFactory<>(
+                            kvState, stateDescriptor, latencyTrackingStateConfig)
+                    .createState();
+        }
         return kvState;
+    }
+
+    private Map<StateDescriptor.Type, SupplierWithException<IS, Exception>> createStateFactories() {
+        return Stream.of(
+                        Tuple2.of(
+                                StateDescriptor.Type.VALUE,
+                                (SupplierWithException<IS, Exception>) this::createValueState),
+                        Tuple2.of(
+                                StateDescriptor.Type.LIST,
+                                (SupplierWithException<IS, Exception>) this::createListState),
+                        Tuple2.of(
+                                StateDescriptor.Type.MAP,
+                                (SupplierWithException<IS, Exception>) this::createMapState),
+                        Tuple2.of(
+                                StateDescriptor.Type.REDUCING,
+                                (SupplierWithException<IS, Exception>) this::createReducingState),
+                        Tuple2.of(
+                                StateDescriptor.Type.AGGREGATING,
+                                (SupplierWithException<IS, Exception>)
+                                        this::createAggregatingState))
+                .collect(Collectors.toMap(t -> t.f0, t -> t.f1));
+    }
+
+    private IS createState() throws Exception {
+        SupplierWithException<IS, Exception> stateFactory =
+                stateFactories.get(stateDescriptor.getType());
+        if (stateFactory == null) {
+            String message =
+                    String.format(
+                            "State %s is not supported by %s",
+                            stateDescriptor.getClass(), LatencyTrackingStateFactory.class);
+            throw new FlinkRuntimeException(message);
+        }
+        return stateFactory.get();
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private IS createValueState() {
+        return (IS)
+                new LatencyTrackingValueState<>(
+                        stateDescriptor.getName(),
+                        (InternalValueState<K, N, V>) kvState,
+                        latencyTrackingStateConfig);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private IS createListState() {
+        return (IS)
+                new LatencyTrackingListState<>(
+                        stateDescriptor.getName(),
+                        (InternalListState<K, N, V>) kvState,
+                        latencyTrackingStateConfig);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <UK, UV> IS createMapState() {
+        return (IS)
+                new LatencyTrackingMapState<>(
+                        stateDescriptor.getName(),
+                        (InternalMapState<K, N, UK, UV>) kvState,
+                        latencyTrackingStateConfig);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private IS createReducingState() {
+        return (IS)
+                new LatencyTrackingReducingState<>(
+                        stateDescriptor.getName(),
+                        (InternalReducingState<K, N, V>) kvState,
+                        latencyTrackingStateConfig);
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private <IN, SV, OUT> IS createAggregatingState() {
+        return (IS)
+                new LatencyTrackingAggregatingState<>(
+                        stateDescriptor.getName(),
+                        (InternalAggregatingState<K, N, IN, SV, OUT>) kvState,
+                        latencyTrackingStateConfig);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+
+/** Factory to create {@link AbstractLatencyTrackState}. */
+public class LatencyTrackingStateFactory {
+
+    @SuppressWarnings("unchecked")
+    public static <K, N, S extends State, V> InternalKvState<K, ?, ?> trackLatencyIfEnabled(
+            InternalKvState<K, ?, ?> kvState,
+            StateDescriptor<S, V> stateDescriptor,
+            LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        return kvState;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/LatencyTrackingValueState.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+import java.io.IOException;
+
+/**
+ * This class wraps value state with latency tracking logic.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <N> The type of the namespace
+ * @param <T> Type of the user value of state
+ */
+class LatencyTrackingValueState<K, N, T>
+        extends AbstractLatencyTrackState<
+                K,
+                N,
+                T,
+                InternalValueState<K, N, T>,
+                LatencyTrackingValueState.ValueStateLatencyMetrics>
+        implements InternalValueState<K, N, T> {
+
+    public LatencyTrackingValueState(
+            String stateName,
+            InternalValueState<K, N, T> original,
+            LatencyTrackingStateConfig latencyTrackingStateConfig) {
+        super(
+                original,
+                new ValueStateLatencyMetrics(
+                        stateName,
+                        latencyTrackingStateConfig.getMetricGroup(),
+                        latencyTrackingStateConfig.getSampleInterval(),
+                        latencyTrackingStateConfig.getHistorySize()));
+    }
+
+    @Override
+    public T value() throws IOException {
+        if (latencyTrackingStateMetric.trackLatencyOnGet()) {
+            return trackLatencyWithIOException(
+                    () -> original.value(), ValueStateLatencyMetrics.VALUE_STATE_GET_LATENCY);
+        } else {
+            return original.value();
+        }
+    }
+
+    @Override
+    public void update(T value) throws IOException {
+        if (latencyTrackingStateMetric.trackLatencyOnUpdate()) {
+            trackLatencyWithIOException(
+                    () -> original.update(value),
+                    ValueStateLatencyMetrics.VALUE_STATE_UPDATE_LATENCY);
+        } else {
+            original.update(value);
+        }
+    }
+
+    static class ValueStateLatencyMetrics extends StateLatencyMetricBase {
+        private static final String VALUE_STATE_GET_LATENCY = "valueStateGetLatency";
+        private static final String VALUE_STATE_UPDATE_LATENCY = "valueStateUpdateLatency";
+
+        private int getCount = 0;
+        private int updateCount = 0;
+
+        private ValueStateLatencyMetrics(
+                String stateName, MetricGroup metricGroup, int sampleInterval, int historySize) {
+            super(stateName, metricGroup, sampleInterval, historySize);
+        }
+
+        int getGetCount() {
+            return getCount;
+        }
+
+        int getUpdateCount() {
+            return updateCount;
+        }
+
+        private boolean trackLatencyOnGet() {
+            getCount = loopUpdateCounter(getCount);
+            return getCount == 1;
+        }
+
+        private boolean trackLatencyOnUpdate() {
+            updateCount = loopUpdateCounter(updateCount);
+            return updateCount == 1;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/StateLatencyMetricBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metrics/StateLatencyMetricBase.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Base class of state latency metric which counts and histogram the state metric. */
+class StateLatencyMetricBase implements AutoCloseable {
+    protected static final String STATE_CLEAR_LATENCY = "stateClearLatency";
+    private final MetricGroup metricGroup;
+    private final int sampleInterval;
+    private final Map<String, Histogram> histogramMetrics;
+    private final Supplier<Histogram> histogramSupplier;
+    private int clearCount = 0;
+
+    StateLatencyMetricBase(
+            String stateName, MetricGroup metricGroup, int sampleInterval, int historySize) {
+        this.metricGroup = metricGroup.addGroup(stateName);
+        this.sampleInterval = sampleInterval;
+        this.histogramMetrics = new HashMap<>();
+        this.histogramSupplier = () -> new DescriptiveStatisticsHistogram(historySize);
+    }
+
+    int getClearCount() {
+        return clearCount;
+    }
+
+    protected boolean trackLatencyOnClear() {
+        clearCount = loopUpdateCounter(clearCount);
+        return clearCount == 1;
+    }
+
+    protected int loopUpdateCounter(int counter) {
+        return (counter + 1 < sampleInterval) ? counter + 1 : 0;
+    }
+
+    protected void updateLatency(String latencyLabel, long duration) {
+        updateHistogram(latencyLabel, duration);
+    }
+
+    private void updateHistogram(final String metricName, final long durationNanoTime) {
+        this.histogramMetrics
+                .computeIfAbsent(
+                        metricName,
+                        (k) -> {
+                            Histogram histogram = histogramSupplier.get();
+                            metricGroup.histogram(metricName, histogram);
+                            return histogram;
+                        })
+                .update(durationNanoTime);
+    }
+
+    @Override
+    public void close() throws Exception {
+        histogramMetrics.clear();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
@@ -54,7 +55,7 @@ public class StateBackendLoadingTest {
 
     private final ClassLoader cl = getClass().getClassLoader();
 
-    private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
+    private final String backendKey = StateBackendOptions.STATE_BACKEND.key();
 
     // ------------------------------------------------------------------------
     //  defaults

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.heap.HeapKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.TestLogger;
 
@@ -106,6 +107,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
                         new KeyGroupRange(0, 15),
                         executionConfig,
                         TtlTimeProvider.DEFAULT,
+                        LatencyTrackingStateConfig.disabled(),
                         stateHandles,
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
                         TestLocalRecoveryConfig.disabled(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import org.junit.runner.RunWith;
@@ -67,6 +68,7 @@ public abstract class HeapStateBackendTestBase {
                         keyGroupRange,
                         executionConfig,
                         TtlTimeProvider.DEFAULT,
+                        LatencyTrackingStateConfig.disabled(),
                         stateHandles,
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
                         TestLocalRecoveryConfig.disabled(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingAggregatingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingAggregatingStateTest.java
@@ -1,0 +1,119 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link LatencyTrackingAggregatingState}. */
+public class LatencyTrackingAggregatingStateTest extends LatencyTrackingStateTestBase<Integer> {
+    @Override
+    @SuppressWarnings("unchecked")
+    AggregatingStateDescriptor<Long, Long, Long> getStateDescriptor() {
+        return new AggregatingStateDescriptor<>(
+                "aggregate",
+                new AggregateFunction<Long, Long, Long>() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Long createAccumulator() {
+                        return 0L;
+                    }
+
+                    @Override
+                    public Long add(Long value, Long accumulator) {
+                        return value + accumulator;
+                    }
+
+                    @Override
+                    public Long getResult(Long accumulator) {
+                        return accumulator;
+                    }
+
+                    @Override
+                    public Long merge(Long a, Long b) {
+                        return a + b;
+                    }
+                },
+                Long.class);
+    }
+
+    @Override
+    TypeSerializer<Integer> getKeySerializer() {
+        return IntSerializer.INSTANCE;
+    }
+
+    @Override
+    void setCurrentKey(AbstractKeyedStateBackend<Integer> keyedBackend) {
+        keyedBackend.setCurrentKey(1);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testLatencyTrackingAggregatingState() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            LatencyTrackingAggregatingState<Integer, VoidNamespace, Long, Long, Long>
+                    latencyTrackingState =
+                            (LatencyTrackingAggregatingState)
+                                    createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            LatencyTrackingAggregatingState.AggregatingStateLatencyMetrics
+                    latencyTrackingStateMetric =
+                            latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertEquals(0, latencyTrackingStateMetric.getAddCount());
+            assertEquals(0, latencyTrackingStateMetric.getGetCount());
+            assertEquals(0, latencyTrackingStateMetric.getMergeNamespaceCount());
+
+            setCurrentKey(keyedBackend);
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+                latencyTrackingState.add(random.nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getAddCount());
+
+                latencyTrackingState.get();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getGetCount());
+
+                latencyTrackingState.mergeNamespaces(
+                        VoidNamespace.INSTANCE, Collections.emptyList());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getMergeNamespaceCount());
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingListStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingListStateTest.java
@@ -1,0 +1,100 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link LatencyTrackingListState}. */
+public class LatencyTrackingListStateTest extends LatencyTrackingStateTestBase<Integer> {
+    @Override
+    @SuppressWarnings("unchecked")
+    ListStateDescriptor<Long> getStateDescriptor() {
+        return new ListStateDescriptor<>("list", Long.class);
+    }
+
+    @Override
+    TypeSerializer<Integer> getKeySerializer() {
+        return IntSerializer.INSTANCE;
+    }
+
+    @Override
+    void setCurrentKey(AbstractKeyedStateBackend<Integer> keyedBackend) {
+        keyedBackend.setCurrentKey(1);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testLatencyTrackingListState() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            LatencyTrackingListState<Integer, VoidNamespace, Long> latencyTrackingState =
+                    (LatencyTrackingListState)
+                            createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            LatencyTrackingListState.ListStateLatencyMetrics latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertEquals(0, latencyTrackingStateMetric.getAddCount());
+            assertEquals(0, latencyTrackingStateMetric.getAddAllCount());
+            assertEquals(0, latencyTrackingStateMetric.getGetCount());
+            assertEquals(0, latencyTrackingStateMetric.getUpdateCount());
+            assertEquals(0, latencyTrackingStateMetric.getMergeNamespaceCount());
+
+            setCurrentKey(keyedBackend);
+            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+                latencyTrackingState.add(ThreadLocalRandom.current().nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getAddCount());
+
+                latencyTrackingState.addAll(
+                        Collections.singletonList(ThreadLocalRandom.current().nextLong()));
+                assertEquals(expectedResult, latencyTrackingStateMetric.getAddAllCount());
+
+                latencyTrackingState.update(
+                        Collections.singletonList(ThreadLocalRandom.current().nextLong()));
+                assertEquals(expectedResult, latencyTrackingStateMetric.getUpdateCount());
+
+                latencyTrackingState.get();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getGetCount());
+
+                latencyTrackingState.mergeNamespaces(
+                        VoidNamespace.INSTANCE, Collections.emptyList());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getMergeNamespaceCount());
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingMapStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingMapStateTest.java
@@ -1,0 +1,195 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link LatencyTrackingMapState}. */
+public class LatencyTrackingMapStateTest extends LatencyTrackingStateTestBase<Integer> {
+    @Override
+    @SuppressWarnings("unchecked")
+    MapStateDescriptor<Integer, Double> getStateDescriptor() {
+        return new MapStateDescriptor<>("map", Integer.class, Double.class);
+    }
+
+    @Override
+    TypeSerializer<Integer> getKeySerializer() {
+        return IntSerializer.INSTANCE;
+    }
+
+    @Override
+    void setCurrentKey(AbstractKeyedStateBackend<Integer> keyedBackend) {
+        keyedBackend.setCurrentKey(1);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testLatencyTrackingMapState() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            LatencyTrackingMapState<Integer, VoidNamespace, Long, Double> latencyTrackingState =
+                    (LatencyTrackingMapState)
+                            createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            LatencyTrackingMapState.MapStateLatencyMetrics latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertEquals(0, latencyTrackingStateMetric.getContainsCount());
+            assertEquals(0, latencyTrackingStateMetric.getEntriesInitCount());
+            assertEquals(0, latencyTrackingStateMetric.getGetCount());
+            assertEquals(0, latencyTrackingStateMetric.getIsEmptyCount());
+            assertEquals(0, latencyTrackingStateMetric.getIteratorInitCount());
+            assertEquals(0, latencyTrackingStateMetric.getIteratorHasNextCount());
+            assertEquals(0, latencyTrackingStateMetric.getIteratorNextCount());
+            assertEquals(0, latencyTrackingStateMetric.getKeysInitCount());
+            assertEquals(0, latencyTrackingStateMetric.getValuesInitCount());
+            assertEquals(0, latencyTrackingStateMetric.getIteratorRemoveCount());
+            assertEquals(0, latencyTrackingStateMetric.getPutAllCount());
+            assertEquals(0, latencyTrackingStateMetric.getPutCount());
+            assertEquals(0, latencyTrackingStateMetric.getRemoveCount());
+
+            setCurrentKey(keyedBackend);
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+                latencyTrackingState.put(random.nextLong(), random.nextDouble());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getPutCount());
+
+                latencyTrackingState.putAll(
+                        Collections.singletonMap(random.nextLong(), random.nextDouble()));
+                assertEquals(expectedResult, latencyTrackingStateMetric.getPutAllCount());
+
+                latencyTrackingState.get(random.nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getGetCount());
+
+                latencyTrackingState.remove(random.nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getRemoveCount());
+
+                latencyTrackingState.contains(random.nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getContainsCount());
+
+                latencyTrackingState.isEmpty();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getIsEmptyCount());
+
+                latencyTrackingState.entries();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getEntriesInitCount());
+
+                latencyTrackingState.keys();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getKeysInitCount());
+
+                latencyTrackingState.values();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getValuesInitCount());
+
+                latencyTrackingState.iterator();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getIteratorInitCount());
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testLatencyTrackingMapStateIterator() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            LatencyTrackingMapState<Integer, VoidNamespace, Long, Double> latencyTrackingState =
+                    (LatencyTrackingMapState)
+                            createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            LatencyTrackingMapState.MapStateLatencyMetrics latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            setCurrentKey(keyedBackend);
+
+            verifyIterator(
+                    latencyTrackingState,
+                    latencyTrackingStateMetric,
+                    latencyTrackingState.iterator(),
+                    true);
+            verifyIterator(
+                    latencyTrackingState,
+                    latencyTrackingStateMetric,
+                    latencyTrackingState.entries().iterator(),
+                    true);
+            verifyIterator(
+                    latencyTrackingState,
+                    latencyTrackingStateMetric,
+                    latencyTrackingState.keys().iterator(),
+                    false);
+            verifyIterator(
+                    latencyTrackingState,
+                    latencyTrackingStateMetric,
+                    latencyTrackingState.values().iterator(),
+                    false);
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+
+    private <E> void verifyIterator(
+            LatencyTrackingMapState<Integer, VoidNamespace, Long, Double> latencyTrackingState,
+            LatencyTrackingMapState.MapStateLatencyMetrics latencyTrackingStateMetric,
+            Iterator<E> iterator,
+            boolean removeIterator)
+            throws Exception {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+            latencyTrackingState.put((long) index, random.nextDouble());
+        }
+        int count = 1;
+        while (iterator.hasNext()) {
+            int expectedResult = count == SAMPLE_INTERVAL ? 0 : count;
+            assertEquals(expectedResult, latencyTrackingStateMetric.getIteratorHasNextCount());
+
+            iterator.next();
+            assertEquals(expectedResult, latencyTrackingStateMetric.getIteratorNextCount());
+
+            if (removeIterator) {
+                iterator.remove();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getIteratorRemoveCount());
+            }
+            count += 1;
+        }
+        // as we call #hasNext on more time than #next, to avoid complex check, just reset hasNext
+        // counter in the end.
+        latencyTrackingStateMetric.resetIteratorHasNextCount();
+        latencyTrackingState.clear();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingReducingStateTest.java
@@ -1,0 +1,91 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link LatencyTrackingReducingState}. */
+public class LatencyTrackingReducingStateTest extends LatencyTrackingStateTestBase<Integer> {
+    @Override
+    @SuppressWarnings("unchecked")
+    ReducingStateDescriptor<Long> getStateDescriptor() {
+        return new ReducingStateDescriptor<>("reducing", Long::sum, Long.class);
+    }
+
+    @Override
+    TypeSerializer<Integer> getKeySerializer() {
+        return IntSerializer.INSTANCE;
+    }
+
+    @Override
+    void setCurrentKey(AbstractKeyedStateBackend<Integer> keyedBackend) {
+        keyedBackend.setCurrentKey(1);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testLatencyTrackingReducingState() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            LatencyTrackingReducingState<Integer, VoidNamespace, Long> latencyTrackingState =
+                    (LatencyTrackingReducingState)
+                            createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            LatencyTrackingReducingState.ReducingStateLatencyMetrics latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertEquals(0, latencyTrackingStateMetric.getAddCount());
+            assertEquals(0, latencyTrackingStateMetric.getGetCount());
+            assertEquals(0, latencyTrackingStateMetric.getMergeNamespaceCount());
+
+            setCurrentKey(keyedBackend);
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+                latencyTrackingState.add(random.nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getAddCount());
+
+                latencyTrackingState.get();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getGetCount());
+
+                latencyTrackingState.mergeNamespaces(
+                        VoidNamespace.INSTANCE, Collections.emptyList());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getMergeNamespaceCount());
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link LatencyTrackingStateConfig}. */
+public class LatencyTrackingStateConfigTest {
+
+    @Test
+    public void testDefaultDisabledLatencyTrackingStateConfig() {
+        LatencyTrackingStateConfig latencyTrackingStateConfig =
+                LatencyTrackingStateConfig.newBuilder().build();
+        Assert.assertFalse(latencyTrackingStateConfig.isEnabled());
+    }
+
+    @Test
+    public void testDefaultEnabledLatencyTrackingStateConfig() {
+        UnregisteredMetricsGroup metricsGroup = new UnregisteredMetricsGroup();
+        LatencyTrackingStateConfig latencyTrackingStateConfig =
+                LatencyTrackingStateConfig.newBuilder()
+                        .setEnabled(true)
+                        .setMetricGroup(metricsGroup)
+                        .build();
+        Assert.assertTrue(latencyTrackingStateConfig.isEnabled());
+        Assert.assertEquals(
+                (int) StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL.defaultValue(),
+                latencyTrackingStateConfig.getSampleInterval());
+        Assert.assertEquals(
+                (long) StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE.defaultValue(),
+                latencyTrackingStateConfig.getHistorySize());
+    }
+
+    @Test
+    public void testSetLatencyTrackingStateConfig() {
+        UnregisteredMetricsGroup metricsGroup = new UnregisteredMetricsGroup();
+        LatencyTrackingStateConfig latencyTrackingStateConfig =
+                LatencyTrackingStateConfig.newBuilder()
+                        .setMetricGroup(metricsGroup)
+                        .setEnabled(true)
+                        .setSampleInterval(10)
+                        .setHistorySize(500)
+                        .build();
+        Assert.assertTrue(latencyTrackingStateConfig.isEnabled());
+        Assert.assertEquals(10, latencyTrackingStateConfig.getSampleInterval());
+        Assert.assertEquals(500L, latencyTrackingStateConfig.getHistorySize());
+    }
+
+    @Test
+    public void testConfigureFromReadableConfig() {
+        LatencyTrackingStateConfig.Builder builder = LatencyTrackingStateConfig.newBuilder();
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.setInteger(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, 10);
+        configuration.setInteger(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, 500);
+        LatencyTrackingStateConfig latencyTrackingStateConfig =
+                builder.configure(configuration)
+                        .setMetricGroup(new UnregisteredMetricsGroup())
+                        .build();
+        Assert.assertTrue(latencyTrackingStateConfig.isEnabled());
+        Assert.assertEquals(10, latencyTrackingStateConfig.getSampleInterval());
+        Assert.assertEquals(500, latencyTrackingStateConfig.getHistorySize());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateFactoryTest.java
@@ -1,0 +1,174 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
+
+/** Tests for {@link LatencyTrackingStateFactory}. */
+@RunWith(Parameterized.class)
+public class LatencyTrackingStateFactoryTest {
+
+    @Parameterized.Parameter public boolean enableLatencyTracking;
+
+    @Parameters(name = "enable latency tracking: {0}")
+    public static Collection<Boolean> enabled() {
+        return Arrays.asList(true, false);
+    }
+
+    private LatencyTrackingStateConfig getLatencyTrackingStateConfig() {
+        UnregisteredMetricsGroup metricsGroup = new UnregisteredMetricsGroup();
+        return LatencyTrackingStateConfig.newBuilder()
+                .setEnabled(enableLatencyTracking)
+                .setMetricGroup(metricsGroup)
+                .build();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public <K, N> void testTrackValueState() throws Exception {
+        InternalValueState<K, N, String> valueState = mock(InternalValueState.class);
+        ValueStateDescriptor<String> valueStateDescriptor =
+                new ValueStateDescriptor<>("value", String.class);
+        InternalKvState<K, ?, ?> latencyTrackingState =
+                LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
+                        valueState, valueStateDescriptor, getLatencyTrackingStateConfig());
+        if (enableLatencyTracking) {
+            Assert.assertTrue(latencyTrackingState instanceof LatencyTrackingValueState);
+        } else {
+            Assert.assertEquals(valueState, latencyTrackingState);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public <K, N> void testTrackListState() throws Exception {
+        InternalListState<K, N, String> listState = mock(InternalListState.class);
+        ListStateDescriptor<String> listStateDescriptor =
+                new ListStateDescriptor<>("list", String.class);
+        InternalKvState<K, N, ?> latencyTrackingState =
+                LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
+                        listState, listStateDescriptor, getLatencyTrackingStateConfig());
+        if (enableLatencyTracking) {
+            Assert.assertTrue(latencyTrackingState instanceof LatencyTrackingListState);
+        } else {
+            Assert.assertEquals(listState, latencyTrackingState);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public <K, N> void testTrackMapState() throws Exception {
+        InternalMapState<K, N, String, Long> mapState = mock(InternalMapState.class);
+        MapStateDescriptor<String, Long> mapStateDescriptor =
+                new MapStateDescriptor<>("map", String.class, Long.class);
+        InternalKvState<K, N, ?> latencyTrackingState =
+                LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
+                        mapState, mapStateDescriptor, getLatencyTrackingStateConfig());
+        if (enableLatencyTracking) {
+            Assert.assertTrue(latencyTrackingState instanceof LatencyTrackingMapState);
+        } else {
+            Assert.assertEquals(mapState, latencyTrackingState);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public <K, N> void testTrackReducingState() throws Exception {
+        InternalReducingState<K, N, Long> reducingState = mock(InternalReducingState.class);
+        ReducingStateDescriptor<Long> reducingStateDescriptor =
+                new ReducingStateDescriptor<>("reducing", Long::sum, Long.class);
+        InternalKvState<K, N, ?> latencyTrackingState =
+                LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
+                        reducingState, reducingStateDescriptor, getLatencyTrackingStateConfig());
+        if (enableLatencyTracking) {
+            Assert.assertTrue(latencyTrackingState instanceof LatencyTrackingReducingState);
+        } else {
+            Assert.assertEquals(reducingState, latencyTrackingState);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public <K, N> void testTrackAggregatingState() throws Exception {
+        InternalAggregatingState<K, N, Long, Long, Long> aggregatingState =
+                mock(InternalAggregatingState.class);
+        AggregatingStateDescriptor<Long, Long, Long> aggregatingStateDescriptor =
+                new AggregatingStateDescriptor<>(
+                        "aggregate",
+                        new AggregateFunction<Long, Long, Long>() {
+                            private static final long serialVersionUID = 1L;
+
+                            @Override
+                            public Long createAccumulator() {
+                                return 0L;
+                            }
+
+                            @Override
+                            public Long add(Long value, Long accumulator) {
+                                return value + accumulator;
+                            }
+
+                            @Override
+                            public Long getResult(Long accumulator) {
+                                return accumulator;
+                            }
+
+                            @Override
+                            public Long merge(Long a, Long b) {
+                                return a + b;
+                            }
+                        },
+                        Long.class);
+        InternalKvState<K, N, ?> latencyTrackingState =
+                LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
+                        aggregatingState,
+                        aggregatingStateDescriptor,
+                        getLatencyTrackingStateConfig());
+        if (enableLatencyTracking) {
+            Assert.assertTrue(latencyTrackingState instanceof LatencyTrackingAggregatingState);
+        } else {
+            Assert.assertEquals(aggregatingState, latencyTrackingState);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateTestBase.java
@@ -1,0 +1,133 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test base for latency tracking state. */
+public abstract class LatencyTrackingStateTestBase<K> {
+    protected static final int SAMPLE_INTERVAL = 10;
+
+    protected AbstractKeyedStateBackend<K> createKeyedBackend(TypeSerializer<K> keySerializer)
+            throws Exception {
+
+        Environment env = new DummyEnvironment();
+        KeyGroupRange keyGroupRange = new KeyGroupRange(0, 127);
+        int numberOfKeyGroups = keyGroupRange.getNumberOfKeyGroups();
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.setInteger(
+                StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
+        // use a very large value to not let metrics data overridden.
+        int historySize = 1000_000;
+        configuration.setInteger(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, historySize);
+        HashMapStateBackend stateBackend =
+                new HashMapStateBackend()
+                        .configure(configuration, Thread.currentThread().getContextClassLoader());
+        return stateBackend.createKeyedStateBackend(
+                env,
+                new JobID(),
+                "test_op",
+                keySerializer,
+                numberOfKeyGroups,
+                keyGroupRange,
+                env.getTaskKvStateRegistry(),
+                TtlTimeProvider.DEFAULT,
+                new UnregisteredMetricsGroup(),
+                Collections.emptyList(),
+                new CloseableRegistry());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <
+                    N,
+                    V,
+                    S extends InternalKvState<K, N, V>,
+                    S2 extends State,
+                    LSM extends StateLatencyMetricBase>
+            AbstractLatencyTrackState<K, N, V, S, LSM> createLatencyTrackingState(
+                    AbstractKeyedStateBackend<K> keyedBackend,
+                    StateDescriptor<S2, V> stateDescriptor)
+                    throws Exception {
+
+        S2 keyedState =
+                keyedBackend.getOrCreateKeyedState(
+                        VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+        Preconditions.checkState(keyedState instanceof AbstractLatencyTrackState);
+        return (AbstractLatencyTrackState<K, N, V, S, LSM>) keyedState;
+    }
+
+    abstract <V, S extends State> StateDescriptor<S, V> getStateDescriptor();
+
+    abstract TypeSerializer<K> getKeySerializer();
+
+    abstract void setCurrentKey(AbstractKeyedStateBackend<K> keyedBackend);
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testLatencyTrackingStateClear() throws Exception {
+        AbstractKeyedStateBackend<K> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            AbstractLatencyTrackState latencyTrackingState =
+                    createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            StateLatencyMetricBase latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertEquals(0, latencyTrackingStateMetric.getClearCount());
+
+            setCurrentKey(keyedBackend);
+            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+                latencyTrackingState.clear();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getClearCount());
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingValueStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingValueStateTest.java
@@ -1,0 +1,83 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+*/
+
+package org.apache.flink.runtime.state.metrics;
+
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+
+import org.junit.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link LatencyTrackingValueState}. */
+public class LatencyTrackingValueStateTest extends LatencyTrackingStateTestBase<Integer> {
+    @Override
+    @SuppressWarnings("unchecked")
+    ValueStateDescriptor<Long> getStateDescriptor() {
+        return new ValueStateDescriptor<>("value", Long.class);
+    }
+
+    @Override
+    IntSerializer getKeySerializer() {
+        return IntSerializer.INSTANCE;
+    }
+
+    @Override
+    void setCurrentKey(AbstractKeyedStateBackend<Integer> keyedBackend) {
+        keyedBackend.setCurrentKey(1);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testLatencyTrackingValueState() throws Exception {
+        AbstractKeyedStateBackend<Integer> keyedBackend = createKeyedBackend(getKeySerializer());
+        try {
+            LatencyTrackingValueState<Integer, VoidNamespace, Long> latencyTrackingState =
+                    (LatencyTrackingValueState)
+                            createLatencyTrackingState(keyedBackend, getStateDescriptor());
+            latencyTrackingState.setCurrentNamespace(VoidNamespace.INSTANCE);
+            LatencyTrackingValueState.ValueStateLatencyMetrics latencyTrackingStateMetric =
+                    latencyTrackingState.getLatencyTrackingStateMetric();
+
+            assertEquals(0, latencyTrackingStateMetric.getUpdateCount());
+            assertEquals(0, latencyTrackingStateMetric.getGetCount());
+
+            setCurrentKey(keyedBackend);
+            for (int index = 1; index <= SAMPLE_INTERVAL; index++) {
+                int expectedResult = index == SAMPLE_INTERVAL ? 0 : index;
+                latencyTrackingState.update(ThreadLocalRandom.current().nextLong());
+                assertEquals(expectedResult, latencyTrackingStateMetric.getUpdateCount());
+
+                latencyTrackingState.value();
+                assertEquals(expectedResult, latencyTrackingStateMetric.getGetCount());
+            }
+        } finally {
+            if (keyedBackend != null) {
+                keyedBackend.close();
+                keyedBackend.dispose();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.state.StateSnapshotTransformers;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlStateFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -103,6 +104,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             ClassLoader userCodeClassLoader,
             ExecutionConfig executionConfig,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             Map<String, Map<K, Map<Object, Object>>> stateValues,
             Map<String, StateSnapshotTransformer<Object>> stateSnapshotFilters,
             CloseableRegistry cancelStreamRegistry,
@@ -113,6 +115,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                 userCodeClassLoader,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 cancelStreamRegistry,
                 keyContext);
         this.stateValues = stateValues;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackendBuilder.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
@@ -50,6 +51,7 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
             KeyGroupRange keyGroupRange,
             ExecutionConfig executionConfig,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             StreamCompressionDecorator keyGroupCompressionDecorator,
             CloseableRegistry cancelStreamRegistry) {
@@ -61,6 +63,7 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 keyGroupRange,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 stateHandles,
                 keyGroupCompressionDecorator,
                 cancelStreamRegistry);
@@ -79,6 +82,7 @@ public class MockKeyedStateBackendBuilder<K> extends AbstractKeyedStateBackendBu
                 userCodeClassLoader,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 stateValues,
                 stateSnapshotFilters,
                 cancelStreamRegistry,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import javax.annotation.Nonnull;
@@ -63,6 +64,7 @@ public class MockStateBackend extends AbstractStateBackend {
                         keyGroupRange,
                         env.getExecutionConfig(),
                         ttlTimeProvider,
+                        LatencyTrackingStateConfig.disabled(),
                         stateHandles,
                         AbstractStateBackend.getCompressionDecorator(env.getExecutionConfig()),
                         cancelStreamRegistry)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import org.slf4j.Logger;
@@ -80,7 +81,7 @@ public class ZooKeeperTestUtils {
         config.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, connTimeout);
 
         // File system state backend
-        config.setString(CheckpointingOptions.STATE_BACKEND, "FILESYSTEM");
+        config.setString(StateBackendOptions.STATE_BACKEND, "FILESYSTEM");
         config.setString(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY, fsStateHandlePath + "/checkpoints");
         config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, fsStateHandlePath + "/recovery");

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.TestableKeyedStateBackend;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateFactory;
 import org.apache.flink.runtime.state.ttl.TtlStateFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -297,8 +298,11 @@ class ChangelogKeyedStateBackend<K>
                 stateDescriptor.initializeSerializerUnlessSet(executionConfig);
             }
             kvState =
-                    TtlStateFactory.createStateAndWrapWithTtlIfEnabled(
-                            namespaceSerializer, stateDescriptor, this, ttlTimeProvider);
+                    LatencyTrackingStateFactory.createStateAndWrapWithLatencyTrackingIfEnabled(
+                            TtlStateFactory.createStateAndWrapWithTtlIfEnabled(
+                                    namespaceSerializer, stateDescriptor, this, ttlTimeProvider),
+                            stateDescriptor,
+                            keyedStateBackend.getLatencyTrackingStateConfig());
             keyValueStatesByName.put(stateDescriptor.getName(), kvState);
             keyedStateBackend.publishQueryableStateIfEnabled(stateDescriptor, kvState);
         }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
@@ -65,7 +66,7 @@ public class ChangelogStateBackendLoadingTest {
 
     private final ClassLoader cl = getClass().getClassLoader();
 
-    private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
+    private final String backendKey = StateBackendOptions.STATE_BACKEND.key();
 
     @Test
     public void testLoadingDefault() throws Exception {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -242,6 +243,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             TypeSerializer<K> keySerializer,
             ExecutionConfig executionConfig,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             RocksDB db,
             LinkedHashMap<String, RocksDbKvStateInfo> kvStateInformation,
             Map<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
@@ -265,6 +267,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                 userCodeClassLoader,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 cancelStreamRegistry,
                 keyGroupCompressionDecorator,
                 keyContext);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
@@ -134,6 +135,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
             LocalRecoveryConfig localRecoveryConfig,
             EmbeddedRocksDBStateBackend.PriorityQueueStateType priorityQueueStateType,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             StreamCompressionDecorator keyGroupCompressionDecorator,
@@ -147,6 +149,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                 keyGroupRange,
                 executionConfig,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 stateHandles,
                 keyGroupCompressionDecorator,
                 cancelStreamRegistry);
@@ -181,6 +184,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
             LocalRecoveryConfig localRecoveryConfig,
             EmbeddedRocksDBStateBackend.PriorityQueueStateType priorityQueueStateType,
             TtlTimeProvider ttlTimeProvider,
+            LatencyTrackingStateConfig latencyTrackingStateConfig,
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             StreamCompressionDecorator keyGroupCompressionDecorator,
@@ -201,6 +205,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                 localRecoveryConfig,
                 priorityQueueStateType,
                 ttlTimeProvider,
+                latencyTrackingStateConfig,
                 metricGroup,
                 stateHandles,
                 keyGroupCompressionDecorator,
@@ -384,6 +389,7 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                 this.keySerializerProvider.currentSchemaSerializer(),
                 this.executionConfig,
                 this.ttlTimeProvider,
+                latencyTrackingStateConfig,
                 db,
                 kvStateInformation,
                 registeredPQStates,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
 
@@ -42,7 +43,7 @@ public class RocksDBStateBackendFactoryTest {
 
     private final ClassLoader cl = getClass().getClassLoader();
 
-    private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
+    private final String backendKey = StateBackendOptions.STATE_BACKEND.key();
 
     // ------------------------------------------------------------------------
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import org.rocksdb.ColumnFamilyHandle;
@@ -72,6 +73,7 @@ public final class RocksDBTestUtils {
                 TestLocalRecoveryConfig.disabled(),
                 queueStateType,
                 TtlTimeProvider.DEFAULT,
+                LatencyTrackingStateConfig.disabled(),
                 new UnregisteredMetricsGroup(),
                 Collections.emptyList(),
                 UncompressedStreamCompressionDecorator.INSTANCE,
@@ -101,6 +103,7 @@ public final class RocksDBTestUtils {
                 TestLocalRecoveryConfig.disabled(),
                 EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP,
                 TtlTimeProvider.DEFAULT,
+                LatencyTrackingStateConfig.disabled(),
                 new UnregisteredMetricsGroup(),
                 Collections.emptyList(),
                 UncompressedStreamCompressionDecorator.INSTANCE,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionStateBackend;
 import org.apache.flink.util.IOUtils;
@@ -122,6 +123,7 @@ public class StateBackendBenchmarkUtils {
                                         recoveryBaseDir, new JobID(), new JobVertexID(), 0)),
                         EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB,
                         TtlTimeProvider.DEFAULT,
+                        LatencyTrackingStateConfig.disabled(),
                         new UnregisteredMetricsGroup(),
                         Collections.emptyList(),
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
@@ -151,6 +153,7 @@ public class StateBackendBenchmarkUtils {
                         keyGroupRange,
                         executionConfig,
                         TtlTimeProvider.DEFAULT,
+                        LatencyTrackingStateConfig.disabled(),
                         Collections.emptyList(),
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
                         new LocalRecoveryConfig(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -433,7 +434,7 @@ public class StreamTaskTest extends TestLogger {
     public void testStateBackendLoadingAndClosing() throws Exception {
         Configuration taskManagerConfig = new Configuration();
         taskManagerConfig.setString(
-                CheckpointingOptions.STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
+                StateBackendOptions.STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
 
         StreamConfig cfg = new StreamConfig(new Configuration());
         cfg.setStateKeySerializer(mock(TypeSerializer.class));
@@ -474,7 +475,7 @@ public class StreamTaskTest extends TestLogger {
     public void testStateBackendClosingOnFailure() throws Exception {
         Configuration taskManagerConfig = new Configuration();
         taskManagerConfig.setString(
-                CheckpointingOptions.STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
+                StateBackendOptions.STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
 
         StreamConfig cfg = new StreamConfig(new Configuration());
         cfg.setStateKeySerializer(mock(TypeSerializer.class));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.StateBackendOptions;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -123,7 +124,7 @@ public class RescalingITCase extends TestLogger {
             final File checkpointDir = temporaryFolder.newFolder();
             final File savepointDir = temporaryFolder.newFolder();
 
-            config.setString(CheckpointingOptions.STATE_BACKEND, currentBackend);
+            config.setString(StateBackendOptions.STATE_BACKEND, currentBackend);
             config.setString(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
             config.setString(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -35,6 +35,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -1275,7 +1276,7 @@ public class SavepointITCase extends TestLogger {
 
     private Configuration getFileBasedCheckpointsConfig(final String savepointDir) {
         final Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+        config.setString(StateBackendOptions.STATE_BACKEND, "filesystem");
         config.setString(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.ZERO);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
 import org.apache.flink.contrib.streaming.state.RocksDBOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -140,7 +141,7 @@ public class TimersSavepointITCase {
                 .addSink(new DiscardingSink<>());
 
         final Configuration config = new Configuration();
-        config.set(CheckpointingOptions.STATE_BACKEND, "rocksdb");
+        config.set(StateBackendOptions.STATE_BACKEND, "rocksdb");
         config.set(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 TMP_FOLDER.newFolder().toURI().toString());

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -45,6 +45,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -735,7 +736,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
 
             conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.9f);
             conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
-            conf.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+            conf.setString(StateBackendOptions.STATE_BACKEND, "filesystem");
             conf.setString(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
             if (restoreCheckpoint != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -103,7 +104,7 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
         LOG.info("Created temporary checkpoint directory: " + checkpointDir + ".");
         LOG.info("Created savepoint directory: " + savepointDir + ".");
 
-        config.setString(CheckpointingOptions.STATE_BACKEND, "memory");
+        config.setString(StateBackendOptions.STATE_BACKEND, "memory");
         config.setString(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.ZERO);

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.client.JobCancellationException;
@@ -104,7 +105,7 @@ public class ClassLoaderITCase extends TestLogger {
 
         // we need to use the "filesystem" state backend to ensure FLINK-2543 is not happening
         // again.
-        config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+        config.setString(StateBackendOptions.STATE_BACKEND, "filesystem");
         config.setString(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 FOLDER.newFolder().getAbsoluteFile().toURI().toString());

--- a/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackendBuilder;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
 import org.junit.rules.TemporaryFolder;
@@ -107,6 +108,7 @@ public final class BackendSwitchSpecs {
                             TestLocalRecoveryConfig.disabled(),
                             queueStateType,
                             TtlTimeProvider.DEFAULT,
+                            LatencyTrackingStateConfig.disabled(),
                             new UnregisteredMetricsGroup(),
                             stateHandles,
                             UncompressedStreamCompressionDecorator.INSTANCE,
@@ -141,6 +143,7 @@ public final class BackendSwitchSpecs {
                             keyGroupRange,
                             executionConfig,
                             TtlTimeProvider.DEFAULT,
+                            LatencyTrackingStateConfig.disabled(),
                             stateHandles,
                             AbstractStateBackend.getCompressionDecorator(executionConfig),
                             TestLocalRecoveryConfig.disabled(),

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
@@ -58,7 +58,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINTS_DIRECTORY;
 import static org.apache.flink.configuration.CheckpointingOptions.INCREMENTAL_CHECKPOINTS;
-import static org.apache.flink.configuration.CheckpointingOptions.STATE_BACKEND;
+import static org.apache.flink.configuration.StateBackendOptions.STATE_BACKEND;
 import static org.junit.Assert.assertEquals;
 
 /** Test for StatefulOperatorChainedTaskTest. */

--- a/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -96,7 +97,7 @@ public class PojoSerializerUpgradeTest extends TestLogger {
     public PojoSerializerUpgradeTest(String backendType)
             throws IOException, DynamicCodeLoadingException {
         Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.STATE_BACKEND, backendType);
+        config.setString(StateBackendOptions.STATE_BACKEND, backendType);
         config.setString(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 temporaryFolder.newFolder().toURI().toString());


### PR DESCRIPTION
## What is the purpose of the change

Track the state latency metrics.

## Brief change log

1. Separate state backend and checkpoint options.
2. Introduce latency tracking state config and basic classes.
3. Enable to tack latency state with introduced `LatencyTrackingValueState`, `LatencyTrackingListState`, `LatencyTrackingMapState`, `LatencyTrackingAggregatingState` and `LatencyTrackingReducingState`.


## Verifying this change

Added test `LatencyTrackingStateConfigTest` to verify configuration test.

Added test `LatencyTrackingValueStateTest`, `LatencyTrackingListStateTest`, `LatencyTrackingMapStateTest`, `LatencyTrackingAggregatingStateTest` and `LatencyTrackingReducingStateTest` to verify different state wrapper.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (add dependency of `io.dropwizard.metrics:metrics-core:3.2.6
`)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes, state with metrics would impact the state performance.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
