### PR TITLE
[FLINK-21731] Add benchmarks for DefaultScheduler's creation, scheduling and deploying

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmark.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.e2e;
+
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+
+/** The benchmark of creating the scheduler in a STREAMING/BATCH job. */
+public class CreateSchedulerBenchmark extends SchedulerBenchmarkBase {
+
+    public DefaultScheduler createScheduler() throws Exception {
+        return createScheduler(jobGraph, physicalSlotProvider, mainThreadExecutor);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmarkTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.e2e;
+
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/** The benchmark of creating the scheduler in a STREAMING/BATCH job. */
+public class CreateSchedulerBenchmarkTest extends TestLogger {
+    @Test
+    public void createSchedulerInStreamingJob() throws Exception {
+        CreateSchedulerBenchmark benchmark = new CreateSchedulerBenchmark();
+        benchmark.setup(JobConfiguration.STREAMING_TEST);
+        benchmark.createScheduler();
+        benchmark.teardown();
+    }
+
+    @Test
+    public void createSchedulerInBatchJob() throws Exception {
+        CreateSchedulerBenchmark benchmark = new CreateSchedulerBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.createScheduler();
+        benchmark.teardown();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerBenchmarkBase.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.e2e;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RpcTaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProviderImpl;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolBuilder;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolImpl;
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createJobGraph;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * The base class of benchmarks related to {@link DefaultScheduler}'s creation, scheduling and
+ * deploying.
+ */
+public class SchedulerBenchmarkBase {
+
+    ScheduledExecutorService scheduledExecutorService;
+    ComponentMainThreadExecutor mainThreadExecutor;
+
+    JobGraph jobGraph;
+    PhysicalSlotProvider physicalSlotProvider;
+
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        scheduledExecutorService);
+
+        final List<JobVertex> jobVertices = createDefaultJobVertices(jobConfiguration);
+        jobGraph = createJobGraph(jobVertices, jobConfiguration);
+
+        physicalSlotProvider =
+                createPhysicalSlotProvider(
+                        jobConfiguration, jobVertices.size(), mainThreadExecutor);
+    }
+
+    public void teardown() throws Exception {
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
+        }
+    }
+
+    private static PhysicalSlotProvider createPhysicalSlotProvider(
+            JobConfiguration jobConfiguration,
+            int numberOfJobVertices,
+            ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception {
+        final int slotPoolSize = jobConfiguration.getParallelism() * numberOfJobVertices;
+
+        final SlotPoolImpl slotPool = new SlotPoolBuilder(mainThreadExecutor).build();
+        final TestingTaskExecutorGateway testingTaskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
+        offerSlots(
+                slotPool,
+                new RpcTaskManagerGateway(testingTaskExecutorGateway, JobMasterId.generate()),
+                slotPoolSize,
+                mainThreadExecutor);
+
+        return new PhysicalSlotProviderImpl(
+                LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
+    }
+
+    private static void offerSlots(
+            SlotPoolImpl slotPool,
+            TaskManagerGateway taskManagerGateway,
+            int slotPoolSize,
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+        CompletableFuture.runAsync(
+                        () -> {
+                            slotPool.registerTaskManager(taskManagerLocation.getResourceID());
+                            final Collection<SlotOffer> slotOffers =
+                                    IntStream.range(0, slotPoolSize)
+                                            .mapToObj(
+                                                    i ->
+                                                            new SlotOffer(
+                                                                    new AllocationID(),
+                                                                    i,
+                                                                    ResourceProfile.ANY))
+                                            .collect(Collectors.toList());
+                            final Collection<SlotOffer> acceptedOffers =
+                                    slotPool.offerSlots(
+                                            taskManagerLocation, taskManagerGateway, slotOffers);
+                            assertThat(acceptedOffers, is(slotOffers));
+                        },
+                        mainThreadExecutor)
+                .join();
+    }
+
+    static DefaultScheduler createScheduler(
+            JobGraph jobGraph,
+            PhysicalSlotProvider physicalSlotProvider,
+            ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception {
+        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
+                .setExecutionSlotAllocatorFactory(
+                        SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
+                                physicalSlotProvider))
+                .build();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmark.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.e2e;
+
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The benchmark of scheduling and deploying tasks in a STREAMING/BATCH job. The related method is
+ * {@link DefaultScheduler#startScheduling}.
+ */
+public class SchedulingAndDeployingBenchmark extends SchedulerBenchmarkBase {
+
+    private DefaultScheduler scheduler;
+
+    @Override
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+
+        super.setup(jobConfiguration);
+
+        scheduler = createScheduler(jobGraph, physicalSlotProvider, mainThreadExecutor);
+    }
+
+    public void startScheduling() throws Exception {
+        CompletableFuture.runAsync(scheduler::startScheduling, mainThreadExecutor).join();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.scheduler.benchmark.e2e;
+
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+/**
+ * The benchmark of scheduling tasks in a STREAMING/BATCH job. The related method is {@link
+ * DefaultScheduler#startScheduling}.
+ */
+public class SchedulingAndDeployingBenchmarkTest extends TestLogger {
+
+    @Test
+    public void scheduleAndDeployInStreamingJob() throws Exception {
+        SchedulingAndDeployingBenchmark benchmark = new SchedulingAndDeployingBenchmark();
+        benchmark.setup(JobConfiguration.STREAMING_TEST);
+        benchmark.startScheduling();
+        benchmark.teardown();
+    }
+
+    @Test
+    public void scheduleAndDeployInBatchJob() throws Exception {
+        SchedulingAndDeployingBenchmark benchmark = new SchedulingAndDeployingBenchmark();
+        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.startScheduling();
+        benchmark.teardown();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ import org.junit.Test;
  * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
  * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
  */
-public class SchedulingDownstreamTasksInBatchJobBenchmarkTest {
+public class SchedulingDownstreamTasksInBatchJobBenchmarkTest extends TestLogger {
 
     @Test
     public void schedulingDownstreamTasksInBatchJobBenchmark() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces benchmarks to evaluate the performance of DefaultScheduler's creation, scheduling and deploying`.*

*For more details please check [FLINK-21731](https://issues.apache.org/jira/browse/FLINK-21731).*


## Brief change log

  - *Introduces benchmarks that evaluates the performance of creating DefaultScheduler.*
  - *Introduces benchmarks that evaluates the performance of scheduling and deploying in DefaultScheduler.*

## Verifying this change

*This change added the unit tests `CreateSchedulerBenchmarkTest` and `SchedulingAndDeployingBenchmarkTest`.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
