### PR TITLE
[FLINK-21661][kinesis] Fix fetch interval for polling consumer

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
@@ -34,6 +34,7 @@ import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -42,6 +43,8 @@ import static org.mockito.Mockito.verify;
 
 /** Tests for {@link PollingRecordPublisher}. */
 public class PollingRecordPublisherTest {
+
+    private static final long FETCH_INTERVAL_MILLIS = 500L;
 
     @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -56,6 +59,21 @@ public class PollingRecordPublisherTest {
         assertEquals(1, consumer.getRecordBatches().size());
         assertEquals(5, consumer.getRecordBatches().get(0).getDeaggregatedRecordSize());
         assertEquals(100L, consumer.getRecordBatches().get(0).getMillisBehindLatest(), 0);
+    }
+
+    @Test
+    public void testRunEmitsRunLoopTimeNanos() throws Exception {
+        PollingRecordPublisherMetricsReporter metricsReporter =
+                spy(new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class)));
+
+        KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 5, 100);
+        PollingRecordPublisher recordPublisher =
+                createPollingRecordPublisher(fakeKinesis, metricsReporter);
+
+        recordPublisher.run(new TestConsumer());
+
+        // Expect that the run loop took at least FETCH_INTERVAL_MILLIS in nanos
+        verify(metricsReporter).setRunLoopTimeNanos(geq(FETCH_INTERVAL_MILLIS * 1_000_000));
     }
 
     @Test
@@ -136,12 +154,19 @@ public class PollingRecordPublisherTest {
         PollingRecordPublisherMetricsReporter metricsReporter =
                 new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class));
 
+        return createPollingRecordPublisher(kinesis, metricsReporter);
+    }
+
+    PollingRecordPublisher createPollingRecordPublisher(
+            final KinesisProxyInterface kinesis,
+            final PollingRecordPublisherMetricsReporter metricGroupReporter)
+            throws Exception {
         return new PollingRecordPublisher(
                 StartingPosition.restartFromSequenceNumber(SENTINEL_EARLIEST_SEQUENCE_NUM.get()),
                 TestUtils.createDummyStreamShardHandle(),
-                metricsReporter,
+                metricGroupReporter,
                 kinesis,
                 10000,
-                500L);
+                FETCH_INTERVAL_MILLIS);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Kinesis Polling consumer does not respect the `SHARD_GETRECORDS_INTERVAL_MILLIS` configuration. This means consumer will poll Kinesis without any delay, resulting in throttle. This bug was introduced with FLINK-18512.

## Brief change log

* Move sleep logic from `AdaptivePollingRecordPublisher` to `PollingRecordPublisher`, to respect `SHARD_GETRECORDS_INTERVAL_MILLIS`

## Verifying this change

This change added tests and can be verified as follows:
- `PollingRecordPublisherTest::testRunEmitsRunLoopTimeNanos`

This change is already covered by existing tests, such as:
- `ShardConsumerTest`
- `PollingRecordPublisherTest`
- Kinesis e2e Test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
