### PR TITLE
[hotfix] Make the way to resolve REST compatibility changes more clear.

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/rest/compatibility/RestAPIStabilityTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/rest/compatibility/RestAPIStabilityTest.java
@@ -161,7 +161,7 @@ public final class RestAPIStabilityTest extends TestLogger {
                         "The API was modified in a compatible way, but the snapshot was not updated. "
                                 + "To update the snapshot, re-run this test with -D"
                                 + REGENERATE_SNAPSHOT_PROPERTY
-                                + " being set.");
+                                + " being set. If you see this message in a CI pipeline, rerun the test locally and commit the generated changes.");
             }
         }
 


### PR DESCRIPTION
The current message when REST API gets changed and compatibility check is run is:
```
The API was modified in a compatible way, but the snapshot was not updated. To update the snapshot, re-run this test with -Dgenerate-rest-snapshot being set.
```
When seeing this message in the CI context, it is unclear if there are any properties of the pipeline that have to modified in the CI system. This hotfix makes the resolution path more clear.
