### PR TITLE
[hotfix][connectors/kafka] Correctly check required configs in KafkaSourceBuilder

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -462,10 +462,8 @@ public class KafkaSourceBuilder<OUT> {
         // Check required configs.
         for (String requiredConfig : REQUIRED_CONFIGS) {
             checkNotNull(
-                    props.getProperty(
-                            requiredConfig,
-                            String.format(
-                                    "Property %s is required but not provided", requiredConfig)));
+                    props.getProperty(requiredConfig),
+                    String.format("Property %s is required but not provided", requiredConfig));
         }
         // Check required settings.
         checkNotNull(


### PR DESCRIPTION
## What is the purpose of the change

The KafkaSourceBuilder is supposed to do null checks on its required config properties. Currently, this validation never happens. Calling `getProperty()` with a second parameter will return the second parameter as a default value, if the property is null. Null values in the property will therefore never be found. This PR fixes this problem.


## Verifying this change

This change is a trivial fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable