### PR TITLE
[FLINK-21294][python] Support state access API for the map/flat_map operation of Python ConnectedStreams

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -367,22 +367,6 @@ class DataStreamFlatMapCoderImpl(StreamCoderImpl):
         return 'DataStreamFlatMapCoderImpl[%s]' % repr(self._field_coder)
 
 
-class DataStreamCoFlatMapCoderImpl(StreamCoderImpl):
-    def __init__(self, field_coder):
-        self._field_coder = field_coder
-
-    def encode_to_stream(self, iter_value, stream,
-                         nested):  # type: (Any, create_OutputStream, bool) -> None
-        for value in iter_value:
-            self._field_coder.encode_to_stream(value, stream, nested)
-
-    def decode_from_stream(self, stream, nested):
-        return self._field_coder.decode_from_stream(stream, nested)
-
-    def __str__(self) -> str:
-        return 'DataStreamCoFlatMapCoderImpl[%s]' % repr(self._field_coder)
-
-
 class MapCoderImpl(StreamCoderImpl):
 
     def __init__(self, key_coder, value_coder):

--- a/flink-python/pyflink/fn_execution/beam/beam_coders.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coders.py
@@ -29,7 +29,7 @@ from apache_beam.typehints import typehints
 
 from pyflink.fn_execution.beam import beam_coder_impl_slow
 from pyflink.fn_execution.coders import FLINK_MAP_CODER_URN, \
-    FLINK_FLAT_MAP_CODER_URN, FLINK_CO_FLAT_MAP_CODER_URN
+    FLINK_FLAT_MAP_CODER_URN
 
 try:
     from pyflink.fn_execution.beam import beam_coder_impl_fast as beam_coder_impl
@@ -326,33 +326,6 @@ class BeamDataStreamFlatMapCoder(FastCoder):
     def _pickled_from_runner_api_parameter(type_info_proto, unused_components, unused_context):
         return BeamDataStreamFlatMapCoder(
             coders.DataStreamFlatMapCoder.from_type_info_proto(type_info_proto))
-
-    def to_type_hint(self):
-        return typehints.Generator
-
-    def __repr__(self):
-        return 'BeamDataStreamFlatMapCoder[%s]' % repr(self._field_coder)
-
-
-class BeamDataStreamCoFlatMapCoder(FastCoder):
-
-    def __init__(self, field_coder):
-        self._field_coder = field_coder
-
-    def _create_impl(self):
-        return self._field_coder.get_impl()
-
-    def get_impl(self):
-        return BeamCoderImpl(self._create_impl())
-
-    def is_deterministic(self):  # type: () -> bool
-        return all(c.is_deterministic() for c in self._field_coder)
-
-    @Coder.register_urn(FLINK_CO_FLAT_MAP_CODER_URN,
-                        flink_fn_execution_pb2.TypeInfo)
-    def _pickled_from_runner_api_parameter(type_info_proto, unused_components, unused_context):
-        return BeamDataStreamCoFlatMapCoder(
-            coders.DataStreamCoFlatMapCoder.from_type_info_proto(type_info_proto))
 
     def to_type_hint(self):
         return typehints.Generator

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -175,19 +175,6 @@ cdef class DataStreamFlatMapCoderImpl(BaseCoderImpl):
             free(self._end_message)
 
 
-cdef class DataStreamCoFlatMapCoderImpl(BaseCoderImpl):
-
-    def __init__(self, field_coder):
-        self._single_field_coder = field_coder
-
-    cpdef void encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
-        for value in iter_value:
-            self._single_field_coder.encode_to_stream(value, output_stream)
-
-    cpdef object decode_from_stream(self, LengthPrefixInputStream input_stream):
-        return self._single_field_coder.decode_from_stream(input_stream)
-
-
 cdef class DataStreamMapCoderImpl(FlattenRowCoderImpl):
 
     def __init__(self, field_coder):

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -47,7 +47,6 @@ FLINK_OVER_WINDOW_ARROW_CODER_URN = "flink:coder:schema:batch_over_window:arrow:
 # datastream coders
 FLINK_MAP_CODER_URN = "flink:coder:map:v1"
 FLINK_FLAT_MAP_CODER_URN = "flink:coder:flat_map:v1"
-FLINK_CO_FLAT_MAP_CODER_URN = "flink:coder:co_flat_map:v1"
 
 
 class BaseCoder(ABC):

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"\x91\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\x12\x1a\n\x12takes_row_as_input\x18\x04 \x01(\x08\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xb3\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"z\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06\x43O_MAP\x10\x02\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x03\x12\x0b\n\x07PROCESS\x10\x04\x12\x11\n\rKEYED_PROCESS\x10\x05\x12\x16\n\x12TIMESTAMP_ASSIGNER\x10\x06\"\x8b\x06\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x12\x1a\n\x12takes_row_as_input\x18\x06 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\x94\x04\n\x0bGroupWindow\x12M\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x38.org.apache.flink.fn_execution.v1.GroupWindow.WindowType\x12\x16\n\x0eis_time_window\x18\x02 \x01(\x08\x12\x14\n\x0cwindow_slide\x18\x03 \x01(\x03\x12\x13\n\x0bwindow_size\x18\x04 \x01(\x03\x12\x12\n\nwindow_gap\x18\x05 \x01(\x03\x12\x13\n\x0bis_row_time\x18\x06 \x01(\x08\x12\x18\n\x10time_field_index\x18\x07 \x01(\x05\x12\x17\n\x0f\x61llowedLateness\x18\x08 \x01(\x03\x12U\n\x0fnamedProperties\x18\t \x03(\x0e\x32<.org.apache.flink.fn_execution.v1.GroupWindow.WindowProperty\"[\n\nWindowType\x12\x19\n\x15TUMBLING_GROUP_WINDOW\x10\x00\x12\x18\n\x14SLIDING_GROUP_WINDOW\x10\x01\x12\x18\n\x14SESSION_GROUP_WINDOW\x10\x02\"c\n\x0eWindowProperty\x12\x10\n\x0cWINDOW_START\x10\x00\x12\x0e\n\nWINDOW_END\x10\x01\x12\x16\n\x12ROW_TIME_ATTRIBUTE\x10\x02\x12\x17\n\x13PROC_TIME_ATTRIBUTE\x10\x03\"\xfd\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\x12\x43\n\x0cgroup_window\x18\x0c \x01(\x0b\x32-.org.apache.flink.fn_execution.v1.GroupWindow\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xa7\x03\n\nCoderParam\x12:\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12?\n\ttype_info\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12H\n\tdata_type\x18\x03 \x01(\x0e\x32\x35.org.apache.flink.fn_execution.v1.CoderParam.DataType\x12L\n\x0boutput_mode\x18\x04 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.CoderParam.OutputMode\"8\n\x08\x44\x61taType\x12\x0f\n\x0b\x46LATTEN_ROW\x10\x00\x12\x07\n\x03ROW\x10\x01\x12\x07\n\x03RAW\x10\x02\x12\t\n\x05\x41RROW\x10\x03\"=\n\nOutputMode\x12\n\n\x06SINGLE\x10\x00\x12\x0c\n\x08MULTIPLE\x10\x01\x12\x15\n\x11MULTIPLE_WITH_END\x10\x02\x42\x0b\n\tdata_info\"\xd8\x08\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1aP\n\rTupleTypeInfo\x12?\n\x0b\x66ield_types\x18\x01 \x03(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\x95\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x42\x0b\n\ttype_infoB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"\x91\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12\x14\n\x0cwindow_index\x18\x03 \x01(\x05\x12\x1a\n\x12takes_row_as_input\x18\x04 \x01(\x08\"\xb2\x01\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12=\n\x07windows\x18\x03 \x03(\x0b\x32,.org.apache.flink.fn_execution.v1.OverWindow\"\xdd\x02\n\nOverWindow\x12L\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.OverWindow.WindowType\x12\x16\n\x0elower_boundary\x18\x02 \x01(\x03\x12\x16\n\x0eupper_boundary\x18\x03 \x01(\x03\"\xd0\x01\n\nWindowType\x12\x13\n\x0fRANGE_UNBOUNDED\x10\x00\x12\x1d\n\x19RANGE_UNBOUNDED_PRECEDING\x10\x01\x12\x1d\n\x19RANGE_UNBOUNDED_FOLLOWING\x10\x02\x12\x11\n\rRANGE_SLIDING\x10\x03\x12\x11\n\rROW_UNBOUNDED\x10\x04\x12\x1b\n\x17ROW_UNBOUNDED_PRECEDING\x10\x05\x12\x1b\n\x17ROW_UNBOUNDED_FOLLOWING\x10\x06\x12\x0f\n\x0bROW_SLIDING\x10\x07\"\xca\x06\n\x1dUserDefinedDataStreamFunction\x12\x63\n\rfunction_type\x18\x01 \x01(\x0e\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.FunctionType\x12g\n\x0fruntime_context\x18\x02 \x01(\x0b\x32N.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.RuntimeContext\x12\x0f\n\x07payload\x18\x03 \x01(\x0c\x12\x16\n\x0emetric_enabled\x18\x04 \x01(\x08\x12\x41\n\rkey_type_info\x18\x05 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a*\n\x0cJobParameter\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x1a\xaf\x02\n\x0eRuntimeContext\x12\x11\n\ttask_name\x18\x01 \x01(\t\x12\x1f\n\x17task_name_with_subtasks\x18\x02 \x01(\t\x12#\n\x1bnumber_of_parallel_subtasks\x18\x03 \x01(\x05\x12\'\n\x1fmax_number_of_parallel_subtasks\x18\x04 \x01(\x05\x12\x1d\n\x15index_of_this_subtask\x18\x05 \x01(\x05\x12\x16\n\x0e\x61ttempt_number\x18\x06 \x01(\x05\x12\x64\n\x0ejob_parameters\x18\x07 \x03(\x0b\x32L.org.apache.flink.fn_execution.v1.UserDefinedDataStreamFunction.JobParameter\"\x90\x01\n\x0c\x46unctionType\x12\x07\n\x03MAP\x10\x00\x12\x0c\n\x08\x46LAT_MAP\x10\x01\x12\n\n\x06\x43O_MAP\x10\x02\x12\x0f\n\x0b\x43O_FLAT_MAP\x10\x03\x12\x0b\n\x07PROCESS\x10\x04\x12\x11\n\rKEYED_PROCESS\x10\x05\x12\x14\n\x10KEYED_CO_PROCESS\x10\x06\x12\x16\n\x12TIMESTAMP_ASSIGNER\x10\x07\"\x8b\x06\n\x1cUserDefinedAggregateFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12\x37\n\x06inputs\x18\x02 \x03(\x0b\x32\'.org.apache.flink.fn_execution.v1.Input\x12Z\n\x05specs\x18\x03 \x03(\x0b\x32K.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec\x12\x12\n\nfilter_arg\x18\x04 \x01(\x05\x12\x10\n\x08\x64istinct\x18\x05 \x01(\x08\x12\x1a\n\x12takes_row_as_input\x18\x06 \x01(\x08\x1a\x82\x04\n\x0c\x44\x61taViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x66ield_index\x18\x02 \x01(\x05\x12i\n\tlist_view\x18\x03 \x01(\x0b\x32T.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.ListViewH\x00\x12g\n\x08map_view\x18\x04 \x01(\x0b\x32S.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.MapViewH\x00\x1aT\n\x08ListView\x12H\n\x0c\x65lement_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x97\x01\n\x07MapView\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeB\x0b\n\tdata_view\"\x94\x04\n\x0bGroupWindow\x12M\n\x0bwindow_type\x18\x01 \x01(\x0e\x32\x38.org.apache.flink.fn_execution.v1.GroupWindow.WindowType\x12\x16\n\x0eis_time_window\x18\x02 \x01(\x08\x12\x14\n\x0cwindow_slide\x18\x03 \x01(\x03\x12\x13\n\x0bwindow_size\x18\x04 \x01(\x03\x12\x12\n\nwindow_gap\x18\x05 \x01(\x03\x12\x13\n\x0bis_row_time\x18\x06 \x01(\x08\x12\x18\n\x10time_field_index\x18\x07 \x01(\x05\x12\x17\n\x0f\x61llowedLateness\x18\x08 \x01(\x03\x12U\n\x0fnamedProperties\x18\t \x03(\x0e\x32<.org.apache.flink.fn_execution.v1.GroupWindow.WindowProperty\"[\n\nWindowType\x12\x19\n\x15TUMBLING_GROUP_WINDOW\x10\x00\x12\x18\n\x14SLIDING_GROUP_WINDOW\x10\x01\x12\x18\n\x14SESSION_GROUP_WINDOW\x10\x02\"c\n\x0eWindowProperty\x12\x10\n\x0cWINDOW_START\x10\x00\x12\x0e\n\nWINDOW_END\x10\x01\x12\x16\n\x12ROW_TIME_ATTRIBUTE\x10\x02\x12\x17\n\x13PROC_TIME_ATTRIBUTE\x10\x03\"\xfd\x03\n\x1dUserDefinedAggregateFunctions\x12L\n\x04udfs\x18\x01 \x03(\x0b\x32>.org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction\x12\x16\n\x0emetric_enabled\x18\x02 \x01(\x08\x12\x10\n\x08grouping\x18\x03 \x03(\x05\x12\x1e\n\x16generate_update_before\x18\x04 \x01(\x08\x12\x44\n\x08key_type\x18\x05 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x1b\n\x13index_of_count_star\x18\x06 \x01(\x05\x12\x1e\n\x16state_cleaning_enabled\x18\x07 \x01(\x08\x12\x18\n\x10state_cache_size\x18\x08 \x01(\x05\x12!\n\x19map_state_read_cache_size\x18\t \x01(\x05\x12\"\n\x1amap_state_write_cache_size\x18\n \x01(\x05\x12\x1b\n\x13\x63ount_star_inserted\x18\x0b \x01(\x08\x12\x43\n\x0cgroup_window\x18\x0c \x01(\x0b\x32-.org.apache.flink.fn_execution.v1.GroupWindow\"\xec\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xa1\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\"\xa7\x03\n\nCoderParam\x12:\n\x06schema\x18\x01 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12?\n\ttype_info\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12H\n\tdata_type\x18\x03 \x01(\x0e\x32\x35.org.apache.flink.fn_execution.v1.CoderParam.DataType\x12L\n\x0boutput_mode\x18\x04 \x01(\x0e\x32\x37.org.apache.flink.fn_execution.v1.CoderParam.OutputMode\"8\n\x08\x44\x61taType\x12\x0f\n\x0b\x46LATTEN_ROW\x10\x00\x12\x07\n\x03ROW\x10\x01\x12\x07\n\x03RAW\x10\x02\x12\t\n\x05\x41RROW\x10\x03\"=\n\nOutputMode\x12\n\n\x06SINGLE\x10\x00\x12\x0c\n\x08MULTIPLE\x10\x01\x12\x15\n\x11MULTIPLE_WITH_END\x10\x02\x42\x0b\n\tdata_info\"\xd8\x08\n\x08TypeInfo\x12\x46\n\ttype_name\x18\x01 \x01(\x0e\x32\x33.org.apache.flink.fn_execution.v1.TypeInfo.TypeName\x12M\n\x17\x63ollection_element_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfoH\x00\x12O\n\rrow_type_info\x18\x03 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfoH\x00\x12S\n\x0ftuple_type_info\x18\x04 \x01(\x0b\x32\x38.org.apache.flink.fn_execution.v1.TypeInfo.TupleTypeInfoH\x00\x12O\n\rmap_type_info\x18\x05 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.TypeInfo.MapTypeInfoH\x00\x1a\x8b\x01\n\x0bMapTypeInfo\x12<\n\x08key_type\x18\x01 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x12>\n\nvalue_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1a\xb8\x01\n\x0bRowTypeInfo\x12L\n\x06\x66ields\x18\x01 \x03(\x0b\x32<.org.apache.flink.fn_execution.v1.TypeInfo.RowTypeInfo.Field\x1a[\n\x05\x46ield\x12\x12\n\nfield_name\x18\x01 \x01(\t\x12>\n\nfield_type\x18\x02 \x01(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\x1aP\n\rTupleTypeInfo\x12?\n\x0b\x66ield_types\x18\x01 \x03(\x0b\x32*.org.apache.flink.fn_execution.v1.TypeInfo\"\x95\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\n\n\x06STRING\x10\x01\x12\x08\n\x04\x42YTE\x10\x02\x12\x0b\n\x07\x42OOLEAN\x10\x03\x12\t\n\x05SHORT\x10\x04\x12\x07\n\x03INT\x10\x05\x12\x08\n\x04LONG\x10\x06\x12\t\n\x05\x46LOAT\x10\x07\x12\n\n\x06\x44OUBLE\x10\x08\x12\x08\n\x04\x43HAR\x10\t\x12\x0b\n\x07\x42IG_INT\x10\n\x12\x0b\n\x07\x42IG_DEC\x10\x0b\x12\x0c\n\x08SQL_DATE\x10\x0c\x12\x0c\n\x08SQL_TIME\x10\r\x12\x11\n\rSQL_TIMESTAMP\x10\x0e\x12\x0f\n\x0b\x42\x41SIC_ARRAY\x10\x0f\x12\x13\n\x0fPRIMITIVE_ARRAY\x10\x10\x12\t\n\x05TUPLE\x10\x11\x12\x08\n\x04LIST\x10\x12\x12\x07\n\x03MAP\x10\x13\x12\x11\n\rPICKLED_BYTES\x10\x14\x42\x0b\n\ttype_infoB-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -118,14 +118,18 @@ _USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='TIMESTAMP_ASSIGNER', index=6, number=6,
+      name='KEYED_CO_PROCESS', index=6, number=6,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='TIMESTAMP_ASSIGNER', index=7, number=7,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=1578,
-  serialized_end=1700,
+  serialized_start=1579,
+  serialized_end=1723,
 )
 _sym_db.RegisterEnumDescriptor(_USERDEFINEDDATASTREAMFUNCTION_FUNCTIONTYPE)
 
@@ -150,8 +154,8 @@ _GROUPWINDOW_WINDOWTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2825,
-  serialized_end=2916,
+  serialized_start=2848,
+  serialized_end=2939,
 )
 _sym_db.RegisterEnumDescriptor(_GROUPWINDOW_WINDOWTYPE)
 
@@ -180,8 +184,8 @@ _GROUPWINDOW_WINDOWPROPERTY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=2918,
-  serialized_end=3017,
+  serialized_start=2941,
+  serialized_end=3040,
 )
 _sym_db.RegisterEnumDescriptor(_GROUPWINDOW_WINDOWPROPERTY)
 
@@ -278,8 +282,8 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=5271,
-  serialized_end=5560,
+  serialized_start=5294,
+  serialized_end=5583,
 )
 _sym_db.RegisterEnumDescriptor(_SCHEMA_TYPENAME)
 
@@ -308,8 +312,8 @@ _CODERPARAM_DATATYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=5854,
-  serialized_end=5910,
+  serialized_start=5877,
+  serialized_end=5933,
 )
 _sym_db.RegisterEnumDescriptor(_CODERPARAM_DATATYPE)
 
@@ -334,8 +338,8 @@ _CODERPARAM_OUTPUTMODE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=5912,
-  serialized_end=5973,
+  serialized_start=5935,
+  serialized_end=5996,
 )
 _sym_db.RegisterEnumDescriptor(_CODERPARAM_OUTPUTMODE)
 
@@ -432,8 +436,8 @@ _TYPEINFO_TYPENAME = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=6811,
-  serialized_end=7088,
+  serialized_start=6834,
+  serialized_end=7111,
 )
 _sym_db.RegisterEnumDescriptor(_TYPEINFO_TYPENAME)
 
@@ -794,7 +798,7 @@ _USERDEFINEDDATASTREAMFUNCTION = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=881,
-  serialized_end=1700,
+  serialized_end=1723,
 )
 
 
@@ -824,8 +828,8 @@ _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC_LISTVIEW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2231,
-  serialized_end=2315,
+  serialized_start=2254,
+  serialized_end=2338,
 )
 
 _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC_MAPVIEW = _descriptor.Descriptor(
@@ -861,8 +865,8 @@ _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC_MAPVIEW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2318,
-  serialized_end=2469,
+  serialized_start=2341,
+  serialized_end=2492,
 )
 
 _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC = _descriptor.Descriptor(
@@ -915,8 +919,8 @@ _USERDEFINEDAGGREGATEFUNCTION_DATAVIEWSPEC = _descriptor.Descriptor(
       name='data_view', full_name='org.apache.flink.fn_execution.v1.UserDefinedAggregateFunction.DataViewSpec.data_view',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1968,
-  serialized_end=2482,
+  serialized_start=1991,
+  serialized_end=2505,
 )
 
 _USERDEFINEDAGGREGATEFUNCTION = _descriptor.Descriptor(
@@ -980,8 +984,8 @@ _USERDEFINEDAGGREGATEFUNCTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1703,
-  serialized_end=2482,
+  serialized_start=1726,
+  serialized_end=2505,
 )
 
 
@@ -1069,8 +1073,8 @@ _GROUPWINDOW = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2485,
-  serialized_end=3017,
+  serialized_start=2508,
+  serialized_end=3040,
 )
 
 
@@ -1177,8 +1181,8 @@ _USERDEFINEDAGGREGATEFUNCTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3020,
-  serialized_end=3529,
+  serialized_start=3043,
+  serialized_end=3552,
 )
 
 
@@ -1215,8 +1219,8 @@ _SCHEMA_MAPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3607,
-  serialized_end=3758,
+  serialized_start=3630,
+  serialized_end=3781,
 )
 
 _SCHEMA_TIMEINFO = _descriptor.Descriptor(
@@ -1245,8 +1249,8 @@ _SCHEMA_TIMEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3760,
-  serialized_end=3789,
+  serialized_start=3783,
+  serialized_end=3812,
 )
 
 _SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
@@ -1275,8 +1279,8 @@ _SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3791,
-  serialized_end=3825,
+  serialized_start=3814,
+  serialized_end=3848,
 )
 
 _SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
@@ -1305,8 +1309,8 @@ _SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3827,
-  serialized_end=3871,
+  serialized_start=3850,
+  serialized_end=3894,
 )
 
 _SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
@@ -1335,8 +1339,8 @@ _SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3873,
-  serialized_end=3912,
+  serialized_start=3896,
+  serialized_end=3935,
 )
 
 _SCHEMA_DECIMALINFO = _descriptor.Descriptor(
@@ -1372,8 +1376,8 @@ _SCHEMA_DECIMALINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3914,
-  serialized_end=3961,
+  serialized_start=3937,
+  serialized_end=3984,
 )
 
 _SCHEMA_BINARYINFO = _descriptor.Descriptor(
@@ -1402,8 +1406,8 @@ _SCHEMA_BINARYINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3963,
-  serialized_end=3991,
+  serialized_start=3986,
+  serialized_end=4014,
 )
 
 _SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
@@ -1432,8 +1436,8 @@ _SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3993,
-  serialized_end=4024,
+  serialized_start=4016,
+  serialized_end=4047,
 )
 
 _SCHEMA_CHARINFO = _descriptor.Descriptor(
@@ -1462,8 +1466,8 @@ _SCHEMA_CHARINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4026,
-  serialized_end=4052,
+  serialized_start=4049,
+  serialized_end=4075,
 )
 
 _SCHEMA_VARCHARINFO = _descriptor.Descriptor(
@@ -1492,8 +1496,8 @@ _SCHEMA_VARCHARINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4054,
-  serialized_end=4083,
+  serialized_start=4077,
+  serialized_end=4106,
 )
 
 _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
@@ -1616,8 +1620,8 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=4086,
-  serialized_end=5158,
+  serialized_start=4109,
+  serialized_end=5181,
 )
 
 _SCHEMA_FIELD = _descriptor.Descriptor(
@@ -1660,8 +1664,8 @@ _SCHEMA_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5160,
-  serialized_end=5268,
+  serialized_start=5183,
+  serialized_end=5291,
 )
 
 _SCHEMA = _descriptor.Descriptor(
@@ -1691,8 +1695,8 @@ _SCHEMA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3532,
-  serialized_end=5560,
+  serialized_start=3555,
+  serialized_end=5583,
 )
 
 
@@ -1748,8 +1752,8 @@ _CODERPARAM = _descriptor.Descriptor(
       name='data_info', full_name='org.apache.flink.fn_execution.v1.CoderParam.data_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=5563,
-  serialized_end=5986,
+  serialized_start=5586,
+  serialized_end=6009,
 )
 
 
@@ -1786,8 +1790,8 @@ _TYPEINFO_MAPTYPEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6400,
-  serialized_end=6539,
+  serialized_start=6423,
+  serialized_end=6562,
 )
 
 _TYPEINFO_ROWTYPEINFO_FIELD = _descriptor.Descriptor(
@@ -1823,8 +1827,8 @@ _TYPEINFO_ROWTYPEINFO_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6635,
-  serialized_end=6726,
+  serialized_start=6658,
+  serialized_end=6749,
 )
 
 _TYPEINFO_ROWTYPEINFO = _descriptor.Descriptor(
@@ -1853,8 +1857,8 @@ _TYPEINFO_ROWTYPEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6542,
-  serialized_end=6726,
+  serialized_start=6565,
+  serialized_end=6749,
 )
 
 _TYPEINFO_TUPLETYPEINFO = _descriptor.Descriptor(
@@ -1883,8 +1887,8 @@ _TYPEINFO_TUPLETYPEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6728,
-  serialized_end=6808,
+  serialized_start=6751,
+  serialized_end=6831,
 )
 
 _TYPEINFO = _descriptor.Descriptor(
@@ -1945,8 +1949,8 @@ _TYPEINFO = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.TypeInfo.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=5989,
-  serialized_end=7101,
+  serialized_start=6012,
+  serialized_end=7124,
 )
 
 _INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -534,31 +534,6 @@ class StreamGroupWindowAggregateOperation(AbstractStreamGroupAggregateOperation)
             return None
 
 
-class DataStreamStatelessFunctionOperation(Operation):
-
-    def __init__(self, spec):
-        super(DataStreamStatelessFunctionOperation, self).__init__(spec)
-
-    def open(self):
-        for user_defined_func in self.user_defined_funcs:
-            if hasattr(user_defined_func, 'open'):
-                runtime_context = RuntimeContext(
-                    self.spec.serialized_fn.runtime_context.task_name,
-                    self.spec.serialized_fn.runtime_context.task_name_with_subtasks,
-                    self.spec.serialized_fn.runtime_context.number_of_parallel_subtasks,
-                    self.spec.serialized_fn.runtime_context.max_number_of_parallel_subtasks,
-                    self.spec.serialized_fn.runtime_context.index_of_this_subtask,
-                    self.spec.serialized_fn.runtime_context.attempt_number,
-                    {p.key: p.value for p in self.spec.serialized_fn.runtime_context.job_parameters}
-                )
-                user_defined_func.open(runtime_context)
-
-    def generate_func(self, serialized_fn):
-        func, user_defined_func = operation_utils.extract_data_stream_stateless_function(
-            serialized_fn)
-        return func, [user_defined_func]
-
-
 class StreamingRuntimeContext(RuntimeContext):
 
     def __init__(self,

--- a/flink-python/pyflink/fn_execution/utils/__init__.py
+++ b/flink-python/pyflink/fn_execution/utils/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################

--- a/flink-python/pyflink/fn_execution/utils/input_handler.py
+++ b/flink-python/pyflink/fn_execution/utils/input_handler.py
@@ -1,0 +1,159 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from abc import ABC, abstractmethod
+from collections import Iterable
+from enum import Enum
+
+from pyflink.common import Row
+from pyflink.datastream import TimeDomain
+
+
+class RunnerInputType(Enum):
+    NORMAL_RECORD = 0
+    TRIGGER_TIMER = 1
+
+
+class TimerType(Enum):
+    EVENT_TIME = 0
+    PROCESSING_TIME = 1
+
+
+class TimerRowInputHandler(ABC):
+
+    @abstractmethod
+    def advance_watermark(self, watermark) -> None:
+        pass
+
+    @abstractmethod
+    def on_normal_record(self, normal_data, timestamp: int) -> Iterable:
+        pass
+
+    @abstractmethod
+    def on_event_time(
+            self, key, timestamp: int, serialized_namespace: bytes) -> Iterable:
+        pass
+
+    @abstractmethod
+    def on_processing_time(
+            self, key, timestamp: int, serialized_namespace: bytes) -> Iterable:
+        pass
+
+    def process_element(self, operation_input):
+        input_type = operation_input[0]
+        normal_data = operation_input[1]
+        timestamp = operation_input[2]
+        watermark = operation_input[3]
+        timer_data = operation_input[4]
+
+        self.advance_watermark(watermark)
+        if input_type == RunnerInputType.NORMAL_RECORD.value:
+            yield from self.on_normal_record(normal_data, timestamp)
+        elif input_type == RunnerInputType.TRIGGER_TIMER.value:
+            timer_type = timer_data[0]
+            key = timer_data[1]
+            serialized_namespace = timer_data[2]
+            if timer_type == TimerType.EVENT_TIME.value:
+                yield from self.on_event_time(key, timestamp, serialized_namespace)
+            elif timer_type == TimerType.PROCESSING_TIME.value:
+                yield from self.on_processing_time(key, timestamp, serialized_namespace)
+            else:
+                raise Exception("Unsupported timer type: %d" % timer_type)
+        else:
+            raise Exception("Unsupported input type: %d" % input_type)
+
+
+class KeyedTwoInputTimerRowHandler(TimerRowInputHandler):
+
+    def __init__(self,
+                 context,
+                 timer_context,
+                 internal_collector,
+                 state_backend,
+                 keyed_co_process_function):
+        """
+        :type context: InternalKeyedProcessFunctionContext
+        :type timer_context: InternalKeyedProcessFunctionOnTimerContext
+        :type internal_collector: InternalCollector
+        :type state_backend: RemoteKeyedStateBackend
+        :type keyed_co_process_function: KeyedCoProcessFunction
+        """
+        super(KeyedTwoInputTimerRowHandler, self).__init__()
+        self._ctx = context
+        self._on_timer_ctx = timer_context
+        self._collector = internal_collector
+        self._keyed_state_backend = state_backend
+        self._process_function = keyed_co_process_function
+
+    def advance_watermark(self, watermark) -> None:
+        self._on_timer_ctx.timer_service().set_current_watermark(watermark)
+
+    def on_normal_record(self, unified_input, timestamp: int) -> Iterable:
+        self._ctx.set_timestamp(timestamp)
+        is_left = unified_input[0]
+        if is_left:
+            user_input = unified_input[1]
+        else:
+            user_input = unified_input[2]
+        user_current_key = user_input[0]
+        user_element = user_input[1]
+
+        state_current_key = Row(user_current_key)
+        self._on_timer_ctx.set_current_key(user_current_key)
+        self._keyed_state_backend.set_current_key(state_current_key)
+
+        if is_left:
+            output_result = self._process_function.process_element1(user_element, self._ctx)
+        else:
+            output_result = self._process_function.process_element2(user_element, self._ctx)
+
+        yield from self._emit_output(output_result)
+
+    def on_event_time(
+            self, key, timestamp: int, serialized_namespace: bytes) -> Iterable:
+        yield from self._on_timer(TimeDomain.EVENT_TIME, key, timestamp)
+
+    def on_processing_time(
+            self, key, timestamp: int, serialized_namespace: bytes) -> Iterable:
+        yield from self._on_timer(TimeDomain.PROCESSING_TIME, key, timestamp)
+
+    def _on_timer(self, time_domain, key, timestamp):
+        self._on_timer_ctx.set_timestamp(timestamp)
+        state_current_key = key
+        user_current_key = state_current_key[0]
+
+        self._on_timer_ctx.set_current_key(user_current_key)
+        self._keyed_state_backend.set_current_key(state_current_key)
+
+        self._on_timer_ctx.set_time_domain(time_domain)
+
+        output_result = self._process_function.on_timer(timestamp, self._on_timer_ctx)
+
+        yield from self._emit_output(output_result)
+
+    def _emit_output(self, output_result):
+        for result in output_result:
+            yield Row(None, None, None, result)
+
+        for result in self._collector.buf:
+            # 0: proc time timer data
+            # 1: event time timer data
+            # 2: normal data
+            # result_row: [TIMER_FLAG, TIMER TYPE, TIMER_KEY, RESULT_DATA]
+            yield Row(result[0], result[1], result[2], None)
+
+        self._collector.clear()

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -85,7 +85,8 @@ message UserDefinedDataStreamFunction {
     CO_FLAT_MAP = 3;
     PROCESS = 4;
     KEYED_PROCESS = 5;
-    TIMESTAMP_ASSIGNER = 6;
+    KEYED_CO_PROCESS = 6;
+    TIMESTAMP_ASSIGNER = 7;
   }
 
   message JobParameter {

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -279,6 +279,7 @@ run sdist.
                 'pyflink.common',
                 'pyflink.fn_execution',
                 'pyflink.fn_execution.beam',
+                'pyflink.fn_execution.utils',
                 'pyflink.metrics',
                 'pyflink.ml',
                 'pyflink.ml.api',

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonCoMapOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonCoMapOperator.java
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
-import org.apache.flink.streaming.api.utils.PythonOperatorUtils;
-import org.apache.flink.types.Row;
 
 /**
  * The {@link PythonCoFlatMapOperator} is responsible for executing the Python CoMap Function.
@@ -34,7 +32,7 @@ import org.apache.flink.types.Row;
  */
 @Internal
 public class PythonCoMapOperator<IN1, IN2, OUT>
-        extends TwoInputPythonFunctionOperator<IN1, IN2, OUT> {
+        extends TwoInputPythonFunctionOperator<IN1, IN2, OUT, OUT> {
 
     private static final long serialVersionUID = 1L;
 
@@ -45,20 +43,14 @@ public class PythonCoMapOperator<IN1, IN2, OUT>
             TypeInformation<IN1> inputTypeInfo1,
             TypeInformation<IN2> inputTypeInfo2,
             TypeInformation<OUT> outputTypeInfo,
-            DataStreamPythonFunctionInfo pythonFunctionInfo,
-            boolean isKeyedStream) {
+            DataStreamPythonFunctionInfo pythonFunctionInfo) {
         super(
                 config,
                 inputTypeInfo1,
                 inputTypeInfo2,
                 outputTypeInfo,
                 pythonFunctionInfo,
-                isKeyedStream);
-    }
-
-    @Override
-    public String getFunctionUrn() {
-        return MAP_CODER_URN;
+                MAP_CODER_URN);
     }
 
     @Override
@@ -66,13 +58,8 @@ public class PythonCoMapOperator<IN1, IN2, OUT>
         byte[] rawResult = resultTuple.f0;
         int length = resultTuple.f1;
         bais.setBuffer(rawResult, 0, length);
-        Row outputRow = runnerOutputTypeSerializer.deserialize(baisWrapper);
-        if ((byte) outputRow.getField(0)
-                == PythonOperatorUtils.CoMapFunctionOutputFlag.LEFT.value) {
-            collector.setAbsoluteTimestamp(bufferedTimestamp1.poll());
-        } else {
-            collector.setAbsoluteTimestamp(bufferedTimestamp2.poll());
-        }
-        collector.collect(outputRow.getField(1));
+        OUT output = getRunnerOutputTypeSerializer().deserialize(baisWrapper);
+        collector.setAbsoluteTimestamp(bufferedTimestamp.poll());
+        collector.collect(output);
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedCoProcessOperator.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.python;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.runners.python.beam.BeamDataStreamPythonFunctionRunner;
+import org.apache.flink.streaming.api.utils.PythonOperatorUtils;
+import org.apache.flink.streaming.api.utils.PythonTypeUtils;
+import org.apache.flink.streaming.api.utils.input.KeyedTwoInputWithTimerRowFactory;
+import org.apache.flink.streaming.api.utils.output.OutputWithTimerRowHandler;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.types.Row;
+
+import java.util.Collections;
+
+/** KeyedCoProcessOperator. */
+public class PythonKeyedCoProcessOperator<OUT>
+        extends TwoInputPythonFunctionOperator<Row, Row, Row, OUT>
+        implements ResultTypeQueryable<OUT>, Triggerable<Row, VoidNamespace> {
+
+    private static final String KEYED_CO_PROCESS_FUNCTION_URN =
+            "flink:transform:keyed_process_function:v1";
+
+    private static final String FLAT_MAP_CODER_URN = "flink:coder:flat_map:v1";
+
+    /** The TypeInformation of current key. */
+    private final TypeInformation<Row> keyTypeInfo;
+
+    /** Serializer for current key. */
+    private final TypeSerializer keyTypeSerializer;
+
+    private final TypeInformation<OUT> outputTypeInfo;
+
+    /** TimerService for current operator to register or fire timer. */
+    private transient TimerService timerService;
+
+    private transient KeyedTwoInputWithTimerRowFactory runnerInputFactory;
+    private transient OutputWithTimerRowHandler runnerOutputHandler;
+
+    private transient Object keyForTimerService;
+
+    public PythonKeyedCoProcessOperator(
+            Configuration config,
+            TypeInformation<Row> inputTypeInfo1,
+            TypeInformation<Row> inputTypeInfo2,
+            TypeInformation<OUT> outputTypeInfo,
+            DataStreamPythonFunctionInfo pythonFunctionInfo) {
+        super(
+                config,
+                pythonFunctionInfo,
+                FLAT_MAP_CODER_URN,
+                KeyedTwoInputWithTimerRowFactory.getRunnerInputTypeInfo(
+                        inputTypeInfo1, inputTypeInfo2, constructKeyTypeInfo(inputTypeInfo1)),
+                OutputWithTimerRowHandler.getRunnerOutputTypeInfo(
+                        outputTypeInfo, constructKeyTypeInfo(inputTypeInfo1)));
+        this.keyTypeInfo = constructKeyTypeInfo(inputTypeInfo1);
+        this.keyTypeSerializer =
+                PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
+                        keyTypeInfo);
+        this.outputTypeInfo = outputTypeInfo;
+    }
+
+    @Override
+    public PythonFunctionRunner createPythonFunctionRunner() throws Exception {
+        return new BeamDataStreamPythonFunctionRunner(
+                getRuntimeContext().getTaskName(),
+                createPythonEnvironmentManager(),
+                getRunnerInputTypeInfo(),
+                getRunnerOutputTypeInfo(),
+                KEYED_CO_PROCESS_FUNCTION_URN,
+                PythonOperatorUtils.getUserDefinedDataStreamStatefulFunctionProto(
+                        getPythonFunctionInfo(),
+                        getRuntimeContext(),
+                        Collections.EMPTY_MAP,
+                        keyTypeInfo),
+                getCoderUrn(),
+                getJobOptions(),
+                getFlinkMetricContainer(),
+                getKeyedStateBackend(),
+                keyTypeSerializer,
+                getContainingTask().getEnvironment().getMemoryManager(),
+                getOperatorConfig()
+                        .getManagedMemoryFractionOperatorUseCaseOfSlot(
+                                ManagedMemoryUseCase.PYTHON,
+                                getContainingTask()
+                                        .getEnvironment()
+                                        .getTaskManagerInfo()
+                                        .getConfiguration(),
+                                getContainingTask()
+                                        .getEnvironment()
+                                        .getUserCodeClassLoader()
+                                        .asClassLoader()));
+    }
+
+    @Override
+    public void open() throws Exception {
+        InternalTimerService<VoidNamespace> internalTimerService =
+                getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
+        timerService = new SimpleTimerService(internalTimerService);
+        this.runnerInputFactory = new KeyedTwoInputWithTimerRowFactory();
+        this.runnerOutputHandler =
+                new OutputWithTimerRowHandler(
+                        getKeyedStateBackend(),
+                        timerService,
+                        new TimestampedCollector<>(output),
+                        this);
+        super.open();
+    }
+
+    @Override
+    public void processElement1(StreamRecord<Row> element) throws Exception {
+        processElement(true, element);
+    }
+
+    @Override
+    public void processElement2(StreamRecord<Row> element) throws Exception {
+        processElement(false, element);
+    }
+
+    @Override
+    public void emitResult(Tuple2<byte[], Integer> resultTuple) throws Exception {
+        byte[] rawResult = resultTuple.f0;
+        int length = resultTuple.f1;
+        if (PythonOperatorUtils.endOfLastFlatMap(length, rawResult)) {
+            bufferedTimestamp.poll();
+        } else {
+            bais.setBuffer(rawResult, 0, length);
+            Row runnerOutput = getRunnerOutputTypeSerializer().deserialize(baisWrapper);
+            runnerOutputHandler.accept(runnerOutput, bufferedTimestamp.peek());
+        }
+    }
+
+    @Override
+    public TypeInformation<OUT> getProducedType() {
+        return outputTypeInfo;
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<Row, VoidNamespace> timer) throws Exception {
+        bufferedTimestamp.offer(timer.getTimestamp());
+        processTimer(TimeDomain.EVENT_TIME, timer);
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<Row, VoidNamespace> timer) throws Exception {
+        bufferedTimestamp.offer(Long.MIN_VALUE);
+        processTimer(TimeDomain.PROCESSING_TIME, timer);
+    }
+
+    /**
+     * It is responsible to send timer data to python worker when a registered timer is fired. The
+     * input data is a Row containing 4 fields: TimerFlag 0 for proc time, 1 for event time;
+     * Timestamp of the fired timer; Current watermark and the key of the timer.
+     *
+     * @param timeDomain The type of the timer.
+     * @param timer The fired timer.
+     * @throws Exception The runnerInputSerializer might throw exception.
+     */
+    private void processTimer(TimeDomain timeDomain, InternalTimer<Row, VoidNamespace> timer)
+            throws Exception {
+        Row row =
+                runnerInputFactory.fromTimer(
+                        timeDomain,
+                        timer.getTimestamp(),
+                        timerService.currentWatermark(),
+                        timer.getKey());
+        getRunnerInputTypeSerializer().serialize(row, baosWrapper);
+        pythonFunctionRunner.process(baos.toByteArray());
+        baos.reset();
+        elementCount++;
+        checkInvokeFinishBundleByCount();
+        emitResults();
+    }
+
+    private void processElement(boolean isLeft, StreamRecord<Row> element) throws Exception {
+        bufferedTimestamp.offer(element.getTimestamp());
+        Row row =
+                runnerInputFactory.fromNormalData(
+                        isLeft,
+                        element.getTimestamp(),
+                        timerService.currentWatermark(),
+                        element.getValue());
+        getRunnerInputTypeSerializer().serialize(row, baosWrapper);
+        pythonFunctionRunner.process(baos.toByteArray());
+        baos.reset();
+        elementCount++;
+        checkInvokeFinishBundleByCount();
+        emitResults();
+    }
+
+    private static TypeInformation<Row> constructKeyTypeInfo(TypeInformation<Row> inputTypeInfo) {
+        return new RowTypeInfo(((RowTypeInfo) inputTypeInfo).getTypeAt(0));
+    }
+
+    /**
+     * As the beam state gRPC service will access the KeyedStateBackend in parallel with this
+     * operator, we must override this method to prevent changing the current key of the
+     * KeyedStateBackend while the beam service is handling requests.
+     */
+    @Override
+    public void setCurrentKey(Object key) {
+        keyForTimerService = key;
+    }
+
+    @Override
+    public Object getCurrentKey() {
+        return keyForTimerService;
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
@@ -275,7 +275,7 @@ public class PythonKeyedProcessOperator<OUT>
     private void processTimer(TimeDomain timeDomain, InternalTimer<Row, VoidNamespace> timer)
             throws Exception {
         long time = timer.getTimestamp();
-        Row timerKey = Row.of(timer.getKey());
+        Row timerKey = timer.getKey();
         if (timeDomain == TimeDomain.PROCESSING_TIME) {
             reusableTimerData.setField(
                     0, PythonOperatorUtils.KeyedProcessFunctionInputFlag.PROC_TIME_TIMER.value);

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonKeyedProcessOperator.java
@@ -35,6 +35,7 @@ import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
 import org.apache.flink.streaming.api.operators.InternalTimer;
@@ -44,6 +45,7 @@ import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.runners.python.beam.BeamDataStreamPythonFunctionRunner;
 import org.apache.flink.streaming.api.utils.PythonOperatorUtils;
 import org.apache.flink.streaming.api.utils.PythonTypeUtils;
+import org.apache.flink.streaming.api.utils.output.OutputWithTimerRowHandler;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.types.Row;
@@ -122,7 +124,9 @@ public class PythonKeyedProcessOperator<OUT>
     /** OutputStream Wrapper. */
     private transient DataOutputViewStreamWrapper baosWrapper;
 
-    private transient TimestampedCollector<OUT> collector;
+    private transient OutputWithTimerRowHandler runnerOutputHandler;
+
+    private transient Object keyForTimerService;
 
     public PythonKeyedProcessOperator(
             Configuration config,
@@ -143,7 +147,8 @@ public class PythonKeyedProcessOperator<OUT>
         // keyData, real data
         runnerInputTypeInfo =
                 Types.ROW(Types.BYTE, Types.LONG, Types.LONG, keyTypeInfo, this.inputTypeInfo);
-        runnerOutputTypeInfo = Types.ROW(Types.BYTE, Types.LONG, keyTypeInfo, this.outputTypeInfo);
+        runnerOutputTypeInfo =
+                OutputWithTimerRowHandler.getRunnerOutputTypeInfo(outputTypeInfo, keyTypeInfo);
         keyTypeSerializer =
                 PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
                         keyTypeInfo);
@@ -165,7 +170,13 @@ public class PythonKeyedProcessOperator<OUT>
         baisWrapper = new DataInputViewStreamWrapper(bais);
         baos = new ByteArrayOutputStreamWithPos();
         baosWrapper = new DataOutputViewStreamWrapper(baos);
-        this.collector = new TimestampedCollector<>(output);
+        runnerOutputHandler =
+                new OutputWithTimerRowHandler(
+                        getKeyedStateBackend(),
+                        timerService,
+                        new TimestampedCollector<>(output),
+                        this);
+
         super.open();
     }
 
@@ -177,13 +188,13 @@ public class PythonKeyedProcessOperator<OUT>
     @Override
     public void onEventTime(InternalTimer<Row, VoidNamespace> timer) throws Exception {
         bufferedTimestamp.offer(timer.getTimestamp());
-        processTimer(false, timer);
+        processTimer(TimeDomain.EVENT_TIME, timer);
     }
 
     @Override
     public void onProcessingTime(InternalTimer<Row, VoidNamespace> timer) throws Exception {
         bufferedTimestamp.offer(Long.MIN_VALUE);
-        processTimer(true, timer);
+        processTimer(TimeDomain.PROCESSING_TIME, timer);
     }
 
     @Override
@@ -232,12 +243,7 @@ public class PythonKeyedProcessOperator<OUT>
         } else {
             bais.setBuffer(rawResult, 0, length);
             Row runnerOutput = (Row) runnerOutputSerializer.deserialize(baisWrapper);
-            if (runnerOutput.getField(0) != null) {
-                registerTimer(runnerOutput);
-            } else {
-                collector.setAbsoluteTimestamp(bufferedTimestamp.peek());
-                collector.collect((OUT) runnerOutput.getField(3));
-            }
+            runnerOutputHandler.accept(runnerOutput, bufferedTimestamp.peek());
         }
     }
 
@@ -262,15 +268,15 @@ public class PythonKeyedProcessOperator<OUT>
      * input data is a Row containing 4 fields: TimerFlag 0 for proc time, 1 for event time;
      * Timestamp of the fired timer; Current watermark and the key of the timer.
      *
-     * @param procTime Whether is it a proc time timer, otherwise event time timer.
+     * @param timeDomain The type of the timer.
      * @param timer The fired timer.
      * @throws Exception The runnerInputSerializer might throw exception.
      */
-    private void processTimer(boolean procTime, InternalTimer<Row, VoidNamespace> timer)
+    private void processTimer(TimeDomain timeDomain, InternalTimer<Row, VoidNamespace> timer)
             throws Exception {
         long time = timer.getTimestamp();
         Row timerKey = Row.of(timer.getKey());
-        if (procTime) {
+        if (timeDomain == TimeDomain.PROCESSING_TIME) {
             reusableTimerData.setField(
                     0, PythonOperatorUtils.KeyedProcessFunctionInputFlag.PROC_TIME_TIMER.value);
         } else {
@@ -289,33 +295,17 @@ public class PythonKeyedProcessOperator<OUT>
     }
 
     /**
-     * Handler the timer registration request from python user defined function. Before registering
-     * the timer, we must set the current key to be the key when the timer is register in python
-     * side.
-     *
-     * @param row The timer registration request data.
+     * As the beam state gRPC service will access the KeyedStateBackend in parallel with this
+     * operator, we must override this method to prevent changing the current key of the
+     * KeyedStateBackend while the beam service is handling requests.
      */
-    private void registerTimer(Row row) {
-        synchronized (getKeyedStateBackend()) {
-            byte type = (byte) row.getField(0);
-            long time = (long) row.getField(1);
-            Object timerKey = ((Row) (row.getField(2))).getField(0);
-            setCurrentKey(timerKey);
-            if (type
-                    == PythonOperatorUtils.KeyedProcessFunctionOutputFlag.REGISTER_EVENT_TIMER
-                            .value) {
-                this.timerService.registerEventTimeTimer(time);
-            } else if (type
-                    == PythonOperatorUtils.KeyedProcessFunctionOutputFlag.REGISTER_PROC_TIMER
-                            .value) {
-                this.timerService.registerProcessingTimeTimer(time);
-            } else if (type
-                    == PythonOperatorUtils.KeyedProcessFunctionOutputFlag.DEL_EVENT_TIMER.value) {
-                this.timerService.deleteEventTimeTimer(time);
-            } else if (type
-                    == PythonOperatorUtils.KeyedProcessFunctionOutputFlag.DEL_PROC_TIMER.value) {
-                this.timerService.deleteProcessingTimeTimer(time);
-            }
-        }
+    @Override
+    public void setCurrentKey(Object key) {
+        keyForTimerService = key;
+    }
+
+    @Override
+    public Object getCurrentKey() {
+        return keyForTimerService;
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/TwoInputPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/TwoInputPythonFunctionOperator.java
@@ -32,7 +32,6 @@ import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.runners.python.beam.BeamDataStreamPythonFunctionRunner;
-import org.apache.flink.streaming.api.utils.PythonTypeUtils;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.types.Row;
@@ -42,13 +41,14 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.getUserDefinedDataStreamFunctionProto;
+import static org.apache.flink.streaming.api.utils.PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter;
 
 /**
  * {@link TwoInputPythonFunctionOperator} is responsible for launching beam runner which will start
  * a python harness to execute two-input user defined python function.
  */
 @Internal
-public abstract class TwoInputPythonFunctionOperator<IN1, IN2, OUT>
+public abstract class TwoInputPythonFunctionOperator<IN1, IN2, RUNNER_OUT, OUT>
         extends AbstractTwoInputPythonFunctionOperator<IN1, IN2, OUT> {
 
     private static final long serialVersionUID = 1L;
@@ -59,47 +59,52 @@ public abstract class TwoInputPythonFunctionOperator<IN1, IN2, OUT>
     /** The options used to configure the Python worker process. */
     private final Map<String, String> jobOptions;
 
-    /** The TypeInformation of the first input. */
-    private final TypeInformation<IN1> inputTypeInfo1;
-
-    /** The TypeInformation of the second input. */
-    private final TypeInformation<IN2> inputTypeInfo2;
-
-    /** The TypeInformation of the output. */
-    private final TypeInformation<OUT> outputTypeInfo;
-
     /** The serialized python function to be executed. */
     private final DataStreamPythonFunctionInfo pythonFunctionInfo;
 
-    // True if input1 and input2 are KeyedStream
-    private final boolean isKeyedStream;
+    /** The coder urn. */
+    private final String coderUrn;
 
     /** The TypeInformation of python worker input data. */
-    private transient TypeInformation<Row> runnerInputTypeInfo;
+    private final TypeInformation<Row> runnerInputTypeInfo;
 
-    private transient TypeInformation<Row> runnerOutputTypeInfo;
+    private final TypeInformation<RUNNER_OUT> runnerOutputTypeInfo;
 
     /** The TypeSerializer of python worker input data. */
-    private transient TypeSerializer<Row> runnerInputTypeSerializer;
+    private final TypeSerializer<Row> runnerInputTypeSerializer;
 
     /** The TypeSerializer of the runner output. */
-    transient TypeSerializer<Row> runnerOutputTypeSerializer;
+    private final TypeSerializer<RUNNER_OUT> runnerOutputTypeSerializer;
 
     protected transient ByteArrayInputStreamWithPos bais;
 
     protected transient DataInputViewStreamWrapper baisWrapper;
 
-    private transient ByteArrayOutputStreamWithPos baos;
+    protected transient ByteArrayOutputStreamWithPos baos;
 
-    private transient DataOutputViewStreamWrapper baosWrapper;
+    protected transient DataOutputViewStreamWrapper baosWrapper;
 
     protected transient TimestampedCollector collector;
 
-    private transient Row reuseRow;
+    protected transient Row reuseRow;
 
-    transient LinkedList<Long> bufferedTimestamp1;
+    transient LinkedList<Long> bufferedTimestamp;
 
-    transient LinkedList<Long> bufferedTimestamp2;
+    public TwoInputPythonFunctionOperator(
+            Configuration config,
+            DataStreamPythonFunctionInfo pythonFunctionInfo,
+            String coderUrn,
+            TypeInformation<Row> runnerInputTypeInfo,
+            TypeInformation<RUNNER_OUT> runnerOutputTypeInfo) {
+        super(config);
+        this.jobOptions = config.toMap();
+        this.pythonFunctionInfo = pythonFunctionInfo;
+        this.coderUrn = coderUrn;
+        this.runnerInputTypeInfo = runnerInputTypeInfo;
+        this.runnerOutputTypeInfo = runnerOutputTypeInfo;
+        this.runnerInputTypeSerializer = typeInfoSerializerConverter(runnerInputTypeInfo);
+        this.runnerOutputTypeSerializer = typeInfoSerializerConverter(runnerOutputTypeInfo);
+    }
 
     public TwoInputPythonFunctionOperator(
             Configuration config,
@@ -107,14 +112,13 @@ public abstract class TwoInputPythonFunctionOperator<IN1, IN2, OUT>
             TypeInformation<IN2> inputTypeInfo2,
             TypeInformation<OUT> outputTypeInfo,
             DataStreamPythonFunctionInfo pythonFunctionInfo,
-            boolean isKeyedStream) {
-        super(config);
-        this.jobOptions = config.toMap();
-        this.inputTypeInfo1 = inputTypeInfo1;
-        this.inputTypeInfo2 = inputTypeInfo2;
-        this.outputTypeInfo = outputTypeInfo;
-        this.pythonFunctionInfo = pythonFunctionInfo;
-        this.isKeyedStream = isKeyedStream;
+            String coderUrn) {
+        this(
+                config,
+                pythonFunctionInfo,
+                coderUrn,
+                new RowTypeInfo(Types.BOOLEAN, inputTypeInfo1, inputTypeInfo2),
+                (TypeInformation<RUNNER_OUT>) outputTypeInfo);
     }
 
     @Override
@@ -124,19 +128,7 @@ public abstract class TwoInputPythonFunctionOperator<IN1, IN2, OUT>
         baos = new ByteArrayOutputStreamWithPos();
         baosWrapper = new DataOutputViewStreamWrapper(baos);
 
-        bufferedTimestamp1 = new LinkedList<>();
-        bufferedTimestamp2 = new LinkedList<>();
-        // The row contains three field. The first field indicate left input or right input
-        // The second field contains left input and the third field contains right input.
-        runnerInputTypeInfo = getRunnerInputTypeInfo();
-        runnerInputTypeSerializer =
-                PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
-                        runnerInputTypeInfo);
-
-        runnerOutputTypeInfo = Types.ROW(Types.BYTE, outputTypeInfo);
-        runnerOutputTypeSerializer =
-                PythonTypeUtils.TypeInfoToSerializerConverter.typeInfoSerializerConverter(
-                        runnerOutputTypeInfo);
+        bufferedTimestamp = new LinkedList<>();
 
         collector = new TimestampedCollector(output);
         reuseRow = new Row(3);
@@ -154,7 +146,7 @@ public abstract class TwoInputPythonFunctionOperator<IN1, IN2, OUT>
                 DATASTREAM_STATELESS_FUNCTION_URN,
                 getUserDefinedDataStreamFunctionProto(
                         pythonFunctionInfo, getRuntimeContext(), Collections.EMPTY_MAP),
-                getFunctionUrn(),
+                coderUrn,
                 jobOptions,
                 getFlinkMetricContainer(),
                 null,
@@ -180,47 +172,50 @@ public abstract class TwoInputPythonFunctionOperator<IN1, IN2, OUT>
 
     @Override
     public void processElement1(StreamRecord<IN1> element) throws Exception {
-        bufferedTimestamp1.offer(element.getTimestamp());
+        bufferedTimestamp.offer(element.getTimestamp());
         // construct combined row.
         reuseRow.setField(0, true);
-        reuseRow.setField(1, getValue(element));
+        reuseRow.setField(1, element.getValue());
         reuseRow.setField(2, null); // need to set null since it is a reuse row.
         processElementInternal();
     }
 
     @Override
     public void processElement2(StreamRecord<IN2> element) throws Exception {
-        bufferedTimestamp2.offer(element.getTimestamp());
+        bufferedTimestamp.offer(element.getTimestamp());
         // construct combined row.
         reuseRow.setField(0, false);
         reuseRow.setField(1, null); // need to set null since it is a reuse row.
-        reuseRow.setField(2, getValue(element));
+        reuseRow.setField(2, element.getValue());
         processElementInternal();
     }
 
-    public abstract String getFunctionUrn();
-
-    private TypeInformation<Row> getRunnerInputTypeInfo() {
-        if (isKeyedStream) {
-            // since we wrap a keyed field for python KeyedStream, we need to extract the
-            // corresponding data input type.
-            return new RowTypeInfo(
-                    Types.BOOLEAN,
-                    ((RowTypeInfo) inputTypeInfo1).getTypeAt(1),
-                    ((RowTypeInfo) inputTypeInfo2).getTypeAt(1));
-        } else {
-            return new RowTypeInfo(Types.BOOLEAN, inputTypeInfo1, inputTypeInfo2);
-        }
+    protected Map<String, String> getJobOptions() {
+        return jobOptions;
     }
 
-    private Object getValue(StreamRecord<?> element) {
-        if (isKeyedStream) {
-            // since we wrap a keyed field for python KeyedStream, we need to extract the
-            // corresponding data input.
-            return ((Row) element.getValue()).getField(1);
-        } else {
-            return element.getValue();
-        }
+    protected String getCoderUrn() {
+        return coderUrn;
+    }
+
+    protected TypeInformation<Row> getRunnerInputTypeInfo() {
+        return runnerInputTypeInfo;
+    }
+
+    protected TypeInformation<RUNNER_OUT> getRunnerOutputTypeInfo() {
+        return runnerOutputTypeInfo;
+    }
+
+    protected DataStreamPythonFunctionInfo getPythonFunctionInfo() {
+        return pythonFunctionInfo;
+    }
+
+    protected TypeSerializer<Row> getRunnerInputTypeSerializer() {
+        return runnerInputTypeSerializer;
+    }
+
+    protected TypeSerializer<RUNNER_OUT> getRunnerOutputTypeSerializer() {
+        return runnerOutputTypeSerializer;
     }
 
     private void processElementInternal() throws Exception {

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonOperatorUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonOperatorUtils.java
@@ -53,47 +53,6 @@ public enum PythonOperatorUtils {
         }
     }
 
-    /** The Flag for PythonKeyedProcessFunction output data. */
-    public enum KeyedProcessFunctionOutputFlag {
-        REGISTER_EVENT_TIMER((byte) 0),
-        REGISTER_PROC_TIMER((byte) 1),
-        NORMAL_DATA((byte) 2),
-        DEL_EVENT_TIMER((byte) 3),
-        DEL_PROC_TIMER((byte) 4);
-
-        public final byte value;
-
-        KeyedProcessFunctionOutputFlag(byte value) {
-            this.value = value;
-        }
-    }
-
-    /** The Flag for PythonCoFlatMapFunction output data. */
-    public enum CoFlatMapFunctionOutputFlag {
-        LEFT((byte) 0),
-        RIGHT((byte) 1),
-        LEFT_END((byte) 2),
-        RIGHT_END((byte) 3);
-
-        public final byte value;
-
-        CoFlatMapFunctionOutputFlag(byte value) {
-            this.value = value;
-        }
-    }
-
-    /** The Flag for PythonCoMapFunction output data. */
-    public enum CoMapFunctionOutputFlag {
-        LEFT((byte) 0),
-        RIGHT((byte) 1);
-
-        public final int value;
-
-        CoMapFunctionOutputFlag(byte value) {
-            this.value = value;
-        }
-    }
-
     public static FlinkFnApi.UserDefinedFunction getUserDefinedFunctionProto(
             PythonFunctionInfo pythonFunctionInfo) {
         FlinkFnApi.UserDefinedFunction.Builder builder =

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/KeyedTwoInputWithTimerRowFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/KeyedTwoInputWithTimerRowFactory.java
@@ -80,7 +80,7 @@ public class KeyedTwoInputWithTimerRowFactory {
         reuseRunnerInput.setField(1, null);
         reuseRunnerInput.setField(2, timestamp);
         reuseRunnerInput.setField(3, watermark);
-        reuseRunnerInput.setField(4, reuseNormalData);
+        reuseRunnerInput.setField(4, reuseTimerData);
         return reuseTimerData;
     }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/KeyedTwoInputWithTimerRowFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/KeyedTwoInputWithTimerRowFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils.input;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.types.Row;
+
+/**
+ * This factory produces runner input row for two input operators which need to send the timer
+ * trigger event to python side.
+ */
+public class KeyedTwoInputWithTimerRowFactory {
+
+    private final Row reuseRunnerInput;
+
+    /** Reusable row for normal data runner inputs. */
+    private final Row reuseNormalData;
+
+    /** Reusable row for timer data runner inputs. */
+    private final Row reuseTimerData;
+
+    public KeyedTwoInputWithTimerRowFactory() {
+        this.reuseRunnerInput = new Row(5);
+        this.reuseNormalData = new Row(3);
+        this.reuseTimerData = new Row(3);
+    }
+
+    public Row fromNormalData(boolean isLeft, long timestamp, long watermark, Row userInput) {
+        reuseNormalData.setField(0, isLeft);
+        if (isLeft) {
+            // The input row is a tuple of key and value.
+            reuseNormalData.setField(1, userInput);
+            // need to set null since it is a reuse row.
+            reuseNormalData.setField(2, null);
+        } else {
+            // need to set null since it is a reuse row.
+            reuseNormalData.setField(1, null);
+            // The input row is a tuple of key and value.
+            reuseNormalData.setField(2, userInput);
+        }
+
+        reuseRunnerInput.setField(0, RunnerInputType.NORMAL_RECORD.value);
+        reuseRunnerInput.setField(1, reuseNormalData);
+        reuseRunnerInput.setField(2, timestamp);
+        reuseRunnerInput.setField(3, watermark);
+        reuseRunnerInput.setField(4, null);
+
+        return reuseRunnerInput;
+    }
+
+    public Row fromTimer(TimeDomain timeDomain, long timestamp, long watermark, Row key) {
+        if (timeDomain == TimeDomain.PROCESSING_TIME) {
+            reuseTimerData.setField(0, TimerType.PROCESSING_TIME.value);
+        } else {
+            reuseTimerData.setField(0, TimerType.EVENT_TIME.value);
+        }
+        reuseTimerData.setField(1, key);
+        reuseTimerData.setField(2, null);
+
+        reuseRunnerInput.setField(0, RunnerInputType.TRIGGER_TIMER.value);
+        reuseRunnerInput.setField(1, null);
+        reuseRunnerInput.setField(2, timestamp);
+        reuseRunnerInput.setField(3, watermark);
+        reuseRunnerInput.setField(4, reuseNormalData);
+        return reuseTimerData;
+    }
+
+    public static TypeInformation<Row> getRunnerInputTypeInfo(
+            TypeInformation<Row> userInputType1,
+            TypeInformation<Row> userInputType2,
+            TypeInformation<Row> keyType) {
+        // leftInput, rightInput structure:
+        // [key, userInput]
+
+        // structure: [isLeftUserInput, leftInput, rightInput]
+        RowTypeInfo normalDataTypeInfo =
+                new RowTypeInfo(Types.BOOLEAN, userInputType1, userInputType2);
+
+        // structure: [timerType, key, serializedNamespace]
+        RowTypeInfo timerDataTypeInfo =
+                new RowTypeInfo(Types.BYTE, keyType, Types.PRIMITIVE_ARRAY(Types.BYTE));
+
+        // structure: [runnerInputType, normalData, timestamp, watermark, timerData]
+        return Types.ROW(Types.BYTE, normalDataTypeInfo, Types.LONG, Types.LONG, timerDataTypeInfo);
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/RunnerInputType.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/RunnerInputType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils.input;
+
+/** The type of the runner input. */
+public enum RunnerInputType {
+    NORMAL_RECORD((byte) 0),
+    TRIGGER_TIMER((byte) 1);
+
+    public final byte value;
+
+    RunnerInputType(byte value) {
+        this.value = value;
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/TimerType.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/input/TimerType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils.input;
+
+/** The type of the triggered timer. */
+public enum TimerType {
+    EVENT_TIME((byte) 0),
+    PROCESSING_TIME((byte) 1);
+
+    public final byte value;
+
+    TimerType(byte value) {
+        this.value = value;
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/output/OutputWithTimerRowHandler.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/output/OutputWithTimerRowHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils.output;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.operators.KeyContext;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.types.Row;
+
+/** This handler can accepts the runner output which contains timer registration event. */
+public class OutputWithTimerRowHandler {
+
+    private final KeyedStateBackend<Row> keyedStateBackend;
+    private final TimerService timerService;
+    private final TimestampedCollector collector;
+    private final KeyContext keyContext;
+
+    public OutputWithTimerRowHandler(
+            KeyedStateBackend<Row> keyedStateBackend,
+            TimerService timerService,
+            TimestampedCollector collector,
+            KeyContext keyContext) {
+        this.keyedStateBackend = keyedStateBackend;
+        this.timerService = timerService;
+        this.collector = collector;
+        this.keyContext = keyContext;
+    }
+
+    public void accept(Row runnerOutput, long timestamp) {
+        if (runnerOutput.getField(0) == null) {
+            // null represents normal data
+            onData(timestamp, runnerOutput.getField(3));
+        } else {
+            TimerOperandType operandType =
+                    TimerOperandType.valueOf((byte) runnerOutput.getField(0));
+            onTimerOperation(
+                    operandType, (long) runnerOutput.getField(1), (Row) runnerOutput.getField(2));
+        }
+    }
+
+    private void onTimerOperation(TimerOperandType operandType, long time, Row key) {
+        synchronized (keyedStateBackend) {
+            keyContext.setCurrentKey(key);
+            switch (operandType) {
+                case REGISTER_EVENT_TIMER:
+                    timerService.registerEventTimeTimer(time);
+                    break;
+                case REGISTER_PROC_TIMER:
+                    timerService.registerProcessingTimeTimer(time);
+                    break;
+                case DELETE_EVENT_TIMER:
+                    timerService.deleteEventTimeTimer(time);
+                    break;
+                case DELETE_PROC_TIMER:
+                    timerService.deleteProcessingTimeTimer(time);
+            }
+        }
+    }
+
+    private void onData(long timestamp, Object data) {
+        if (timestamp != Long.MIN_VALUE) {
+            collector.setAbsoluteTimestamp(timestamp);
+        } else {
+            collector.eraseTimestamp();
+        }
+        collector.collect(data);
+    }
+
+    public static TypeInformation<Row> getRunnerOutputTypeInfo(
+            TypeInformation<?> outputType, TypeInformation<Row> keyType) {
+        // structure: [timerOperandType, timestamp, key, userOutput]
+        // for more details about the output flag, see `TimerOperandType`
+        return Types.ROW(Types.BYTE, Types.LONG, keyType, outputType);
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/output/TimerOperandType.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/output/TimerOperandType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils.output;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** The Flag for indicating the timer operation type. */
+public enum TimerOperandType {
+    REGISTER_EVENT_TIMER((byte) 0),
+    REGISTER_PROC_TIMER((byte) 1),
+    DELETE_EVENT_TIMER((byte) 2),
+    DELETE_PROC_TIMER((byte) 3);
+
+    private final byte value;
+
+    TimerOperandType(byte value) {
+        this.value = value;
+    }
+
+    private static Map<Byte, TimerOperandType> mapping;
+
+    static {
+        mapping = new HashMap<>();
+        for (TimerOperandType timerOperandType : TimerOperandType.values()) {
+            mapping.put(timerOperandType.value, timerOperandType);
+        }
+    }
+
+    public static TimerOperandType valueOf(byte value) {
+        if (mapping.containsKey(value)) {
+            return mapping.get(value);
+        } else {
+            throw new IllegalArgumentException(
+                    String.format("Value '%d' can not be converted to TimerOperandType.", value));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports state access API for the map/flat_map operation of Python ConnectedStreams.*

## Brief change log

  - *Support state access API for the map/flat_map operation of Python ConnectedStreams*
  - *Improve the implementation of CoFlatMapOperator*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
