### PR TITLE
[FLINK-21620][table-api / sql-parser ] Support abbreviation TIMESTAMP_LTZ FOR TIMESTAMP WITH LOCAL TIME ZONE

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/canal.md
+++ b/docs/content.zh/docs/connectors/table/formats/canal.md
@@ -174,7 +174,7 @@ metadata fields for its value format.
     </tr>
     <tr>
       <td><code>ingestion-timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NULL</code></td>
       <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts</code>
       field in the Canal record.</td>
     </tr>

--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -179,13 +179,13 @@ metadata fields for its value format.
     </tr>
     <tr>
       <td><code>ingestion-timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NULL</code></td>
       <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts_ms</code>
       field in the Debezium record.</td>
     </tr>
     <tr>
       <td><code>source.timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NULL</code></td>
       <td>The timestamp at which the source system created the event. Corresponds to the <code>source.ts_ms</code>
       field in the Debezium record.</td>
     </tr>

--- a/docs/content.zh/docs/connectors/table/formats/json.md
+++ b/docs/content.zh/docs/connectors/table/formats/json.md
@@ -99,12 +99,12 @@ Format 参数
       <td>可选</td>
       <td style="word-wrap: break-word;"><code>'SQL'</code></td>
       <td>String</td>
-      <td>声明输入和输出的 <code>TIMESTAMP</code> 和 <code>TIMESTAMP WITH LOCAL TIME ZONE</code> 的格式。当前支持的格式为<code>'SQL'</code> 以及 <code>'ISO-8601'</code>：
+      <td>声明输入和输出的 <code>TIMESTAMP</code> 和 <code>TIMESTAMP_LTZ</code> 的格式。当前支持的格式为<code>'SQL'</code> 以及 <code>'ISO-8601'</code>：
       <ul>
         <li>可选参数 <code>'SQL'</code> 将会以 "yyyy-MM-dd HH:mm:ss.s{precision}" 的格式解析 TIMESTAMP, 例如 "2020-12-30 12:13:14.123"，
-        以 "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" 的格式解析 TIMESTAMP WITH LOCAL TIME ZONE, 例如 "2020-12-30 12:13:14.123Z" 且会以相同的格式输出。</li>
+        以 "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" 的格式解析 TIMESTAMP_LTZ, 例如 "2020-12-30 12:13:14.123Z" 且会以相同的格式输出。</li>
         <li>可选参数 <code>'ISO-8601'</code> 将会以 "yyyy-MM-ddTHH:mm:ss.s{precision}" 的格式解析输入 TIMESTAMP, 例如 "2020-12-30T12:13:14.123" ，
-        以 "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" 的格式解析 TIMESTAMP WITH LOCAL TIME ZONE, 例如 "2020-12-30T12:13:14.123Z" 且会以相同的格式输出。</li>
+        以 "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" 的格式解析 TIMESTAMP_LTZ, 例如 "2020-12-30T12:13:14.123Z" 且会以相同的格式输出。</li>
       </ul>
       </td>
     </tr>

--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -110,7 +110,7 @@ Read-only columns must be declared `VIRTUAL` to exclude them during an `INSERT I
     </tr>
     <tr>
       <td><code>timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NOT NULL</code></td>
       <td>Timestamp of the Kafka record.</td>
       <td><code>R/W</code></td>
     </tr>

--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -76,7 +76,7 @@ The following metadata can be exposed as read-only (`VIRTUAL`) columns in a tabl
     <tbody>
     <tr>
       <td><code><a href="https://docs.aws.amazon.com/kinesis/latest/APIReference/API_Record.html#Streams-Type-Record-ApproximateArrivalTimestamp">timestamp</a></code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NOT NULL</code></td>
       <td>The approximate time when the record was inserted into the stream.</td>
     </tr>
     <tr>

--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -302,7 +302,7 @@ public static class OverloadedFunction extends ScalarFunction {
   }
 
   // 定义嵌套数据类型
-  @DataTypeHint("ROW<s STRING, t TIMESTAMP(3) WITH LOCAL TIME ZONE>")
+  @DataTypeHint("ROW<s STRING, t TIMESTAMP_LTZ(3)>")
   public Row eval(int i) {
     return Row.of(String.valueOf(i), Instant.ofEpochSecond(i));
   }
@@ -339,7 +339,7 @@ class OverloadedFunction extends ScalarFunction {
   }
 
   // 定义嵌套数据类型
-  @DataTypeHint("ROW<s STRING, t TIMESTAMP(3) WITH LOCAL TIME ZONE>")
+  @DataTypeHint("ROW<s STRING, t TIMESTAMP_LTZ(3)>")
   def eval(Int i): Row = {
     Row.of(java.lang.String.valueOf(i), java.time.Instant.ofEpochSecond(i))
   }

--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -227,7 +227,7 @@ The following statement creates a table with an additional metadata column that 
 CREATE TABLE MyTable (
   `user_id` BIGINT,
   `name` STRING,
-  `record_time` TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA FROM 'timestamp'    -- reads and writes a Kafka record's timestamp
+  `record_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'    -- reads and writes a Kafka record's timestamp
 ) WITH (
   'connector' = 'kafka'
   ...
@@ -235,7 +235,7 @@ CREATE TABLE MyTable (
 ```
 
 Every metadata field is identified by a string-based key and has a documented data type. For example,
-the Kafka connector exposes a metadata field with key `timestamp` and data type `TIMESTAMP(3) WITH LOCAL TIME ZONE`
+the Kafka connector exposes a metadata field with key `timestamp` and data type `TIMESTAMP_LTZ(3)`
 that can be used for both reading and writing records.
 
 In the example above, the metadata column `record_time` becomes part of the table's schema and can be
@@ -251,7 +251,7 @@ For convenience, the `FROM` clause can be omitted if the column name should be u
 CREATE TABLE MyTable (
   `user_id` BIGINT,
   `name` STRING,
-  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA    -- use column name as metadata key
+  `timestamp` TIMESTAMP_LTZ(3) METADATA    -- use column name as metadata key
 ) WITH (
   'connector' = 'kafka'
   ...

--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -163,7 +163,7 @@ The default planner supports the following set of SQL types:
 | `DATE` | |
 | `TIME` | Supports only a precision of `0`. |
 | `TIMESTAMP` | |
-| `TIMESTAMP WITH LOCAL TIME ZONE` | |
+| `TIMESTAMP_LTZ` | |
 | `INTERVAL` | Supports only interval of `MONTH` and `SECOND(3)`. |
 | `ARRAY` | |
 | `MULTISET` | |
@@ -730,13 +730,13 @@ the semantics are closer to `java.time.LocalDateTime`.
 
 A conversion from and to `BIGINT` (a JVM `long` type) is not supported as this would imply a time
 zone. However, this type is time zone free. For more `java.time.Instant`-like semantics use
-`TIMESTAMP WITH LOCAL TIME ZONE`.
+`TIMESTAMP_LTZ`.
 {{< /tab >}}
 {{< tab "Python" >}}
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported.
 
 A conversion from and to `BIGINT` is not supported as this would imply a time zone.
-However, this type is time zone free. If you have such a requirement please use `TIMESTAMP WITH LOCAL TIME ZONE`.
+However, this type is time zone free. If you have such a requirement please use `TIMESTAMP_LTZ`.
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -797,7 +797,7 @@ Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not s
 {{< /tab >}}
 {{< /tabs >}}
 
-Compared to `TIMESTAMP WITH LOCAL TIME ZONE`, the time zone offset information is physically
+Compared to `TIMESTAMP_LTZ`, the time zone offset information is physically
 stored in every datum. It is used individually for every computation, visualization, or communication
 to external systems.
 
@@ -840,7 +840,7 @@ precision is specified, `p` is equal to `6`.
 {{< /tab >}}
 {{< /tabs >}}
 
-#### `TIMESTAMP WITH LOCAL TIME ZONE`
+#### `TIMESTAMP_LTZ`
 
 Data type of a timestamp *with local* time zone consisting of `year-month-day hour:minute:second[.fractional] zone`
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
@@ -872,12 +872,16 @@ the interpretation of UTC timestamps according to the configured session time zo
 {{< tabs "75734ebe-7f16-4df8-83e9-99fcd2a28527" >}}
 {{< tab "SQL" >}}
 ```text
+TIMESTAMP_LTZ
+TIMESTAMP_LTZ(p)
+
 TIMESTAMP WITH LOCAL TIME ZONE
 TIMESTAMP(p) WITH LOCAL TIME ZONE
 ```
 {{< /tab >}}
 {{< tab "Java/Scala" >}}
 ```java
+DataTypes.TIMESTAMP_LTZ(p)
 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 ```
 
@@ -895,16 +899,19 @@ DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
+DataTypes.TIMESTAMP_LTZ(p)
 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 ```
 
-<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)` must be `3` currently.
+<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIMESTAMP_LTZ(p)` must be `3` currently.
 {{< /tab >}}
 {{< /tabs >}}
 
-The type can be declared using `TIMESTAMP(p) WITH LOCAL TIME ZONE` where `p` is the number
+The type can be declared using `TIMESTAMPLTZ(p)` where `p` is the number
 of digits of fractional seconds (*precision*). `p` must have a value between `0` and `9`
 (both inclusive). If no precision is specified, `p` is equal to `6`.
+
+`TIMESTAMP(p) WITH LOCAL TIME ZONE` is a synonym for this type.
 
 #### `INTERVAL YEAR TO MONTH`
 
@@ -1521,7 +1528,7 @@ information similar to `java.util.Map[java.lang.Object, java.lang.Object]`.
 | `java.sql.Timestamp`        | `TIMESTAMP(9)`                      |
 | `java.time.LocalDateTime`   | `TIMESTAMP(9)`                      |
 | `java.time.OffsetDateTime`  | `TIMESTAMP(9) WITH TIME ZONE`       |
-| `java.time.Instant`         | `TIMESTAMP(9) WITH LOCAL TIME ZONE` |
+| `java.time.Instant`         | `TIMESTAMP_LTZ(9)`                  |
 | `java.time.Duration`        | `INVERVAL SECOND(9)`                |
 | `java.time.Period`          | `INTERVAL YEAR(4) TO MONTH`         |
 | `byte[]`                    | `BYTES`                             |

--- a/docs/content.zh/docs/dev/table/types.md
+++ b/docs/content.zh/docs/dev/table/types.md
@@ -907,7 +907,7 @@ DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 {{< /tab >}}
 {{< /tabs >}}
 
-The type can be declared using `TIMESTAMPLTZ(p)` where `p` is the number
+The type can be declared using `TIMESTAMP_LTZ(p)` where `p` is the number
 of digits of fractional seconds (*precision*). `p` must have a value between `0` and `9`
 (both inclusive). If no precision is specified, `p` is equal to `6`.
 

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -160,7 +160,7 @@ Types
             <td>Always resolves to the current timestamp of the local machine.</td>
         </tr>
         <tr>
-            <td>TIMESTAMP WITH LOCAL TIMEZONE</td>
+            <td>TIMESTAMP_LTZ</td>
             <td>random</td>
             <td>Always resolves to the current timestamp of the local machine.</td>
         </tr>

--- a/docs/content/docs/connectors/table/formats/canal.md
+++ b/docs/content/docs/connectors/table/formats/canal.md
@@ -177,7 +177,7 @@ metadata fields for its value format.
     </tr>
     <tr>
       <td><code>ingestion-timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NULL</code></td>
       <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts</code>
       field in the Canal record.</td>
     </tr>

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -172,13 +172,13 @@ metadata fields for its value format.
     </tr>
     <tr>
       <td><code>ingestion-timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NULL</code></td>
       <td>The timestamp at which the connector processed the event. Corresponds to the <code>ts_ms</code>
       field in the Debezium record.</td>
     </tr>
     <tr>
       <td><code>source.timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NULL</code></td>
       <td>The timestamp at which the source system created the event. Corresponds to the <code>source.ts_ms</code>
       field in the Debezium record.</td>
     </tr>

--- a/docs/content/docs/connectors/table/formats/json.md
+++ b/docs/content/docs/connectors/table/formats/json.md
@@ -100,12 +100,12 @@ Format Options
       <td>optional</td>
       <td style="word-wrap: break-word;"><code>'SQL'</code></td>
       <td>String</td>
-      <td>Specify the input and output timestamp format for <code>TIMESTAMP</code> and <code>TIMESTAMP WITH LOCAL TIME ZONE</code> type. Currently supported values are <code>'SQL'</code> and <code>'ISO-8601'</code>:
+      <td>Specify the input and output timestamp format for <code>TIMESTAMP</code> and <code>TIMESTAMP_LTZ</code> type. Currently supported values are <code>'SQL'</code> and <code>'ISO-8601'</code>:
       <ul>
         <li>Option <code>'SQL'</code> will parse input TIMESTAMP values in "yyyy-MM-dd HH:mm:ss.s{precision}" format, e.g "2020-12-30 12:13:14.123", 
-        parse input TIMESTAMP WITH LOCAL TIME ZONE values in "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30 12:13:14.123Z" and output timestamp in the same format.</li>
+        parse input TIMESTAMP_LTZ values in "yyyy-MM-dd HH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30 12:13:14.123Z" and output timestamp in the same format.</li>
         <li>Option <code>'ISO-8601'</code>will parse input TIMESTAMP in "yyyy-MM-ddTHH:mm:ss.s{precision}" format, e.g "2020-12-30T12:13:14.123" 
-        parse input TIMESTAMP WITH LOCAL TIME ZONE in "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30T12:13:14.123Z" and output timestamp in the same format.</li>
+        parse input TIMESTAMP_LTZ in "yyyy-MM-ddTHH:mm:ss.s{precision}'Z'" format, e.g "2020-12-30T12:13:14.123Z" and output timestamp in the same format.</li>
       </ul>
       </td>
     </tr>

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -110,7 +110,7 @@ Read-only columns must be declared `VIRTUAL` to exclude them during an `INSERT I
     </tr>
     <tr>
       <td><code>timestamp</code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NOT NULL</code></td>
       <td>Timestamp of the Kafka record.</td>
       <td><code>R/W</code></td>
     </tr>

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -76,7 +76,7 @@ The following metadata can be exposed as read-only (`VIRTUAL`) columns in a tabl
     <tbody>
     <tr>
       <td><code><a href="https://docs.aws.amazon.com/kinesis/latest/APIReference/API_Record.html#Streams-Type-Record-ApproximateArrivalTimestamp">timestamp</a></code></td>
-      <td><code>TIMESTAMP(3) WITH LOCAL TIME ZONE NOT NULL</code></td>
+      <td><code>TIMESTAMP_LTZ(3) NOT NULL</code></td>
       <td>The approximate time when the record was inserted into the stream.</td>
     </tr>
     <tr>

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -308,7 +308,7 @@ public static class OverloadedFunction extends ScalarFunction {
   }
 
   // define a nested data type
-  @DataTypeHint("ROW<s STRING, t TIMESTAMP(3) WITH LOCAL TIME ZONE>")
+  @DataTypeHint("ROW<s STRING, t TIMESTAMP_LTZ(3)>")
   public Row eval(int i) {
     return Row.of(String.valueOf(i), Instant.ofEpochSecond(i));
   }
@@ -345,7 +345,7 @@ class OverloadedFunction extends ScalarFunction {
   }
 
   // define a nested data type
-  @DataTypeHint("ROW<s STRING, t TIMESTAMP(3) WITH LOCAL TIME ZONE>")
+  @DataTypeHint("ROW<s STRING, t TIMESTAMP_LTZ(3)>")
   def eval(Int i): Row = {
     Row.of(java.lang.String.valueOf(i), java.time.Instant.ofEpochSecond(i))
   }

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -227,7 +227,7 @@ The following statement creates a table with an additional metadata column that 
 CREATE TABLE MyTable (
   `user_id` BIGINT,
   `name` STRING,
-  `record_time` TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA FROM 'timestamp'    -- reads and writes a Kafka record's timestamp
+  `record_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'    -- reads and writes a Kafka record's timestamp
 ) WITH (
   'connector' = 'kafka'
   ...
@@ -235,7 +235,7 @@ CREATE TABLE MyTable (
 ```
 
 Every metadata field is identified by a string-based key and has a documented data type. For example,
-the Kafka connector exposes a metadata field with key `timestamp` and data type `TIMESTAMP(3) WITH LOCAL TIME ZONE`
+the Kafka connector exposes a metadata field with key `timestamp` and data type `TIMESTAMP_LTZ(3)`
 that can be used for both reading and writing records.
 
 In the example above, the metadata column `record_time` becomes part of the table's schema and can be
@@ -251,7 +251,7 @@ For convenience, the `FROM` clause can be omitted if the column name should be u
 CREATE TABLE MyTable (
   `user_id` BIGINT,
   `name` STRING,
-  `timestamp` TIMESTAMP(3) WITH LOCAL TIME ZONE METADATA    -- use column name as metadata key
+  `timestamp` TIMESTAMP_LTZ(3) METADATA    -- use column name as metadata key
 ) WITH (
   'connector' = 'kafka'
   ...

--- a/docs/content/docs/dev/table/types.md
+++ b/docs/content/docs/dev/table/types.md
@@ -163,7 +163,7 @@ The default planner supports the following set of SQL types:
 | `DATE` | |
 | `TIME` | Supports only a precision of `0`. |
 | `TIMESTAMP` | |
-| `TIMESTAMP WITH LOCAL TIME ZONE` | |
+| `TIMESTAMP_LTZ` | |
 | `INTERVAL` | Supports only interval of `MONTH` and `SECOND(3)`. |
 | `ARRAY` | |
 | `MULTISET` | |
@@ -730,13 +730,13 @@ the semantics are closer to `java.time.LocalDateTime`.
 
 A conversion from and to `BIGINT` (a JVM `long` type) is not supported as this would imply a time
 zone. However, this type is time zone free. For more `java.time.Instant`-like semantics use
-`TIMESTAMP WITH LOCAL TIME ZONE`.
+`TIMESTAMP_LTZ`.
 {{< /tab >}}
 {{< tab "Python" >}}
 Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not supported.
 
 A conversion from and to `BIGINT` is not supported as this would imply a time zone.
-However, this type is time zone free. If you have such a requirement please use `TIMESTAMP WITH LOCAL TIME ZONE`.
+However, this type is time zone free. If you have such a requirement please use `TIMESTAMP_LTZ`.
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -797,7 +797,7 @@ Compared to the SQL standard, leap seconds (`23:59:60` and `23:59:61`) are not s
 {{< /tab >}}
 {{< /tabs >}}
 
-Compared to `TIMESTAMP WITH LOCAL TIME ZONE`, the time zone offset information is physically
+Compared to `TIMESTAMP_LTZ`, the time zone offset information is physically
 stored in every datum. It is used individually for every computation, visualization, or communication
 to external systems.
 
@@ -840,7 +840,7 @@ precision is specified, `p` is equal to `6`.
 {{< /tab >}}
 {{< /tabs >}}
 
-#### `TIMESTAMP WITH LOCAL TIME ZONE`
+#### `TIMESTAMP_LTZ`
 
 Data type of a timestamp *with local* time zone consisting of `year-month-day hour:minute:second[.fractional] zone`
 with up to nanosecond precision and values ranging from `0000-01-01 00:00:00.000000000 +14:59` to
@@ -872,12 +872,16 @@ the interpretation of UTC timestamps according to the configured session time zo
 {{< tabs "75734ebe-7f16-4df8-83e9-99fcd2a28527" >}}
 {{< tab "SQL" >}}
 ```text
+TIMESTAMP_LTZ
+TIMESTAMP_LTZ(p)
+
 TIMESTAMP WITH LOCAL TIME ZONE
 TIMESTAMP(p) WITH LOCAL TIME ZONE
 ```
 {{< /tab >}}
 {{< tab "Java/Scala" >}}
 ```java
+DataTypes.TIMESTAMP_LTZ(p)
 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 ```
 
@@ -895,16 +899,19 @@ DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
+DataTypes.TIMESTAMP_LTZ(p)
 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)
 ```
 
-<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(p)` must be `3` currently.
+<span class="label label-danger">Attention</span> The `precision` specified in `DataTypes.TIMESTAMP_LTZ(p)` must be `3` currently.
 {{< /tab >}}
 {{< /tabs >}}
 
-The type can be declared using `TIMESTAMP(p) WITH LOCAL TIME ZONE` where `p` is the number
+The type can be declared using `TIMESTAMP_LTZ(p)` where `p` is the number
 of digits of fractional seconds (*precision*). `p` must have a value between `0` and `9`
 (both inclusive). If no precision is specified, `p` is equal to `6`.
+
+`TIMESTAMP(p) WITH LOCAL TIME ZONE` is a synonym for this type.
 
 #### `INTERVAL YEAR TO MONTH`
 
@@ -1521,7 +1528,7 @@ information similar to `java.util.Map[java.lang.Object, java.lang.Object]`.
 | `java.sql.Timestamp`        | `TIMESTAMP(9)`                      |
 | `java.time.LocalDateTime`   | `TIMESTAMP(9)`                      |
 | `java.time.OffsetDateTime`  | `TIMESTAMP(9) WITH TIME ZONE`       |
-| `java.time.Instant`         | `TIMESTAMP(9) WITH LOCAL TIME ZONE` |
+| `java.time.Instant`         | `TIMESTAMP_LTZ(9)`                  |
 | `java.time.Duration`        | `INVERVAL SECOND(9)`                |
 | `java.time.Period`          | `INTERVAL YEAR(4) TO MONTH`         |
 | `byte[]`                    | `BYTES`                             |

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -563,6 +563,27 @@ class TypesTests(PyFlinkTestCase):
             ts2 = lztst.from_sql_type(0)
             self.assertEqual(ts.astimezone(), ts2.astimezone())
 
+    def test_timestampLtz_type(self):
+        lztst = DataTypes.TIMESTAMP_LTZ()
+        ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000)
+        self.assertEqual(0, lztst.to_sql_type(ts))
+
+        import pytz
+        # suppose the timezone of the data is +9:00
+        timezone = pytz.timezone("Asia/Tokyo")
+        orig_epoch = LocalZonedTimestampType.EPOCH_ORDINAL
+        try:
+            # suppose the local timezone is +8:00
+            LocalZonedTimestampType.EPOCH_ORDINAL = 28800000000
+            ts_tokyo = timezone.localize(ts)
+            self.assertEqual(-3600000000, lztst.to_sql_type(ts_tokyo))
+        finally:
+            LocalZonedTimestampType.EPOCH_ORDINAL = orig_epoch
+
+        if sys.version_info >= (3, 6):
+            ts2 = lztst.from_sql_type(0)
+            self.assertEqual(ts.astimezone(), ts2.astimezone())
+
     def test_zoned_timestamp_type(self):
         ztst = ZonedTimestampType()
         ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000, tzinfo=UTCOffsetTimezone(1))

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -544,27 +544,9 @@ class TypesTests(PyFlinkTestCase):
                                    "under Windows platform")
     def test_local_zoned_timestamp_type(self):
         lztst = DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()
-        ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000)
-        self.assertEqual(0, lztst.to_sql_type(ts))
+        last_abbreviation = DataTypes.TIMESTAMP_LTZ()
+        self.assertEqual(lztst, last_abbreviation)
 
-        import pytz
-        # suppose the timezone of the data is +9:00
-        timezone = pytz.timezone("Asia/Tokyo")
-        orig_epoch = LocalZonedTimestampType.EPOCH_ORDINAL
-        try:
-            # suppose the local timezone is +8:00
-            LocalZonedTimestampType.EPOCH_ORDINAL = 28800000000
-            ts_tokyo = timezone.localize(ts)
-            self.assertEqual(-3600000000, lztst.to_sql_type(ts_tokyo))
-        finally:
-            LocalZonedTimestampType.EPOCH_ORDINAL = orig_epoch
-
-        if sys.version_info >= (3, 6):
-            ts2 = lztst.from_sql_type(0)
-            self.assertEqual(ts.astimezone(), ts2.astimezone())
-
-    def test_timestampLtz_type(self):
-        lztst = DataTypes.TIMESTAMP_LTZ()
         ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000)
         self.assertEqual(0, lztst.to_sql_type(ts))
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -2673,6 +2673,21 @@ class DataTypes(object):
         return LocalZonedTimestampType(precision, nullable)
 
     @staticmethod
+    def TIMESTAMP_LTZ(precision: int = 6, nullable: bool = True) \
+            -> LocalZonedTimestampType:
+        """
+        Data type of a timestamp WITH LOCAL time zone.
+        This is a shortcut for ``DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(precision, nullable)``.
+
+        :param precision: int, the number of digits of fractional seconds.
+                          It must have a value between 0 and 9 (both inclusive). (default: 6)
+        :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. seealso:: :func:`~DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(precision, nullable)`
+        """
+        return LocalZonedTimestampType(precision, nullable)
+
+    @staticmethod
     def ARRAY(element_type: DataType, nullable: bool = True) -> ArrayType:
         """
         Data type of an array of elements with same subtype.

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -73,6 +73,7 @@
     "org.apache.flink.sql.parser.type.ExtendedSqlRowTypeNameSpec"
     "org.apache.flink.sql.parser.type.SqlMapTypeNameSpec"
     "org.apache.flink.sql.parser.type.SqlRawTypeNameSpec"
+    "org.apache.flink.sql.parser.type.SqlTimestampLtzTypeNameSpec"
     "org.apache.flink.sql.parser.utils.ParserResource"
     "org.apache.flink.sql.parser.validate.FlinkSqlConformance"
     "org.apache.flink.sql.parser.SqlProperty"
@@ -114,6 +115,7 @@
     "VIRTUAL"
     "WATERMARK"
     "WATERMARKS"
+    "TIMESTAMP_LTZ"
   ]
 
   # List of keywords from "keywords" section that are not reserved.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -1073,8 +1073,10 @@ SqlDrop SqlDropView(Span s, boolean replace, boolean isTemporary) :
 * A sql type name extended basic data type, it has a counterpart basic
 * sql type name but always represents as a special alias compared with the standard name.
 *
-* <p>For example, STRING is synonym of VARCHAR(INT_MAX)
-* and BYTES is synonym of VARBINARY(INT_MAX).
+* <p>For example:
+*  1. STRING is synonym of VARCHAR(INT_MAX),
+*  2. BYTES is synonym of VARBINARY(INT_MAX),
+*  3. TIMESTAMP_LTZ(precision) is synonym of TIMESTAMP(precision) WITH LOCAL TIME ZONE.
 */
 SqlTypeNameSpec ExtendedSqlBasicTypeName() :
 {
@@ -1095,6 +1097,16 @@ SqlTypeNameSpec ExtendedSqlBasicTypeName() :
             typeAlias = token.image;
             precision = Integer.MAX_VALUE;
         }
+    |
+       <TIMESTAMP_LTZ>
+       {
+           typeAlias = token.image;
+       }
+       precision = PrecisionOpt()
+       {
+            typeName = SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
+            return new SqlTimestampLtzTypeNameSpec(typeAlias, typeName, precision, getPos());
+       }
     )
     {
         return new SqlAlienSystemTypeNameSpec(typeAlias, typeName, precision, getPos());

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/SqlTimestampLtzTypeNameSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/SqlTimestampLtzTypeNameSpec.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.type;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.calcite.sql.SqlBasicTypeNameSpec;
+import org.apache.calcite.sql.SqlTypeNameSpec;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Litmus;
+
+import java.util.Objects;
+
+/**
+ * Represents type TIMESTAMP_LTZ(int) which is a synonym of type TIMESTAMP(int) WITH LOCAL TIME
+ * ZONE.
+ */
+@Internal
+public final class SqlTimestampLtzTypeNameSpec extends SqlBasicTypeNameSpec {
+
+    // Type alias for unparsing.
+    private final String typeAlias;
+    private final SqlTypeName sqlTypeName;
+    private final int precision;
+
+    /**
+     * Creates a {@code SqlTimestampLtzTypeNameSpec} instance.
+     *
+     * @param typeAlias Type alias of the alien system
+     * @param typeName Type name the {@code typeAlias} implies as the (standard) basic type name
+     * @param precision Type Precision
+     * @param pos The parser position
+     */
+    public SqlTimestampLtzTypeNameSpec(
+            String typeAlias, SqlTypeName typeName, int precision, SqlParserPos pos) {
+        super(typeName, precision, pos);
+        this.typeAlias = typeAlias;
+        this.sqlTypeName = typeName;
+        this.precision = precision;
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword(typeAlias);
+        if (sqlTypeName.allowsPrec() && (precision >= 0)) {
+            final SqlWriter.Frame frame =
+                    writer.startList(SqlWriter.FrameTypeEnum.FUN_CALL, "(", ")");
+            writer.print(precision);
+            writer.endList(frame);
+        }
+    }
+
+    @Override
+    public boolean equalsDeep(SqlTypeNameSpec node, Litmus litmus) {
+        if (!(node instanceof SqlTimestampLtzTypeNameSpec)) {
+            return litmus.fail("{} != {}", this, node);
+        }
+        SqlTimestampLtzTypeNameSpec that = (SqlTimestampLtzTypeNameSpec) node;
+        if (!Objects.equals(this.typeAlias, that.typeAlias)) {
+            return litmus.fail("{} != {}", this, node);
+        }
+        return super.equalsDeep(node, litmus);
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -136,15 +136,29 @@ public class FlinkDDLDataTypeTest {
                         nullable(FIXTURE.timestampWithLocalTimeZoneType),
                         "TIMESTAMP WITH LOCAL TIME ZONE"),
                 createTestItem(
+                        "TIMESTAMP_LTZ",
+                        nullable(FIXTURE.timestampWithLocalTimeZoneType),
+                        "TIMESTAMP_LTZ"),
+                createTestItem(
                         "TIMESTAMP(3) WITH LOCAL TIME ZONE",
                         nullable(FIXTURE.timestamp3WithLocalTimeZoneType),
                         "TIMESTAMP(3) WITH LOCAL TIME ZONE"),
+                createTestItem(
+                        "TIMESTAMP_LTZ(3)",
+                        nullable(FIXTURE.timestamp3WithLocalTimeZoneType),
+                        "TIMESTAMP_LTZ(3)"),
                 createTestItem(
                         "ARRAY<TIMESTAMP(3) WITH LOCAL TIME ZONE>",
                         nullable(
                                 FIXTURE.createArrayType(
                                         nullable(FIXTURE.timestamp3WithLocalTimeZoneType))),
                         "ARRAY< TIMESTAMP(3) WITH LOCAL TIME ZONE >"),
+                createTestItem(
+                        "ARRAY<TIMESTAMP_LTZ(3)>",
+                        nullable(
+                                FIXTURE.createArrayType(
+                                        nullable(FIXTURE.timestamp3WithLocalTimeZoneType))),
+                        "ARRAY< TIMESTAMP_LTZ(3) >"),
                 createTestItem(
                         "ARRAY<INT NOT NULL>",
                         nullable(FIXTURE.createArrayType(FIXTURE.intType)),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -478,6 +478,16 @@ public final class DataTypes {
     }
 
     /**
+     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP(p) WITH LOCAL TIME ZONE}. This is a
+     * synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)}.
+     *
+     * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)
+     */
+    public static DataType TIMESTAMP_LTZ(int precision) {
+        return new AtomicDataType(new LocalZonedTimestampType(precision));
+    }
+
+    /**
      * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP WITH LOCAL TIME ZONE} with 6
      * digits of fractional seconds by default.
      *
@@ -500,6 +510,16 @@ public final class DataTypes {
      * @see LocalZonedTimestampType
      */
     public static DataType TIMESTAMP_WITH_LOCAL_TIME_ZONE() {
+        return new AtomicDataType(new LocalZonedTimestampType());
+    }
+
+    /**
+     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP WITH LOCAL TIME ZONE}. This is a
+     * synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE()}.
+     *
+     * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE()
+     */
+    public static DataType TIMESTAMP_LTZ() {
         return new AtomicDataType(new LocalZonedTimestampType());
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -478,8 +478,8 @@ public final class DataTypes {
     }
 
     /**
-     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP(p) WITH LOCAL TIME ZONE}. This is a
-     * synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)}.
+     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP(p) WITH LOCAL TIME ZONE}. This
+     * is a synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)}.
      *
      * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)
      */
@@ -514,8 +514,8 @@ public final class DataTypes {
     }
 
     /**
-     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP WITH LOCAL TIME ZONE}. This is a
-     * synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE()}.
+     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP WITH LOCAL TIME ZONE}. This is
+     * a synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE()}.
      *
      * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE()
      */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -478,10 +478,8 @@ public final class DataTypes {
     }
 
     /**
-     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP(p) WITH LOCAL TIME ZONE}. This
-     * is a synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)}.
-     *
-     * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)
+     * Data type of a timestamp WITH LOCAL time zone. This is a synonym for {@link
+     * DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE(int)}.
      */
     public static DataType TIMESTAMP_LTZ(int precision) {
         return new AtomicDataType(new LocalZonedTimestampType(precision));
@@ -514,10 +512,8 @@ public final class DataTypes {
     }
 
     /**
-     * Data type of a timestamp WITH LOCAL time zone {@code TIMESTAMP WITH LOCAL TIME ZONE}. This is
-     * a synonyms for {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE()}.
-     *
-     * @see #TIMESTAMP_WITH_LOCAL_TIME_ZONE()
+     * Data type of a timestamp WITH LOCAL time zone. This is a synonym for {@link
+     * DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE()}.
      */
     public static DataType TIMESTAMP_LTZ() {
         return new AtomicDataType(new LocalZonedTimestampType());

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeParser.java
@@ -79,6 +79,7 @@ import java.util.stream.Stream;
  *   <li>{@code DOUBLE PRECISION} as a synonym for {@code DOUBLE}
  *   <li>{@code TIME WITHOUT TIME ZONE} as a synonym for {@code TIME}
  *   <li>{@code TIMESTAMP WITHOUT TIME ZONE} as a synonym for {@code TIMESTAMP}
+ *   <li>{@code TIMESTAMP WITH LOCAL TIME ZONE} as a synonym for {@code TIMESTAMP_LTZ}
  *   <li>{@code type ARRAY} as a synonym for {@code ARRAY<type>}
  *   <li>{@code type MULTISET} as a synonym for {@code MULTISET<type>}
  *   <li>{@code ROW(...)} as a synonym for {@code ROW<...>}
@@ -319,6 +320,7 @@ public final class LogicalTypeParser {
         LOCAL,
         ZONE,
         TIMESTAMP,
+        TIMESTAMP_LTZ,
         INTERVAL,
         YEAR,
         MONTH,
@@ -558,6 +560,8 @@ public final class LogicalTypeParser {
                     return parseTimeType();
                 case TIMESTAMP:
                     return parseTimestampType();
+                case TIMESTAMP_LTZ:
+                    return parseTimestampLtzType();
                 case INTERVAL:
                     return parseIntervalType();
                 case ARRAY:
@@ -711,6 +715,11 @@ public final class LogicalTypeParser {
                 }
             }
             return new TimestampType(precision);
+        }
+
+        private LogicalType parseTimestampLtzType() {
+            int precision = parseOptionalPrecision(LocalZonedTimestampType.DEFAULT_PRECISION);
+            return new LocalZonedTimestampType(precision);
         }
 
         private LogicalType parseIntervalType() {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -92,6 +92,7 @@ import static org.apache.flink.table.api.DataTypes.SMALLINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP_LTZ;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
@@ -183,6 +184,12 @@ public class DataTypesTest {
                 TestSpec.forDataType(TIMESTAMP_WITH_LOCAL_TIME_ZONE())
                         .expectLogicalType(new LocalZonedTimestampType(6))
                         .expectConversionClass(java.time.Instant.class),
+                TestSpec.forDataType(TIMESTAMP_LTZ(3))
+                    .expectLogicalType(new LocalZonedTimestampType(3))
+                    .expectConversionClass(java.time.Instant.class),
+                TestSpec.forDataType(TIMESTAMP_LTZ())
+                    .expectLogicalType(new LocalZonedTimestampType(6))
+                    .expectConversionClass(java.time.Instant.class),
                 TestSpec.forDataType(INTERVAL(MINUTE(), SECOND(3)))
                         .expectLogicalType(
                                 new DayTimeIntervalType(MINUTE_TO_SECOND, DEFAULT_DAY_PRECISION, 3))

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -185,11 +185,11 @@ public class DataTypesTest {
                         .expectLogicalType(new LocalZonedTimestampType(6))
                         .expectConversionClass(java.time.Instant.class),
                 TestSpec.forDataType(TIMESTAMP_LTZ(3))
-                    .expectLogicalType(new LocalZonedTimestampType(3))
-                    .expectConversionClass(java.time.Instant.class),
+                        .expectLogicalType(new LocalZonedTimestampType(3))
+                        .expectConversionClass(java.time.Instant.class),
                 TestSpec.forDataType(TIMESTAMP_LTZ())
-                    .expectLogicalType(new LocalZonedTimestampType(6))
-                    .expectConversionClass(java.time.Instant.class),
+                        .expectLogicalType(new LocalZonedTimestampType(6))
+                        .expectConversionClass(java.time.Instant.class),
                 TestSpec.forDataType(INTERVAL(MINUTE(), SECOND(3)))
                         .expectLogicalType(
                                 new DayTimeIntervalType(MINUTE_TO_SECOND, DEFAULT_DAY_PRECISION, 3))

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeParserTest.java
@@ -132,8 +132,10 @@ public class LogicalTypeParserTest {
                         .expectType(new ZonedTimestampType(3)),
                 TestSpec.forString("TIMESTAMP WITH LOCAL TIME ZONE")
                         .expectType(new LocalZonedTimestampType()),
+                TestSpec.forString("TIMESTAMP_LTZ").expectType(new LocalZonedTimestampType()),
                 TestSpec.forString("TIMESTAMP(3) WITH LOCAL TIME ZONE")
                         .expectType(new LocalZonedTimestampType(3)),
+                TestSpec.forString("TIMESTAMP_LTZ(3)").expectType(new LocalZonedTimestampType(3)),
                 TestSpec.forString("INTERVAL YEAR")
                         .expectType(new YearMonthIntervalType(YearMonthResolution.YEAR)),
                 TestSpec.forString("INTERVAL YEAR(4)")

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/ComparableInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/ComparableInputTypeStrategyTest.java
@@ -74,15 +74,17 @@ public class ComparableInputTypeStrategyTest extends InputTypeStrategiesTestBase
                 TestSpec.forStrategy(
                                 "Datetime types are comparable",
                                 InputTypeStrategies.comparable(
-                                        ConstantArgumentCount.of(4), StructuredComparision.EQUALS))
+                                        ConstantArgumentCount.of(5), StructuredComparision.EQUALS))
                         .calledWithArgumentTypes(
                                 DataTypes.TIMESTAMP(),
                                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
+                                DataTypes.TIMESTAMP_LTZ(),
                                 DataTypes.TIMESTAMP_WITH_TIME_ZONE(),
                                 DataTypes.DATE())
                         .expectArgumentTypes(
                                 DataTypes.TIMESTAMP(),
                                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
+                                DataTypes.TIMESTAMP_LTZ(),
                                 DataTypes.TIMESTAMP_WITH_TIME_ZONE(),
                                 DataTypes.DATE()),
                 TestSpec.forStrategy(


### PR DESCRIPTION
## What is the purpose of the change

* This pull request introduce abbreviation TIMESTAMP_LTZ for data type TIMESTAMP WITH LOCAL TIME ZONE

## Brief change log

 - Support  `TIMESTAMP_LTZ` in sql parser
 - Support `TIMESTAMP_LTZ()`, `TIMESTAMP_LTZ(precision)`  in `DataTypes`

## Verifying this change

Add unit test to cover the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( docs & JavaDocs )
