### PR TITLE
[FLINK-20979] [elasticsearch] Corrected Elasticsearch Documentation for sink.bulk-flush.max-actions 

### DIFF
--- a/docs/content.zh/docs/connectors/table/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/table/elasticsearch.md
@@ -158,7 +158,7 @@ Connector Options
       <td style="word-wrap: break-word;">1000</td>
       <td>Integer</td>
       <td>Maximum number of buffered actions per bulk request.
-      Can be set to <code>'0'</code> to disable it.
+      Can be set to <code>'-1'</code> to disable it.
       </td>
     </tr>
     <tr>

--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -158,7 +158,7 @@ Connector Options
       <td style="word-wrap: break-word;">1000</td>
       <td>Integer</td>
       <td>Maximum number of buffered actions per bulk request.
-      Can be set to <code>'0'</code> to disable it.
+      Can be set to <code>'-1'</code> to disable it.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## What is the purpose of the change

This pull request corrects an error within the documentation for the Elasticsearch connector for the `sink.bulk-flush.max-actions` option that could potentially cause users to use an invalid value '0' as opposed to the correct value '-1' when attempting to disable this feature.

## Brief change log

Minor documentation change that should align the documentation with its functionality.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
