### PR TITLE
[FLINK-21393] [formats] Implement ParquetAvroInputFormat

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
@@ -19,15 +19,13 @@
 package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.avro.typeutils.AvroConversions;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.avro.LogicalType;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
@@ -37,25 +35,12 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
-import org.apache.avro.util.Utf8;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.TimeZone;
 
 /**
  * Serialization schema that serializes {@link Row} into Avro bytes.
@@ -67,9 +52,6 @@ import java.util.TimeZone;
  * {@link AvroRowDeserializationSchema} and schema converter {@link AvroSchemaConverter}.
  */
 public class AvroRowSerializationSchema implements SerializationSchema<Row> {
-
-    /** Used for time conversions from SQL types. */
-    private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
 
     /** Avro record class for serialization. Might be null if record class is not available. */
     private Class<? extends SpecificRecord> recordClazz;
@@ -127,7 +109,7 @@ public class AvroRowSerializationSchema implements SerializationSchema<Row> {
     public byte[] serialize(Row row) {
         try {
             // convert to record
-            final GenericRecord record = convertRowToAvroRecord(schema, row);
+            final GenericRecord record = AvroConversions.convertRowToAvroRecord(schema, row);
             arrayOutputStream.reset();
             datumWriter.write(record, encoder);
             encoder.flush();
@@ -156,176 +138,6 @@ public class AvroRowSerializationSchema implements SerializationSchema<Row> {
     }
 
     // --------------------------------------------------------------------------------------------
-
-    private GenericRecord convertRowToAvroRecord(Schema schema, Row row) {
-        final List<Schema.Field> fields = schema.getFields();
-        final int length = fields.size();
-        final GenericRecord record = new GenericData.Record(schema);
-        for (int i = 0; i < length; i++) {
-            final Schema.Field field = fields.get(i);
-            record.put(i, convertFlinkType(field.schema(), row.getField(i)));
-        }
-        return record;
-    }
-
-    private Object convertFlinkType(Schema schema, Object object) {
-        if (object == null) {
-            return null;
-        }
-        switch (schema.getType()) {
-            case RECORD:
-                if (object instanceof Row) {
-                    return convertRowToAvroRecord(schema, (Row) object);
-                }
-                throw new IllegalStateException("Row expected but was: " + object.getClass());
-            case ENUM:
-                return new GenericData.EnumSymbol(schema, object.toString());
-            case ARRAY:
-                final Schema elementSchema = schema.getElementType();
-                final Object[] array = (Object[]) object;
-                final GenericData.Array<Object> convertedArray =
-                        new GenericData.Array<>(array.length, schema);
-                for (Object element : array) {
-                    convertedArray.add(convertFlinkType(elementSchema, element));
-                }
-                return convertedArray;
-            case MAP:
-                final Map<?, ?> map = (Map<?, ?>) object;
-                final Map<Utf8, Object> convertedMap = new HashMap<>();
-                for (Map.Entry<?, ?> entry : map.entrySet()) {
-                    convertedMap.put(
-                            new Utf8(entry.getKey().toString()),
-                            convertFlinkType(schema.getValueType(), entry.getValue()));
-                }
-                return convertedMap;
-            case UNION:
-                final List<Schema> types = schema.getTypes();
-                final int size = types.size();
-                final Schema actualSchema;
-                if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
-                    actualSchema = types.get(1);
-                } else if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
-                    actualSchema = types.get(0);
-                } else if (size == 1) {
-                    actualSchema = types.get(0);
-                } else {
-                    // generic type
-                    return object;
-                }
-                return convertFlinkType(actualSchema, object);
-            case FIXED:
-                // check for logical type
-                if (object instanceof BigDecimal) {
-                    return new GenericData.Fixed(
-                            schema, convertFromDecimal(schema, (BigDecimal) object));
-                }
-                return new GenericData.Fixed(schema, (byte[]) object);
-            case STRING:
-                return new Utf8(object.toString());
-            case BYTES:
-                // check for logical type
-                if (object instanceof BigDecimal) {
-                    return ByteBuffer.wrap(convertFromDecimal(schema, (BigDecimal) object));
-                }
-                return ByteBuffer.wrap((byte[]) object);
-            case INT:
-                // check for logical types
-                if (object instanceof Date) {
-                    return convertFromDate(schema, (Date) object);
-                } else if (object instanceof LocalDate) {
-                    return convertFromDate(schema, Date.valueOf((LocalDate) object));
-                } else if (object instanceof Time) {
-                    return convertFromTimeMillis(schema, (Time) object);
-                } else if (object instanceof LocalTime) {
-                    return convertFromTimeMillis(schema, Time.valueOf((LocalTime) object));
-                }
-                return object;
-            case LONG:
-                // check for logical type
-                if (object instanceof Timestamp) {
-                    return convertFromTimestamp(schema, (Timestamp) object);
-                } else if (object instanceof LocalDateTime) {
-                    return convertFromTimestamp(schema, Timestamp.valueOf((LocalDateTime) object));
-                } else if (object instanceof Time) {
-                    return convertFromTimeMicros(schema, (Time) object);
-                }
-                return object;
-            case FLOAT:
-            case DOUBLE:
-            case BOOLEAN:
-                return object;
-        }
-        throw new RuntimeException("Unsupported Avro type:" + schema);
-    }
-
-    private byte[] convertFromDecimal(Schema schema, BigDecimal decimal) {
-        final LogicalType logicalType = schema.getLogicalType();
-        if (logicalType instanceof LogicalTypes.Decimal) {
-            final LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) logicalType;
-            // rescale to target type
-            final BigDecimal rescaled =
-                    decimal.setScale(decimalType.getScale(), BigDecimal.ROUND_UNNECESSARY);
-            // byte array must contain the two's-complement representation of the
-            // unscaled integer value in big-endian byte order
-            return decimal.unscaledValue().toByteArray();
-        } else {
-            throw new RuntimeException("Unsupported decimal type.");
-        }
-    }
-
-    private int convertFromDate(Schema schema, Date date) {
-        final LogicalType logicalType = schema.getLogicalType();
-        if (logicalType == LogicalTypes.date()) {
-            // adopted from Apache Calcite
-            final long converted = toEpochMillis(date);
-            return (int) (converted / 86400000L);
-        } else {
-            throw new RuntimeException("Unsupported date type.");
-        }
-    }
-
-    private int convertFromTimeMillis(Schema schema, Time date) {
-        final LogicalType logicalType = schema.getLogicalType();
-        if (logicalType == LogicalTypes.timeMillis()) {
-            // adopted from Apache Calcite
-            final long converted = toEpochMillis(date);
-            return (int) (converted % 86400000L);
-        } else {
-            throw new RuntimeException("Unsupported time type.");
-        }
-    }
-
-    private long convertFromTimeMicros(Schema schema, Time date) {
-        final LogicalType logicalType = schema.getLogicalType();
-        if (logicalType == LogicalTypes.timeMicros()) {
-            // adopted from Apache Calcite
-            final long converted = toEpochMillis(date);
-            return (converted % 86400000L) * 1000L;
-        } else {
-            throw new RuntimeException("Unsupported time type.");
-        }
-    }
-
-    private long convertFromTimestamp(Schema schema, Timestamp date) {
-        final LogicalType logicalType = schema.getLogicalType();
-        if (logicalType == LogicalTypes.timestampMillis()) {
-            // adopted from Apache Calcite
-            final long time = date.getTime();
-            return time + (long) LOCAL_TZ.getOffset(time);
-        } else if (logicalType == LogicalTypes.timestampMicros()) {
-            long millis = date.getTime();
-            long micros = millis * 1000 + (date.getNanos() % 1_000_000 / 1000);
-            long offset = LOCAL_TZ.getOffset(millis) * 1000L;
-            return micros + offset;
-        } else {
-            throw new RuntimeException("Unsupported timestamp type.");
-        }
-    }
-
-    private long toEpochMillis(java.util.Date date) {
-        final long time = date.getTime();
-        return time + (long) LOCAL_TZ.getOffset(time);
-    }
 
     private void writeObject(ObjectOutputStream outputStream) throws IOException {
         outputStream.writeObject(recordClazz);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroConversions.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroConversions.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.typeutils;
+
+import org.apache.flink.types.Row;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+/** Utility class that takes care of conversions between avro and flink types. */
+public class AvroConversions {
+    /** Used for time conversions from SQL types. */
+    private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+    public static GenericRecord convertRowToAvroRecord(Schema schema, Row row) {
+        final List<Schema.Field> fields = schema.getFields();
+        final int length = fields.size();
+        final GenericRecord record = new GenericData.Record(schema);
+        for (int i = 0; i < length; i++) {
+            final Schema.Field field = fields.get(i);
+            record.put(i, convertFlinkType(field.schema(), row.getField(i)));
+        }
+        return record;
+    }
+
+    private static Object convertFlinkType(Schema schema, Object object) {
+        if (object == null) {
+            return null;
+        }
+        switch (schema.getType()) {
+            case RECORD:
+                if (object instanceof Row) {
+                    return convertRowToAvroRecord(schema, (Row) object);
+                }
+                throw new IllegalStateException("Row expected but was: " + object.getClass());
+            case ENUM:
+                return new GenericData.EnumSymbol(schema, object.toString());
+            case ARRAY:
+                final Schema elementSchema = schema.getElementType();
+                final Object[] array = (Object[]) object;
+                final GenericData.Array<Object> convertedArray =
+                        new GenericData.Array<>(array.length, schema);
+                for (Object element : array) {
+                    convertedArray.add(convertFlinkType(elementSchema, element));
+                }
+                return convertedArray;
+            case MAP:
+                final Map<?, ?> map = (Map<?, ?>) object;
+                final Map<Utf8, Object> convertedMap = new HashMap<>();
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    convertedMap.put(
+                            new Utf8(entry.getKey().toString()),
+                            convertFlinkType(schema.getValueType(), entry.getValue()));
+                }
+                return convertedMap;
+            case UNION:
+                final List<Schema> types = schema.getTypes();
+                final int size = types.size();
+                final Schema actualSchema;
+                if (size == 2 && types.get(0).getType() == Schema.Type.NULL) {
+                    actualSchema = types.get(1);
+                } else if (size == 2 && types.get(1).getType() == Schema.Type.NULL) {
+                    actualSchema = types.get(0);
+                } else if (size == 1) {
+                    actualSchema = types.get(0);
+                } else {
+                    // generic type
+                    return object;
+                }
+                return convertFlinkType(actualSchema, object);
+            case FIXED:
+                // check for logical type
+                if (object instanceof BigDecimal) {
+                    return new GenericData.Fixed(
+                            schema, convertFromDecimal(schema, (BigDecimal) object));
+                }
+                return new GenericData.Fixed(schema, (byte[]) object);
+            case STRING:
+                return new Utf8(object.toString());
+            case BYTES:
+                // check for logical type
+                if (object instanceof BigDecimal) {
+                    return ByteBuffer.wrap(convertFromDecimal(schema, (BigDecimal) object));
+                }
+                return ByteBuffer.wrap((byte[]) object);
+            case INT:
+                // check for logical types
+                if (object instanceof Date) {
+                    return convertFromDate(schema, (Date) object);
+                } else if (object instanceof LocalDate) {
+                    return convertFromDate(schema, Date.valueOf((LocalDate) object));
+                } else if (object instanceof Time) {
+                    return convertFromTimeMillis(schema, (Time) object);
+                } else if (object instanceof LocalTime) {
+                    return convertFromTimeMillis(schema, Time.valueOf((LocalTime) object));
+                }
+                return object;
+            case LONG:
+                // check for logical type
+                if (object instanceof Timestamp) {
+                    return convertFromTimestamp(schema, (Timestamp) object);
+                } else if (object instanceof LocalDateTime) {
+                    return convertFromTimestamp(schema, Timestamp.valueOf((LocalDateTime) object));
+                } else if (object instanceof Time) {
+                    return convertFromTimeMicros(schema, (Time) object);
+                }
+                return object;
+            case FLOAT:
+            case DOUBLE:
+            case BOOLEAN:
+                return object;
+        }
+        throw new RuntimeException("Unsupported Avro type:" + schema);
+    }
+
+    private static byte[] convertFromDecimal(Schema schema, BigDecimal decimal) {
+        final LogicalType logicalType = schema.getLogicalType();
+        if (logicalType instanceof LogicalTypes.Decimal) {
+            final LogicalTypes.Decimal decimalType = (LogicalTypes.Decimal) logicalType;
+            // rescale to target type
+            final BigDecimal rescaled =
+                    decimal.setScale(decimalType.getScale(), BigDecimal.ROUND_UNNECESSARY);
+            // byte array must contain the two's-complement representation of the
+            // unscaled integer value in big-endian byte order
+            return decimal.unscaledValue().toByteArray();
+        } else {
+            throw new RuntimeException("Unsupported decimal type.");
+        }
+    }
+
+    private static int convertFromDate(Schema schema, Date date) {
+        final LogicalType logicalType = schema.getLogicalType();
+        if (logicalType == LogicalTypes.date()) {
+            // adopted from Apache Calcite
+            final long converted = toEpochMillis(date);
+            return (int) (converted / 86400000L);
+        } else {
+            throw new RuntimeException("Unsupported date type.");
+        }
+    }
+
+    private static int convertFromTimeMillis(Schema schema, Time date) {
+        final LogicalType logicalType = schema.getLogicalType();
+        if (logicalType == LogicalTypes.timeMillis()) {
+            // adopted from Apache Calcite
+            final long converted = toEpochMillis(date);
+            return (int) (converted % 86400000L);
+        } else {
+            throw new RuntimeException("Unsupported time type.");
+        }
+    }
+
+    private static long convertFromTimeMicros(Schema schema, Time date) {
+        final LogicalType logicalType = schema.getLogicalType();
+        if (logicalType == LogicalTypes.timeMicros()) {
+            // adopted from Apache Calcite
+            final long converted = toEpochMillis(date);
+            return (converted % 86400000L) * 1000L;
+        } else {
+            throw new RuntimeException("Unsupported time type.");
+        }
+    }
+
+    private static long convertFromTimestamp(Schema schema, Timestamp date) {
+        final LogicalType logicalType = schema.getLogicalType();
+        if (logicalType == LogicalTypes.timestampMillis()) {
+            // adopted from Apache Calcite
+            final long time = date.getTime();
+            return time + (long) LOCAL_TZ.getOffset(time);
+        } else if (logicalType == LogicalTypes.timestampMicros()) {
+            long millis = date.getTime();
+            long micros = millis * 1000 + (date.getNanos() % 1_000_000 / 1000);
+            long offset = LOCAL_TZ.getOffset(millis) * 1000L;
+            return micros + offset;
+        } else {
+            throw new RuntimeException("Unsupported timestamp type.");
+        }
+    }
+
+    private static long toEpochMillis(java.util.Date date) {
+        final long time = date.getTime();
+        return time + (long) LOCAL_TZ.getOffset(time);
+    }
+}

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -51,6 +51,13 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-avro</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+
 		<!-- Table ecosystem -->
 		<!-- Projects depending on this project won't depend on flink-table-*. -->
 		<dependency>
@@ -168,13 +175,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetAvroInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetAvroInputFormat.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.avro.typeutils.AvroConversions;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.types.Row;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.schema.MessageType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An implementation of {@link ParquetInputFormat} to read records from Parquet files and convert
+ * them to Avro GenericRecord. To use it the user needs to add {@code flink-avro} optional
+ * dependency to the classpath. Usage:
+ *
+ * <pre>{@code
+ * final ParquetAvroInputFormat inputFormat = new ParquetAvroInputFormat(new Path(filePath), parquetSchema);
+ * DataSource<GenericRecord> source = env.createInput(inputFormat, new GenericRecordAvroTypeInfo(inputFormat.getAvroSchema()));
+ *
+ * }</pre>
+ */
+public class ParquetAvroInputFormat extends ParquetInputFormat<GenericRecord>
+        implements ResultTypeQueryable<GenericRecord> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient Schema avroSchema;
+    private String avroSchemaString;
+
+    public ParquetAvroInputFormat(Path filePath, MessageType messageType) {
+        super(filePath, messageType);
+        avroSchema = new AvroSchemaConverter().convert(messageType);
+        avroSchemaString = avroSchema.toString();
+    }
+
+    @Override
+    public void selectFields(String[] fieldNames) {
+        avroSchema = getProjectedSchema(fieldNames, avroSchema);
+        avroSchemaString = avroSchema.toString();
+        super.selectFields(fieldNames);
+    }
+
+    @Override
+    protected GenericRecord convert(Row row) {
+        // after deserialization
+        if (avroSchema == null) {
+            avroSchema = new Schema.Parser().parse(avroSchemaString);
+        }
+        return AvroConversions.convertRowToAvroRecord(avroSchema, row);
+    }
+
+    @Override
+    public GenericRecordAvroTypeInfo getProducedType() {
+        return new GenericRecordAvroTypeInfo(avroSchema);
+    }
+
+    private Schema getProjectedSchema(String[] projectedFieldNames, Schema sourceAvroSchema) {
+        // Avro fields need to be in the same order than row field for compatibility with flink 1.12
+        // (row
+        // fields not accessible by name). Row field order now is the order of
+        // ParquetInputFormat.selectFields()
+        // for flink 1.13+ where row fields are accessible by name, we will match the fields names
+        // between avro schema and row schema.
+
+        List<Schema.Field> projectedFields = new ArrayList<>();
+        for (String fieldName : projectedFieldNames) {
+            projectedFields.add(deepCopyField(sourceAvroSchema.getField(fieldName)));
+        }
+        return Schema.createRecord(
+                sourceAvroSchema.getName() + "_projected",
+                sourceAvroSchema.getDoc(),
+                sourceAvroSchema.getNamespace(),
+                sourceAvroSchema.isError(),
+                projectedFields);
+    }
+
+    private Schema.Field deepCopyField(Schema.Field field) {
+        Schema.Field newField =
+                new Schema.Field(
+                        field.name(),
+                        field.schema(),
+                        field.doc(),
+                        field.defaultVal(),
+                        field.order());
+        for (Map.Entry<String, Object> kv : field.getObjectProps().entrySet()) {
+            newField.addProp(kv.getKey(), kv.getValue());
+        }
+        if (field.aliases() != null) {
+            for (String alias : field.aliases()) {
+                newField.addAlias(alias);
+            }
+        }
+        return newField;
+    }
+
+    public Schema getAvroSchema() {
+        return avroSchema;
+    }
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetAvroInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetAvroInputFormatTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.utils.TestUtil;
+import org.apache.flink.types.Row;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.apache.parquet.schema.MessageType;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/** Test cases for reading Parquet files and convert parquet records to Avro GenericRecords. */
+public class ParquetAvroInputFormatTest {
+
+    @ClassRule public static TemporaryFolder tempRoot = new TemporaryFolder();
+    private final Configuration configuration = new Configuration();
+    private final AvroSchemaConverter schemaConverter = new AvroSchemaConverter(configuration);
+
+    @Test
+    public void testReadFromSimpleRecord() throws IOException {
+        Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
+                TestUtil.getSimpleRecordTestData();
+        MessageType messageType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+        Path path =
+                TestUtil.createTempParquetFile(
+                        tempRoot.getRoot(),
+                        TestUtil.SIMPLE_SCHEMA,
+                        Collections.singletonList(testData.f1),
+                        configuration);
+
+        ParquetAvroInputFormat inputFormat = new ParquetAvroInputFormat(path, messageType);
+        inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+
+        FileInputSplit[] splits = inputFormat.createInputSplits(1);
+        assertEquals(1, splits.length);
+        inputFormat.open(splits[0]);
+
+        final GenericRecord genericRecord = inputFormat.nextRecord(null);
+        assertEquals(testData.f2.getField(0), genericRecord.get("foo"));
+        assertEquals(testData.f2.getField(1), genericRecord.get("bar").toString());
+        assertArrayEquals(
+                (Long[]) testData.f2.getField(2),
+                ((List<Long>) genericRecord.get("arr")).toArray());
+    }
+
+    @Test(expected = AvroRuntimeException.class)
+    public void testProjectedReadFromSimpleRecord()
+            throws IOException, NoSuchFieldError, AvroRuntimeException {
+        Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> testData =
+                TestUtil.getSimpleRecordTestData();
+        MessageType messageType = schemaConverter.convert(TestUtil.SIMPLE_SCHEMA);
+        Path path =
+                TestUtil.createTempParquetFile(
+                        tempRoot.getRoot(),
+                        TestUtil.SIMPLE_SCHEMA,
+                        Collections.singletonList(testData.f1),
+                        configuration);
+
+        ParquetAvroInputFormat inputFormat = new ParquetAvroInputFormat(path, messageType);
+        inputFormat.setRuntimeContext(TestUtil.getMockRuntimeContext());
+
+        FileInputSplit[] splits = inputFormat.createInputSplits(1);
+        assertEquals(1, splits.length);
+
+        inputFormat.selectFields(new String[] {"foo", "bar"});
+        inputFormat.open(splits[0]);
+
+        final GenericRecord genericRecord = inputFormat.nextRecord(null);
+        assertEquals(testData.f2.getField(0), genericRecord.get("foo"));
+        assertEquals(testData.f2.getField(1), genericRecord.get("bar").toString());
+        // should throw AvroRuntimeException("Not a valid schema field: arr")
+        genericRecord.get("arr");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


Implement ParquetAvroInputFormat

## Verifying this change


This change added tests and can be verified as follows:
new ParquetAvroInputFormatTest test both simple record and projected fields with simple record but sets parquet.avro.write-old-list-structure to true because AvroRowSerializationSchema does not work with parquet.avro.write-old-list-structure set to false 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, flink-parquet now depends on flink-avro
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes adds new API  (new input format)
  - The serializers: not really, just make AvroRowSerializationSchema#convertRowToAvroRecord public
  - The runtime per-record code paths (performance sensitive): yes as ParquetInputFormat#convert is implemented
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? javadoc with code example
