### PR TITLE
[FLINK-21433][runtime] Pass number of slots as dynamic properties to TMs.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -210,6 +210,7 @@ public class ConfigurationUtils {
             }
         }
 
+        checkConfigContains(configs, TaskManagerOptions.CPU_CORES.key());
         checkConfigContains(configs, TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key());
         checkConfigContains(configs, TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key());
         checkConfigContains(configs, TaskManagerOptions.TASK_HEAP_MEMORY.key());

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -221,6 +221,7 @@ public class ConfigurationUtils {
         checkConfigContains(configs, TaskManagerOptions.JVM_METASPACE.key());
         checkConfigContains(configs, TaskManagerOptions.JVM_OVERHEAD_MIN.key());
         checkConfigContains(configs, TaskManagerOptions.JVM_OVERHEAD_MAX.key());
+        checkConfigContains(configs, TaskManagerOptions.NUM_TASK_SLOTS.key());
 
         return configs;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
@@ -85,6 +85,8 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
 
     private final CPUResource cpuCores;
 
+    private final int numSlots;
+
     @VisibleForTesting
     public TaskExecutorProcessSpec(
             CPUResource cpuCores,
@@ -106,16 +108,19 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
                         taskOffHeapSize,
                         networkMemSize,
                         managedMemorySize),
-                new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize));
+                new JvmMetaspaceAndOverhead(jvmMetaspaceSize, jvmOverheadSize),
+                1);
     }
 
     protected TaskExecutorProcessSpec(
             CPUResource cpuCores,
             TaskExecutorFlinkMemory flinkMemory,
-            JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
+            JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead,
+            int numSlots) {
 
         super(flinkMemory, jvmMetaspaceAndOverhead);
         this.cpuCores = cpuCores;
+        this.numSlots = numSlots;
     }
 
     public CPUResource getCpuCores() {
@@ -146,6 +151,10 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
         return getFlinkMemory().getManaged();
     }
 
+    public int getNumSlots() {
+        return numSlots;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -155,14 +164,15 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
             return Objects.equals(this.cpuCores, that.cpuCores)
                     && Objects.equals(
                             this.getJvmMetaspaceAndOverhead(), that.getJvmMetaspaceAndOverhead())
-                    && Objects.equals(this.getFlinkMemory(), that.getFlinkMemory());
+                    && Objects.equals(this.getFlinkMemory(), that.getFlinkMemory())
+                    && Objects.equals(this.numSlots, that.numSlots);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getJvmMetaspaceAndOverhead(), getFlinkMemory(), cpuCores);
+        return Objects.hash(getJvmMetaspaceAndOverhead(), getFlinkMemory(), cpuCores, numSlots);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
@@ -196,6 +196,8 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
                 + getJvmMetaspaceSize().toHumanReadableString()
                 + ", jvmOverheadSize="
                 + getJvmOverheadSize().toHumanReadableString()
+                + ", numSlots="
+                + numSlots
                 + '}';
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -163,7 +163,10 @@ public class TaskExecutorProcessUtils {
                         config, flinkMemory.getTotalFlinkMemorySize());
 
         return new TaskExecutorProcessSpec(
-                workerResourceSpec.getCpuCores(), flinkMemory, jvmMetaspaceAndOverhead);
+                workerResourceSpec.getCpuCores(),
+                flinkMemory,
+                jvmMetaspaceAndOverhead,
+                workerResourceSpec.getNumSlots());
     }
 
     private static TaskExecutorProcessSpec createMemoryProcessSpec(
@@ -173,11 +176,15 @@ public class TaskExecutorProcessUtils {
         JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead =
                 processMemory.getJvmMetaspaceAndOverhead();
         return new TaskExecutorProcessSpec(
-                getCpuCores(config), flinkMemory, jvmMetaspaceAndOverhead);
+                getCpuCores(config), flinkMemory, jvmMetaspaceAndOverhead, getNumSlots(config));
     }
 
     private static CPUResource getCpuCores(final Configuration config) {
         return getCpuCoresWithFallback(config, -1.0);
+    }
+
+    private static int getNumSlots(final Configuration config) {
+        return config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
     }
 
     public static double getCpuCoresWithFallbackConfigOption(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -120,6 +120,9 @@ public class TaskExecutorProcessUtils {
                 TaskManagerOptions.JVM_OVERHEAD_MAX.key(),
                 taskExecutorProcessSpec.getJvmMetaspaceAndOverhead().getOverhead().getBytes()
                         + "b");
+        configs.put(
+                TaskManagerOptions.NUM_TASK_SLOTS.key(),
+                String.valueOf(taskExecutorProcessSpec.getNumSlots()));
         return assembleDynamicConfigsStr(configs);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
@@ -46,18 +46,22 @@ public final class WorkerResourceSpec implements Serializable {
 
     private final MemorySize managedMemSize;
 
+    private final int numSlots;
+
     private WorkerResourceSpec(
             CPUResource cpuCores,
             MemorySize taskHeapSize,
             MemorySize taskOffHeapSize,
             MemorySize networkMemSize,
-            MemorySize managedMemSize) {
+            MemorySize managedMemSize,
+            int numSlots) {
 
         this.cpuCores = Preconditions.checkNotNull(cpuCores);
         this.taskHeapSize = Preconditions.checkNotNull(taskHeapSize);
         this.taskOffHeapSize = Preconditions.checkNotNull(taskOffHeapSize);
         this.networkMemSize = Preconditions.checkNotNull(networkMemSize);
         this.managedMemSize = Preconditions.checkNotNull(managedMemSize);
+        this.numSlots = numSlots;
     }
 
     public static WorkerResourceSpec fromTaskExecutorProcessSpec(
@@ -68,18 +72,20 @@ public final class WorkerResourceSpec implements Serializable {
                 taskExecutorProcessSpec.getTaskHeapSize(),
                 taskExecutorProcessSpec.getTaskOffHeapSize(),
                 taskExecutorProcessSpec.getNetworkMemSize(),
-                taskExecutorProcessSpec.getManagedMemorySize());
+                taskExecutorProcessSpec.getManagedMemorySize(),
+                taskExecutorProcessSpec.getNumSlots());
     }
 
     public static WorkerResourceSpec fromTotalResourceProfile(
-            final ResourceProfile resourceProfile) {
+            final ResourceProfile resourceProfile, final int numSlots) {
         Preconditions.checkNotNull(resourceProfile);
         return new WorkerResourceSpec(
                 (CPUResource) resourceProfile.getCpuCores(),
                 resourceProfile.getTaskHeapMemory(),
                 resourceProfile.getTaskOffHeapMemory(),
                 resourceProfile.getNetworkMemory(),
-                resourceProfile.getManagedMemory());
+                resourceProfile.getManagedMemory(),
+                numSlots);
     }
 
     public CPUResource getCpuCores() {
@@ -102,10 +108,14 @@ public final class WorkerResourceSpec implements Serializable {
         return managedMemSize;
     }
 
+    public int getNumSlots() {
+        return numSlots;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(
-                cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize);
+                cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize, numSlots);
     }
 
     @Override
@@ -118,7 +128,8 @@ public final class WorkerResourceSpec implements Serializable {
                     && Objects.equals(this.taskHeapSize, that.taskHeapSize)
                     && Objects.equals(this.taskOffHeapSize, that.taskOffHeapSize)
                     && Objects.equals(this.networkMemSize, that.networkMemSize)
-                    && Objects.equals(this.managedMemSize, that.managedMemSize);
+                    && Objects.equals(this.managedMemSize, that.managedMemSize)
+                    && Objects.equals(this.numSlots, that.numSlots);
         }
         return false;
     }
@@ -146,6 +157,7 @@ public final class WorkerResourceSpec implements Serializable {
         private MemorySize taskOffHeapSize = MemorySize.ZERO;
         private MemorySize networkMemSize = MemorySize.ZERO;
         private MemorySize managedMemSize = MemorySize.ZERO;
+        private int numSlots = 1;
 
         public Builder() {}
 
@@ -174,9 +186,19 @@ public final class WorkerResourceSpec implements Serializable {
             return this;
         }
 
+        public Builder setNumSlots(int numSlots) {
+            this.numSlots = numSlots;
+            return this;
+        }
+
         public WorkerResourceSpec build() {
             return new WorkerResourceSpec(
-                    cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize);
+                    cpuCores,
+                    taskHeapSize,
+                    taskOffHeapSize,
+                    networkMemSize,
+                    managedMemSize,
+                    numSlots);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
@@ -147,6 +147,8 @@ public final class WorkerResourceSpec implements Serializable {
                 + networkMemSize.toHumanReadableString()
                 + ", managedMemSize="
                 + managedMemSize.toHumanReadableString()
+                + ", numSlots="
+                + numSlots
                 + "}";
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -90,7 +90,7 @@ public class FineGrainedSlotManager implements SlotManager {
 
     private boolean sendNotEnoughResourceNotifications = true;
 
-    private Set<JobID> unfulfillableJobs = new HashSet<>();
+    private final Set<JobID> unfulfillableJobs = new HashSet<>();
 
     /** ResourceManager's id. */
     @Nullable private ResourceManagerId resourceManagerId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -585,8 +585,11 @@ public class FineGrainedSlotManager implements SlotManager {
     @Override
     public Map<WorkerResourceSpec, Integer> getRequiredResources() {
         return taskManagerTracker.getPendingTaskManagers().stream()
-                .map(PendingTaskManager::getTotalResourceProfile)
-                .map(WorkerResourceSpec::fromTotalResourceProfile)
+                .map(
+                        pendingTaskManager ->
+                                WorkerResourceSpec.fromTotalResourceProfile(
+                                        pendingTaskManager.getTotalResourceProfile(),
+                                        pendingTaskManager.getNumSlots()))
                 .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(e -> 1)));
     }
 
@@ -668,7 +671,8 @@ public class FineGrainedSlotManager implements SlotManager {
     private boolean allocateResource(PendingTaskManager pendingTaskManager) {
         if (!resourceActions.allocateResource(
                 WorkerResourceSpec.fromTotalResourceProfile(
-                        pendingTaskManager.getTotalResourceProfile()))) {
+                        pendingTaskManager.getTotalResourceProfile(),
+                        pendingTaskManager.getNumSlots()))) {
             // resource cannot be allocated
             return false;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -123,6 +123,7 @@ public class TaskExecutorProcessUtilsTest
                         .setTaskOffHeapMemoryMB(200)
                         .setNetworkMemoryMB(300)
                         .setManagedMemoryMB(400)
+                        .setNumSlots(5)
                         .build();
         final TaskExecutorProcessSpec taskExecutorProcessSpec =
                 TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(
@@ -139,6 +140,7 @@ public class TaskExecutorProcessUtilsTest
         assertEquals(
                 workerResourceSpec.getManagedMemSize(),
                 taskExecutorProcessSpec.getManagedMemorySize());
+        assertEquals(workerResourceSpec.getNumSlots(), taskExecutorProcessSpec.getNumSlots());
     }
 
     @Test
@@ -594,6 +596,20 @@ public class TaskExecutorProcessUtilsTest
             assertThat(
                     e.getMessage(), containsString(TaskManagerOptions.TOTAL_PROCESS_MEMORY.key()));
         }
+    }
+
+    @Test
+    public void testConfigNumSlots() {
+        final int numSlots = 5;
+
+        Configuration conf = new Configuration();
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, numSlots);
+
+        validateInAllConfigurations(
+                conf,
+                taskExecutorProcessSpec -> {
+                    assertThat(taskExecutorProcessSpec.getNumSlots(), is(numSlots));
+                });
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -112,6 +112,9 @@ public class TaskExecutorProcessUtilsTest
         assertThat(
                 MemorySize.parse(configs.get(TaskManagerOptions.JVM_OVERHEAD_MAX.key())),
                 is(TM_RESOURCE_SPEC.getJvmMetaspaceAndOverhead().getOverhead()));
+        assertThat(
+                Integer.valueOf(configs.get(TaskManagerOptions.NUM_TASK_SLOTS.key())),
+                is(TM_RESOURCE_SPEC.getNumSlots()));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecTest.java
@@ -42,6 +42,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec2 =
                 new WorkerResourceSpec.Builder()
@@ -50,6 +51,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec3 =
                 new WorkerResourceSpec.Builder()
@@ -58,6 +60,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec4 =
                 new WorkerResourceSpec.Builder()
@@ -66,6 +69,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec5 =
                 new WorkerResourceSpec.Builder()
@@ -74,6 +78,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(110)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec6 =
                 new WorkerResourceSpec.Builder()
@@ -82,6 +87,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(110)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec7 =
                 new WorkerResourceSpec.Builder()
@@ -90,6 +96,16 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(110)
+                        .setNumSlots(1)
+                        .build();
+        final WorkerResourceSpec spec8 =
+                new WorkerResourceSpec.Builder()
+                        .setCpuCores(1.0)
+                        .setTaskHeapMemoryMB(100)
+                        .setTaskOffHeapMemoryMB(100)
+                        .setNetworkMemoryMB(100)
+                        .setManagedMemoryMB(100)
+                        .setNumSlots(2)
                         .build();
 
         assertEquals(spec1, spec1);
@@ -99,6 +115,7 @@ public class WorkerResourceSpecTest extends TestLogger {
         assertNotEquals(spec1, spec5);
         assertNotEquals(spec1, spec6);
         assertNotEquals(spec1, spec7);
+        assertNotEquals(spec1, spec8);
     }
 
     @Test
@@ -110,6 +127,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec2 =
                 new WorkerResourceSpec.Builder()
@@ -118,6 +136,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec3 =
                 new WorkerResourceSpec.Builder()
@@ -126,6 +145,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec4 =
                 new WorkerResourceSpec.Builder()
@@ -134,6 +154,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec5 =
                 new WorkerResourceSpec.Builder()
@@ -142,6 +163,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(110)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec6 =
                 new WorkerResourceSpec.Builder()
@@ -150,6 +172,7 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(110)
                         .setManagedMemoryMB(100)
+                        .setNumSlots(1)
                         .build();
         final WorkerResourceSpec spec7 =
                 new WorkerResourceSpec.Builder()
@@ -158,6 +181,16 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskOffHeapMemoryMB(100)
                         .setNetworkMemoryMB(100)
                         .setManagedMemoryMB(110)
+                        .setNumSlots(1)
+                        .build();
+        final WorkerResourceSpec spec8 =
+                new WorkerResourceSpec.Builder()
+                        .setCpuCores(1.0)
+                        .setTaskHeapMemoryMB(100)
+                        .setTaskOffHeapMemoryMB(100)
+                        .setNetworkMemoryMB(100)
+                        .setManagedMemoryMB(100)
+                        .setNumSlots(2)
                         .build();
 
         assertEquals(spec1.hashCode(), spec1.hashCode());
@@ -167,6 +200,7 @@ public class WorkerResourceSpecTest extends TestLogger {
         assertNotEquals(spec1.hashCode(), spec5.hashCode());
         assertNotEquals(spec1.hashCode(), spec6.hashCode());
         assertNotEquals(spec1.hashCode(), spec7.hashCode());
+        assertNotEquals(spec1.hashCode(), spec8.hashCode());
     }
 
     @Test
@@ -189,10 +223,12 @@ public class WorkerResourceSpecTest extends TestLogger {
         assertEquals(
                 workerResourceSpec.getManagedMemSize(),
                 taskExecutorProcessSpec.getManagedMemorySize());
+        assertEquals(workerResourceSpec.getNumSlots(), taskExecutorProcessSpec.getNumSlots());
     }
 
     @Test
     public void testCreateFromResourceProfile() {
+        final int numSlots = 3;
         final ResourceProfile resourceProfile =
                 ResourceProfile.newBuilder()
                         .setCpuCores(1)
@@ -202,12 +238,13 @@ public class WorkerResourceSpecTest extends TestLogger {
                         .setTaskHeapMemoryMB(10)
                         .build();
         final WorkerResourceSpec workerResourceSpec =
-                WorkerResourceSpec.fromTotalResourceProfile(resourceProfile);
+                WorkerResourceSpec.fromTotalResourceProfile(resourceProfile, numSlots);
         assertEquals(workerResourceSpec.getCpuCores(), resourceProfile.getCpuCores());
         assertEquals(workerResourceSpec.getTaskHeapSize(), resourceProfile.getTaskHeapMemory());
         assertEquals(
                 workerResourceSpec.getTaskOffHeapSize(), resourceProfile.getTaskOffHeapMemory());
         assertEquals(workerResourceSpec.getNetworkMemSize(), resourceProfile.getNetworkMemory());
         assertEquals(workerResourceSpec.getManagedMemSize(), resourceProfile.getManagedMemory());
+        assertEquals(workerResourceSpec.getNumSlots(), numSlots);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerUtilsTest.java
@@ -102,7 +102,7 @@ public class SlotManagerUtilsTest extends TestLogger {
                 TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(
                         taskExecutorResourceSpec);
         final WorkerResourceSpec workerResourceSpec =
-                WorkerResourceSpec.fromTotalResourceProfile(totalResourceProfile);
+                WorkerResourceSpec.fromTotalResourceProfile(totalResourceProfile, numSlots);
 
         assertThat(
                 SlotManagerUtils.generateDefaultSlotResourceProfile(totalResourceProfile, numSlots),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
