### PR TITLE
[FLINK-21621] [table-planner] Support TIMESTAMP_LTZ arithmetic

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -33,6 +33,7 @@ import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.{isInteroperable, isPrimitive}
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils._
+import org.apache.flink.table.types.logical.LogicalTypeFamily.DATETIME
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts
@@ -167,48 +168,6 @@ object ScalarOperatorGens {
 
     val op = if (plus) "+" else "-"
 
-    def isValidOpTypeForTsLtzArithmetic(opType: LogicalTypeRoot) : Boolean = {
-      opType match {
-        case TIMESTAMP_WITH_LOCAL_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE |
-             TIME_WITHOUT_TIME_ZONE | DATE
-          => true
-        case _
-          => false
-      }
-    }
-
-    def generateTsLtzArithmetic(resultType: LogicalType) : GeneratedExpression = {
-      resultType.getTypeRoot match {
-        case INTERVAL_YEAR_MONTH =>
-          generateOperatorIfNotNull(ctx, resultType, left, right) {
-            (ll, rr) => (left.resultType.getTypeRoot, right.resultType.getTypeRoot) match {
-              case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
-                val leftTerm = s"$ll.getMillisecond()"
-                val rightTerm = s"$rr.getMillisecond()"
-                s"${qualifyMethod(BuiltInMethods.SUBTRACT_MONTHS)}($leftTerm, $rightTerm)"
-              case _ =>
-                throw new CodeGenException(
-                  "TIMESTAMP_LTZ only supports diff between the same type.")
-            }
-          }
-
-        case INTERVAL_DAY_TIME =>
-          generateOperatorIfNotNull(ctx, resultType, left, right) {
-            (ll, rr) => (left.resultType.getTypeRoot, right.resultType.getTypeRoot) match {
-              case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
-                val leftTerm = s"$ll.getMillisecond()"
-                val rightTerm = s"$rr.getMillisecond()"
-                s"$leftTerm $op $rightTerm"
-              case _ =>
-                throw new CodeGenException(
-                  "TIMESTAMP_LTZ only supports diff between the same type.")
-            }
-          }
-        case _ =>
-          throw new CodeGenException("Unsupported temporal arithmetic.")
-      }
-    }
-
     (left.resultType.getTypeRoot, right.resultType.getTypeRoot) match {
       // arithmetic of time point and time interval
       case (INTERVAL_YEAR_MONTH, INTERVAL_YEAR_MONTH) |
@@ -315,10 +274,49 @@ object ScalarOperatorGens {
         }
 
       // minus arithmetic of time points (i.e. for TIMESTAMPDIFF for TIMESTAMP_LTZ)
-      case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, t) if isValidOpTypeForTsLtzArithmetic(t) && !plus =>
-        generateTsLtzArithmetic(resultType)
-      case (t, TIMESTAMP_WITH_LOCAL_TIME_ZONE) if isValidOpTypeForTsLtzArithmetic(t) && !plus =>
-        generateTsLtzArithmetic(resultType)
+      case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, t)
+        if t.getFamilies.contains(DATETIME) && !plus =>
+        generateTimestampLtzMinus(ctx, resultType, left, right)
+      case (t, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+        if t.getFamilies.contains(DATETIME) && !plus =>
+        generateTimestampLtzMinus(ctx, resultType, left, right)
+      case _ =>
+        throw new CodeGenException("Unsupported temporal arithmetic.")
+    }
+  }
+
+  private def generateTimestampLtzMinus(
+     ctx: CodeGeneratorContext,
+     resultType: LogicalType,
+     left: GeneratedExpression,
+     right: GeneratedExpression)
+  : GeneratedExpression = {
+    resultType.getTypeRoot match {
+      case INTERVAL_YEAR_MONTH =>
+        generateOperatorIfNotNull(ctx, resultType, left, right) {
+          (ll, rr) => (left.resultType.getTypeRoot, right.resultType.getTypeRoot) match {
+            case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
+              val leftTerm = s"$ll.getMillisecond()"
+              val rightTerm = s"$rr.getMillisecond()"
+              s"${qualifyMethod(BuiltInMethods.SUBTRACT_MONTHS)}($leftTerm, $rightTerm)"
+            case _ =>
+              throw new CodeGenException(
+                "TIMESTAMP_LTZ only supports diff between the same type.")
+          }
+        }
+
+      case INTERVAL_DAY_TIME =>
+        generateOperatorIfNotNull(ctx, resultType, left, right) {
+          (ll, rr) => (left.resultType.getTypeRoot, right.resultType.getTypeRoot) match {
+            case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
+              val leftTerm = s"$ll.getMillisecond()"
+              val rightTerm = s"$rr.getMillisecond()"
+              s"$leftTerm - $rightTerm"
+            case _ =>
+              throw new CodeGenException(
+                "TIMESTAMP_LTZ only supports diff between the same type.")
+          }
+        }
       case _ =>
         throw new CodeGenException("Unsupported temporal arithmetic.")
     }


### PR DESCRIPTION
## What is the purpose of the change

* This pull request support TIMESTAMP_LTZ arithmetics like `TIMESTAMP_LTZ + interval '1' DAY`

## Brief change log

 -  Enable TIMESTAMP_LTZ type when generate Temporal PlusMinus code

## Verifying this change

- Add temporal arithmetics unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
