### PR TITLE
[FLINK-21622][table-planner] Introduce function TO_TIMESTAMP_LTZ(numeric [, precision])

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -415,10 +415,10 @@ temporal:
       NUMERIC.milli
       NUMERIC.millis
     description: Creates an interval of NUMERIC milliseconds.
-  - sql: CURRENT_DATE()
+  - sql: CURRENT_DATE
     table: currentDate()
     description: Returns the current SQL date in the UTC time zone.
-  - sql: CURRENT_TIME()
+  - sql: CURRENT_TIME
     table: currentTime()
     description: Returns the current SQL time in the UTC time zone.
   - sql: LOCALTIME

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -473,6 +473,9 @@ temporal:
     description: 'Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.'
   - sql: TO_DATE(string1[, string2])
     description: Converts a date string string1 with format string2 (by default 'yyyy-MM-dd') to a date.
+  - sql: TO_TIMESTAMP_LTZ(numeric[, precision])
+    table: toTimestampLtz(NUMERIC[, PRECISION])
+    description: "Converts a epoch seconds or epoch milliseconds to a TIMESTAMP_LTZ, the valid precision is 0 or 3, the 0 is default value which means TO_TIMESTAMP_LTZ(epochSeconds, 0), the 3 represents TO_TIMESTAMP_LTZ(epochMilliseconds, 3)."
   - sql: TO_TIMESTAMP(string1[, string2])
     description: "Converts date time string string1 with format string2 (by default: 'yyyy-MM-dd HH:mm:ss') under the session time zone (specified by TableConfig) to a timestamp."
   - sql: NOW()

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -216,6 +216,21 @@ def local_timestamp() -> Expression:
     return _leaf_op("localTimestamp")
 
 
+def to_timestamp_ltz(numeric_epoch_time, precision) -> Expression:
+    """
+    Converts a numeric type epoch time to TIMESTAMP_LTZ.
+
+    The supported precision is 0 or 3:
+    0 means the numericEpochTime is in second.
+    3 means the numericEpochTime is in millisecond.
+
+    :param numeric_epoch_time: The epoch time with numeric type
+    :param precision: The precision to indicate the epoch time is in second or millisecond
+    :return: The timestamp value with TIMESTAMP_LTZ type.
+    """
+    return _binary_op("toTimestampLtz", numeric_epoch_time, precision)
+
+
 def temporal_overlaps(left_time_point,
                       left_temporal,
                       right_time_point,

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -24,7 +24,8 @@ from pyflink.table.expressions import (col, lit, range_, and_, or_, current_date
                                        local_timestamp, temporal_overlaps, date_format,
                                        timestamp_diff, array, row, map_, row_interval, pi, e,
                                        rand, rand_integer, atan2, negative, concat, concat_ws, uuid,
-                                       null_of, log, if_then_else, with_columns, call)
+                                       null_of, log, if_then_else, with_columns, call,
+                                       to_timestamp_ltz)
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 
@@ -212,6 +213,7 @@ class PyFlinkBlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('currentTimestamp()', str(current_timestamp()))
         self.assertEqual('localTime()', str(local_time()))
         self.assertEqual('localTimestamp()', str(local_timestamp()))
+        self.assertEquals('toTimestampLtz(123, 1)', str(to_timestamp_ltz(123, 1)))
         self.assertEqual("temporalOverlaps(cast('2:55:00', TIME(0)), 3600000, "
                          "cast('3:30:00', TIME(0)), 7200000)",
                          str(temporal_overlaps(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -212,6 +212,24 @@ public final class Expressions {
     }
 
     /**
+     * Converts a numeric type epoch time to {@link DataTypes#TIMESTAMP_LTZ(int)}.
+     *
+     * <p>The supported precision is 0 or 3:
+     *
+     * <ul>
+     *   <li>0 means the numericEpochTime is in second.
+     *   <li>3 means the numericEpochTime is in millisecond.
+     * </ul>
+     *
+     * @param numericEpochTime The epoch time with numeric type.
+     * @param precision The precision to indicate the epoch time is in second or millisecond.
+     * @return The timestamp value with {@link DataTypes#TIMESTAMP_LTZ(int)} type.
+     */
+    public static ApiExpression toTimestampLtz(Object numericEpochTime, Object precision) {
+        return apiCall(BuiltInFunctionDefinitions.TO_TIMESTAMP_LTZ, numericEpochTime, precision);
+    }
+
+    /**
      * Determines whether two anchored time intervals overlap. Time point and temporal are
      * transformed into a range defined by two time points (start, end). The function evaluates
      * <code>leftEnd >= rightStart && rightEnd >= leftStart</code>.

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -456,6 +456,27 @@ trait ImplicitExpressionConversions {
   }
 
   /**
+   * Converts a numeric type epoch seconds to {@link DataTypes#TIMESTAMP_LTZ()}.
+   */
+  def toTimestampLtz(numericEpochTime: Expression): Expression = {
+    Expressions.toTimestampLtz(numericEpochTime, lit(0))
+  }
+
+  /**
+   * Converts a numeric type epoch time to {@link DataTypes#TIMESTAMP_LTZ()}.
+   *
+   * <p>The supported precision is 0 or 3:
+   *
+   * <ul>
+   *   <li>0 means the numericEpochTime is in second.
+   *   <li>3 means the numericEpochTime is in millisecond.
+   * </ul>
+   */
+  def toTimestampLtz(numericEpochTime: Expression, precision: Expression): Expression = {
+    Expressions.toTimestampLtz(numericEpochTime, precision)
+  }
+
+  /**
     * Determines whether two anchored time intervals overlap. Time point and temporal are
     * transformed into a range defined by two time points (start, end). The function
     * evaluates <code>leftEnd >= rightStart && rightEnd >= leftStart</code>.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1145,6 +1145,12 @@ public final class BuiltInFunctionDefinitions {
                     .kind(SCALAR)
                     .outputTypeStrategy(TypeStrategies.MISSING)
                     .build();
+    public static final BuiltInFunctionDefinition TO_TIMESTAMP_LTZ =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("toTimestampLtz")
+                    .kind(SCALAR)
+                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .build();
 
     // --------------------------------------------------------------------------------------------
     // Collection functions

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -177,6 +177,9 @@ public class DirectConvertRule implements CallExpressionConvertRule {
                 BuiltInFunctionDefinitions.LOCAL_TIMESTAMP, FlinkSqlOperatorTable.LOCALTIMESTAMP);
         DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.DATE_FORMAT, FlinkSqlOperatorTable.DATE_FORMAT);
+        DEFINITION_OPERATOR_MAP.put(
+                BuiltInFunctionDefinitions.TO_TIMESTAMP_LTZ,
+                FlinkSqlOperatorTable.TO_TIMESTAMP_LTZ);
 
         // collection
         DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.AT, FlinkSqlOperatorTable.ITEM);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -739,10 +739,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),
                     SqlFunctionCategory.STRING);
 
-    // TODO: the return type of TO_TIMESTAMP should be TIMESTAMP(9)
-    //  but conversion of DataType and TypeInformation only support TIMESTAMP(3) now.
-    //  change to TIMESTAMP(9) when FLINK-14645 is fixed.
-    //  https://issues.apache.org/jira/browse/FLINK-14925
+    // TODO: the return type of TO_TIMESTAMP should be TIMESTAMP(9),
+    //  but we keep TIMESTAMP(3) now because we did not support TIMESTAMP(9) as time attribute.
+    //  See: https://issues.apache.org/jira/browse/FLINK-14925
     public static final SqlFunction TO_TIMESTAMP =
             new SqlFunction(
                     "TO_TIMESTAMP",
@@ -754,6 +753,19 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     OperandTypes.or(
                             OperandTypes.family(SqlTypeFamily.CHARACTER),
                             OperandTypes.family(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER)),
+                    SqlFunctionCategory.TIMEDATE);
+
+    public static final SqlFunction TO_TIMESTAMP_LTZ =
+            new SqlFunction(
+                    "TO_TIMESTAMP_LTZ",
+                    SqlKind.OTHER_FUNCTION,
+                    ReturnTypes.cascade(
+                            ReturnTypes.explicit(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3),
+                            SqlTypeTransforms.FORCE_NULLABLE),
+                    null,
+                    OperandTypes.or(
+                            OperandTypes.family(SqlTypeFamily.NUMERIC),
+                            OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER)),
                     SqlFunctionCategory.TIMEDATE);
 
     public static final SqlFunction TO_DATE =

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -347,6 +347,36 @@ object BuiltInMethods {
     "toTimestamp",
     classOf[DecimalData])
 
+  val LONG_TO_TIMESTAMP_LTZ = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "toTimestampData",
+    classOf[Long])
+
+  val LONG_TO_TIMESTAMP_LTZ_WITH_PRECISION = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "toTimestampData",
+    classOf[Long], classOf[Int])
+
+  val DOUBLE_TO_TIMESTAMP_LTZ = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "toTimestampData",
+    classOf[Double])
+
+  val DOUBLE_TO_TIMESTAMP_LTZ_WITH_PRECISION = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "toTimestampData",
+    classOf[Double], classOf[Int])
+
+  val DECIMAL_TO_TIMESTAMP_LTZ = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "toTimestampData",
+    classOf[DecimalData])
+
+  val DECIMAL_TO_TIMESTAMP_LTZ_WITH_PRECISION = Types.lookupMethod(
+    classOf[SqlDateTimeUtils],
+    "toTimestampData",
+    classOf[DecimalData], classOf[Int])
+
   val STRING_TO_TIMESTAMP = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "toTimestampData",

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable
 object FunctionGenerator {
 
   val INTEGRAL_TYPES = Array(
-    INTEGER,
+    TINYINT,
     SMALLINT,
     INTEGER,
     BIGINT)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -695,6 +695,38 @@ object FunctionGenerator {
     BuiltInMethods.DECIMAL_TO_TIMESTAMP)
 
   INTEGRAL_TYPES foreach (
+    dt => {
+      addSqlFunctionMethod(
+        TO_TIMESTAMP_LTZ,
+        Seq(dt),
+        BuiltInMethods.LONG_TO_TIMESTAMP_LTZ)
+      addSqlFunctionMethod(
+        TO_TIMESTAMP_LTZ,
+        Seq(dt, INTEGER),
+        BuiltInMethods.LONG_TO_TIMESTAMP_LTZ_WITH_PRECISION)})
+
+  FRACTIONAL_TYPES foreach (
+    dt => {
+      addSqlFunctionMethod(
+        TO_TIMESTAMP_LTZ,
+        Seq(dt),
+        BuiltInMethods.DOUBLE_TO_TIMESTAMP_LTZ)
+      addSqlFunctionMethod(
+        TO_TIMESTAMP_LTZ,
+        Seq(dt, INTEGER),
+        BuiltInMethods.DOUBLE_TO_TIMESTAMP_LTZ_WITH_PRECISION)})
+
+  addSqlFunctionMethod(
+    TO_TIMESTAMP_LTZ,
+    Seq(DECIMAL),
+    BuiltInMethods.DECIMAL_TO_TIMESTAMP_LTZ)
+
+  addSqlFunctionMethod(
+    TO_TIMESTAMP_LTZ,
+    Seq(DECIMAL, INTEGER),
+    BuiltInMethods.DECIMAL_TO_TIMESTAMP_LTZ_WITH_PRECISION)
+
+  INTEGRAL_TYPES foreach (
     dt => addSqlFunctionMethod(
       FROM_UNIXTIME,
       Seq(dt),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -234,6 +234,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.size == 3)
             TimestampDiff(args.head, args(1), args.last)
 
+          case TO_TIMESTAMP_LTZ =>
+            assert(args.size == 2)
+            ToTimestampLtz(args.head, args.last)
+
           case AT =>
             assert(args.size == 2)
             ItemAt(args.head, args.last)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/time.scala
@@ -271,3 +271,32 @@ case class TimestampDiff(
 
   override private[flink] def resultType = INT_TYPE_INFO
 }
+
+case class ToTimestampLtz(
+    numericEpochTime: PlannerExpression,
+    precision: PlannerExpression)
+  extends PlannerExpression {
+
+  override private[flink] def children: Seq[PlannerExpression] =
+    numericEpochTime :: precision :: Nil
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (TypeInfoCheckUtils.assertNumericExpr(
+      numericEpochTime.resultType, "toTimestampLtz").isFailure) {
+      return ValidationFailure(
+        s"$this requires numeric type for the first input, " +
+          s"but the actual type '${numericEpochTime.resultType}'.")
+    }
+    if (TypeInfoCheckUtils
+      .assertNumericExpr(precision.resultType, "toTimestampLtz").isFailure) {
+      return ValidationFailure(
+        s"$this requires numeric type for the second input, " +
+          s"but the actual type '${numericEpochTime.resultType}'.")
+    }
+    ValidationSuccess
+  }
+
+  override def toString: String = s"toTimestampLtz(${children.mkString(", ")})"
+
+  override private[flink] def resultType = SqlTimeTypeInfo.TIMESTAMP
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -914,6 +914,13 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"from_unixtime(f22, '$fmt3')",
       sdf3.format(new Timestamp(3000)))
 
+    testSqlApi(
+      s"from_unixtime(f26, '$fmt2')",
+      sdf2.format(new Timestamp(124000)))
+    testSqlApi(
+      s"from_unixtime(f26, '$fmt3')",
+      sdf3.format(new Timestamp(124000)))
+
     // test with null input
     testSqlApi(
       "from_unixtime(cast(null as int))",
@@ -1154,7 +1161,7 @@ class TemporalTypesTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = {
-    val testData = new Row(26)
+    val testData = new Row(27)
     testData.setField(0, localDate("1990-10-14"))
     testData.setField(1, DateTimeTestUtil.localTime("10:20:45"))
     testData.setField(2, localDateTime("1990-10-14 10:20:45.123"))
@@ -1187,6 +1194,7 @@ class TemporalTypesTest extends ExpressionTestBase {
     testData.setField(24, localDateTime("1970-01-01 00:00:00.123456789")
       .atZone(config.getLocalTimeZone).toInstant)
     testData.setField(25, localDateTime("1970-01-01 00:00:00.123456789").toInstant(ZoneOffset.UTC))
+    testData setField(26, new Integer(124).byteValue())
     testData
   }
 
@@ -1216,7 +1224,8 @@ class TemporalTypesTest extends ExpressionTestBase {
     DataTypes.FIELD("f22", DataTypes.INT()),
     DataTypes.FIELD("f23", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)),
     DataTypes.FIELD("f24", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)),
-    DataTypes.FIELD("f25", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9))
+    DataTypes.FIELD("f25", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(9)),
+    DataTypes.FIELD("f26", DataTypes.TINYINT())
   )
 
   override def containsLegacyTypes: Boolean = false


### PR DESCRIPTION
## What is the purpose of the change

* This pull request supports  TO_TIMESTAMP_LTZ(epochSeconds , 0), TO_TIMESTAMP_LTZ(epochMilliseconds , 3)

## Brief change log
  - Hotfix integral types list in FunctionGenerator
  - Hotfix sql functions name typo
  - Supports  TO_TIMESTAMP_LTZ(epochSeconds , 0), TO_TIMESTAMP_LTZ(epochMilliseconds , 3)

## Verifying this change

* Add SQL API tests to cover this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**docs**)
