### PR TITLE
[FLINK-21709][table] Officially deprecate the legacy planner

### DIFF
--- a/docs/content.zh/docs/dev/table/legacy_planner.md
+++ b/docs/content.zh/docs/dev/table/legacy_planner.md
@@ -35,8 +35,10 @@ The primary reason to continue using the legacy planner is [DataSet]({{< ref "do
 
 {{< hint warning >}}
 If you are not using the Legacy planner for DataSet interop, the community strongly
-encourages you to consider the modern table planner.
-The legacy planner will be dropped at some point in the future.
+encourages you to consider the modern table planner. Both batch and stream processing pipelines
+can be expressed in the unified `TableEnvironment`.
+
+** The legacy planner is deprecated and will be dropped in Flink 1.14.**
 {{< /hint >}}
 
 This page describes how to use the Legacy planner and where its semantics differ from the 

--- a/docs/content/docs/dev/table/legacy_planner.md
+++ b/docs/content/docs/dev/table/legacy_planner.md
@@ -35,8 +35,10 @@ The primary reason to continue using the legacy planner is [DataSet]({{< ref "do
 
 {{< hint warning >}}
 If you are not using the Legacy planner for DataSet interop, the community strongly
-encourages you to consider the modern table planner.
-The legacy planner will be dropped at some point in the future.
+encourages you to consider the modern table planner. Both batch and stream processing pipelines
+can be expressed in the unified `TableEnvironment`.
+
+** The legacy planner is deprecated and will be dropped in Flink 1.14.**
 {{< /hint >}}
 
 This page describes how to use the Legacy planner and where its semantics differ from the 
@@ -335,6 +337,5 @@ The following built-in functions are not supported by the legacy planner.
 `DATE_FORMAT(timestamp, string)` is available in the legacy planner but has serious bugs and should not be used.
 Please implement a custom UDF instead or use `EXTRACT` as a workaround.
 {{< /hint >}}
-
 
 

--- a/docs/layouts/shortcodes/generated/table_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/table_config_configuration.html
@@ -9,12 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>table.planner</h5></td>
-            <td style="word-wrap: break-word;">BLINK</td>
-            <td><p>Enum</p>Possible values: [BLINK, OLD]</td>
-            <td>Use either 'blink' planner or 'old' planner. Default is blink planner. For TableEnvironment, this option is used to construct a TableEnvironment, but this option can't be changed after that. However there is no such limitation for SQL Client.</td>
-        </tr>
-        <tr>
             <td><h5>table.dynamic-table-options.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -31,6 +25,12 @@
             <td style="word-wrap: break-word;">"default"</td>
             <td>String</td>
             <td>The local time zone defines current session time zone id. It is used when converting to/from &lt;code&gt;TIMESTAMP WITH LOCAL TIME ZONE&lt;/code&gt;. Internally, timestamps with local time zone are always represented in the UTC time zone. However, when converting to data types that don't include a time zone (e.g. TIMESTAMP, TIME, or simply STRING), the session time zone is used during conversion. The input of option is either an abbreviation such as "PST", a full name such as "America/Los_Angeles", or a custom timezone id such as "GMT-8:00".</td>
+        </tr>
+        <tr>
+            <td><h5>table.planner</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">BLINK</td>
+            <td><p>Enum</p>Possible values: [BLINK, OLD]</td>
+            <td>Use either 'blink' planner or 'old' planner. Default is blink planner. For TableEnvironment, this option is used to construct a TableEnvironment, but this option can't be changed after that. However, there is no such limitation for SQL Client. Note: The old planner will be removed in Flink 1.14, so this option will become obsolete.</td>
         </tr>
         <tr>
             <td><h5>table.sql-dialect</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>

--- a/flink-python/pyflink/table/environment_settings.py
+++ b/flink-python/pyflink/table/environment_settings.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import warnings
 from pyflink.java_gateway import get_gateway
 
 from pyflink.common import Configuration
@@ -32,7 +33,6 @@ class EnvironmentSettings(object):
     ::
 
         >>> EnvironmentSettings.new_instance() \\
-        ...     .use_old_planner() \\
         ...     .in_streaming_mode() \\
         ...     .with_built_in_catalog_name("my_catalog") \\
         ...     .with_built_in_database_name("my_database") \\
@@ -55,14 +55,19 @@ class EnvironmentSettings(object):
             This is the default behavior.
 
             :return: This object.
+
+            .. note:: The old planner will be dropped in Flink 1.14. Please update to the new
+                      planner (i.e. Blink planner).
             """
+            warnings.warn(
+                "Deprecated in 1.13. Please update to the new planner (i.e. Blink planner).",
+                DeprecationWarning)
             self._j_builder = self._j_builder.useOldPlanner()
             return self
 
         def use_blink_planner(self) -> 'EnvironmentSettings.Builder':
             """
-            Sets the Blink planner as the required module. By default, :func:`use_old_planner` is
-            enabled.
+            Sets the Blink planner as the required module.
 
             :return: This object.
             """
@@ -75,7 +80,7 @@ class EnvironmentSettings(object):
 
             A planner will be discovered automatically, if there is only one planner available.
 
-            By default, :func:`use_old_planner` is enabled.
+            By default, :func:`use_blink_planner` is enabled.
 
             :return: This object.
             """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1797,6 +1797,12 @@ class StreamTableEnvironment(TableEnvironment):
 
 
 class BatchTableEnvironment(TableEnvironment):
+    """
+    .. note:: BatchTableEnvironment will be dropped in Flink 1.14 because it only supports the old
+              planner. Use the unified :class:`~pyflink.table.TableEnvironment` instead, which
+              supports both batch and streaming. More advanced operations previously covered by
+              the DataSet API can now use the DataStream API in BATCH execution mode.
+    """
 
     def __init__(self, j_tenv):
         super(BatchTableEnvironment, self).__init__(j_tenv)
@@ -1875,7 +1881,15 @@ class BatchTableEnvironment(TableEnvironment):
                                      selection(flink or blink), optional.
         :return: The BatchTableEnvironment created from given ExecutionEnvironment and
                  configuration.
+
+        .. note:: This part of the API will be dropped in Flink 1.14 because it only supports the
+                  old planner. Use the unified :class:`~pyflink.table.TableEnvironment` instead, it
+                  supports both batch and streaming. For more advanced operations, the new batch
+                  mode of the DataStream API might be useful.
         """
+        warnings.warn(
+            "Deprecated in 1.14. Use the unified TableEnvironment instead.",
+            DeprecationWarning)
         if execution_environment is None and \
                 table_config is None and \
                 environment_settings is None:

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/BatchTableEnvironment.java
@@ -56,7 +56,13 @@ import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
  *   <li>convert a {@link Table} into a {@link DataSet}
  *   <li>explain the AST and execution plan of a {@link Table}
  * </ul>
+ *
+ * @deprecated {@link BatchTableEnvironment} will be dropped in Flink 1.14 because it only supports
+ *     the old planner. Use the unified {@link TableEnvironment} instead, which supports both batch
+ *     and streaming. More advanced operations previously covered by the DataSet API can now use the
+ *     DataStream API in BATCH execution mode.
  */
+@Deprecated
 @PublicEvolving
 public interface BatchTableEnvironment extends TableEnvironment {
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
@@ -228,7 +228,11 @@ public class EnvironmentSettings {
         /**
          * Sets the old Flink planner as the required module. By default, {@link #useBlinkPlanner()}
          * is enabled.
+         *
+         * @deprecated The old planner will be dropped in Flink 1.14. Please update to the new
+         *     planner (i.e. Blink planner).
          */
+        @Deprecated
         public Builder useOldPlanner() {
             this.plannerClass = OLD_PLANNER_FACTORY;
             this.executorClass = OLD_EXECUTOR_FACTORY;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -44,7 +44,9 @@ public class TableConfigOptions {
                             "Use either 'blink' planner or 'old' planner. Default is blink planner. "
                                     + "For TableEnvironment, this option is used to construct a TableEnvironment, "
                                     + "but this option can't be changed after that. "
-                                    + "However there is no such limitation for SQL Client.");
+                                    + "However, there is no such limitation for SQL Client. "
+                                    + "Note: The old planner will be removed in Flink 1.14, "
+                                    + "so this option will become obsolete.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED =

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/BatchTableEnvironment.scala
@@ -41,7 +41,13 @@ import org.apache.flink.table.module.ModuleManager
   * - specify a SQL query on registered tables to obtain a [[Table]]
   * - convert a [[Table]] into a [[DataSet]]
   * - explain the AST and execution plan of a [[Table]]
+  *
+  * @deprecated [[BatchTableEnvironment]] will be dropped in Flink 1.14 because it only supports
+  *              the old planner. Use the unified [[TableEnvironment]] instead, which supports both
+  *              batch and streaming. More advanced operations previously covered by the DataSet API
+  *              can now use the DataStream API in BATCH execution mode.
   */
+@deprecated
 trait BatchTableEnvironment extends TableEnvironment {
 
   /**
@@ -340,6 +346,13 @@ trait BatchTableEnvironment extends TableEnvironment {
   override def connect(connectorDescriptor: ConnectorDescriptor): BatchTableDescriptor
 }
 
+/**
+ * @deprecated [[BatchTableEnvironment]] will be dropped in Flink 1.14 because it only supports
+ *              the old planner. Use the unified [[TableEnvironment]] instead, which supports both
+ *              batch and streaming. More advanced operations previously covered by the DataSet API
+ *              can now use the DataStream API in BATCH execution mode.
+ */
+@deprecated
 object BatchTableEnvironment {
 
   /**

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -32,7 +32,8 @@ under the License.
 	<description>
 		This module bridges Table/SQL API and runtime. It contains
 		all resources that are required during pre-flight and runtime
-		phase.
+		phase. NOTE: This module is deprecated and will be removed in Flink 1.14.
+		Please upgrade to the new planner.
 	</description>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
## What is the purpose of the change

This deprecates the legacy planner in Java, Scala and Python API. It adds a warning to the documentation.

## Brief change log

Add deprecation warnings at various locations.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
