### PR TITLE
[FLINK-21690][checkpoint] Remove redundant tolerableCheckpointFailureNumber setting in CheckpointConfig

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -146,7 +146,6 @@ public class CheckpointConfig implements java.io.Serializable {
         this.externalizedCheckpointCleanup = checkpointConfig.externalizedCheckpointCleanup;
         this.forceCheckpointing = checkpointConfig.forceCheckpointing;
         this.forceUnalignedCheckpoints = checkpointConfig.forceUnalignedCheckpoints;
-        this.tolerableCheckpointFailureNumber = checkpointConfig.tolerableCheckpointFailureNumber;
         this.storage = checkpointConfig.getCheckpointStorage();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The field `tolerableCheckpointFailureNumber` have been setting twice in `CheckpointConfig`. Maybe it was an oversight by the previous developers.


## Brief change log

  - *Remove the seconde setting of `tolerableCheckpointFailureNumber`*.

## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
