### PR TITLE
[FLINK-21679][table] Set output type for transformations from SourceProvider and DataStreamScanProvider in CommonExecTableSourceScan

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -85,11 +85,9 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData> {
         } else if (provider instanceof SourceProvider) {
             Source<RowData, ?, ?> source = ((SourceProvider) provider).createSource();
             // TODO: Push down watermark strategy to source scan
-            Transformation<RowData> transformation =
-                    env.fromSource(source, WatermarkStrategy.noWatermarks(), operatorName)
-                            .getTransformation();
-            transformation.setOutputType(outputTypeInfo);
-            return transformation;
+            return env.fromSource(
+                            source, WatermarkStrategy.noWatermarks(), operatorName, outputTypeInfo)
+                    .getTransformation();
         } else if (provider instanceof DataStreamScanProvider) {
             Transformation<RowData> transformation =
                     ((DataStreamScanProvider) provider).produceDataStream(env).getTransformation();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -81,12 +81,18 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData> {
         } else if (provider instanceof InputFormatProvider) {
             InputFormat<RowData, ?> inputFormat =
                     ((InputFormatProvider) provider).createInputFormat();
-            return createInputFormatTransformation(env, inputFormat, outputTypeInfo, operatorName);
+            Transformation<RowData> transformation =
+                    createInputFormatTransformation(env, inputFormat, outputTypeInfo, operatorName);
+            transformation.setOutputType(outputTypeInfo);
+            return transformation;
         } else if (provider instanceof SourceProvider) {
             Source<RowData, ?, ?> source = ((SourceProvider) provider).createSource();
             // TODO: Push down watermark strategy to source scan
-            return env.fromSource(source, WatermarkStrategy.noWatermarks(), operatorName)
-                    .getTransformation();
+            Transformation<RowData> transformation =
+                    env.fromSource(source, WatermarkStrategy.noWatermarks(), operatorName)
+                            .getTransformation();
+            transformation.setOutputType(outputTypeInfo);
+            return transformation;
         } else if (provider instanceof DataStreamScanProvider) {
             return ((DataStreamScanProvider) provider).produceDataStream(env).getTransformation();
         } else {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -81,10 +81,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData> {
         } else if (provider instanceof InputFormatProvider) {
             InputFormat<RowData, ?> inputFormat =
                     ((InputFormatProvider) provider).createInputFormat();
-            Transformation<RowData> transformation =
-                    createInputFormatTransformation(env, inputFormat, outputTypeInfo, operatorName);
-            transformation.setOutputType(outputTypeInfo);
-            return transformation;
+            return createInputFormatTransformation(env, inputFormat, outputTypeInfo, operatorName);
         } else if (provider instanceof SourceProvider) {
             Source<RowData, ?, ?> source = ((SourceProvider) provider).createSource();
             // TODO: Push down watermark strategy to source scan
@@ -94,7 +91,10 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData> {
             transformation.setOutputType(outputTypeInfo);
             return transformation;
         } else if (provider instanceof DataStreamScanProvider) {
-            return ((DataStreamScanProvider) provider).produceDataStream(env).getTransformation();
+            Transformation<RowData> transformation =
+                    ((DataStreamScanProvider) provider).produceDataStream(env).getTransformation();
+            transformation.setOutputType(outputTypeInfo);
+            return transformation;
         } else {
             throw new UnsupportedOperationException(
                     provider.getClass().getSimpleName() + " is unsupported now.");

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestFileFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestFileFactory.java
@@ -31,7 +31,6 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkProvider;
@@ -45,7 +44,6 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.filesystem.FileSystemOptions;
-import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -198,7 +196,9 @@ public class TestFileFactory implements DynamicTableSourceFactory, DynamicTableS
 
         @Override
         public TypeInformation<RowData> getProducedType() {
-            return InternalTypeInfo.ofFields(DataTypes.STRING().getLogicalType());
+            // For ScanTableSource the output type is determined by planner,
+            // the result of this method would not be used.
+            return null;
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestFileFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestFileFactory.java
@@ -196,8 +196,10 @@ public class TestFileFactory implements DynamicTableSourceFactory, DynamicTableS
 
         @Override
         public TypeInformation<RowData> getProducedType() {
-            // For ScanTableSource the output type is determined by planner,
-            // the result of this method would not be used.
+            // For ScanTableSource, the output type is determined by the planner,
+            // and the result of this method will not be used.
+            // The purpose of returning null is to verify that the planner can
+            // handle the output type correctly.
             return null;
         }
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -725,7 +725,7 @@ public final class TestValuesTableFactory
                             @Override
                             public DataStream<RowData> produceDataStream(
                                     StreamExecutionEnvironment execEnv) {
-                                return execEnv.addSource(function, type);
+                                return execEnv.addSource(function);
                             }
 
                             @Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request set output type for transformations from SourceProvider and DataStreamScanProvider in CommonExecTableSourceScan.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
