### PR TITLE
[FLINK-21725][core] Name constructor arguments of Tuples like fields

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
@@ -61,10 +61,10 @@ public class Tuple1<T0> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
+     * @param f0 The value for field 0
      */
-    public Tuple1(T0 value0) {
-        this.f0 = value0;
+    public Tuple1(T0 f0) {
+        this.f0 = f0;
     }
 
     @Override
@@ -98,10 +98,10 @@ public class Tuple1<T0> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
+     * @param f0 The value for field 0
      */
-    public void setFields(T0 value0) {
-        this.f0 = value0;
+    public void setFields(T0 f0) {
+        this.f0 = f0;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -164,7 +164,7 @@ public class Tuple1<T0> extends Tuple {
      * arguments implicitly. For example: {@code Tuple3.of(n, x, s)} instead of {@code new
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
-    public static <T0> Tuple1<T0> of(T0 value0) {
-        return new Tuple1<>(value0);
+    public static <T0> Tuple1<T0> of(T0 f0) {
+        return new Tuple1<>(f0);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
@@ -88,38 +88,28 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
      */
-    public Tuple10(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
+    public Tuple10(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
     }
 
     @Override
@@ -198,38 +188,28 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
      */
-    public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -353,17 +333,7 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
             Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9) {
-        return new Tuple10<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9);
+                    T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9) {
+        return new Tuple10<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
@@ -91,41 +91,30 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
      */
-    public Tuple11(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
+    public Tuple11(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9, T10 f10) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
     }
 
     @Override
@@ -209,41 +198,31 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9, T10 f10) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -373,19 +352,7 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
             Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10) {
-        return new Tuple11<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10);
+                    T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9, T10 f10) {
+        return new Tuple11<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
@@ -94,44 +94,44 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
      */
     public Tuple12(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
     }
 
     @Override
@@ -220,44 +220,44 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -393,20 +393,18 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
             Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11) {
-        return new Tuple12<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11);
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11) {
+        return new Tuple12<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
@@ -97,47 +97,47 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
      */
     public Tuple13(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
     }
 
     @Override
@@ -231,47 +231,47 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -413,21 +413,19 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
             Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12) {
-        return new Tuple13<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12);
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12) {
+        return new Tuple13<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
@@ -100,50 +100,50 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
      */
     public Tuple14(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
     }
 
     @Override
@@ -242,50 +242,50 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -433,22 +433,20 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
             Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13) {
-        return new Tuple14<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13);
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13) {
+        return new Tuple14<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
@@ -104,53 +104,53 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
      */
     public Tuple15(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
     }
 
     @Override
@@ -254,53 +254,53 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -454,23 +454,21 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
             Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14) {
-        return new Tuple15<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14);
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14) {
+        return new Tuple15<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
@@ -107,56 +107,56 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
      */
     public Tuple16(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
     }
 
     @Override
@@ -265,56 +265,56 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -474,24 +474,22 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
             Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15) {
-        return new Tuple16<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15);
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15) {
+        return new Tuple16<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
@@ -110,59 +110,59 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
      */
     public Tuple17(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
     }
 
     @Override
@@ -276,59 +276,59 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -495,25 +495,24 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
             Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16) {
         return new Tuple17<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
@@ -113,62 +113,62 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
      */
     public Tuple18(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
     }
 
     @Override
@@ -287,62 +287,62 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -517,26 +517,25 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>
             Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17) {
         return new Tuple18<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
@@ -117,65 +117,65 @@ public class Tuple19<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
      */
     public Tuple19(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
     }
 
     @Override
@@ -299,65 +299,65 @@ public class Tuple19<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -595,27 +595,27 @@ public class Tuple19<
                             T17,
                             T18>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18) {
         return new Tuple19<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17,
+                f18);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
@@ -64,12 +64,12 @@ public class Tuple2<T0, T1> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
      */
-    public Tuple2(T0 value0, T1 value1) {
-        this.f0 = value0;
-        this.f1 = value1;
+    public Tuple2(T0 f0, T1 f1) {
+        this.f0 = f0;
+        this.f1 = f1;
     }
 
     @Override
@@ -108,12 +108,12 @@ public class Tuple2<T0, T1> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
      */
-    public void setFields(T0 value0, T1 value1) {
-        this.f0 = value0;
-        this.f1 = value1;
+    public void setFields(T0 f0, T1 f1) {
+        this.f0 = f0;
+        this.f1 = f1;
     }
 
     /**
@@ -193,7 +193,7 @@ public class Tuple2<T0, T1> extends Tuple {
      * arguments implicitly. For example: {@code Tuple3.of(n, x, s)} instead of {@code new
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
-    public static <T0, T1> Tuple2<T0, T1> of(T0 value0, T1 value1) {
-        return new Tuple2<>(value0, value1);
+    public static <T0, T1> Tuple2<T0, T1> of(T0 f0, T1 f1) {
+        return new Tuple2<>(f0, f1);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
@@ -139,68 +139,68 @@ public class Tuple20<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
      */
     public Tuple20(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
     }
 
     @Override
@@ -329,68 +329,68 @@ public class Tuple20<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -637,29 +637,28 @@ public class Tuple20<
                             T18,
                             T19>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18,
-                            T19 value19) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18,
+                            T19 f19) {
         return new Tuple20<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18,
-                value19);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18,
+                f19);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
@@ -143,71 +143,71 @@ public class Tuple21<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
      */
     public Tuple21(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
     }
 
     @Override
@@ -341,71 +341,71 @@ public class Tuple21<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -661,30 +661,29 @@ public class Tuple21<
                             T19,
                             T20>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18,
-                            T19 value19,
-                            T20 value20) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18,
+                            T19 f19,
+                            T20 f20) {
         return new Tuple21<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18,
-                value19, value20);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18,
+                f19, f20);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
@@ -147,74 +147,74 @@ public class Tuple22<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
      */
     public Tuple22(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
     }
 
     @Override
@@ -353,74 +353,74 @@ public class Tuple22<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -685,31 +685,30 @@ public class Tuple22<
                             T20,
                             T21>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18,
-                            T19 value19,
-                            T20 value20,
-                            T21 value21) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18,
+                            T19 f19,
+                            T20 f20,
+                            T21 f21) {
         return new Tuple22<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18,
-                value19, value20, value21);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18,
+                f19, f20, f21);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
@@ -151,77 +151,77 @@ public class Tuple23<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
-     * @param value22 The value for field 22
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
+     * @param f22 The value for field 22
      */
     public Tuple23(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21,
-            T22 value22) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
-        this.f22 = value22;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21,
+            T22 f22) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
+        this.f22 = f22;
     }
 
     @Override
@@ -365,77 +365,77 @@ public class Tuple23<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
-     * @param value22 The value for field 22
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
+     * @param f22 The value for field 22
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21,
-            T22 value22) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
-        this.f22 = value22;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21,
+            T22 f22) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
+        this.f22 = f22;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -709,32 +709,31 @@ public class Tuple23<
                             T21,
                             T22>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18,
-                            T19 value19,
-                            T20 value20,
-                            T21 value21,
-                            T22 value22) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18,
+                            T19 f19,
+                            T20 f20,
+                            T21 f21,
+                            T22 f22) {
         return new Tuple23<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18,
-                value19, value20, value21, value22);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18,
+                f19, f20, f21, f22);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
@@ -155,80 +155,80 @@ public class Tuple24<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
-     * @param value22 The value for field 22
-     * @param value23 The value for field 23
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
+     * @param f22 The value for field 22
+     * @param f23 The value for field 23
      */
     public Tuple24(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21,
-            T22 value22,
-            T23 value23) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
-        this.f22 = value22;
-        this.f23 = value23;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21,
+            T22 f22,
+            T23 f23) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
+        this.f22 = f22;
+        this.f23 = f23;
     }
 
     @Override
@@ -377,80 +377,80 @@ public class Tuple24<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
-     * @param value22 The value for field 22
-     * @param value23 The value for field 23
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
+     * @param f22 The value for field 22
+     * @param f23 The value for field 23
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21,
-            T22 value22,
-            T23 value23) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
-        this.f22 = value22;
-        this.f23 = value23;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21,
+            T22 f22,
+            T23 f23) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
+        this.f22 = f22;
+        this.f23 = f23;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -733,33 +733,32 @@ public class Tuple24<
                             T22,
                             T23>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18,
-                            T19 value19,
-                            T20 value20,
-                            T21 value21,
-                            T22 value22,
-                            T23 value23) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18,
+                            T19 f19,
+                            T20 f20,
+                            T21 f21,
+                            T22 f22,
+                            T23 f23) {
         return new Tuple24<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18,
-                value19, value20, value21, value22, value23);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18,
+                f19, f20, f21, f22, f23);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
@@ -159,83 +159,83 @@ public class Tuple25<
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
-     * @param value22 The value for field 22
-     * @param value23 The value for field 23
-     * @param value24 The value for field 24
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
+     * @param f22 The value for field 22
+     * @param f23 The value for field 23
+     * @param f24 The value for field 24
      */
     public Tuple25(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21,
-            T22 value22,
-            T23 value23,
-            T24 value24) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
-        this.f22 = value22;
-        this.f23 = value23;
-        this.f24 = value24;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21,
+            T22 f22,
+            T23 f23,
+            T24 f24) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
+        this.f22 = f22;
+        this.f23 = f23;
+        this.f24 = f24;
     }
 
     @Override
@@ -389,83 +389,83 @@ public class Tuple25<
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
-     * @param value9 The value for field 9
-     * @param value10 The value for field 10
-     * @param value11 The value for field 11
-     * @param value12 The value for field 12
-     * @param value13 The value for field 13
-     * @param value14 The value for field 14
-     * @param value15 The value for field 15
-     * @param value16 The value for field 16
-     * @param value17 The value for field 17
-     * @param value18 The value for field 18
-     * @param value19 The value for field 19
-     * @param value20 The value for field 20
-     * @param value21 The value for field 21
-     * @param value22 The value for field 22
-     * @param value23 The value for field 23
-     * @param value24 The value for field 24
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
+     * @param f9 The value for field 9
+     * @param f10 The value for field 10
+     * @param f11 The value for field 11
+     * @param f12 The value for field 12
+     * @param f13 The value for field 13
+     * @param f14 The value for field 14
+     * @param f15 The value for field 15
+     * @param f16 The value for field 16
+     * @param f17 The value for field 17
+     * @param f18 The value for field 18
+     * @param f19 The value for field 19
+     * @param f20 The value for field 20
+     * @param f21 The value for field 21
+     * @param f22 The value for field 22
+     * @param f23 The value for field 23
+     * @param f24 The value for field 24
      */
     public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15,
-            T16 value16,
-            T17 value17,
-            T18 value18,
-            T19 value19,
-            T20 value20,
-            T21 value21,
-            T22 value22,
-            T23 value23,
-            T24 value24) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
-        this.f9 = value9;
-        this.f10 = value10;
-        this.f11 = value11;
-        this.f12 = value12;
-        this.f13 = value13;
-        this.f14 = value14;
-        this.f15 = value15;
-        this.f16 = value16;
-        this.f17 = value17;
-        this.f18 = value18;
-        this.f19 = value19;
-        this.f20 = value20;
-        this.f21 = value21;
-        this.f22 = value22;
-        this.f23 = value23;
-        this.f24 = value24;
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15,
+            T16 f16,
+            T17 f17,
+            T18 f18,
+            T19 f19,
+            T20 f20,
+            T21 f21,
+            T22 f22,
+            T23 f23,
+            T24 f24) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
+        this.f9 = f9;
+        this.f10 = f10;
+        this.f11 = f11;
+        this.f12 = f12;
+        this.f13 = f13;
+        this.f14 = f14;
+        this.f15 = f15;
+        this.f16 = f16;
+        this.f17 = f17;
+        this.f18 = f18;
+        this.f19 = f19;
+        this.f20 = f20;
+        this.f21 = f21;
+        this.f22 = f22;
+        this.f23 = f23;
+        this.f24 = f24;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -757,34 +757,33 @@ public class Tuple25<
                             T23,
                             T24>
                     of(
-                            T0 value0,
-                            T1 value1,
-                            T2 value2,
-                            T3 value3,
-                            T4 value4,
-                            T5 value5,
-                            T6 value6,
-                            T7 value7,
-                            T8 value8,
-                            T9 value9,
-                            T10 value10,
-                            T11 value11,
-                            T12 value12,
-                            T13 value13,
-                            T14 value14,
-                            T15 value15,
-                            T16 value16,
-                            T17 value17,
-                            T18 value18,
-                            T19 value19,
-                            T20 value20,
-                            T21 value21,
-                            T22 value22,
-                            T23 value23,
-                            T24 value24) {
+                            T0 f0,
+                            T1 f1,
+                            T2 f2,
+                            T3 f3,
+                            T4 f4,
+                            T5 f5,
+                            T6 f6,
+                            T7 f7,
+                            T8 f8,
+                            T9 f9,
+                            T10 f10,
+                            T11 f11,
+                            T12 f12,
+                            T13 f13,
+                            T14 f14,
+                            T15 f15,
+                            T16 f16,
+                            T17 f17,
+                            T18 f18,
+                            T19 f19,
+                            T20 f20,
+                            T21 f21,
+                            T22 f22,
+                            T23 f23,
+                            T24 f24) {
         return new Tuple25<>(
-                value0, value1, value2, value3, value4, value5, value6, value7, value8, value9,
-                value10, value11, value12, value13, value14, value15, value16, value17, value18,
-                value19, value20, value21, value22, value23, value24);
+                f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16, f17, f18,
+                f19, f20, f21, f22, f23, f24);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
@@ -67,14 +67,14 @@ public class Tuple3<T0, T1, T2> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
      */
-    public Tuple3(T0 value0, T1 value1, T2 value2) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
+    public Tuple3(T0 f0, T1 f1, T2 f2) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
     }
 
     @Override
@@ -118,14 +118,14 @@ public class Tuple3<T0, T1, T2> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
      */
-    public void setFields(T0 value0, T1 value1, T2 value2) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
+    public void setFields(T0 f0, T1 f1, T2 f2) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -202,7 +202,7 @@ public class Tuple3<T0, T1, T2> extends Tuple {
      * arguments implicitly. For example: {@code Tuple3.of(n, x, s)} instead of {@code new
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
-    public static <T0, T1, T2> Tuple3<T0, T1, T2> of(T0 value0, T1 value1, T2 value2) {
-        return new Tuple3<>(value0, value1, value2);
+    public static <T0, T1, T2> Tuple3<T0, T1, T2> of(T0 f0, T1 f1, T2 f2) {
+        return new Tuple3<>(f0, f1, f2);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
@@ -70,16 +70,16 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
      */
-    public Tuple4(T0 value0, T1 value1, T2 value2, T3 value3) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
+    public Tuple4(T0 f0, T1 f1, T2 f2, T3 f3) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
     }
 
     @Override
@@ -128,16 +128,16 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
      */
-    public void setFields(T0 value0, T1 value1, T2 value2, T3 value3) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -220,8 +220,7 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
      * arguments implicitly. For example: {@code Tuple3.of(n, x, s)} instead of {@code new
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
-    public static <T0, T1, T2, T3> Tuple4<T0, T1, T2, T3> of(
-            T0 value0, T1 value1, T2 value2, T3 value3) {
-        return new Tuple4<>(value0, value1, value2, value3);
+    public static <T0, T1, T2, T3> Tuple4<T0, T1, T2, T3> of(T0 f0, T1 f1, T2 f2, T3 f3) {
+        return new Tuple4<>(f0, f1, f2, f3);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
@@ -73,18 +73,18 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
      */
-    public Tuple5(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
+    public Tuple5(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
     }
 
     @Override
@@ -138,18 +138,18 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
      */
-    public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -239,7 +239,7 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
     public static <T0, T1, T2, T3, T4> Tuple5<T0, T1, T2, T3, T4> of(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
-        return new Tuple5<>(value0, value1, value2, value3, value4);
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4) {
+        return new Tuple5<>(f0, f1, f2, f3, f4);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
@@ -76,20 +76,20 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
      */
-    public Tuple6(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
+    public Tuple6(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
     }
 
     @Override
@@ -148,20 +148,20 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
      */
-    public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -257,7 +257,7 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
     public static <T0, T1, T2, T3, T4, T5> Tuple6<T0, T1, T2, T3, T4, T5> of(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
-        return new Tuple6<>(value0, value1, value2, value3, value4, value5);
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5) {
+        return new Tuple6<>(f0, f1, f2, f3, f4, f5);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
@@ -79,22 +79,22 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
      */
-    public Tuple7(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
+    public Tuple7(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
     }
 
     @Override
@@ -158,23 +158,22 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
      */
-    public void setFields(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -277,7 +276,7 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
     public static <T0, T1, T2, T3, T4, T5, T6> Tuple7<T0, T1, T2, T3, T4, T5, T6> of(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
-        return new Tuple7<>(value0, value1, value2, value3, value4, value5, value6);
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6) {
+        return new Tuple7<>(f0, f1, f2, f3, f4, f5, f6);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
@@ -82,32 +82,24 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
      */
-    public Tuple8(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
+    public Tuple8(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
     }
 
     @Override
@@ -176,32 +168,24 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
      */
-    public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -310,14 +294,7 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
      * Tuple3<Integer, Double, String>(n, x, s)}
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7> Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> of(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7) {
-        return new Tuple8<>(value0, value1, value2, value3, value4, value5, value6, value7);
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7) {
+        return new Tuple8<>(f0, f1, f2, f3, f4, f5, f6, f7);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
@@ -85,35 +85,26 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
     /**
      * Creates a new tuple and assigns the given values to the tuple's fields.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
      */
-    public Tuple9(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
+    public Tuple9(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
     }
 
     @Override
@@ -187,35 +178,26 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
     /**
      * Sets new values to all fields of the tuple.
      *
-     * @param value0 The value for field 0
-     * @param value1 The value for field 1
-     * @param value2 The value for field 2
-     * @param value3 The value for field 3
-     * @param value4 The value for field 4
-     * @param value5 The value for field 5
-     * @param value6 The value for field 6
-     * @param value7 The value for field 7
-     * @param value8 The value for field 8
+     * @param f0 The value for field 0
+     * @param f1 The value for field 1
+     * @param f2 The value for field 2
+     * @param f3 The value for field 3
+     * @param f4 The value for field 4
+     * @param f5 The value for field 5
+     * @param f6 The value for field 6
+     * @param f7 The value for field 7
+     * @param f8 The value for field 8
      */
-    public void setFields(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8) {
-        this.f0 = value0;
-        this.f1 = value1;
-        this.f2 = value2;
-        this.f3 = value3;
-        this.f4 = value4;
-        this.f5 = value5;
-        this.f6 = value6;
-        this.f7 = value7;
-        this.f8 = value8;
+    public void setFields(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8) {
+        this.f0 = f0;
+        this.f1 = f1;
+        this.f2 = f2;
+        this.f3 = f3;
+        this.f4 = f4;
+        this.f5 = f5;
+        this.f6 = f6;
+        this.f7 = f7;
+        this.f8 = f8;
     }
 
     // -------------------------------------------------------------------------------------------------
@@ -332,15 +314,7 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
      */
     public static <T0, T1, T2, T3, T4, T5, T6, T7, T8>
             Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> of(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8) {
-        return new Tuple9<>(value0, value1, value2, value3, value4, value5, value6, value7, value8);
+                    T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8) {
+        return new Tuple9<>(f0, f1, f2, f3, f4, f5, f6, f7, f8);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple10Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple10Builder.java
@@ -49,20 +49,8 @@ public class Tuple10Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> {
     private List<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tuples = new ArrayList<>();
 
     public Tuple10Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9) {
-        tuples.add(
-                new Tuple10<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9));
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9) {
+        tuples.add(new Tuple10<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple11Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple11Builder.java
@@ -50,21 +50,8 @@ public class Tuple11Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
     private List<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tuples = new ArrayList<>();
 
     public Tuple11Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10) {
-        tuples.add(
-                new Tuple11<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10));
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8, T9 f9, T10 f10) {
+        tuples.add(new Tuple11<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple12Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple12Builder.java
@@ -52,22 +52,19 @@ public class Tuple12Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> {
             new ArrayList<>();
 
     public Tuple12Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11) {
-        tuples.add(
-                new Tuple12<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11));
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11) {
+        tuples.add(new Tuple12<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple13Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple13Builder.java
@@ -53,23 +53,20 @@ public class Tuple13Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             new ArrayList<>();
 
     public Tuple13Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12) {
-        tuples.add(
-                new Tuple13<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12));
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12) {
+        tuples.add(new Tuple13<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple14Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple14Builder.java
@@ -54,24 +54,21 @@ public class Tuple14Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             new ArrayList<>();
 
     public Tuple14Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13) {
-        tuples.add(
-                new Tuple14<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13));
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13) {
+        tuples.add(new Tuple14<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple15Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple15Builder.java
@@ -55,25 +55,22 @@ public class Tuple15Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             new ArrayList<>();
 
     public Tuple15Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14) {
-        tuples.add(
-                new Tuple15<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14));
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14) {
+        tuples.add(new Tuple15<>(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple16Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple16Builder.java
@@ -56,26 +56,25 @@ public class Tuple16Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             tuples = new ArrayList<>();
 
     public Tuple16Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8,
-            T9 value9,
-            T10 value10,
-            T11 value11,
-            T12 value12,
-            T13 value13,
-            T14 value14,
-            T15 value15) {
+            T0 f0,
+            T1 f1,
+            T2 f2,
+            T3 f3,
+            T4 f4,
+            T5 f5,
+            T6 f6,
+            T7 f7,
+            T8 f8,
+            T9 f9,
+            T10 f10,
+            T11 f11,
+            T12 f12,
+            T13 f13,
+            T14 f14,
+            T15 f15) {
         tuples.add(
                 new Tuple16<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple17Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple17Builder.java
@@ -59,27 +59,26 @@ public class Tuple17Builder<
 
     public Tuple17Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16) {
         tuples.add(
                 new Tuple17<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple18Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple18Builder.java
@@ -80,29 +80,28 @@ public class Tuple18Builder<
     public Tuple18Builder<
                     T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17) {
         tuples.add(
                 new Tuple18<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple19Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple19Builder.java
@@ -100,30 +100,29 @@ public class Tuple19Builder<
                     T17,
                     T18>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18) {
         tuples.add(
                 new Tuple19<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple1Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple1Builder.java
@@ -39,8 +39,8 @@ public class Tuple1Builder<T0> {
 
     private List<Tuple1<T0>> tuples = new ArrayList<>();
 
-    public Tuple1Builder<T0> add(T0 value0) {
-        tuples.add(new Tuple1<>(value0));
+    public Tuple1Builder<T0> add(T0 f0) {
+        tuples.add(new Tuple1<>(f0));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple20Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple20Builder.java
@@ -103,31 +103,30 @@ public class Tuple20Builder<
                     T18,
                     T19>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18,
-                    T19 value19) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18,
+                    T19 f19) {
         tuples.add(
                 new Tuple20<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18, value19));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18, f19));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple21Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple21Builder.java
@@ -126,32 +126,31 @@ public class Tuple21Builder<
                     T19,
                     T20>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18,
-                    T19 value19,
-                    T20 value20) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18,
+                    T19 f19,
+                    T20 f20) {
         tuples.add(
                 new Tuple21<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18, value19, value20));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18, f19, f20));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple22Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple22Builder.java
@@ -130,33 +130,32 @@ public class Tuple22Builder<
                     T20,
                     T21>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18,
-                    T19 value19,
-                    T20 value20,
-                    T21 value21) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18,
+                    T19 f19,
+                    T20 f20,
+                    T21 f21) {
         tuples.add(
                 new Tuple22<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18, value19, value20, value21));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18, f19, f20, f21));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple23Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple23Builder.java
@@ -134,34 +134,33 @@ public class Tuple23Builder<
                     T21,
                     T22>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18,
-                    T19 value19,
-                    T20 value20,
-                    T21 value21,
-                    T22 value22) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18,
+                    T19 f19,
+                    T20 f20,
+                    T21 f21,
+                    T22 f22) {
         tuples.add(
                 new Tuple23<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18, value19, value20, value21, value22));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18, f19, f20, f21, f22));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple24Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple24Builder.java
@@ -138,35 +138,34 @@ public class Tuple24Builder<
                     T22,
                     T23>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18,
-                    T19 value19,
-                    T20 value20,
-                    T21 value21,
-                    T22 value22,
-                    T23 value23) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18,
+                    T19 f19,
+                    T20 f20,
+                    T21 f21,
+                    T22 f22,
+                    T23 f23) {
         tuples.add(
                 new Tuple24<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18, value19, value20, value21, value22, value23));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18, f19, f20, f21, f22, f23));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple25Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple25Builder.java
@@ -142,36 +142,35 @@ public class Tuple25Builder<
                     T23,
                     T24>
             add(
-                    T0 value0,
-                    T1 value1,
-                    T2 value2,
-                    T3 value3,
-                    T4 value4,
-                    T5 value5,
-                    T6 value6,
-                    T7 value7,
-                    T8 value8,
-                    T9 value9,
-                    T10 value10,
-                    T11 value11,
-                    T12 value12,
-                    T13 value13,
-                    T14 value14,
-                    T15 value15,
-                    T16 value16,
-                    T17 value17,
-                    T18 value18,
-                    T19 value19,
-                    T20 value20,
-                    T21 value21,
-                    T22 value22,
-                    T23 value23,
-                    T24 value24) {
+                    T0 f0,
+                    T1 f1,
+                    T2 f2,
+                    T3 f3,
+                    T4 f4,
+                    T5 f5,
+                    T6 f6,
+                    T7 f7,
+                    T8 f8,
+                    T9 f9,
+                    T10 f10,
+                    T11 f11,
+                    T12 f12,
+                    T13 f13,
+                    T14 f14,
+                    T15 f15,
+                    T16 f16,
+                    T17 f17,
+                    T18 f18,
+                    T19 f19,
+                    T20 f20,
+                    T21 f21,
+                    T22 f22,
+                    T23 f23,
+                    T24 f24) {
         tuples.add(
                 new Tuple25<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8,
-                        value9, value10, value11, value12, value13, value14, value15, value16,
-                        value17, value18, value19, value20, value21, value22, value23, value24));
+                        f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
+                        f17, f18, f19, f20, f21, f22, f23, f24));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple2Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple2Builder.java
@@ -40,8 +40,8 @@ public class Tuple2Builder<T0, T1> {
 
     private List<Tuple2<T0, T1>> tuples = new ArrayList<>();
 
-    public Tuple2Builder<T0, T1> add(T0 value0, T1 value1) {
-        tuples.add(new Tuple2<>(value0, value1));
+    public Tuple2Builder<T0, T1> add(T0 f0, T1 f1) {
+        tuples.add(new Tuple2<>(f0, f1));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple3Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple3Builder.java
@@ -41,8 +41,8 @@ public class Tuple3Builder<T0, T1, T2> {
 
     private List<Tuple3<T0, T1, T2>> tuples = new ArrayList<>();
 
-    public Tuple3Builder<T0, T1, T2> add(T0 value0, T1 value1, T2 value2) {
-        tuples.add(new Tuple3<>(value0, value1, value2));
+    public Tuple3Builder<T0, T1, T2> add(T0 f0, T1 f1, T2 f2) {
+        tuples.add(new Tuple3<>(f0, f1, f2));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple4Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple4Builder.java
@@ -42,8 +42,8 @@ public class Tuple4Builder<T0, T1, T2, T3> {
 
     private List<Tuple4<T0, T1, T2, T3>> tuples = new ArrayList<>();
 
-    public Tuple4Builder<T0, T1, T2, T3> add(T0 value0, T1 value1, T2 value2, T3 value3) {
-        tuples.add(new Tuple4<>(value0, value1, value2, value3));
+    public Tuple4Builder<T0, T1, T2, T3> add(T0 f0, T1 f1, T2 f2, T3 f3) {
+        tuples.add(new Tuple4<>(f0, f1, f2, f3));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple5Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple5Builder.java
@@ -43,9 +43,8 @@ public class Tuple5Builder<T0, T1, T2, T3, T4> {
 
     private List<Tuple5<T0, T1, T2, T3, T4>> tuples = new ArrayList<>();
 
-    public Tuple5Builder<T0, T1, T2, T3, T4> add(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
-        tuples.add(new Tuple5<>(value0, value1, value2, value3, value4));
+    public Tuple5Builder<T0, T1, T2, T3, T4> add(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4) {
+        tuples.add(new Tuple5<>(f0, f1, f2, f3, f4));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple6Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple6Builder.java
@@ -44,9 +44,8 @@ public class Tuple6Builder<T0, T1, T2, T3, T4, T5> {
 
     private List<Tuple6<T0, T1, T2, T3, T4, T5>> tuples = new ArrayList<>();
 
-    public Tuple6Builder<T0, T1, T2, T3, T4, T5> add(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
-        tuples.add(new Tuple6<>(value0, value1, value2, value3, value4, value5));
+    public Tuple6Builder<T0, T1, T2, T3, T4, T5> add(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5) {
+        tuples.add(new Tuple6<>(f0, f1, f2, f3, f4, f5));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple7Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple7Builder.java
@@ -46,8 +46,8 @@ public class Tuple7Builder<T0, T1, T2, T3, T4, T5, T6> {
     private List<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tuples = new ArrayList<>();
 
     public Tuple7Builder<T0, T1, T2, T3, T4, T5, T6> add(
-            T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
-        tuples.add(new Tuple7<>(value0, value1, value2, value3, value4, value5, value6));
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6) {
+        tuples.add(new Tuple7<>(f0, f1, f2, f3, f4, f5, f6));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple8Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple8Builder.java
@@ -47,15 +47,8 @@ public class Tuple8Builder<T0, T1, T2, T3, T4, T5, T6, T7> {
     private List<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tuples = new ArrayList<>();
 
     public Tuple8Builder<T0, T1, T2, T3, T4, T5, T6, T7> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7) {
-        tuples.add(new Tuple8<>(value0, value1, value2, value3, value4, value5, value6, value7));
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7) {
+        tuples.add(new Tuple8<>(f0, f1, f2, f3, f4, f5, f6, f7));
         return this;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple9Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple9Builder.java
@@ -48,18 +48,8 @@ public class Tuple9Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8> {
     private List<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tuples = new ArrayList<>();
 
     public Tuple9Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8> add(
-            T0 value0,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            T5 value5,
-            T6 value6,
-            T7 value7,
-            T8 value8) {
-        tuples.add(
-                new Tuple9<>(
-                        value0, value1, value2, value3, value4, value5, value6, value7, value8));
+            T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5, T6 f6, T7 f7, T8 f8) {
+        tuples.add(new Tuple9<>(f0, f1, f2, f3, f4, f5, f6, f7, f8));
         return this;
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -43,6 +43,8 @@ class TupleGenerator {
 
     private static final String GEN_TYPE_PREFIX = "T";
 
+    private static final String SETTER_ARG_NAME = "f";
+
     // Parameters for tuple-dependent classes
     private static final String BEGIN_INDICATOR = "BEGIN_OF_TUPLE_DEPENDENT_CODE";
 
@@ -245,12 +247,12 @@ class TupleGenerator {
         }
         w.println();
 
-        String paramList = "("; // This will be like "(T0 value0, T1 value1)"
+        String paramList = "("; // This will be like "(T0 f0, T1 f1)"
         for (int i = 0; i < numFields; i++) {
             if (i > 0) {
                 paramList += ", ";
             }
-            paramList += GEN_TYPE_PREFIX + i + " value" + i;
+            paramList += GEN_TYPE_PREFIX + i + " " + SETTER_ARG_NAME + i;
         }
         paramList += ")";
 
@@ -264,12 +266,12 @@ class TupleGenerator {
         w.println("\t * Creates a new tuple and assigns the given values to the tuple's fields.");
         w.println("\t *");
         for (int i = 0; i < numFields; i++) {
-            w.println("\t * @param value" + i + " The value for field " + i);
+            w.println("\t * @param " + SETTER_ARG_NAME + i + " The value for field " + i);
         }
         w.println("\t */");
         w.println("\tpublic " + className + paramList + " {");
         for (int i = 0; i < numFields; i++) {
-            w.println("\t\tthis.f" + i + " = value" + i + ';');
+            w.println("\t\tthis.f" + i + " = " + SETTER_ARG_NAME + i + ';');
         }
         w.println("\t}");
         w.println();
@@ -314,12 +316,12 @@ class TupleGenerator {
         w.println("\t * Sets new values to all fields of the tuple.");
         w.println("\t *");
         for (int i = 0; i < numFields; i++) {
-            w.println("\t * @param value" + i + " The value for field " + i);
+            w.println("\t * @param " + SETTER_ARG_NAME + i + " The value for field " + i);
         }
         w.println("\t */");
         w.println("\tpublic void setFields" + paramList + " {");
         for (int i = 0; i < numFields; i++) {
-            w.println("\t\tthis.f" + i + " = value" + i + ';');
+            w.println("\t\tthis.f" + i + " = " + SETTER_ARG_NAME + i + ';');
         }
         w.println("\t}");
         w.println();
@@ -466,12 +468,12 @@ class TupleGenerator {
                         + paramList
                         + " {");
 
-        w.print("\t\treturn new " + className + "<>(value0");
+        w.print("\t\treturn new " + className + "<>(" + SETTER_ARG_NAME + "0");
         if (numFields > 1) {
             w.println(",");
         }
         for (int i = 1; i < numFields; i++) {
-            w.print("\t\t\tvalue" + i);
+            w.print("\t\t\t" + SETTER_ARG_NAME + i);
             if (i < numFields - 1) {
                 w.println(",");
             }
@@ -552,7 +554,7 @@ class TupleGenerator {
             if (i > 0) {
                 w.print(", ");
             }
-            w.print(GEN_TYPE_PREFIX + i + " value" + i);
+            w.print(GEN_TYPE_PREFIX + i + " " + SETTER_ARG_NAME + i);
         }
         w.println("){");
         w.print("\t\ttuples.add(new Tuple" + numFields + "<>(");
@@ -560,7 +562,7 @@ class TupleGenerator {
             if (i > 0) {
                 w.print(", ");
             }
-            w.print("value" + i);
+            w.print(SETTER_ARG_NAME + i);
         }
         w.println("));");
         w.println("\t\treturn this;");

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.types.extraction;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple12;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.HintFlag;
@@ -445,7 +446,27 @@ public class DataTypeExtractorTest {
                                                         DataTypes.INT(), DataTypes.STRING())))),
                 TestSpec.forType("Invalid data view", AccumulatorWithInvalidView.class)
                         .expectErrorMessage(
-                                "Annotated list views should have a logical type of ARRAY."));
+                                "Annotated list views should have a logical type of ARRAY."),
+                TestSpec.forGeneric(
+                                "Assigning constructor for tuples",
+                                TableFunction.class,
+                                0,
+                                Tuple12TableFunction.class)
+                        .expectDataType(
+                                DataTypes.STRUCTURED(
+                                        Tuple12.class,
+                                        DataTypes.FIELD("f0", DataTypes.STRING()),
+                                        DataTypes.FIELD("f1", DataTypes.STRING()),
+                                        DataTypes.FIELD("f2", DataTypes.STRING()),
+                                        DataTypes.FIELD("f3", DataTypes.STRING()),
+                                        DataTypes.FIELD("f4", DataTypes.STRING()),
+                                        DataTypes.FIELD("f5", DataTypes.STRING()),
+                                        DataTypes.FIELD("f6", DataTypes.STRING()),
+                                        DataTypes.FIELD("f7", DataTypes.STRING()),
+                                        DataTypes.FIELD("f8", DataTypes.STRING()),
+                                        DataTypes.FIELD("f9", DataTypes.STRING()),
+                                        DataTypes.FIELD("f10", DataTypes.STRING()),
+                                        DataTypes.FIELD("f11", DataTypes.INT()))));
     }
 
     @Parameter public TestSpec testSpec;
@@ -1023,5 +1044,28 @@ public class DataTypeExtractorTest {
     public static class AccumulatorWithInvalidView {
         @DataTypeHint("INT")
         public ListView<?> listView;
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    /** Table function that uses a big tuple with constructor defined field order. */
+    public static class Tuple12TableFunction
+            extends TableFunction<
+                    Tuple12<
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            Integer>> {
+        public void eval() {
+            // nothing to do
+        }
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedTableFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedTableFunctions.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.runtime.utils;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple12;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.TableFunction;
 
@@ -126,6 +127,42 @@ public class JavaUserDefinedTableFunctions {
         @Override
         public boolean isDeterministic() {
             return false;
+        }
+    }
+
+    /** Function with large tuple. */
+    public static class JavaTableFuncTuple12
+            extends TableFunction<
+                    Tuple12<
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            String,
+                            Integer,
+                            Integer,
+                            Integer,
+                            Integer,
+                            Integer,
+                            Integer>> {
+        private static final long serialVersionUID = -8258882510989374448L;
+
+        public void eval(String str) {
+            collect(
+                    Tuple12.of(
+                            str + "_a",
+                            str + "_b",
+                            str + "_c",
+                            str + "_d",
+                            str + "_e",
+                            str + "_f",
+                            str.length(),
+                            str.length() + 1,
+                            str.length() + 2,
+                            str.length() + 3,
+                            str.length() + 4,
+                            str.length() + 5));
         }
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
@@ -31,6 +31,28 @@ PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$MockPythonTable
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelateTuple12">
+    <Resource name="sql">
+      <![CDATA[
+SELECT *
+FROM MyTable, LATERAL TABLE(func1(c)) AS T
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], f0=[$3], f1=[$4], f2=[$5], f3=[$6], f4=[$7], f5=[$8], f6=[$9], f7=[$10], f8=[$11], f9=[$12], f10=[$13], f11=[$14])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableFunctionScan(invocation=[func1($cor0.c)], rowType=[*org.apache.flink.api.java.tuple.Tuple12* NOT NULL])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Correlate(invocation=[func1($cor0.c)], correlate=[table(func1($cor0.c))], select=[a,b,c,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, VARCHAR(2147483647) f0, VARCHAR(2147483647) f1, VARCHAR(2147483647) f2, VARCHAR(2147483647) f3, VARCHAR(2147483647) f4, VARCHAR(2147483647) f5, INTEGER f6, INTEGER f7, INTEGER f8, INTEGER f9, INTEGER f10, INTEGER f11)], joinType=[INNER])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCorrelateWithMultiFilter">
     <Resource name="ast">
       <![CDATA[


### PR DESCRIPTION
## What is the purpose of the change

This renames the arguments of tuple classes to the corresponding name of the field. Having a common name for argument and field is a common pattern for POJOs and allows the Table API to treat tuples as regular structured types where the constructor args determine the fields order.

This change should not have any impact on API stability and should be portable to older Flink versions without issues.

## Brief change log

- Change the name of arguments from `valueN` to `fieldN`.

## Verifying this change

This change added tests and can be verified as follows: `DataTypeExtractorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
