### PR TITLE
[FLINK-21698][table-planner] Disable problematic cast conversion between NUMERIC type and TIMESTAMP type

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -187,7 +187,7 @@ public class SQLClientSchemaRegistryITCase {
                                 + "'",
                         ");",
                         "",
-                        "INSERT INTO user_behavior VALUES (1, 1, 1, 'buy', CAST (1234 AS TIMESTAMP(3)));");
+                        "INSERT INTO user_behavior VALUES (1, 1, 1, 'buy', TO_TIMESTAMP(FROM_UNIXTIME(1234)));");
 
         executeSqlStatements(sqlLines);
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1160,13 +1160,6 @@ object ScalarOperatorGens {
         operandTerm => s"$DECIMAL_UTIL.castToBoolean($operandTerm)"
       }
 
-    // DECIMAL -> Timestamp
-    case (DECIMAL, TIMESTAMP_WITHOUT_TIME_ZONE) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm =>
-          s"$TIMESTAMP_DATA.fromEpochMillis($DECIMAL_UTIL.castToTimestamp($operandTerm))"
-      }
-
     // NUMERIC TYPE -> Boolean
     case (_, BOOLEAN) if isNumeric(operand.resultType) =>
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
@@ -1248,72 +1241,111 @@ object ScalarOperatorGens {
         s"$method($operandTerm.getMillisecond(), $zone)"
       }
 
-    // Timestamp -> Decimal
-    case  (TIMESTAMP_WITHOUT_TIME_ZONE, DECIMAL) =>
+    // Disable cast conversion between Numeric type and  Timestamp type
+    case (TINYINT, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (SMALLINT, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (INTEGER, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (BIGINT, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (FLOAT, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (DOUBLE, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (DECIMAL, TIMESTAMP_WITHOUT_TIME_ZONE) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, TINYINT) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, SMALLINT) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, INTEGER) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, BIGINT) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, FLOAT) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, DOUBLE) |
+         (TIMESTAMP_WITHOUT_TIME_ZONE, DECIMAL) => {
+      if (TIMESTAMP_WITHOUT_TIME_ZONE.equals(targetType.getTypeRoot)) {
+        throw new ValidationException("The cast conversion from NUMERIC type to TIMESTAMP type" +
+          " is problematic, it's recommended to use" +
+          " TO_TIMESTAMP(FROM_UNIXTIME(epochSeconds)) as an replacement.")
+      } else {
+        throw new ValidationException("The cast conversion from TIMESTAMP type to NUMERIC type" +
+          " is problematic, it's recommended to use" +
+          " UNIX_TIMESTAMP(CAST(timestampCol AS STRING)) as an replacement.")
+      }
+    }
+
+    // Tinyint -> TimestampLtz
+    // Smallint -> TimestampLtz
+    // Int -> TimestampLtz
+    // Bigint -> TimestampLtz
+    case (TINYINT, TIMESTAMP_WITH_LOCAL_TIME_ZONE) |
+         (SMALLINT, TIMESTAMP_WITH_LOCAL_TIME_ZONE) |
+         (INTEGER, TIMESTAMP_WITH_LOCAL_TIME_ZONE) |
+         (BIGINT, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"$TIMESTAMP_DATA.fromEpochMillis(((long) $operandTerm) * 1000)"
+      }
+
+    // Float -> TimestampLtz
+    // Double -> TimestampLtz
+    case (FLOAT, TIMESTAMP_WITH_LOCAL_TIME_ZONE) |
+         (DOUBLE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"$TIMESTAMP_DATA.fromEpochMillis((long) ($operandTerm * 1000)," +
+          s" (int)($operandTerm * 1000_000_000 % 1000_000))"
+      }
+
+    // DECIMAL -> TimestampLtz
+    case (DECIMAL, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm =>
+          s"$TIMESTAMP_DATA.fromEpochMillis(" +
+            s"(long) ($DECIMAL_UTIL.doubleValue($operandTerm) * 1000), " +
+            s"(int)($DECIMAL_UTIL.doubleValue($operandTerm) * 1000_000_000 % 1000_000) )"
+      }
+
+    // TimestampLtz -> Tinyint
+    case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TINYINT) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"((byte) ($operandTerm.getMillisecond() / 1000))"
+      }
+
+    // TimestampLtz -> Smallint
+    case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, SMALLINT) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"((short) ($operandTerm.getMillisecond() / 1000))"
+      }
+
+    // TimestampLtz -> Int
+    case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, INTEGER) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"((int) ($operandTerm.getMillisecond() / 1000))"
+      }
+
+    // TimestampLtz -> BigInt
+    case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, BIGINT) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"((long) ($operandTerm.getMillisecond() / 1000))"
+      }
+
+    // TimestampLtz -> Float
+    case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, FLOAT) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"((float) ($operandTerm.getMillisecond() / 1000.0" +
+          s" + $operandTerm.getNanoOfMillisecond() / 1000_000_000.0))"
+      }
+
+    // TimestampLtz -> Double
+    case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, DOUBLE) =>
+      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
+        operandTerm => s"((double) ($operandTerm.getMillisecond() / 1000.0" +
+          s" + $operandTerm.getNanoOfMillisecond() / 1000_000_000.0))"
+      }
+
+    // TimestampLtz -> Decimal
+    case  (TIMESTAMP_WITH_LOCAL_TIME_ZONE, DECIMAL) =>
       val dt = targetType.asInstanceOf[DecimalType]
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           s"""
              |$DECIMAL_UTIL.castFrom(
-             |  ((double) ($operandTerm.getMillisecond() / 1000.0)),
+             |  ((double) ($operandTerm.getMillisecond() / 1000.0
+             |   + $operandTerm.getNanoOfMillisecond() / 1000_000_000.0)),
              |  ${dt.getPrecision}, ${dt.getScale})
            """.stripMargin
-      }
-
-    // Tinyint -> Timestamp
-    // Smallint -> Timestamp
-    // Int -> Timestamp
-    // Bigint -> Timestamp
-    case (TINYINT, TIMESTAMP_WITHOUT_TIME_ZONE) |
-         (SMALLINT, TIMESTAMP_WITHOUT_TIME_ZONE) |
-         (INTEGER, TIMESTAMP_WITHOUT_TIME_ZONE) |
-         (BIGINT, TIMESTAMP_WITHOUT_TIME_ZONE) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"$TIMESTAMP_DATA.fromEpochMillis(((long) $operandTerm) * 1000)"
-      }
-
-    // Float -> Timestamp
-    // Double -> Timestamp
-    case (FLOAT, TIMESTAMP_WITHOUT_TIME_ZONE) |
-         (DOUBLE, TIMESTAMP_WITHOUT_TIME_ZONE) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"$TIMESTAMP_DATA.fromEpochMillis((long) ($operandTerm * 1000))"
-      }
-
-    // Timestamp -> Tinyint
-    case (TIMESTAMP_WITHOUT_TIME_ZONE, TINYINT) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"((byte) ($operandTerm.getMillisecond() / 1000))"
-      }
-
-    // Timestamp -> Smallint
-    case (TIMESTAMP_WITHOUT_TIME_ZONE, SMALLINT) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"((short) ($operandTerm.getMillisecond() / 1000))"
-      }
-
-    // Timestamp -> Int
-    case (TIMESTAMP_WITHOUT_TIME_ZONE, INTEGER) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"((int) ($operandTerm.getMillisecond() / 1000))"
-      }
-
-    // Timestamp -> BigInt
-    case (TIMESTAMP_WITHOUT_TIME_ZONE, BIGINT) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"((long) ($operandTerm.getMillisecond() / 1000))"
-      }
-
-    // Timestamp -> Float
-    case (TIMESTAMP_WITHOUT_TIME_ZONE, FLOAT) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"((float) ($operandTerm.getMillisecond() / 1000.0))"
-      }
-
-    // Timestamp -> Double
-    case (TIMESTAMP_WITHOUT_TIME_ZONE, DOUBLE) =>
-      generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
-        operandTerm => s"((double) ($operandTerm.getMillisecond() / 1000.0))"
       }
 
     // internal temporal casting

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1286,12 +1286,9 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           s"""
-             |$DECIMAL_UTIL.castToTimestamp(
-             |  $DECIMAL_UTIL.castFrom(
-             |    (double) $operandTerm,
-             |    $DECIMAL_UTIL.DECIMAL_SYSTEM_DEFAULT.getPrecision(),
-             |    $DECIMAL_UTIL.DECIMAL_SYSTEM_DEFAULT.getScale()))
-             """.stripMargin
+              |$TIMESTAMP_DATA.fromEpochMillis((long) ($operandTerm * 1000),
+              |(int) (($operandTerm - (int) $operandTerm) * 1000_000_000 % 1000_000))
+              """.stripMargin
       }
 
     // DECIMAL -> TimestampLtz
@@ -1330,12 +1327,9 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           s"""
-             |$DECIMAL_UTIL.castToFloat(
-             |  $DECIMAL_UTIL.castFrom(
-             |    $operandTerm,
-             |    $DECIMAL_UTIL.DECIMAL_SYSTEM_DEFAULT.getPrecision(),
-             |    $DECIMAL_UTIL.DECIMAL_SYSTEM_DEFAULT.getScale()))
-             """.stripMargin
+             |((float) ($operandTerm.getMillisecond() / 1000.0 +
+             |$operandTerm.getNanoOfMillisecond() / 1000_000_000.0))
+          """.stripMargin
       }
 
     // TimestampLtz -> Double
@@ -1343,12 +1337,9 @@ object ScalarOperatorGens {
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
         operandTerm =>
           s"""
-             |$DECIMAL_UTIL.castToDouble(
-             |  $DECIMAL_UTIL.castFrom(
-             |    $operandTerm,
-             |    $DECIMAL_UTIL.DECIMAL_SYSTEM_DEFAULT.getPrecision(),
-             |    $DECIMAL_UTIL.DECIMAL_SYSTEM_DEFAULT.getScale()))
-             """.stripMargin
+             |((double) ($operandTerm.getMillisecond() / 1000.0 +
+             |$operandTerm.getNanoOfMillisecond() / 1000_000_000.0))
+          """.stripMargin
       }
 
     // TimestampLtz -> Decimal

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -288,6 +288,9 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       "CAST(CAST(100.1234 as DECIMAL(38, 18)) AS TIMESTAMP_LTZ(3))",
       "1970-01-01 08:01:40.123")
+    testSqlApi(
+      "CAST(CAST(1616490480.123 AS DECIMAL(38, 18)) AS TIMESTAMP_LTZ(9))",
+      "2021-03-23 17:08:00.123000000")
 
     // TIMESTAMP_LTZ -> TIME
     testSqlApi(
@@ -370,6 +373,9 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 6))",
       "123.123456")
     testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456789")} AS DECIMAL(38, 9))",
+      "123.123456789")
+    testSqlApi(
       s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 4))",
       "123.1235")
 
@@ -385,11 +391,12 @@ class TemporalTypesTest extends ExpressionTestBase {
   @Test
   def tesInvalidCastBetweenNumericAndTimestamp(): Unit = {
     val castFromTimestampExceptionMsg = "The cast conversion from TIMESTAMP type to NUMERIC type" +
-      " is problematic, it's recommended to use UNIX_TIMESTAMP(CAST(timestampCol AS STRING))" +
-      " as an replacement."
+      " is not allowed,it's recommended to use" +
+      " UNIX_TIMESTAMP(CAST(timestamp_col AS STRING)) instead."
+
     val castToTimestampExceptionMsg = "The cast conversion from NUMERIC type to TIMESTAMP type" +
-      " is problematic, it's recommended to use TO_TIMESTAMP(FROM_UNIXTIME(epochSeconds)) as" +
-      " an replacement."
+      " is not allowed, it's recommended to use TO_TIMESTAMP(FROM_UNIXTIME(numeric_col))" +
+      " instead, note the numeric is in seconds."
 
     testExpectedSqlException(
       "CAST(CAST(123 as TINYINT) AS TIMESTAMP)",
@@ -1580,64 +1587,64 @@ class TemporalTypesTest extends ExpressionTestBase {
   def testTimestampLtzArithmetic(): Unit = {
     // TIMESTAMP_LTZ +/- INTERVAL should support nanosecond
     testSqlApi(
-      s"${timestampTz("1970-02-01 00:00:00.123456789")} + INTERVAL '1' YEAR",
+      s"${timestampLtz("1970-02-01 00:00:00.123456789")} + INTERVAL '1' YEAR",
       "1971-02-01 00:00:00.123456789")
 
     testSqlApi(
-      s"${timestampTz("1970-02-01 00:00:00.123456789")} - INTERVAL '1' MONTH",
+      s"${timestampLtz("1970-02-01 00:00:00.123456789")} - INTERVAL '1' MONTH",
       "1970-01-01 00:00:00.123456789")
 
     testSqlApi(
-      s"${timestampTz("1970-02-01 00:00:00.123456789")} + INTERVAL '1' DAY",
+      s"${timestampLtz("1970-02-01 00:00:00.123456789")} + INTERVAL '1' DAY",
       "1970-02-02 00:00:00.123456789")
 
     testSqlApi(
-      s"${timestampTz("1970-02-01 00:00:00.123456789")} - INTERVAL '1' HOUR",
+      s"${timestampLtz("1970-02-01 00:00:00.123456789")} - INTERVAL '1' HOUR",
       "1970-01-31 23:00:00.123456789")
 
     testSqlApi(
-      s"${timestampTz("1970-02-01 00:00:00.123456789")} + INTERVAL '1' MINUTE",
+      s"${timestampLtz("1970-02-01 00:00:00.123456789")} + INTERVAL '1' MINUTE",
       "1970-02-01 00:01:00.123456789")
 
     testSqlApi(
-      s"${timestampTz("1970-02-01 00:00:00.123456789")} - INTERVAL '1' SECOND",
+      s"${timestampLtz("1970-02-01 00:00:00.123456789")} - INTERVAL '1' SECOND",
       "1970-01-31 23:59:59.123456789")
 
     // test TIMESTAMPDIFF for TIMESTAMP_LTZ type
     testSqlApi(
-      s"TIMESTAMPDIFF(YEAR, ${timestampTz("1970-01-01 00:00:00.123456789")}," +
-        s" ${timestampTz("1971-01-02 01:02:03.123456789")})",
+      s"TIMESTAMPDIFF(YEAR, ${timestampLtz("1970-01-01 00:00:00.123456789")}," +
+        s" ${timestampLtz("1971-01-02 01:02:03.123456789")})",
       "1")
 
     testSqlApi(
-      s"TIMESTAMPDIFF(MONTH, ${timestampTz("1970-01-01 00:00:00.123456789")}," +
-        s" ${timestampTz("1971-01-02 01:02:03.123456789")})",
+      s"TIMESTAMPDIFF(MONTH, ${timestampLtz("1970-01-01 00:00:00.123456789")}," +
+        s" ${timestampLtz("1971-01-02 01:02:03.123456789")})",
       "12")
 
     testSqlApi(
-      s"TIMESTAMPDIFF(DAY, ${timestampTz("1970-01-01 00:00:00.123")}," +
-        s" ${timestampTz("1971-01-02 01:02:03.123")})",
+      s"TIMESTAMPDIFF(DAY, ${timestampLtz("1970-01-01 00:00:00.123")}," +
+        s" ${timestampLtz("1971-01-02 01:02:03.123")})",
       "366")
 
     testSqlApi(
-      s"TIMESTAMPDIFF(HOUR, ${timestampTz("1970-01-01 00:00:00.123")}," +
-        s" ${timestampTz("1970-01-01 01:02:03.123")})",
+      s"TIMESTAMPDIFF(HOUR, ${timestampLtz("1970-01-01 00:00:00.123")}," +
+        s" ${timestampLtz("1970-01-01 01:02:03.123")})",
       "1")
 
     testSqlApi(
-      s"TIMESTAMPDIFF(MINUTE, ${timestampTz("1970-01-01 01:02:03.123")}," +
-        s" ${timestampTz("1970-01-01 00:00:00")})",
+      s"TIMESTAMPDIFF(MINUTE, ${timestampLtz("1970-01-01 01:02:03.123")}," +
+        s" ${timestampLtz("1970-01-01 00:00:00")})",
       "-62")
 
     testSqlApi(
-      s"TIMESTAMPDIFF(SECOND, ${timestampTz("1970-01-01 00:00:00.123")}," +
-        s" ${timestampTz("1970-01-01 00:02:03.234")})",
+      s"TIMESTAMPDIFF(SECOND, ${timestampLtz("1970-01-01 00:00:00.123")}," +
+        s" ${timestampLtz("1970-01-01 00:02:03.234")})",
       "123")
 
     // test null input
     testSqlApi(
       s"TIMESTAMPDIFF(SECOND, CAST(null AS TIMESTAMP_LTZ)," +
-        s" ${timestampTz("1970-01-01 00:02:03.234")})",
+        s" ${timestampLtz("1970-01-01 00:02:03.234")})",
       "null")
   }
 
@@ -1647,30 +1654,30 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     // unsupported operand type
     testExpectedSqlException(
-      s"TIMESTAMPDIFF(MONTH, ${timestampTz("1970-01-01 00:00:00.123")}, TIME '00:00:01')",
+      s"TIMESTAMPDIFF(MONTH, ${timestampLtz("1970-01-01 00:00:00.123")}, TIME '00:00:01')",
       exceptionMsg,
       classOf[CodeGenException])
 
     testExpectedSqlException(
-      s"TIMESTAMPDIFF(MONTH, ${timestampTz("1970-01-01 00:00:00.123")}, DATE '1970-01-01')",
+      s"TIMESTAMPDIFF(MONTH, ${timestampLtz("1970-01-01 00:00:00.123")}, DATE '1970-01-01')",
       exceptionMsg,
       classOf[CodeGenException])
 
     testExpectedSqlException(
-      s"TIMESTAMPDIFF(MONTH, ${timestampTz("1970-01-01 00:00:00.123")}," +
+      s"TIMESTAMPDIFF(MONTH, ${timestampLtz("1970-01-01 00:00:00.123")}," +
         s" TIMESTAMP '1970-01-01 00:00:00.123')",
       exceptionMsg,
       classOf[CodeGenException])
 
     testExpectedSqlException(
-      s"TIMESTAMPDIFF(SECOND, ${timestampTz("1970-01-01 00:00:00.123")}," +
+      s"TIMESTAMPDIFF(SECOND, ${timestampLtz("1970-01-01 00:00:00.123")}," +
         s" TIME '00:00:00.123')",
       exceptionMsg,
       classOf[CodeGenException])
 
     // invalid operand type
     testExpectedSqlException(
-      s"TIMESTAMPDIFF(SECOND, ${timestampTz("1970-01-01 00:00:00.123")}, 'test_string_type')",
+      s"TIMESTAMPDIFF(SECOND, ${timestampLtz("1970-01-01 00:00:00.123")}, 'test_string_type')",
       "Cannot apply 'TIMESTAMPDIFF' to arguments of type" +
         " 'TIMESTAMPDIFF(<SYMBOL>, <TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)>, <CHAR(16)>)'." +
         " Supported form(s): 'TIMESTAMPDIFF(<ANY>, <DATETIME>, <DATETIME>)'")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -379,6 +379,17 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 4))",
       "123.1235")
 
+    // test cast between TIMESTAMP_LTZ and TIMESTAMP_LTZ
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:00:01.123")
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS TIMESTAMP_LTZ(6))",
+      "1970-01-01 08:00:01.123456")
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS TIMESTAMP_LTZ(9))",
+      "1970-01-01 08:00:01.123456000")
+
     // test cast with null value
     testSqlApi(
       s"CAST(CAST(null AS BIGINT) AS TIMESTAMP_LTZ(3))",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -185,82 +185,267 @@ class TemporalTypesTest extends ExpressionTestBase {
 
   @Test
   def testTimePointCasting(): Unit = {
+    // DATE -> TIMESTAMP
     testAllApis(
       'f0.cast(DataTypes.TIMESTAMP(3)),
       "CAST(f0 AS TIMESTAMP(3))",
       "1990-10-14 00:00:00.000")
 
+    // TIME -> TIMESTAMP
     testAllApis(
       'f1.cast(DataTypes.TIMESTAMP(3)),
       "CAST(f1 AS TIMESTAMP(3))",
       "1970-01-01 10:20:45.000")
 
+    // TIMESTAMP -> DATE
     testAllApis(
       'f2.cast(DataTypes.DATE),
       "CAST(f2 AS DATE)",
       "1990-10-14")
 
+    // TIMESTAMP -> TIME
     testAllApis(
       'f2.cast(DataTypes.TIME),
       "CAST(f2 AS TIME)",
       "10:20:45")
+  }
 
-    testAllApis(
-      'f2.cast(DataTypes.TIME),
-      "CAST(f2 AS TIME)",
-      "10:20:45")
+  @Test
+  def testTimestampLtzCastInUTC(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("UTC"))
 
+    //DATE -> TIMESTAMP_LTZ
     testSqlApi(
-      "CAST(CAST('123' as DECIMAL(5, 2)) AS TIMESTAMP)",
-      "1970-01-01 00:02:03.000000")
-
-    testSqlApi(
-      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DECIMAL(5, 2))",
-      "123.00")
-
-    testSqlApi(
-      "CAST(CAST('123' AS FLOAT) AS TIMESTAMP)",
-      "1970-01-01 00:02:03.000000")
-
-    testSqlApi(
-      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS FLOAT)",
-      "123.0")
-
-    testSqlApi(
-      "CAST(CAST('123' AS DOUBLE) AS TIMESTAMP)",
-      "1970-01-01 00:02:03.000000")
-
-    testSqlApi(
-      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DOUBLE)",
-      "123.0")
-
-    testSqlApi(
-      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS TINYINT)",
-      "123")
-
-    testSqlApi(
-      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS SMALLINT)",
-      "123")
-
-    testSqlApi(
-      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS INT)",
-      "123")
-
-    testSqlApi(
-      "CAST(f0 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
+      "CAST(f0 AS TIMESTAMP_LTZ(3))",
       "1990-10-14 00:00:00.000")
 
+    //TIME -> TIMESTAMP_LTZ
     testSqlApi(
-      "CAST(f1 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
+      "CAST(f1 AS TIMESTAMP_LTZ(3))",
       "1970-01-01 10:20:45.000")
 
+    //TIMESTAMP_LTZ -> TIME
     testSqlApi(
-      s"CAST(${timestampTz("2018-03-14 01:02:03")} AS TIME)",
+      s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS TIME)",
       "01:02:03")
 
+    //TIMESTAMP_LTZ -> DATE
     testSqlApi(
-      s"CAST(${timestampTz("2018-03-14 01:02:03")} AS DATE)",
+      s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS DATE)",
       "2018-03-14")
+  }
+
+  @Test
+  def testTimestampLtzCastInShanghai(): Unit = {
+    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
+
+    // DATE -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(f0 AS TIMESTAMP_LTZ(3))",
+      "1990-10-14 00:00:00.000")
+
+    // TIME -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(f1 AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 10:20:45.000")
+
+    // TIMESTAMP -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(f2 AS TIMESTAMP_LTZ(3))",
+      "1990-10-14 10:20:45.123")
+
+    // TINYINT -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(100 AS TINYINT) AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.000")
+
+    // SMALLINT -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(100 AS SMALLINT) AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.000")
+
+    // INT -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(100 AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.000")
+
+    // BIGINT -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(100 AS BIGINT) AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.000")
+
+    // FLOAT -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(100.01 AS FLOAT) AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.010")
+
+    // DOUBLE -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(100.123 AS DOUBLE) AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.123")
+
+    // DECIMAL -> TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(100.1234 as DECIMAL(38, 18)) AS TIMESTAMP_LTZ(3))",
+      "1970-01-01 08:01:40.123")
+
+    // TIMESTAMP_LTZ -> TIME
+    testSqlApi(
+      s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS TIME)",
+      "01:02:03")
+
+    // TIMESTAMP_LTZ -> DATE
+    testSqlApi(
+      s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS DATE)",
+      "2018-03-14")
+
+    // TIMESTAMP_LTZ -> TIMESTAMP
+    testSqlApi(
+      s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS TIMESTAMP(3))",
+      "2018-03-14 01:02:03.000")
+
+    // TIMESTAMP_LTZ -> TINYINT
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS TINYINT)",
+      "123")
+
+    // TIMESTAMP_LTZ -> SMALLINT
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS SMALLINT)",
+      "123")
+
+    // TIMESTAMP_LTZ -> INT
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS INT)",
+      "123")
+
+    // TIMESTAMP_LTZ -> BIGINT
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS BIGINT)",
+      "123")
+
+    // TIMESTAMP_LTZ -> FLOAT
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS FLOAT)",
+      "123.123")
+
+    // TIMESTAMP_LTZ -> DOUBLE
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS DOUBLE)",
+      "123.123")
+
+    // TIMESTAMP_LTZ -> DECIMAL
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS DECIMAL(38, 3))",
+      "123.123")
+
+    // test precision when cast to TIMESTAMP_LTZ
+    testSqlApi(
+      "CAST(CAST(1.1234567 AS FLOAT) AS TIMESTAMP_LTZ(6))",
+      "1970-01-01 08:00:01.123456")
+    testSqlApi(
+      "CAST(CAST(1.12 AS FLOAT) AS TIMESTAMP_LTZ(6))",
+      "1970-01-01 08:00:01.120000")
+    testSqlApi(
+      "CAST(CAST(1.1234567899 AS DOUBLE) AS TIMESTAMP_LTZ(9))",
+      "1970-01-01 08:00:01.123456789")
+    testSqlApi(
+      "CAST(CAST(1.12 AS DOUBLE) AS TIMESTAMP_LTZ(6))",
+      "1970-01-01 08:00:01.120000")
+    testSqlApi(
+      "CAST(CAST(1.1234567899 AS DECIMAL(38, 18)) AS TIMESTAMP_LTZ(9))",
+      "1970-01-01 08:00:01.123456789")
+    testSqlApi(
+      "CAST(CAST(1.12 AS DECIMAL(38, 18)) AS TIMESTAMP_LTZ(6))",
+      "1970-01-01 08:00:01.120000")
+
+    // test precision when cast from TIMESTAMP_LTZ
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS FLOAT)",
+      "1.123456")
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DOUBLE)",
+      "123.123456")
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 6))",
+      "123.123456")
+    testSqlApi(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 4))",
+      "123.1235")
+
+    // test cast with null value
+    testSqlApi(
+      s"CAST(CAST(null AS BIGINT) AS TIMESTAMP_LTZ(3))",
+      "null")
+    testSqlApi(
+      s"CAST(CAST(null AS TIMESTAMP_LTZ(3)) AS BIGINT)",
+      "null")
+  }
+
+  @Test
+  def tesInvalidCastBetweenNumericAndTimestamp(): Unit = {
+    val castFromTimestampExceptionMsg = "The cast conversion from TIMESTAMP type to NUMERIC type" +
+      " is problematic, it's recommended to use UNIX_TIMESTAMP(CAST(timestampCol AS STRING))" +
+      " as an replacement."
+    val castToTimestampExceptionMsg = "The cast conversion from NUMERIC type to TIMESTAMP type" +
+      " is problematic, it's recommended to use TO_TIMESTAMP(FROM_UNIXTIME(epochSeconds)) as" +
+      " an replacement."
+
+    testExpectedSqlException(
+      "CAST(CAST(123 as TINYINT) AS TIMESTAMP)",
+      castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(CAST(123 AS SMALLINT) AS TIMESTAMP)",
+      castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(CAST(123 AS INT) AS TIMESTAMP)",
+      castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(CAST(123 AS BIGINT) AS TIMESTAMP)",
+      castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(CAST(123 AS FLOAT) AS TIMESTAMP)",
+      castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(CAST(123 AS DOUBLE) AS TIMESTAMP)",
+      castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+    "CAST(CAST(123 as DECIMAL(5, 2)) AS TIMESTAMP)",
+        castToTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS TINYINT)",
+      castFromTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS SMALLINT)",
+      castFromTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS INT)",
+      castFromTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS BIGINT)",
+      castFromTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS FLOAT)",
+      castFromTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DOUBLE)",
+      castFromTimestampExceptionMsg)
+
+    testExpectedSqlException(
+      "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DECIMAL(5, 2))",
+      castFromTimestampExceptionMsg)
   }
 
   @Test
@@ -589,11 +774,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03.123456")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
       "2018-03-14 01:02:03.123456")
   }
 
@@ -610,11 +795,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03.123456")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
       "2018-03-14 01:02:03.123456")
 
   }
@@ -632,11 +817,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03.123456")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03.123456")}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
       "2018-03-14 01:02:03.123456")
 
   }
@@ -675,12 +860,12 @@ class TemporalTypesTest extends ExpressionTestBase {
     //testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:10:31' TO HOUR)", "2018-03-20 07:00:00.000")
   }
 
-  private def timestampTz(str: String): String = {
+  private def timestampLtz(str: String): String = {
     val precision = extractPrecision(str)
-    timestampTz(str, precision)
+    timestampLtz(str, precision)
   }
 
-  private def timestampTz(str: String, precision: Int): String = {
+  private def timestampLtz(str: String, precision: Int): String = {
     s"CAST(TIMESTAMP '$str' AS TIMESTAMP($precision) WITH LOCAL TIME ZONE)"
   }
 
@@ -700,19 +885,19 @@ class TemporalTypesTest extends ExpressionTestBase {
   def testTemporalShanghai(): Unit = {
     config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
-    testSqlApi(timestampTz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123")
-    testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010")
+    testSqlApi(timestampLtz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123")
+    testSqlApi(timestampLtz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010")
 
     testSqlApi(
-      timestampTz("2018-03-14 19:00:00.010") + " > " + "f25",
+      timestampLtz("2018-03-14 19:00:00.010") + " > " + "f25",
       "true")
 
     testSqlApi(
-      s"${timestampTz("2018-03-14 01:02:03.123456789", 9)}",
+      s"${timestampLtz("2018-03-14 01:02:03.123456789", 9)}",
       "2018-03-14 01:02:03.123456789")
 
     testSqlApi(
-      s"${timestampTz("2018-03-14 01:02:03.123456", 6)}",
+      s"${timestampLtz("2018-03-14 01:02:03.123456", 6)}",
       "2018-03-14 01:02:03.123456")
 
 
@@ -722,11 +907,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       "2018/03/14 01:02:03")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03")}, 'yyyy-MM-dd HH:mm:ss')",
       "2018-03-14 01:02:03")
 
     // EXTRACT
-    val extractT1 = timestampTz("2018-03-20 07:59:59")
+    val extractT1 = timestampLtz("2018-03-20 07:59:59")
     testSqlApi(s"EXTRACT(DAY FROM $extractT1)", "20")
     testSqlApi(s"EXTRACT(HOUR FROM $extractT1)", "7")
     testSqlApi(s"EXTRACT(MONTH FROM $extractT1)", "3")
@@ -766,25 +951,25 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO YEAR)", "2018-01-01 00:00:00")
     testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO YEAR)", "2019-01-01 00:00:00")
 
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 00:00:00")} TO DAY)", "2018-03-20 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2021-02-27 00:00:00")} TO WEEK)", "2021-02-21 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2021-03-01 00:00:00")} TO WEEK)", "2021-02-28 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-04-01 06:44:31")} TO MONTH)", "2018-04-01 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-01-01 06:44:31")} TO MONTH)", "2018-01-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 07:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:00:00")} TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-21 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-1 00:00:00")} TO DAY)", "2018-03-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-31 00:00:01")} TO DAY)", "2018-04-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2021-02-27 00:00:00")} TO WEEK)", "2021-02-28 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2021-03-01 00:00:00")} TO WEEK)", "2021-03-07 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-01 21:00:01")} TO MONTH)", "2018-03-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-01 00:00:00")} TO MONTH)", "2018-03-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-12-02 00:00:00")} TO MONTH)", "2019-01-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-01-01 21:00:01")} TO YEAR)", "2018-01-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-01-02 21:00:01")} TO YEAR)", "2019-01-01 00:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2018-03-20 00:00:00")} TO DAY)", "2018-03-20 00:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2021-02-27 00:00:00")} TO WEEK)", "2021-02-21 00:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2021-03-01 00:00:00")} TO WEEK)", "2021-02-28 00:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2018-04-01 06:44:31")} TO MONTH)", "2018-04-01 00:00:00")
+    testSqlApi(s"FLOOR(${timestampLtz("2018-01-01 06:44:31")} TO MONTH)", "2018-01-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 07:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-20 06:00:00")} TO HOUR)", "2018-03-20 06:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-20 06:44:31")} TO DAY)", "2018-03-21 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-1 00:00:00")} TO DAY)", "2018-03-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-31 00:00:01")} TO DAY)", "2018-04-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2021-02-27 00:00:00")} TO WEEK)", "2021-02-28 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2021-03-01 00:00:00")} TO WEEK)", "2021-03-07 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-01 21:00:01")} TO MONTH)", "2018-03-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-03-01 00:00:00")} TO MONTH)", "2018-03-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-12-02 00:00:00")} TO MONTH)", "2019-01-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-01-01 21:00:01")} TO YEAR)", "2018-01-01 00:00:00")
+    testSqlApi(s"CEIL(${timestampLtz("2018-01-02 21:00:01")} TO YEAR)", "2019-01-01 00:00:00")
 
     // others
     testSqlApi("QUARTER(DATE '2016-04-12')", "2")
@@ -833,8 +1018,8 @@ class TemporalTypesTest extends ExpressionTestBase {
     // Asia/Rangoon UTC Offset 6.5
     config.setLocalTimeZone(ZoneId.of("Asia/Rangoon"))
 
-    val t1 = timestampTz("2018-03-20 06:10:31")
-    val t2 = timestampTz("2018-03-20 06:00:00")
+    val t1 = timestampLtz("2018-03-20 06:10:31")
+    val t2 = timestampLtz("2018-03-20 06:00:00")
     // 1521502831000,  2018-03-19 23:40:31 UTC,  2018-03-20 06:10:31 +06:30
     testSqlApi(s"EXTRACT(HOUR FROM $t1)", "6")
     testSqlApi(s"FLOOR($t1 TO HOUR)", "2018-03-20 06:00:00")
@@ -994,15 +1179,15 @@ class TemporalTypesTest extends ExpressionTestBase {
       "123456789")
 
     testSqlApi(
-      s"EXTRACT(MILLISECOND FROM ${timestampTz("1970-01-01 00:00:00.123456789", 9)})",
+      s"EXTRACT(MILLISECOND FROM ${timestampLtz("1970-01-01 00:00:00.123456789", 9)})",
       "123")
 
     testSqlApi(
-      s"EXTRACT(MICROSECOND FROM ${timestampTz("1970-01-01 00:00:00.123456789", 9)})",
+      s"EXTRACT(MICROSECOND FROM ${timestampLtz("1970-01-01 00:00:00.123456789", 9)})",
       "123456")
 
     testSqlApi(
-      s"EXTRACT(NANOSECOND FROM ${timestampTz("1970-01-01 00:00:00.123456789", 9)})",
+      s"EXTRACT(NANOSECOND FROM ${timestampLtz("1970-01-01 00:00:00.123456789", 9)})",
       "123456789")
 
 
@@ -1073,7 +1258,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       "1970-01-01 00:00:00")
 
     testSqlApi(
-      s"CAST(${timestampTz("1970-01-01 00:00:00.123456789", 9)} " +
+      s"CAST(${timestampLtz("1970-01-01 00:00:00.123456789", 9)} " +
         "AS TIMESTAMP(6) WITH LOCAL TIME ZONE)",
       "1970-01-01 00:00:00.123456"
     )
@@ -1127,13 +1312,13 @@ class TemporalTypesTest extends ExpressionTestBase {
 
 
     testSqlApi(
-      s"${timestampTz("1970-01-01 00:00:00.123456789", 9)} > " +
-        s"${timestampTz("1970-01-01 00:00:00.123456788", 9)}",
+      s"${timestampLtz("1970-01-01 00:00:00.123456789", 9)} > " +
+        s"${timestampLtz("1970-01-01 00:00:00.123456788", 9)}",
       "true")
 
     testSqlApi(
-      s"${timestampTz("1970-01-01 00:00:00.123456788", 9)} < " +
-        s"${timestampTz("1970-01-01 00:00:00.123456789", 9)}",
+      s"${timestampLtz("1970-01-01 00:00:00.123456788", 9)} < " +
+        s"${timestampLtz("1970-01-01 00:00:00.123456789", 9)}",
       "true")
 
 
@@ -1143,7 +1328,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       "1970/01/01 00:00:00.123456789")
 
     testSqlApi(
-      s"DATE_FORMAT(${timestampTz("2018-03-14 01:02:03.123456789", 9)}, " +
+      s"DATE_FORMAT(${timestampLtz("2018-03-14 01:02:03.123456789", 9)}, " +
         "'yyyy-MM-dd HH:mm:ss.SSSSSSSSS')",
       "2018-03-14 01:02:03.123456789")
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
@@ -461,11 +461,12 @@ class TemporalJoinTest extends TableTestBase {
         "'2020-11-11 13:12:13' is not supported yet.",
       classOf[AssertionError])
 
-    val sqlQuery7 = "SELECT * FROM RatesHistory FOR SYSTEM_TIME AS OF CAST(1 AS TIMESTAMP)"
+    val sqlQuery7 = "SELECT * FROM RatesHistory FOR SYSTEM_TIME AS OF " +
+      "TO_TIMESTAMP(FROM_UNIXTIME(1))"
     expectExceptionThrown(
       sqlQuery7,
       "Querying a temporal table using 'FOR SYSTEM TIME AS OF' syntax with an expression call " +
-        "'CAST(1):TIMESTAMP(6) NOT NULL' is not supported yet.",
+        "'TO_TIMESTAMP(FROM_UNIXTIME(1))' is not supported yet.",
       classOf[AssertionError])
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -38,6 +38,9 @@ import static org.apache.flink.table.data.DecimalData.fromBigDecimal;
 public final class DecimalDataUtils {
 
     private static final MathContext MC_DIVIDE = new MathContext(38, RoundingMode.HALF_UP);
+    private static final long MILLS_PER_SECOND = 1000L;
+    private static final long NANOS_PER_SECOND = 1000_000_000L;
+    private static final long NANOS_PER_MILLISECOND = 1000_000L;
 
     public static final DecimalType DECIMAL_SYSTEM_DEFAULT =
             new DecimalType(DecimalType.MAX_PRECISION, 18);
@@ -205,8 +208,23 @@ public final class DecimalDataUtils {
         return dec.toBigDecimal().compareTo(BigDecimal.ZERO) != 0;
     }
 
-    public static long castToTimestamp(DecimalData dec) {
-        return (long) (doubleValue(dec) * 1000);
+    public static TimestampData castToTimestamp(DecimalData dec) {
+        BigDecimal bd = dec.toBigDecimal().multiply(new BigDecimal(MILLS_PER_SECOND));
+        long mills = bd.longValue();
+        int nanos =
+                bd.remainder(BigDecimal.ONE)
+                        .multiply(new BigDecimal(NANOS_PER_MILLISECOND))
+                        .intValue();
+        return TimestampData.fromEpochMillis(mills, nanos);
+    }
+
+    public static DecimalData castFrom(TimestampData val, int precision, int scale) {
+        BigDecimal decimalSeconds =
+                new BigDecimal(val.getMillisecond())
+                        .multiply(new BigDecimal(NANOS_PER_MILLISECOND))
+                        .add(new BigDecimal(val.getNanoOfMillisecond()))
+                        .divide(new BigDecimal(NANOS_PER_SECOND));
+        return fromBigDecimal(decimalSeconds, precision, scale);
     }
 
     public static DecimalData castFrom(DecimalData dec, int precision, int scale) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -115,7 +115,7 @@ public class DecimalDataTest {
         assertTrue(castToBoolean(castFrom(true, 5, 0)));
         assertEquals(5, castToIntegral(castFrom(5, 5, 0)));
         assertEquals(5, castToIntegral(castFrom("5", 5, 0)));
-        assertEquals(5000, castToTimestamp(castFrom("5", 5, 0)));
+        assertEquals(5000, castToTimestamp(castFrom("5", 5, 0)).getMillisecond());
 
         DecimalData newDecimal = castFrom(castFrom(10, 5, 2), 10, 4);
         assertEquals(10, newDecimal.precision());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -116,6 +116,9 @@ public class DecimalDataTest {
         assertEquals(5, castToIntegral(castFrom(5, 5, 0)));
         assertEquals(5, castToIntegral(castFrom("5", 5, 0)));
         assertEquals(5000, castToTimestamp(castFrom("5", 5, 0)).getMillisecond());
+        assertEquals(12300456, castToTimestamp(castFrom("12300.4567", 10, 4)).getMillisecond());
+        assertEquals(
+                780000, castToTimestamp(castFrom("12300.45678", 10, 5)).getNanoOfMillisecond());
 
         DecimalData newDecimal = castFrom(castFrom(10, 5, 2), 10, 4);
         assertEquals(10, newDecimal.precision());
@@ -170,6 +173,8 @@ public class DecimalDataTest {
         assertNull(DecimalData.fromBigDecimal(new BigDecimal(Long.MAX_VALUE), 5, 0));
         assertEquals(0, DecimalData.zero(20, 2).toBigDecimal().intValue());
         assertEquals(0, DecimalData.zero(20, 2).toBigDecimal().intValue());
+        assertEquals(1234000, castToTimestamp(castFrom("1234", 20, 4)).getMillisecond());
+        assertEquals(0, castToTimestamp(castFrom("1234", 20, 4)).getNanoOfMillisecond());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

* This pull request disables problematic cast conversion between NUMERIC type and TIMESTAMP type

## Brief change log

  -  Disable the cast conversion between NUMERIC type and TIMESTAMP type
  - Throw readable exception message for when user call this kind of cast conversion.
  - Support the cast conversion between NUMERIC type and TIMESTAMP type

  
## Verifying this change

- Add SQL/Table API tests for this change 
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
