### PR TITLE
[FLINK-21722][docs] Fix class reference in 'Generating Watermarks' page for Scala example

### DIFF
--- a/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
@@ -319,7 +319,7 @@ public class TimeLagWatermarkGenerator implements WatermarkGenerator<MyEvent> {
  * but only to a certain degree. The latest elements for a certain timestamp t will arrive
  * at most n milliseconds after the earliest elements for timestamp t.
  */
-class BoundedOutOfOrdernessGenerator extends AssignerWithPeriodicWatermarks[MyEvent] {
+class BoundedOutOfOrdernessGenerator extends WatermarkGenerator[MyEvent] {
 
     val maxOutOfOrderness = 3500L // 3.5 seconds
 
@@ -340,7 +340,7 @@ class BoundedOutOfOrdernessGenerator extends AssignerWithPeriodicWatermarks[MyEv
  * time by a fixed amount. It assumes that elements arrive in Flink after 
  * a bounded delay.
  */
-class TimeLagWatermarkGenerator extends AssignerWithPeriodicWatermarks[MyEvent] {
+class TimeLagWatermarkGenerator extends WatermarkGenerator[MyEvent] {
 
     val maxTimeLag = 5000L // 5 seconds
 
@@ -386,7 +386,7 @@ public class PunctuatedAssigner implements WatermarkGenerator<MyEvent> {
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-class PunctuatedAssigner extends AssignerWithPunctuatedWatermarks[MyEvent] {
+class PunctuatedAssigner extends WatermarkGenerator[MyEvent] {
 
     override def onEvent(element: MyEvent, eventTimestamp: Long): Unit = {
         if (event.hasWatermarkMarker()) {


### PR DESCRIPTION
## What is the purpose of the change

The 'Generating Watermarks' documentation page has examples on 'Periodic WatermarkGenerator' and 'Punctuated WatermarkGenerator'.
The Java examples implement the class `WatermarkGenerator`, whereas the Scala examples extend the `AssignerWithPeriodicWatermarks`. Both examples should be using `WatermarkGenerator` which is the correct class for the example. 

This pull request fixes this documentation issue. 


## Brief change log

  - *Update Scala examples in 'Generating Watermarks' documentation page*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
