### PR TITLE
[FLINK-21654][test] Added @throws information to tests

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -576,6 +576,8 @@ public class SavepointITCase extends TestLogger {
     @Test
     @Category(FailsWithAdaptiveScheduler.class) // FLINK-21333
     public void testStopWithSavepointFailingAfterSnapshotCreation() throws Exception {
+        // the trigger need to be reset in case the test is run multiple times
+        CancelFailingInfiniteTestSource.cancelTriggered = false;
         testStopWithFailingSourceInOnePipeline(
                 new CancelFailingInfiniteTestSource(),
                 folder.newFolder(),

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -307,8 +307,8 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
         CommonTestUtils.waitUntilCondition(
                 () ->
-                        !yarnClient
-                                .getApplications(
+                        !getApplicationReportWithRetryOnNPE(
+                                        yarnClient,
                                         EnumSet.of(
                                                 YarnApplicationState.KILLED,
                                                 YarnApplicationState.FINISHED))

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -232,10 +232,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
      * <p>This ensures that with (any) pre-allocated off-heap memory by us, there is some off-heap
      * memory remaining for Flink's libraries. Creating task managers will thus fail if no off-heap
      * memory remains.
-     *
-     * @throws NullPointerException There is a known Hadoop bug (YARN-7007) that got fixed in Hadoop
-     *     2.8.6 but might cause test instabilities. See FLINK-20659/FLINK-15534 for further
-     *     information.
      */
     @Test
     public void perJobYarnClusterOffHeap() throws Exception {
@@ -293,10 +289,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
      *
      * <p><b>Hint: </b> If you think it is a good idea to add more assertions to this test, think
      * again!
-     *
-     * @throws NullPointerException There is a known Hadoop bug (YARN-7007) that got fixed in Hadoop
-     *     2.8.6 but might cause test instabilities. See FLINK-13009/FLINK-15534 for further
-     *     information.
      */
     @Test
     public void
@@ -459,9 +451,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
      * Test deployment to non-existing queue & ensure that the system logs a WARN message for the
      * user. (Users had unexpected behavior of Flink on YARN because they mistyped the target queue.
      * With an error message, we can help users identifying the issue)
-     *
-     * @throws NullPointerException There is a known Hadoop bug (YARN-7007) that got fixed in Hadoop
-     *     2.8.6 but might cause test instabilities. See FLINK-15534 for further information.
      */
     @Test
     public void testNonexistingQueueWARNmessage() throws Exception {
@@ -504,9 +493,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
     /**
      * Test per-job yarn cluster with the parallelism set at the CliFrontend instead of the YARN
      * client.
-     *
-     * @throws NullPointerException There is a known Hadoop bug (YARN-7007) that got fixed in Hadoop
-     *     2.8.6 but might cause test instabilities. See FLINK-15534 for further information.
      */
     @Test
     public void perJobYarnClusterWithParallelism() throws Exception {
@@ -642,7 +628,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
         // find out the application id and wait until it has finished.
         try {
             List<ApplicationReport> apps =
-                    yc.getApplications(EnumSet.of(YarnApplicationState.RUNNING));
+                    getApplicationReportWithRetryOnNPE(
+                            yc, EnumSet.of(YarnApplicationState.RUNNING));
 
             ApplicationId tmpAppId;
             if (apps.size() == 1) {
@@ -653,12 +640,15 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 
                 LOG.info("waiting for the job with appId {} to finish", tmpAppId);
                 // wait until the app has finished
-                while (yc.getApplications(EnumSet.of(YarnApplicationState.RUNNING)).size() > 0) {
+                while (getApplicationReportWithRetryOnNPE(
+                                        yc, EnumSet.of(YarnApplicationState.RUNNING))
+                                .size()
+                        > 0) {
                     sleep(500);
                 }
             } else {
                 // get appId by finding the latest finished appid
-                apps = yc.getApplications();
+                apps = getApplicationReportWithRetryOnNPE(yc);
                 Collections.sort(
                         apps,
                         new Comparator<ApplicationReport>() {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -181,7 +181,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
                         yc.init(YARN_CONFIGURATION);
                         yc.start();
                         List<ApplicationReport> apps =
-                                yc.getApplications(EnumSet.of(YarnApplicationState.RUNNING));
+                                getApplicationReportWithRetryOnNPE(
+                                        yc, EnumSet.of(YarnApplicationState.RUNNING));
                         Assert.assertEquals(1, apps.size()); // Only one running
                         ApplicationReport app = apps.get(0);
 
@@ -190,9 +191,13 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
                         ApplicationId id = app.getApplicationId();
                         yc.killApplication(id);
 
-                        while (yc.getApplications(EnumSet.of(YarnApplicationState.KILLED)).size()
+                        while (getApplicationReportWithRetryOnNPE(
+                                                        yc, EnumSet.of(YarnApplicationState.KILLED))
+                                                .size()
                                         == 0
-                                && yc.getApplications(EnumSet.of(YarnApplicationState.FINISHED))
+                                && getApplicationReportWithRetryOnNPE(
+                                                        yc,
+                                                        EnumSet.of(YarnApplicationState.FINISHED))
                                                 .size()
                                         == 0) {
                             sleep(500);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
@@ -292,7 +293,7 @@ public abstract class YarnTestBase extends TestLogger {
             Deadline deadline = Deadline.now().plus(Duration.ofSeconds(10));
 
             boolean isAnyJobRunning =
-                    yarnClient.getApplications().stream()
+                    getApplicationReportWithRetryOnNPE(yarnClient).stream()
                             .anyMatch(YarnTestBase::isApplicationRunning);
 
             while (deadline.hasTimeLeft() && isAnyJobRunning) {
@@ -302,13 +303,13 @@ public abstract class YarnTestBase extends TestLogger {
                     Assert.fail("Should not happen");
                 }
                 isAnyJobRunning =
-                        yarnClient.getApplications().stream()
+                        getApplicationReportWithRetryOnNPE(yarnClient).stream()
                                 .anyMatch(YarnTestBase::isApplicationRunning);
             }
 
             if (isAnyJobRunning) {
                 final List<String> runningApps =
-                        yarnClient.getApplications().stream()
+                        getApplicationReportWithRetryOnNPE(yarnClient).stream()
                                 .filter(YarnTestBase::isApplicationRunning)
                                 .map(
                                         app ->
@@ -325,6 +326,44 @@ public abstract class YarnTestBase extends TestLogger {
                 }
             }
         }
+    }
+
+    static List<ApplicationReport> getApplicationReportWithRetryOnNPE(final YarnClient yarnClient)
+            throws IOException, YarnException {
+        return getApplicationReportWithRetryOnNPE(yarnClient, null);
+    }
+
+    static List<ApplicationReport> getApplicationReportWithRetryOnNPE(
+            final YarnClient yarnClient, @Nullable EnumSet<YarnApplicationState> states)
+            throws IOException, YarnException {
+        final int maxRetryCount = 10;
+        NullPointerException mostRecentNPE = null;
+        for (int i = 0; i < maxRetryCount; i++) {
+            try {
+                return yarnClient.getApplications(states);
+            } catch (NullPointerException e) {
+                String npeStr = ExceptionUtils.stringifyException(e);
+                if (!npeStr.contains("RMAppAttemptMetrics.getAggregateAppResourceUsage")) {
+                    // unrelated NullPointerExceptions should be forwarded to the calling method
+                    throw e;
+                }
+
+                mostRecentNPE = e;
+                final String logMessage =
+                        "NullPointerException was caught most likely being related to YARN-7007. The related discussion is happening in FLINK-15534. The exception is going to be ignored.";
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(logMessage, mostRecentNPE);
+                } else {
+                    LOG.warn(logMessage);
+                }
+            }
+        }
+
+        throw new IllegalStateException(
+                "YarnClient.getApplications command failed "
+                        + maxRetryCount
+                        + " times to gather the application report. Check FLINK-15534 for further details.",
+                mostRecentNPE);
     }
 
     private static boolean isApplicationRunning(ApplicationReport app) {
@@ -690,7 +729,8 @@ public abstract class YarnTestBase extends TestLogger {
         checkState(yarnClient != null);
 
         final List<ApplicationReport> apps =
-                yarnClient.getApplications(EnumSet.of(YarnApplicationState.RUNNING));
+                getApplicationReportWithRetryOnNPE(
+                        yarnClient, EnumSet.of(YarnApplicationState.RUNNING));
         assertEquals(1, apps.size()); // Only one running
         return apps.get(0);
     }


### PR DESCRIPTION
## What is the purpose of the change

We had a few test failures that were supposedly caused by a bug in Hadoop Yarn 2.8.3 (see [YARN-7007](https://issues.apache.org/jira/browse/YARN-7007)). The related discussion can be found in [FLINK-15534](https://issues.apache.org/jira/browse/FLINK-15534). This PR tries to overcome this issue by catching the `NullPointerException` when calling `YarnClient.getApplications` and retrying the call.

## Brief change log

* Adds retry logic around `YarnClient.getApplications` and removes the recently added JavaDoc about the `NullPointerException`. Hopefully, this info is not necessary anymore considering the change.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
