### PR TITLE
[FLINK-21717][docs] Fix broken links to Java and Python Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -218,3 +218,12 @@ Renders a link to the apache flink repo.
     
 Renders a link to a file in the Apache Flink repo with a given name. 
  
+#### JavaDocs Link
+    {{< javadoc file="some/file" name="Some file" >}}
+
+Renders a link to a file in the Apache Flink Java Documentation. 
+
+#### PythonDocs Link
+    {< pythondoc file="some/file" name="Some file" >}}
+
+Renders a link to a file in the Apache Flink Python Documentation. 

--- a/docs/content.zh/docs/dev/datastream/execution_mode.md
+++ b/docs/content.zh/docs/dev/datastream/execution_mode.md
@@ -3,7 +3,7 @@ title: "Execution Mode (Batch/Streaming)"
 weight: 2
 type: docs
 aliases:
-  - /dev/datastream_execution_mode.html
+  - /zh/dev/datastream_execution_mode.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -364,10 +364,8 @@ As explained [above](#failure-recovery), failure recovery for batch programs
 does not use checkpointing.
 
 It is important to remember that because there are no checkpoints, certain
-features such as [CheckpointListener]({{ site.javadocs_baseurl
-}}/api/java/org/apache/flink/api/common/state/CheckpointListener.html) and, as
-a result,  Kafka's [EXACTLY_ONCE]({{< ref "docs/connectors/datastream/kafka" >}}
-#kafka-producers-and-fault-tolerance) mode or `StreamingFileSink`'s
+features such as {{< javadoc file="org/apache/flink/api/common/state/CheckpointListener.html" name="CheckpointListener">}}
+and, as a result,  Kafka's [EXACTLY_ONCE]({{< ref "docs/connectors/datastream/kafka" >}}#kafka-producers-and-fault-tolerance) mode or `StreamingFileSink`'s
 [OnCheckpointRollingPolicy]({{< ref "docs/connectors/datastream/streamfile_sink" >}}#rolling-policy)
 won't work. If you need a transactional sink that works in
 `BATCH` mode make sure it uses the Unified Sink API as proposed in

--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -85,7 +85,7 @@ TableEnvironment API
         通过元素集合来创建表。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_elements">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_elements" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -96,7 +96,7 @@ TableEnvironment API
         通过 pandas DataFrame 来创建表。 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_pandas">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_pandas" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -107,7 +107,7 @@ TableEnvironment API
         通过指定路径下已注册的表来创建一个表，例如通过 <strong>create_temporary_view</strong> 注册表。 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_path">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_path" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -118,7 +118,7 @@ TableEnvironment API
         执行一条 SQL 查询，并将查询的结果作为一个 `Table` 对象。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.sql_query">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.sql_query" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -129,7 +129,7 @@ TableEnvironment API
         将一个 `Table` 对象注册为一张临时表，类似于 SQL 的临时表。 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_view">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_view" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -140,7 +140,7 @@ TableEnvironment API
         删除指定路径下已注册的临时表。 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_view">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_view" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -152,7 +152,7 @@ TableEnvironment API
         你可以使用这个接口来删除临时 source 表和临时 sink 表。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_table">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_table" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -167,7 +167,7 @@ TableEnvironment API
         更多关于 SQL 语句的细节，可查阅 <a href="{{< ref "docs/dev/table/sql/overview" >}}">SQL</a> 文档。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.execute_sql">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.execute_sql" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -192,7 +192,7 @@ TableEnvironment API
         通过 table source 创建一张表。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_table_source">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_table_source" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -204,7 +204,7 @@ TableEnvironment API
         它可以使用 <strong>from_path</strong> 来替换。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.scan">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.scan" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -217,7 +217,7 @@ TableEnvironment API
         它可以使用 <strong>create_temporary_view</strong> 替换。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_table">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_table" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -228,7 +228,7 @@ TableEnvironment API
         在 TableEnvironment 的 catalog 中注册一个外部 `TableSource`。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_table_source">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_table_source" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -239,7 +239,7 @@ TableEnvironment API
         在 TableEnvironment 的 catalog 中注册一个外部 `TableSink`。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_table_sink">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_table_sink" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -252,7 +252,7 @@ TableEnvironment API
         你需要调用 `execute` 方法来执行你的作业。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.insert_into">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.insert_into" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -264,7 +264,7 @@ TableEnvironment API
         它可以使用 <strong>execute_sql</strong> 来替换。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.sql_update">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.sql_update" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -276,7 +276,7 @@ TableEnvironment API
         目前推荐的方式是使用 <strong>execute_sql</strong> 来注册临时表。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.connect">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.connect" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -303,7 +303,7 @@ TableEnvironment API
        返回指定语句的抽象语法树和执行计划。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.explain_sql">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.explain_sql" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -315,7 +315,7 @@ TableEnvironment API
         它可用于执行包含多个 sink 的作业。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_statement_set">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_statement_set" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -342,7 +342,7 @@ TableEnvironment API
         它也可以用 <strong>TableEnvironment.explain_sql</strong>，<strong>Table.explain</strong> 或者 <strong>StatementSet.explain</strong> 来替换。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.explain">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.explain" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -355,7 +355,7 @@ TableEnvironment API
         这个方法将阻塞客户端程序，直到任务完成/取消/失败。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.execute">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.execute" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -384,7 +384,7 @@ TableEnvironment API
         将一个 Python 用户自定义函数注册为临时 catalog 函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -396,7 +396,7 @@ TableEnvironment API
         如果临时系统函数的名称与临时 catalog 函数名称相同，优先使用临时系统函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_system_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_system_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -408,7 +408,7 @@ TableEnvironment API
         如果 catalog 是持久化的，则可以跨多个 Flink 会话和集群使用已注册的 catalog 函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_java_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_java_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -419,7 +419,7 @@ TableEnvironment API
         将 Java 用户自定义函数注册为临时 catalog 函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -430,7 +430,7 @@ TableEnvironment API
         将 Java 用户定义的函数注册为临时系统函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_system_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_system_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -441,7 +441,7 @@ TableEnvironment API
         删除指定路径下已注册的 catalog 函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -452,7 +452,7 @@ TableEnvironment API
         删除指定名称下已注册的临时系统函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -463,7 +463,7 @@ TableEnvironment API
         删除指定名称下已注册的临时系统函数。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_system_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_system_function" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -490,7 +490,7 @@ TableEnvironment API
         它可以通过 <strong>create_temporary_system_function</strong> 来替换。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_function" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -503,7 +503,7 @@ TableEnvironment API
         它可以通过 <strong>create_java_temporary_system_function</strong> 来替换。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_java_function">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_java_function" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -532,7 +532,7 @@ TableEnvironment API
         它们将会被添加到 Python UDF 工作程序的 PYTHONPATH 中。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.add_python_file">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.add_python_file" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -544,7 +544,7 @@ TableEnvironment API
         这些依赖项将安装到一个临时 catalog 中，并添加到 Python UDF 工作程序的 PYTHONPATH 中。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.set_python_requirements">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.set_python_requirements" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -555,7 +555,7 @@ TableEnvironment API
         添加 Python 归档文件。该文件将被解压到 Python UDF 程序的工作目录中。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.add_python_archive">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.add_python_archive" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -588,7 +588,7 @@ table_env.get_config().get_configuration().set_string(
 ```
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_config">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_config" name="链接">}}
       </td>
     </tr>
   </tbody>
@@ -615,7 +615,7 @@ table_env.get_config().get_configuration().set_string(
         注册具有唯一名称的 `Catalog`。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_catalog">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_catalog" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -626,7 +626,7 @@ table_env.get_config().get_configuration().set_string(
         通过指定的名称来获得已注册的 `Catalog` 。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_catalog">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_catalog" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -638,7 +638,7 @@ table_env.get_config().get_configuration().set_string(
         它也将默认数据库设置为所指定 catalog 的默认数据库。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.use_catalog">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.use_catalog" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -649,7 +649,7 @@ table_env.get_config().get_configuration().set_string(
         获取当前会话默认的 catalog 名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_current_catalog">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_current_catalog" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -660,7 +660,7 @@ table_env.get_config().get_configuration().set_string(
         获取正在运行会话中的当前默认数据库名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_current_database">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_current_database" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -673,7 +673,7 @@ table_env.get_config().get_configuration().set_string(
         当寻找未限定的对象名称时，该路径将被用作默认路径。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.use_database">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.use_database" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -685,7 +685,7 @@ table_env.get_config().get_configuration().set_string(
         模块将按照加载的顺序进行保存。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.load_module">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.load_module" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -696,7 +696,7 @@ table_env.get_config().get_configuration().set_string(
         卸载给定名称的 `Module`。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.unload_module">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.unload_module" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -707,7 +707,7 @@ table_env.get_config().get_configuration().set_string(
         获取在这个环境中注册的所有 catalog 目录名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_catalogs">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_catalogs" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -718,7 +718,7 @@ table_env.get_config().get_configuration().set_string(
         获取在这个环境中注册的所有模块名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_modules">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_modules" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -729,7 +729,7 @@ table_env.get_config().get_configuration().set_string(
         获取当前 catalog 中所有数据库的名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_databases">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_databases" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -741,7 +741,7 @@ table_env.get_config().get_configuration().set_string(
         它可以返回永久和临时的表和视图。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_tables">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_tables" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -753,7 +753,7 @@ table_env.get_config().get_configuration().set_string(
         它既可以返回永久的也可以返回临时的临时表。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_views">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_views" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -764,7 +764,7 @@ table_env.get_config().get_configuration().set_string(
         获取在该环境中已注册的所有用户自定义函数的名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_user_defined_functions">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_user_defined_functions" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -775,7 +775,7 @@ table_env.get_config().get_configuration().set_string(
         获取该环境中所有函数的名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_functions">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_functions" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -786,7 +786,7 @@ table_env.get_config().get_configuration().set_string(
        获取当前命名空间（当前 catalog 的当前数据库）中所有可用的表和临时表名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_tables">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_tables" name="链接">}}
       </td>
     </tr>
     <tr>
@@ -797,7 +797,7 @@ table_env.get_config().get_configuration().set_string(
         获取当前命名空间（当前 catalog 的当前数据库）中所有可用的临时表名称。
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_views">链接</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_views" name="链接">}}
       </td>
     </tr>
   </tbody>

--- a/docs/content/docs/connectors/datastream/file_sink.md
+++ b/docs/content/docs/connectors/datastream/file_sink.md
@@ -65,7 +65,7 @@ These two variants come with their respective builders that can be created with 
 When creating either a row or a bulk encoded sink we have to specify the base path where the buckets will be
 stored and the encoding logic for our data.
 
-Please check out the JavaDoc for [FileSink]({{ site.javadocs_baseurl }}/api/java/org/apache/flink/connector/file/sink/FileSink.html)
+Please check out the JavaDoc for {{< javadoc file="org/apache/flink/connector/file/sink/FileSink.html" name="FileSink">}}
 for all the configuration options and more documentation about the implementation of the different data formats.
 
 ### Row-encoded Formats
@@ -140,7 +140,7 @@ a rolling policy that rolls the in-progress part file on any of the following 3 
 ### Bulk-encoded Formats
 
 Bulk-encoded sinks are created similarly to the row-encoded ones, but instead of
-specifying an `Encoder`, we have to specify a [BulkWriter.Factory]({{ site.javadocs_baseurl }}/api/java/org/apache/flink/api/common/serialization/BulkWriter.Factory.html).
+specifying an `Encoder`, we have to specify a {{< javadoc file="org/apache/flink/api/common/serialization/BulkWriter.Factory.html" name="BulkWriter.Factory">}}.
 The `BulkWriter` logic defines how new elements are added and flushed, and how a batch of records
 is finalized for further encoding purposes.
 

--- a/docs/content/docs/dev/datastream/execution_mode.md
+++ b/docs/content/docs/dev/datastream/execution_mode.md
@@ -364,10 +364,8 @@ As explained [above](#failure-recovery), failure recovery for batch programs
 does not use checkpointing.
 
 It is important to remember that because there are no checkpoints, certain
-features such as [CheckpointListener]({{ site.javadocs_baseurl
-}}/api/java/org/apache/flink/api/common/state/CheckpointListener.html) and, as
-a result,  Kafka's [EXACTLY_ONCE]({{< ref "docs/connectors/datastream/kafka" >}}
-#kafka-producers-and-fault-tolerance) mode or `StreamingFileSink`'s
+features such as {{< javadoc file="org/apache/flink/api/common/state/CheckpointListener.html" name="CheckpointListener">}}
+and, as a result,  Kafka's [EXACTLY_ONCE]({{< ref "docs/connectors/datastream/kafka" >}}#kafka-producers-and-fault-tolerance) mode or `StreamingFileSink`'s
 [OnCheckpointRollingPolicy]({{< ref "docs/connectors/datastream/streamfile_sink" >}}#rolling-policy)
 won't work. If you need a transactional sink that works in
 `BATCH` mode make sure it uses the Unified Sink API as proposed in

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -83,7 +83,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Creates a table from a collection of elements. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_elements">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_elements" name="link">}}
       </td>
     </tr>
     <tr>
@@ -94,7 +94,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Creates a table from a pandas DataFrame. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_pandas">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_pandas" name="link">}}
       </td>
     </tr>
     <tr>
@@ -105,7 +105,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Creates a table from a registered table under the specified path, e.g. tables registered via <strong>create_temporary_view</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_path">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_path" name="link">}}
       </td>
     </tr>
     <tr>
@@ -116,7 +116,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Evaluates a SQL query and retrieves the result as a `Table` object. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.sql_query">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.sql_query" name="link">}}
       </td>
     </tr>
     <tr>
@@ -127,7 +127,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Registers a `Table` object as a temporary view similar to SQL temporary views. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_view">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_view" name="link">}}
       </td>
     </tr>
     <tr>
@@ -138,7 +138,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Drops a temporary view registered under the given path. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_view">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_view" name="link">}}
       </td>
     </tr>
     <tr>
@@ -150,7 +150,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         You can use this interface to drop the temporary source table and temporary sink table.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_table">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_table" name="link">}}
       </td>
     </tr>
     <tr>
@@ -165,7 +165,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Please refer the <a href="{{< ref "docs/dev/table/sql/overview" >}}">SQL</a> documentation for more details about SQL statement.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.execute_sql">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.execute_sql" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -190,7 +190,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Creates a table from a table source. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.from_table_source">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_table_source" name="link">}}
       </td>
     </tr>
     <tr>
@@ -202,7 +202,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         It can be replaced by <strong>from_path</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.scan">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.scan" name="link">}}
       </td>
     </tr>
     <tr>
@@ -215,7 +215,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         It can be replaced by <strong>create_temporary_view</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_table">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_table" name="link">}}
       </td>
     </tr>
     <tr>
@@ -226,7 +226,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Registers an external `TableSource` in the TableEnvironment's catalog.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_table_source">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_table_source" name="link">}}
       </td>
     </tr>
     <tr>
@@ -237,7 +237,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Registers an external `TableSink` in the TableEnvironment's catalog.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_table_sink">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_table_sink" name="link">}}
       </td>
     </tr>
     <tr>
@@ -250,7 +250,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         You need to call the "execute" method to execute your job.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.insert_into">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.insert_into" name="link">}}
       </td>
     </tr>
     <tr>
@@ -262,7 +262,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         It can be replaced by <strong>execute_sql</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.sql_update">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.sql_update" name="link">}}
       </td>
     </tr>
     <tr>
@@ -274,7 +274,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
         Currently the recommended way is using <strong>execute_sql</strong> to register temporary tables.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.connect">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.connect" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -301,7 +301,7 @@ These APIs are used to explain/execute jobs. Note that the API `execute_sql` can
         Returns the AST and the execution plan of the specified statement.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.explain_sql">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.explain_sql" name="link">}}
       </td>
     </tr>
     <tr>
@@ -313,7 +313,7 @@ These APIs are used to explain/execute jobs. Note that the API `execute_sql` can
         It can be used to execute a multi-sink job. 
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_statement_set">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_statement_set" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -342,7 +342,7 @@ These APIs are used to explain/execute jobs. Note that the API `execute_sql` can
         It can be replaced by <strong>TableEnvironment.explain_sql</strong>, <strong>Table.explain</strong> or <strong>StatementSet.explain</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.explain">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.explain" name="link">}}
       </td>
     </tr>
     <tr>
@@ -356,7 +356,7 @@ These APIs are used to explain/execute jobs. Note that the API `execute_sql` can
         This method will block the client program until the job is finished/canceled/failed.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.execute">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.execute" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -385,7 +385,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         Registers a Python user defined function class as a temporary catalog function.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -398,7 +398,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         the temporary system function takes precedence.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_system_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_temporary_system_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -410,7 +410,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         If the catalog is persistent, the registered catalog function can be used across multiple Flink sessions and clusters.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_java_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_java_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -421,7 +421,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         Registers a Java user defined function class as a temporary catalog function.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -432,7 +432,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         Registers a Java user defined function class as a temporary system function.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_system_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.create_java_temporary_system_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -443,7 +443,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         Drops a catalog function registered under the given path.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -454,7 +454,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         Drops a temporary system function registered under the given name.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -465,7 +465,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         Drops a temporary system function registered under the given name.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_system_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_system_function" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -492,7 +492,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         It can be replaced by <strong>create_temporary_system_function</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_function" name="link">}}
       </td>
     </tr>
     <tr>
@@ -505,7 +505,7 @@ For more details about the different kinds of UDFs, please refer to [User Define
         It can be replaced by <strong>create_java_temporary_system_function</strong>.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_java_function">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_java_function" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -534,7 +534,7 @@ Please refer to the [Dependency Management]({{< ref "docs/dev/python/table/depen
         They will be added to the PYTHONPATH of the Python UDF worker.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.add_python_file">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.add_python_file" name="link">}}
       </td>
     </tr>
     <tr>
@@ -546,7 +546,7 @@ Please refer to the [Dependency Management]({{< ref "docs/dev/python/table/depen
         These dependencies will be installed to a temporary directory and added to the PYTHONPATH of the Python UDF worker.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.set_python_requirements">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.set_python_requirements" name="link">}}
       </td>
     </tr>
     <tr>
@@ -557,7 +557,7 @@ Please refer to the [Dependency Management]({{< ref "docs/dev/python/table/depen
         Adds a Python archive file. The file will be extracted to the working directory of Python UDF worker.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.add_python_archive">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.add_python_archive" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -590,7 +590,7 @@ table_env.get_config().get_configuration().set_string(
 ```
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_config">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_config" name="link">}}
       </td>
     </tr>
   </tbody>
@@ -617,7 +617,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Registers a `Catalog` under a unique name.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.register_catalog">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.register_catalog" name="link">}}
       </td>
     </tr>
     <tr>
@@ -628,7 +628,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets a registered `Catalog` by name.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_catalog">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_catalog" name="link">}}
       </td>
     </tr>
     <tr>
@@ -640,7 +640,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         It also sets the default database to the catalog's default one.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.use_catalog">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.use_catalog" name="link">}}
       </td>
     </tr>
     <tr>
@@ -651,7 +651,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the current default catalog name of the current session.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_current_catalog">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_current_catalog" name="link">}}
       </td>
     </tr>
     <tr>
@@ -662,7 +662,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the current default database name of the running session.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.get_current_database">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.get_current_database" name="link">}}
       </td>
     </tr>
     <tr>
@@ -675,7 +675,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         That path will be used as the default one when looking for unqualified object names.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.use_database">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.use_database" name="link">}}
       </td>
     </tr>
     <tr>
@@ -687,7 +687,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Modules will be kept in the loaded order.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.load_module">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.load_module" name="link">}}
       </td>
     </tr>
     <tr>
@@ -698,7 +698,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Unloads a `Module` with given name.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.unload_module">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.unload_module" name="link">}}
       </td>
     </tr>
     <tr>
@@ -709,7 +709,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the names of all catalogs registered in this environment.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_catalogs">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_catalogs" name="link">}}
       </td>
     </tr>
     <tr>
@@ -717,10 +717,10 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         <strong>list_modules()</strong>
       </td>
       <td>
-        Gets the names of all modules registered in this environment.
+        Gets the names of all enabled modules registered in this environment.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_modules">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_modules" name="link">}}
       </td>
     </tr>
     <tr>
@@ -731,7 +731,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the names of all databases in the current catalog.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_databases">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_databases" name="link">}}
       </td>
     </tr>
     <tr>
@@ -743,7 +743,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         It returns both temporary and permanent tables and views.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_tables">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_tables" name="link">}}
       </td>
     </tr>
     <tr>
@@ -755,7 +755,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         It returns both temporary and permanent views.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_views">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_views" name="link">}}
       </td>
     </tr>
     <tr>
@@ -766,7 +766,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the names of all user defined functions registered in this environment.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_user_defined_functions">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_user_defined_functions" name="link">}}
       </td>
     </tr>
     <tr>
@@ -777,7 +777,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the names of all functions in this environment.
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_functions">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_functions" name="link">}}
       </td>
     </tr>
     <tr>
@@ -788,7 +788,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the names of all temporary tables and views available in the current namespace (the current database of the current catalog).
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_tables">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_tables" name="link">}}
       </td>
     </tr>
     <tr>
@@ -799,7 +799,7 @@ These APIs are used to access catalogs and modules. You can find more detailed i
         Gets the names of all temporary views available in the current namespace (the current database of the current catalog).
       </td>
       <td class="text-center">
-        <a href="{{ site.pythondocs_baseurl }}/api/python/pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_views">link</a>
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.list_temporary_views" name="link">}}
       </td>
     </tr>
   </tbody>

--- a/docs/content/docs/dev/table/catalogs.md
+++ b/docs/content/docs/dev/table/catalogs.md
@@ -55,7 +55,8 @@ The `HiveCatalog` serves two purposes; as persistent storage for pure Flink meta
 Flink's [Hive documentation]({{< ref "docs/connectors/table/hive/overview" >}}) provides full details on setting up the catalog and interfacing with an existing Hive installation.
 
 
-{% warn %} The Hive Metastore stores all meta-object names in lower case. This is unlike `GenericInMemoryCatalog` which is case-sensitive
+{{< hint warning >}} The Hive Metastore stores all meta-object names in lower case. This is unlike `GenericInMemoryCatalog` which is case-sensitive
+{{< /hint >}}
 
 ### User-Defined Catalog
 

--- a/docs/layouts/shortcodes/javadoc.html
+++ b/docs/layouts/shortcodes/javadoc.html
@@ -16,11 +16,11 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 */}}{{/*
-    Shortcode for linking to Flinks JavaDoc
+    Shortcode for linking to Flink's JavaDoc
 
     Parmeters: 
         - name: The rendered link name (required)
 */}}
-<a href="{{ .Site.Params.JavaDoc }}/{{ .Get "file" }}">
-    {{ .Get "name" }}
+<a href="{{ .Site.Params.JavaDocs }}/{{ .Get "file" }}">
+    {{ .Get "name" | markdownify }}
 </a>

--- a/docs/layouts/shortcodes/javadoc.html
+++ b/docs/layouts/shortcodes/javadoc.html
@@ -18,7 +18,8 @@ under the License.
 */}}{{/*
     Shortcode for linking to Flink's JavaDoc
 
-    Parmeters: 
+    Parameters:
+        - file: The relative path to the doc file (required)
         - name: The rendered link name (required)
 */}}
 <a href="{{ .Site.Params.JavaDocs }}/{{ .Get "file" }}">

--- a/docs/layouts/shortcodes/pythondoc.html
+++ b/docs/layouts/shortcodes/pythondoc.html
@@ -1,0 +1,44 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+    Shortcode for linking to Flink's PythonDoc
+
+    Parmeters:
+        - name: The rendered link name (required)
+*/}}
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<a href="{{ .Site.Params.PyDocs }}/{{ .Get "file"}}">
+    {{ .Get "name" | markdownify}}
+</a>

--- a/docs/layouts/shortcodes/pythondoc.html
+++ b/docs/layouts/shortcodes/pythondoc.html
@@ -18,7 +18,8 @@ under the License.
 */}}{{/*
     Shortcode for linking to Flink's PythonDoc
 
-    Parmeters:
+    Parameters:
+        - file: The relative path to the doc file (required)
         - name: The rendered link name (required)
 */}}
 <!--


### PR DESCRIPTION
## What is the purpose of the change

This PR is to fix the broken links to Java/Python docs since after migrating to Hugo, the old references became unreachable.


## Brief change log

  - Fix the typo in `javadoc.html`.
  - Add shortcode for Python docs -> `pythondoc.html` 
  - Replace and fix references in docs.


## Verifying this change

Rebuild the docs will verify the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
