### PR TITLE
 [FLINK-19682] Actively timeout checkpoint barriers on the inputs 

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingController.java
@@ -164,14 +164,6 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
         chooseController(barrier).obsoleteBarrierReceived(channelInfo, barrier);
     }
 
-    private void checkActiveController(CheckpointBarrier barrier) {
-        if (isAligned(barrier)) {
-            checkState(activeController == alignedController);
-        } else {
-            checkState(activeController == unalignedController);
-        }
-    }
-
     private boolean isAligned(CheckpointBarrier barrier) {
         return barrier.getCheckpointOptions().needsAlignment();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingController.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingController.java
@@ -183,6 +183,9 @@ public class AlternatingController implements CheckpointBarrierBehaviourControll
         }
         if (activeController == unalignedController) {
             barrier = barrier.asUnaligned();
+        } else if (activeController == alignedController
+                && barrier.getCheckpointOptions().isUnalignedCheckpoint()) {
+            checkState(!switchToUnaligned(barrier).isPresent());
         }
         return activeController.preProcessFirstBarrier(channelInfo, barrier);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.util.clock.Clock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,8 +73,8 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
     private long latestPendingCheckpointID = -1;
 
     public CheckpointBarrierTracker(
-            int totalNumberOfInputChannels, AbstractInvokable toNotifyOnCheckpoint) {
-        super(toNotifyOnCheckpoint);
+            int totalNumberOfInputChannels, AbstractInvokable toNotifyOnCheckpoint, Clock clock) {
+        super(toNotifyOnCheckpoint, clock);
         this.totalNumberOfInputChannels = totalNumberOfInputChannels;
         this.pendingCheckpoints = new ArrayDeque<>();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtil.java
@@ -31,6 +31,7 @@ import org.apache.flink.streaming.runtime.io.StreamOneInputProcessor;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessor;
 import org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinator;
+import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.SystemClock;
 
@@ -41,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Stream;
 
 /**
@@ -57,7 +59,8 @@ public class InputProcessorUtil {
             IndexedInputGate[] inputGates,
             TaskIOMetricGroup taskIOMetricGroup,
             String taskName,
-            MailboxExecutor mailboxExecutor) {
+            MailboxExecutor mailboxExecutor,
+            TimerService timerService) {
         CheckpointedInputGate[] checkpointedInputGates =
                 createCheckpointedMultipleInputGate(
                         toNotifyOnCheckpoint,
@@ -67,7 +70,8 @@ public class InputProcessorUtil {
                         taskName,
                         mailboxExecutor,
                         new List[] {Arrays.asList(inputGates)},
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        timerService);
         return Iterables.getOnlyElement(Arrays.asList(checkpointedInputGates));
     }
 
@@ -83,7 +87,8 @@ public class InputProcessorUtil {
             String taskName,
             MailboxExecutor mailboxExecutor,
             List<IndexedInputGate>[] inputGates,
-            List<StreamTaskSourceInput<?>> sourceInputs) {
+            List<StreamTaskSourceInput<?>> sourceInputs,
+            TimerService timerService) {
         CheckpointBarrierHandler barrierHandler =
                 createCheckpointBarrierHandler(
                         toNotifyOnCheckpoint,
@@ -91,7 +96,9 @@ public class InputProcessorUtil {
                         checkpointCoordinator,
                         taskName,
                         inputGates,
-                        sourceInputs);
+                        sourceInputs,
+                        mailboxExecutor,
+                        timerService);
         return createCheckpointedMultipleInputGate(
                 mailboxExecutor, inputGates, taskIOMetricGroup, barrierHandler, config);
     }
@@ -130,7 +137,9 @@ public class InputProcessorUtil {
             SubtaskCheckpointCoordinator checkpointCoordinator,
             String taskName,
             List<IndexedInputGate>[] inputGates,
-            List<StreamTaskSourceInput<?>> sourceInputs) {
+            List<StreamTaskSourceInput<?>> sourceInputs,
+            MailboxExecutor mailboxExecutor,
+            TimerService timerService) {
 
         CheckpointableInput[] inputs =
                 Stream.<CheckpointableInput>concat(
@@ -155,7 +164,22 @@ public class InputProcessorUtil {
                                         clock)
                                 : new AlignedController(inputs);
                 return new SingleCheckpointBarrierHandler(
-                        taskName, toNotifyOnCheckpoint, clock, numberOfChannels, controller);
+                        taskName,
+                        toNotifyOnCheckpoint,
+                        clock,
+                        numberOfChannels,
+                        controller,
+                        (callable, delay) -> {
+                            ScheduledFuture<?> scheduledFuture =
+                                    timerService.registerTimer(
+                                            timerService.getCurrentProcessingTime()
+                                                    + delay.toMillis(),
+                                            timestamp ->
+                                                    mailboxExecutor.submit(
+                                                            callable,
+                                                            "Execute checkpoint barrier handler delayed action"));
+                            return () -> scheduledFuture.cancel(false);
+                        });
             case AT_LEAST_ONCE:
                 if (config.isUnalignedCheckpointsEnabled()) {
                     throw new IllegalStateException(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinator;
+import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.function.TriFunctionWithException;
 
 import org.slf4j.Logger;
@@ -80,10 +81,12 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             SubtaskCheckpointCoordinator checkpointCoordinator,
             String taskName,
             AbstractInvokable toNotifyOnCheckpoint,
+            Clock clock,
             CheckpointableInput... inputs) {
         return new SingleCheckpointBarrierHandler(
                 taskName,
                 toNotifyOnCheckpoint,
+                clock,
                 (int)
                         Arrays.stream(inputs)
                                 .flatMap(gate -> gate.getChannelInfos().stream())
@@ -94,9 +97,10 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
     SingleCheckpointBarrierHandler(
             String taskName,
             AbstractInvokable toNotifyOnCheckpoint,
+            Clock clock,
             int numOpenChannels,
             CheckpointBarrierBehaviourController controller) {
-        super(toNotifyOnCheckpoint);
+        super(toNotifyOnCheckpoint, clock);
 
         this.taskName = taskName;
         this.numOpenChannels = numOpenChannels;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -97,7 +97,10 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                                 .flatMap(gate -> gate.getChannelInfos().stream())
                                 .count(),
                 new UnalignedController(checkpointCoordinator, inputs),
-                null /* TODO */);
+                (callable, duration) -> {
+                    throw new IllegalStateException(
+                            "Strictly unaligned checkpoints should never register any callbacks");
+                });
     }
 
     SingleCheckpointBarrierHandler(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -138,7 +138,9 @@ public class MultipleInputStreamTask<OUT>
                         getCheckpointCoordinator(),
                         getTaskNameWithSubtaskAndId(),
                         inputGates,
-                        operatorChain.getSourceTaskInputs());
+                        operatorChain.getSourceTaskInputs(),
+                        mainMailboxExecutor,
+                        timerService);
 
         CheckpointedInputGate[] checkpointedInputGates =
                 InputProcessorUtil.createCheckpointedMultipleInputGate(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -144,7 +144,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                 inputGates,
                 getEnvironment().getMetricGroup().getIOMetricGroup(),
                 getTaskNameWithSubtaskAndId(),
-                mainMailboxExecutor);
+                mainMailboxExecutor,
+                timerService);
     }
 
     private DataOutput<IN> createDataOutput(Counter numRecordsIn) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -59,7 +59,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
                         getTaskNameWithSubtaskAndId(),
                         mainMailboxExecutor,
                         new List[] {inputGates1, inputGates2},
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        timerService);
         checkState(checkpointedInputGates.length == 2);
 
         inputProcessor =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.After;
 import org.junit.Test;
@@ -152,6 +153,7 @@ public class StreamTaskNetworkInputTest {
                                                 TestSubtaskCheckpointCoordinator.INSTANCE,
                                                 "test",
                                                 new DummyCheckpointInvokable(),
+                                                SystemClock.getInstance(),
                                                 inputGate.getInputGate()),
                                 new SyncMailboxExecutor()),
                         inSerializer,
@@ -228,7 +230,8 @@ public class StreamTaskNetworkInputTest {
     private static CheckpointedInputGate createCheckpointedInputGate(InputGate inputGate) {
         return new CheckpointedInputGate(
                 inputGate,
-                new CheckpointBarrierTracker(1, new DummyCheckpointInvokable()),
+                new CheckpointBarrierTracker(
+                        1, new DummyCheckpointInvokable(), SystemClock.getInstance()),
                 new SyncMailboxExecutor());
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerMassiveRandomTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.Test;
 
@@ -72,6 +73,7 @@ public class AlignedControllerMassiveRandomTest {
                             new SingleCheckpointBarrierHandler(
                                     "Testing: No task associated",
                                     new DummyCheckpointInvokable(),
+                                    SystemClock.getInstance(),
                                     myIG.getNumberOfInputChannels(),
                                     new AlignedController(myIG) {
                                         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerMassiveRandomTest.java
@@ -78,7 +78,8 @@ public class AlignedControllerMassiveRandomTest {
                                     new AlignedController(myIG) {
                                         @Override
                                         protected void resetPendingCheckpoint(long cancelledId) {}
-                                    }),
+                                    },
+                                    (callable, duration) -> () -> {}),
                             new SyncMailboxExecutor());
 
             for (int i = 0; i < 2000000; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedControllerTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 import org.apache.flink.streaming.runtime.io.MockInputGate;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -135,6 +136,7 @@ public class AlignedControllerTest {
                 new SingleCheckpointBarrierHandler(
                         "Testing",
                         toNotify,
+                        SystemClock.getInstance(),
                         gate.getNumberOfInputChannels(),
                         new AlignedController(gate) {
                             @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 import org.apache.flink.streaming.runtime.io.MockInputGate;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.After;
 import org.junit.Test;
@@ -600,7 +601,9 @@ public class CheckpointBarrierTrackerTest {
         return new CheckpointedInputGate(
                 inputGate,
                 new CheckpointBarrierTracker(
-                        inputGate.getNumberOfInputChannels(), toNotifyOnCheckpoint),
+                        inputGate.getNumberOfInputChannels(),
+                        toNotifyOnCheckpoint,
+                        SystemClock.getInstance()),
                 new SyncMailboxExecutor());
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -219,8 +219,8 @@ public class CheckpointedInputGateTest {
 
                 ValidatingCheckpointHandler validatingHandler = new ValidatingCheckpointHandler(1);
                 SingleCheckpointBarrierHandler barrierHandler =
-                        AlternatingControllerTest.barrierHandler(
-                                singleInputGate, validatingHandler, new MockChannelStateWriter());
+                        TestBarrierHandlerBuilder.builder(validatingHandler)
+                                .build(singleInputGate, new MockChannelStateWriter());
                 CheckpointedInputGate checkpointedInputGate =
                         new CheckpointedInputGate(
                                 singleInputGate,
@@ -376,8 +376,8 @@ public class CheckpointedInputGateTest {
                         new TaskMailboxImpl(), 0, StreamTaskActionExecutor.IMMEDIATE);
 
         SingleCheckpointBarrierHandler barrierHandler =
-                AlternatingControllerTest.barrierHandler(
-                        singleInputGate, abstractInvokable, stateWriter);
+                TestBarrierHandlerBuilder.builder(abstractInvokable)
+                        .build(singleInputGate, stateWriter);
         CheckpointedInputGate checkpointedInputGate =
                 new CheckpointedInputGate(
                         singleInputGate,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.apache.flink.shaded.guava18.com.google.common.io.Closer;
 
@@ -334,7 +335,8 @@ public class CheckpointedInputGateTest {
                         new AbstractInvokable(new DummyEnvironment()) {
                             @Override
                             public void invoke() {}
-                        });
+                        },
+                        SystemClock.getInstance());
 
         CheckpointedInputGate checkpointedInputGate =
                 new CheckpointedInputGate(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator;
 import org.apache.flink.streaming.util.MockStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
@@ -77,7 +78,8 @@ public class InputProcessorUtilTest {
                             streamTask.getName(),
                             new SyncMailboxExecutor(),
                             inputGates,
-                            Collections.emptyList());
+                            Collections.emptyList(),
+                            new TestProcessingTimeService());
             for (CheckpointedInputGate checkpointedInputGate : checkpointedMultipleInputGate) {
                 registry.registerCloseable(checkpointedInputGate);
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/TestBarrierHandlerBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/TestBarrierHandlerBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
+
+/** A builder for creating instances of {@link SingleCheckpointBarrierHandler} for tests. */
+public class TestBarrierHandlerBuilder {
+    private final AbstractInvokable target;
+    private Clock clock = SystemClock.getInstance();
+
+    private TestBarrierHandlerBuilder(AbstractInvokable target) {
+        this.target = target;
+    }
+
+    public static TestBarrierHandlerBuilder builder(AbstractInvokable target) {
+        return new TestBarrierHandlerBuilder(target);
+    }
+
+    public TestBarrierHandlerBuilder withClock(Clock clock) {
+        this.clock = clock;
+        return this;
+    }
+
+    public SingleCheckpointBarrierHandler build(SingleInputGate inputGate) {
+        return build(inputGate, new RecordingChannelStateWriter());
+    }
+
+    public SingleCheckpointBarrierHandler build(
+            SingleInputGate inputGate, ChannelStateWriter stateWriter) {
+        String taskName = "test";
+        return new SingleCheckpointBarrierHandler(
+                taskName,
+                target,
+                clock,
+                inputGate.getNumberOfInputChannels(),
+                new AlternatingController(
+                        new AlignedController(inputGate),
+                        new UnalignedController(
+                                new TestSubtaskCheckpointCoordinator(stateWriter), inputGate),
+                        clock));
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerCancellationTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBui
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,7 +95,11 @@ public class UnalignedControllerCancellationTest {
                         .build();
         SingleCheckpointBarrierHandler unaligner =
                 SingleCheckpointBarrierHandler.createUnalignedCheckpointBarrierHandler(
-                        TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
+                        TestSubtaskCheckpointCoordinator.INSTANCE,
+                        "test",
+                        invokable,
+                        SystemClock.getInstance(),
+                        inputGate);
 
         for (RuntimeEvent e : events) {
             if (e instanceof CancelCheckpointMarker) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedControllerTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -722,7 +723,11 @@ public class UnalignedControllerTest {
                         .build();
         final SingleCheckpointBarrierHandler handler =
                 SingleCheckpointBarrierHandler.createUnalignedCheckpointBarrierHandler(
-                        TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
+                        TestSubtaskCheckpointCoordinator.INSTANCE,
+                        "test",
+                        invokable,
+                        SystemClock.getInstance(),
+                        inputGate);
 
         // should trigger respective checkpoint
         handler.processBarrier(
@@ -743,7 +748,11 @@ public class UnalignedControllerTest {
                         .build();
         final SingleCheckpointBarrierHandler handler =
                 SingleCheckpointBarrierHandler.createUnalignedCheckpointBarrierHandler(
-                        TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
+                        TestSubtaskCheckpointCoordinator.INSTANCE,
+                        "test",
+                        invokable,
+                        SystemClock.getInstance(),
+                        inputGate);
 
         handler.processCancellationBarrier(new CancelCheckpointMarker(DEFAULT_CHECKPOINT_ID));
 
@@ -795,7 +804,11 @@ public class UnalignedControllerTest {
                         .build();
         final SingleCheckpointBarrierHandler handler =
                 SingleCheckpointBarrierHandler.createUnalignedCheckpointBarrierHandler(
-                        TestSubtaskCheckpointCoordinator.INSTANCE, "test", invokable, inputGate);
+                        TestSubtaskCheckpointCoordinator.INSTANCE,
+                        "test",
+                        invokable,
+                        SystemClock.getInstance(),
+                        inputGate);
 
         // should trigger respective checkpoint
         handler.processBarrier(
@@ -924,6 +937,7 @@ public class UnalignedControllerTest {
                         new TestSubtaskCheckpointCoordinator(channelStateWriter),
                         "Test",
                         toNotify,
+                        SystemClock.getInstance(),
                         gate);
         return new CheckpointedInputGate(gate, barrierHandler, new SyncMailboxExecutor());
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestCheckpointedInputGateBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestCheckpointedInputGateBuilder.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.TestInputChannel;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
+import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
+import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+
+/** A builder for creating instances of {@link CheckpointedInputGate} for tests. */
+public class TestCheckpointedInputGateBuilder {
+    private final int numChannels;
+    private final BiFunction<SingleInputGate, ChannelStateWriter, CheckpointBarrierHandler>
+            barrierHandlerFactory;
+
+    private ChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
+    private SupplierWithException<SingleInputGate, IOException> gateBuilder = this::buildTestGate;
+    private MailboxExecutor mailboxExecutor;
+
+    private TestCheckpointedInputGateBuilder(
+            int numChannels,
+            BiFunction<SingleInputGate, ChannelStateWriter, CheckpointBarrierHandler>
+                    barrierHandler) {
+        this.numChannels = numChannels;
+        this.barrierHandlerFactory = barrierHandler;
+
+        this.mailboxExecutor = new SyncMailboxExecutor();
+    }
+
+    public static TestCheckpointedInputGateBuilder builder(
+            int numChannels,
+            BiFunction<SingleInputGate, ChannelStateWriter, CheckpointBarrierHandler>
+                    barrierHandlerFactory) {
+        return new TestCheckpointedInputGateBuilder(numChannels, barrierHandlerFactory);
+    }
+
+    /**
+     * Uses {@link RemoteInputChannel RemoteInputChannels} and enables {@link
+     * #withMailboxExecutor()} by default.
+     */
+    public TestCheckpointedInputGateBuilder withRemoteChannels() {
+        this.gateBuilder = this::buildRemoteGate;
+        return withMailboxExecutor();
+    }
+
+    /** Uses {@link TestInputChannel TestInputChannels}. */
+    public TestCheckpointedInputGateBuilder withTestChannels() {
+        this.gateBuilder = this::buildTestGate;
+        return this;
+    }
+
+    public TestCheckpointedInputGateBuilder withSyncExecutor() {
+        this.mailboxExecutor = new SyncMailboxExecutor();
+        return this;
+    }
+
+    public TestCheckpointedInputGateBuilder withMailboxExecutor() {
+        // do not fire events automatically. If you need events, you should expose mailboxProcessor
+        // and
+        // execute it step by step
+        this.mailboxExecutor = new MailboxProcessor().getMainMailboxExecutor();
+        return this;
+    }
+
+    public TestCheckpointedInputGateBuilder withChannelStateWriter(
+            ChannelStateWriter channelStateWriter) {
+        this.channelStateWriter = channelStateWriter;
+        return this;
+    }
+
+    public CheckpointedInputGate build() throws IOException {
+        SingleInputGate gate = gateBuilder.get();
+
+        return new CheckpointedInputGate(
+                gate, barrierHandlerFactory.apply(gate, channelStateWriter), mailboxExecutor);
+    }
+
+    private SingleInputGate buildTestGate() {
+        SingleInputGate gate =
+                new SingleInputGateBuilder().setNumberOfChannels(numChannels).build();
+        TestInputChannel[] channels = new TestInputChannel[numChannels];
+        for (int i = 0; i < numChannels; i++) {
+            channels[i] = new TestInputChannel(gate, i, false, true);
+        }
+        gate.setInputChannels(channels);
+        return gate;
+    }
+
+    private SingleInputGate buildRemoteGate() throws IOException {
+        int maxUsedBuffers = 10;
+        NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(numChannels * maxUsedBuffers, 4096);
+        SingleInputGate gate =
+                new SingleInputGateBuilder()
+                        .setChannelFactory(InputChannelBuilder::buildRemoteChannel)
+                        .setNumberOfChannels(numChannels)
+                        .setSegmentProvider(networkBufferPool)
+                        .setBufferPoolFactory(
+                                networkBufferPool.createBufferPool(numChannels, maxUsedBuffers))
+                        .setChannelStateWriter(channelStateWriter)
+                        .build();
+        gate.setup();
+        gate.requestPartitions();
+        return gate;
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.flink.test.util.MiniClusterPipelineExecutorServiceLoader;
 import org.apache.flink.util.TestNameProvider;
 
 import java.net.URL;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -95,6 +96,14 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
             final PseudoRandomValueSelector valueSelector =
                     PseudoRandomValueSelector.create(testName != null ? testName : "unknown");
             valueSelector.select(conf, ExecutionCheckpointingOptions.ENABLE_UNALIGNED, true, false);
+            valueSelector.select(
+                    conf,
+                    ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT,
+                    Duration.ofSeconds(0),
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(5),
+                    Duration.ofSeconds(30),
+                    Duration.ofMillis(100));
         }
     }
 

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -100,10 +100,8 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                     conf,
                     ExecutionCheckpointingOptions.ALIGNMENT_TIMEOUT,
                     Duration.ofSeconds(0),
-                    Duration.ofSeconds(1),
-                    Duration.ofSeconds(5),
-                    Duration.ofSeconds(30),
-                    Duration.ofMillis(100));
+                    Duration.ofMillis(100),
+                    Duration.ofSeconds(2));
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -126,6 +126,10 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                 "parallel pipeline with mixed channels, p = 20, timeout=1",
                 createPipelineSettings(20, 10, true, 1)
             },
+            new Object[] {
+                "parallel pipeline with mixed channels, p = 20, timeout=5",
+                createPipelineSettings(20, 10, true, 5)
+            },
             new Object[] {"Parallel cogroup, p = 5", createCogroupSettings(5)},
             new Object[] {"Parallel cogroup, p = 10", createCogroupSettings(10)},
             new Object[] {"Parallel union, p = 5", createUnionSettings(5)},


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces an active, timer based time out for checkpoints alignment. After the time out we switch over to unaligned checkpoint. Compared to the passive time out it accounts for the situation that the barriers are stuck in the network stack for a considerable amount of time.


## Brief change log

* Added `Clock` to the `AlternatingController` to ease up testing
* Reworked static helper test methods into builders for CheckpointedInputGate and SingleInputBarrierHandler
* Added methods for registering callbacks on time out via `TimerService` which are executed in the mailbox thread.


## Verifying this change

Added tests in:
* AlternatingControllerTest
* Added one more test case in UnalignedCheckpointsITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
