### PR TITLE
[FLINK-20114][connector/kafka,common] Fix a few KafkaSource-related bugs

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -442,14 +442,10 @@ public class KafkaSourceBuilder<OUT> {
                 true);
 
         // If the source is bounded, do not run periodic partition discovery.
-        if (maybeOverride(
+        maybeOverride(
                 KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
                 "-1",
-                boundedness == Boundedness.BOUNDED)) {
-            LOG.warn(
-                    "{} property is overridden to -1 because the source is bounded.",
-                    KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS);
-        }
+                boundedness == Boundedness.BOUNDED);
 
         // If the client id prefix is not set, reuse the consumer group id as the client id prefix.
         maybeOverride(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -435,6 +435,7 @@ public class KafkaSourceBuilder<OUT> {
                 true);
         maybeOverride(
                 ConsumerConfig.GROUP_ID_CONFIG, "KafkaSource-" + new Random().nextLong(), false);
+        maybeOverride(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false", false);
         maybeOverride(
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
                 startingOffsetsInitializer.getAutoOffsetResetStrategy().name().toLowerCase(),

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -36,7 +36,7 @@ public class KafkaSourceOptions {
     public static final ConfigOption<Long> PARTITION_DISCOVERY_INTERVAL_MS =
             ConfigOptions.key("partition.discovery.interval.ms")
                     .longType()
-                    .defaultValue(30000L)
+                    .noDefaultValue()
                     .withDescription(
                             "The interval in milliseconds for the Kafka source to discover "
                                     + "the new partitions. A non-positive value disables the partition discovery.");

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -41,12 +41,6 @@ public class KafkaSourceOptions {
                             "The interval in milliseconds for the Kafka source to discover "
                                     + "the new partitions. A non-positive value disables the partition discovery.");
 
-    public static final ConfigOption<Long> CLOSE_TIMEOUT_MS =
-            ConfigOptions.key("close.timeout.ms")
-                    .longType()
-                    .defaultValue(10000L)
-                    .withDescription("The max time to wait when closing components.");
-
     @SuppressWarnings("unchecked")
     public static <T> T getOption(
             Properties props, ConfigOption configOption, Function<String, T> parser) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -149,7 +149,15 @@ public class KafkaSourceEnumerator
                             + "without periodic partition discovery.",
                     consumerGroupId);
             context.callAsync(
-                    this::discoverAndInitializePartitionSplit, this::handlePartitionSplitChanges);
+                    () -> {
+                        try {
+                            return discoverAndInitializePartitionSplit();
+                        } finally {
+                            // Close the admin client early because we won't use it anymore.
+                            adminClient.close();
+                        }
+                    },
+                    this::handlePartitionSplitChanges);
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -407,7 +407,12 @@ public class KafkaSourceEnumerator
                         .thenApply(
                                 result -> {
                                     Map<TopicPartition, Long> offsets = new HashMap<>();
-                                    result.forEach((tp, oam) -> offsets.put(tp, oam.offset()));
+                                    result.forEach(
+                                            (tp, oam) -> {
+                                                if (oam != null) {
+                                                    offsets.put(tp, oam.offset());
+                                                }
+                                            });
                                     return offsets;
                                 })
                         .get();

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
@@ -60,6 +60,12 @@ class SpecifiedOffsetsInitializer implements OffsetsInitializer {
             }
         }
         if (!toLookup.isEmpty()) {
+            // First check the committed offsets.
+            Map<TopicPartition, Long> committedOffsets =
+                    partitionOffsetsRetriever.committedOffsets(toLookup);
+            offsets.putAll(committedOffsets);
+            toLookup.removeAll(committedOffsets.keySet());
+
             switch (offsetResetStrategy) {
                 case EARLIEST:
                     offsets.putAll(partitionOffsetsRetriever.beginningOffsets(toLookup));

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
+import org.apache.flink.streaming.connectors.kafka.KafkaConsumerTestBase;
+import org.apache.flink.streaming.connectors.kafka.KafkaProducerTestBase;
+import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * An IT case class that runs all the IT cases of the legacy {@link
+ * org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer} with the new {@link KafkaSource}.
+ */
+public class KafkaSourceLegacyITCase extends KafkaConsumerTestBase {
+
+    public KafkaSourceLegacyITCase() throws Exception {
+        super(true);
+    }
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        KafkaProducerTestBase.prepare();
+        ((KafkaTestEnvironmentImpl) kafkaServer)
+                .setProducerSemantic(FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
+    }
+
+    @Test(timeout = 120000)
+    public void testFailOnNoBroker() throws Exception {
+        runFailOnNoBrokerTest();
+    }
+
+    @Test(timeout = 60000)
+    public void testConcurrentProducerConsumerTopology() throws Exception {
+        runSimpleConcurrentProducerConsumerTopology();
+    }
+
+    @Test(timeout = 60000)
+    public void testKeyValueSupport() throws Exception {
+        runKeyValueTest();
+    }
+
+    // --- canceling / failures ---
+
+    @Test(timeout = 60000)
+    public void testCancelingEmptyTopic() throws Exception {
+        runCancelingOnEmptyInputTest();
+    }
+
+    @Test(timeout = 60000)
+    public void testCancelingFullTopic() throws Exception {
+        runCancelingOnFullInputTest();
+    }
+
+    // --- source to partition mappings and exactly once ---
+
+    @Test(timeout = 60000)
+    public void testOneToOneSources() throws Exception {
+        runOneToOneExactlyOnceTest();
+    }
+
+    @Test(timeout = 60000)
+    public void testOneSourceMultiplePartitions() throws Exception {
+        runOneSourceMultiplePartitionsExactlyOnceTest();
+    }
+
+    @Test(timeout = 60000)
+    public void testMultipleSourcesOnePartition() throws Exception {
+        runMultipleSourcesOnePartitionExactlyOnceTest();
+    }
+
+    // --- broker failure ---
+
+    @Test(timeout = 60000)
+    public void testBrokerFailure() throws Exception {
+        runBrokerFailureTest();
+    }
+
+    // --- special executions ---
+
+    @Test(timeout = 60000)
+    public void testBigRecordJob() throws Exception {
+        runBigRecordTestTopology();
+    }
+
+    @Test(timeout = 60000)
+    public void testMultipleTopicsWithLegacySerializer() throws Exception {
+        runProduceConsumeMultipleTopics(true);
+    }
+
+    @Test(timeout = 60000)
+    public void testMultipleTopicsWithKafkaSerializer() throws Exception {
+        runProduceConsumeMultipleTopics(false);
+    }
+
+    @Test(timeout = 60000)
+    public void testAllDeletes() throws Exception {
+        runAllDeletesTest();
+    }
+
+    // --- startup mode ---
+
+    @Test(timeout = 60000)
+    public void testStartFromEarliestOffsets() throws Exception {
+        runStartFromEarliestOffsets();
+    }
+
+    @Test(timeout = 60000)
+    public void testStartFromLatestOffsets() throws Exception {
+        runStartFromLatestOffsets();
+    }
+
+    @Test(timeout = 60000)
+    public void testStartFromGroupOffsets() throws Exception {
+        runStartFromGroupOffsets();
+    }
+
+    @Test(timeout = 60000)
+    public void testStartFromSpecificOffsets() throws Exception {
+        runStartFromSpecificOffsets();
+    }
+
+    @Test(timeout = 60000)
+    public void testStartFromTimestamp() throws Exception {
+        runStartFromTimestamp();
+    }
+
+    // --- offset committing ---
+
+    @Test(timeout = 60000)
+    public void testCommitOffsetsToKafka() throws Exception {
+        runCommitOffsetsToKafka();
+    }
+
+    @Test(timeout = 60000)
+    public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+        runAutoOffsetRetrievalAndCommitToKafka();
+    }
+
+    @Test(timeout = 60000)
+    public void testCollectingSchema() throws Exception {
+        runCollectingSchemaTest();
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -41,12 +41,14 @@ import static org.junit.Assert.assertTrue;
 /** Unit tests for {@link OffsetsInitializer}. */
 public class OffsetsInitializerTest {
     private static final String TOPIC = "topic";
+    private static final String TOPIC2 = "topic2";
     private static KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl retriever;
 
     @BeforeClass
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
         KafkaSourceTestEnv.setupTopic(TOPIC, true, true);
+        KafkaSourceTestEnv.setupTopic(TOPIC2, false, false);
         retriever =
                 new KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl(
                         KafkaSourceTestEnv.getConsumer(),
@@ -116,19 +118,28 @@ public class OffsetsInitializerTest {
         List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
         Map<TopicPartition, OffsetAndMetadata> committedOffsets =
                 KafkaSourceTestEnv.getCommittedOffsets(partitions);
-        committedOffsets.forEach((tp, oam) -> specifiedOffsets.put(tp, oam.offset()));
+        partitions.forEach(tp -> specifiedOffsets.put(tp, (long) tp.partition()));
         // Remove the specified offsets for partition 0.
-        TopicPartition missingPartition = new TopicPartition(TOPIC, 0);
-        specifiedOffsets.remove(missingPartition);
+        TopicPartition partitionSetToCommitted = new TopicPartition(TOPIC, 0);
+        specifiedOffsets.remove(partitionSetToCommitted);
         OffsetsInitializer initializer = OffsetsInitializer.offsets(specifiedOffsets);
 
         assertEquals(OffsetResetStrategy.EARLIEST, initializer.getAutoOffsetResetStrategy());
+        // The partition without committed offset should fallback to offset reset strategy.
+        TopicPartition partitionSetToEarliest = new TopicPartition(TOPIC2, 0);
+        partitions.add(partitionSetToEarliest);
 
         Map<TopicPartition, Long> offsets = initializer.getPartitionOffsets(partitions, retriever);
         for (TopicPartition tp : partitions) {
             Long offset = offsets.get(tp);
-            long expectedOffset =
-                    tp.equals(missingPartition) ? 0L : committedOffsets.get(tp).offset();
+            long expectedOffset;
+            if (tp.equals(partitionSetToCommitted)) {
+                expectedOffset = committedOffsets.get(tp).offset();
+            } else if (tp.equals(partitionSetToEarliest)) {
+                expectedOffset = 0L;
+            } else {
+                expectedOffset = specifiedOffsets.get(tp);
+            }
             assertEquals(
                     String.format("%s has incorrect offset.", tp), expectedOffset, (long) offset);
         }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -207,6 +207,20 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
         }
     }
 
+    @Test
+    public void testNotCommitOffsetsForUninitializedSplits() throws Exception {
+        final long checkpointId = 1234L;
+        try (KafkaSourceReader<Integer> reader = (KafkaSourceReader<Integer>) createReader()) {
+            KafkaPartitionSplit split =
+                    new KafkaPartitionSplit(
+                            new TopicPartition(TOPIC, 0), KafkaPartitionSplit.EARLIEST_OFFSET);
+            reader.addSplits(Collections.singletonList(split));
+            reader.snapshotState(checkpointId);
+            assertEquals(1, reader.getOffsetsToCommit().size());
+            assertTrue(reader.getOffsetsToCommit().get(checkpointId).isEmpty());
+        }
+    }
+
     // ------------------------------------------
 
     @Override

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
@@ -40,6 +41,9 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
@@ -82,8 +86,10 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 import kafka.server.KafkaServer;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.junit.Assert;
@@ -125,10 +131,19 @@ import static org.junit.Assert.fail;
 /** Abstract test base for all Kafka consumer tests. */
 @SuppressWarnings("serial")
 public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
+    protected final boolean useNewSource;
 
     @Rule public RetryRule retryRule = new RetryRule();
 
     private ClusterClient<?> client;
+
+    protected KafkaConsumerTestBase() {
+        this(false);
+    }
+
+    protected KafkaConsumerTestBase(boolean useNewSource) {
+        this.useNewSource = useNewSource;
+    }
 
     // ------------------------------------------------------------------------
     //  Common Test Preparation
@@ -175,9 +190,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
             properties.setProperty("fetch.max.wait.ms", "2000");
             properties.setProperty("heartbeat.interval.ms", "1000");
             properties.putAll(secureProps);
-            FlinkKafkaConsumerBase<String> source =
-                    kafkaServer.getConsumer("doesntexist", new SimpleStringSchema(), properties);
-            DataStream<String> stream = see.addSource(source);
+            DataStream<String> stream =
+                    getStream(see, "doesntexist", new SimpleStringSchema(), properties);
             stream.print();
             see.execute("No broker test");
         } catch (JobExecutionException jee) {
@@ -190,9 +204,15 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
                 assertTrue(optionalTimeoutException.isPresent());
 
                 final TimeoutException timeoutException = optionalTimeoutException.get();
-                assertEquals(
-                        "Timeout expired while fetching topic metadata",
-                        timeoutException.getMessage());
+                if (useNewSource) {
+                    assertEquals(
+                            "Timed out waiting for a node assignment.",
+                            timeoutException.getMessage());
+                } else {
+                    assertEquals(
+                            "Timeout expired while fetching topic metadata",
+                            timeoutException.getMessage());
+                }
             } else {
                 final Optional<Throwable> optionalThrowable =
                         ExceptionUtils.findThrowableWithMessage(
@@ -222,9 +242,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         env.enableCheckpointing(200);
 
         DataStream<String> stream =
-                env.addSource(
-                        kafkaServer.getConsumer(
-                                topicName, new SimpleStringSchema(), standardProps));
+                getStream(env, topicName, new SimpleStringSchema(), standardProps);
         stream.addSink(new DiscardingSink<String>());
 
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -316,9 +334,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
                 "auto.offset.reset",
                 "latest"); // set to reset to latest, so that partitions are initially not read
 
-        DataStream<String> stream =
-                env.addSource(
-                        kafkaServer.getConsumer(topicName, new SimpleStringSchema(), readProps));
+        DataStream<String> stream = getStream(env, topicName, new SimpleStringSchema(), readProps);
         stream.addSink(new DiscardingSink<String>());
 
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
@@ -471,12 +487,22 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         readProps.putAll(standardProps);
         readProps.setProperty("auto.offset.reset", "earliest"); // this should be ignored
 
-        FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> latestReadingConsumer =
-                kafkaServer.getConsumer(topicName, deserSchema, readProps);
-        latestReadingConsumer.setStartFromLatest();
+        DataStreamSource<Tuple2<Integer, Integer>> stream;
+        if (useNewSource) {
+            KafkaSource<Tuple2<Integer, Integer>> source =
+                    kafkaServer
+                            .getSourceBuilder(topicName, deserSchema, readProps)
+                            .setStartingOffsets(OffsetsInitializer.latest())
+                            .build();
+            stream = env.fromSource(source, WatermarkStrategy.noWatermarks(), "KafkaSource");
+        } else {
+            FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> latestReadingConsumer =
+                    kafkaServer.getConsumer(topicName, deserSchema, readProps);
+            latestReadingConsumer.setStartFromLatest();
+            stream = env.addSource(latestReadingConsumer);
+        }
 
-        env.addSource(latestReadingConsumer)
-                .setParallelism(parallelism)
+        stream.setParallelism(parallelism)
                 .flatMap(
                         new FlatMapFunction<Tuple2<Integer, Integer>, Object>() {
                             @Override
@@ -874,11 +900,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        FlinkKafkaConsumerBase<Tuple2<Long, String>> source =
-                kafkaServer.getConsumer(topics, sourceSchema, props);
-
         DataStreamSource<Tuple2<Long, String>> consuming =
-                env.addSource(source).setParallelism(parallelism);
+                getStream(env, topics, sourceSchema, props);
 
         consuming
                 .addSink(
@@ -976,9 +999,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         props.putAll(standardProps);
         props.putAll(secureProps);
 
-        FlinkKafkaConsumerBase<Integer> kafkaSource = kafkaServer.getConsumer(topic, schema, props);
-
-        env.addSource(kafkaSource)
+        getStream(env, topic, schema, props)
                 .map(new PartitionValidatingMapper(parallelism, 1))
                 .map(new FailingIdentityMapper<Integer>(failAfterElements))
                 .addSink(new ValidatingExactlyOnceSink(totalElements))
@@ -1027,9 +1048,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        FlinkKafkaConsumerBase<Integer> kafkaSource = kafkaServer.getConsumer(topic, schema, props);
 
-        env.addSource(kafkaSource)
+        getStream(env, topic, schema, props)
                 .map(new PartitionValidatingMapper(numPartitions, 3))
                 .map(new FailingIdentityMapper<Integer>(failAfterElements))
                 .addSink(new ValidatingExactlyOnceSink(totalElements))
@@ -1081,9 +1101,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        FlinkKafkaConsumerBase<Integer> kafkaSource = kafkaServer.getConsumer(topic, schema, props);
 
-        env.addSource(kafkaSource)
+        getStream(env, topic, schema, props)
                 .map(new PartitionValidatingMapper(numPartitions, 1))
                 .map(new FailingIdentityMapper<Integer>(failAfterElements))
                 .addSink(new ValidatingExactlyOnceSink(totalElements))
@@ -1118,10 +1137,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        FlinkKafkaConsumerBase<String> source =
-                kafkaServer.getConsumer(topic, new SimpleStringSchema(), props);
-
-        env.addSource(source).addSink(new DiscardingSink<String>());
+        getStream(env, topic, new SimpleStringSchema(), props)
+                .addSink(new DiscardingSink<String>());
 
         JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
         final JobID jobId = jobGraph.getJobID();
@@ -1187,10 +1204,9 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        FlinkKafkaConsumerBase<String> source =
-                kafkaServer.getConsumer(topic, new SimpleStringSchema(), props);
 
-        env.addSource(source).addSink(new DiscardingSink<String>());
+        getStream(env, topic, new SimpleStringSchema(), props)
+                .addSink(new DiscardingSink<String>());
 
         JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
         final JobID jobId = jobGraph.getJobID();
@@ -1233,6 +1249,9 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      * @throws Exception
      */
     public void runProduceConsumeMultipleTopics(boolean useLegacySchema) throws Exception {
+        final String topicNamePrefix =
+                "runProduceConsumeMultipleTopics-" + (useLegacySchema ? "legacy" : "");
+
         final int numTopics = 5;
         final int numElements = 20;
 
@@ -1241,7 +1260,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         // create topics with content
         final List<String> topics = new ArrayList<>();
         for (int i = 0; i < numTopics; i++) {
-            final String topic = "topic-" + i;
+            final String topic = topicNamePrefix + i;
             topics.add(topic);
             // create topic
             createTestTopic(topic, i + 1 /*partitions*/, 1);
@@ -1262,7 +1281,9 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
                                 for (int topicId = 0; topicId < numTopics; topicId++) {
                                     for (int i = 0; i < numElements; i++) {
-                                        ctx.collect(new Tuple3<>(partition, i, "topic-" + topicId));
+                                        ctx.collect(
+                                                new Tuple3<>(
+                                                        partition, i, topicNamePrefix + topicId));
                                     }
                                 }
                             }
@@ -1290,10 +1311,10 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
         if (useLegacySchema) {
             Tuple2WithTopicSchema schema = new Tuple2WithTopicSchema(env.getConfig());
-            stream = env.addSource(kafkaServer.getConsumer(topics, schema, props));
+            stream = getStream(env, topics, schema, props);
         } else {
             TestDeserializer schema = new TestDeserializer(env.getConfig());
-            stream = env.addSource(kafkaServer.getConsumer(topics, schema, props));
+            stream = getStream(env, topics, schema, props);
         }
 
         stream.flatMap(
@@ -1335,7 +1356,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
         // delete all topics again
         for (int i = 0; i < numTopics; i++) {
-            final String topic = "topic-" + i;
+            final String topic = topicNamePrefix + i;
             deleteTestTopic(topic);
         }
     }
@@ -1373,9 +1394,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         consumerProps.setProperty("queued.max.message.chunks", "1");
         consumerProps.putAll(secureProps);
 
-        FlinkKafkaConsumerBase<Tuple2<Long, byte[]>> source =
-                kafkaServer.getConsumer(topic, serSchema, consumerProps);
-        DataStreamSource<Tuple2<Long, byte[]>> consuming = env.addSource(source);
+        DataStreamSource<Tuple2<Long, byte[]>> consuming =
+                getStream(env, topic, serSchema, consumerProps);
 
         consuming.addSink(
                 new SinkFunction<Tuple2<Long, byte[]>>() {
@@ -1489,9 +1509,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        FlinkKafkaConsumerBase<Integer> kafkaSource = kafkaServer.getConsumer(topic, schema, props);
 
-        env.addSource(kafkaSource)
+        getStream(env, topic, schema, props)
                 .map(new PartitionValidatingMapper(parallelism, 1))
                 .map(new BrokerKillingMapper<Integer>(leaderId, failAfterElements))
                 .addSink(new ValidatingExactlyOnceSink(totalElements))
@@ -1560,8 +1579,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        DataStream<Tuple2<Long, PojoValue>> fromKafka =
-                env.addSource(kafkaServer.getConsumer(topic, readSchema, props));
+        DataStream<Tuple2<Long, PojoValue>> fromKafka = getStream(env, topic, readSchema, props);
         fromKafka.flatMap(
                 new RichFlatMapFunction<Tuple2<Long, PojoValue>, Object>() {
                     long counter = 0;
@@ -1652,8 +1670,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-        DataStream<Tuple2<byte[], PojoValue>> fromKafka =
-                env.addSource(kafkaServer.getConsumer(topic, schema, props));
+        DataStream<Tuple2<byte[], PojoValue>> fromKafka = getStream(env, topic, schema, props);
 
         fromKafka.flatMap(
                 new RichFlatMapFunction<Tuple2<byte[], PojoValue>, Object>() {
@@ -1696,11 +1713,9 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties props = new Properties();
         props.putAll(standardProps);
         props.putAll(secureProps);
-
         DataStream<Tuple2<Integer, Integer>> fromKafka =
-                env1.addSource(
-                        kafkaServer.getConsumer(
-                                topic, new FixedNumberDeserializationSchema(elementCount), props));
+                getStream(env1, topic, new FixedNumberDeserializationSchema(elementCount), props);
+
         fromKafka.flatMap(
                 new FlatMapFunction<Tuple2<Integer, Integer>, Void>() {
                     @Override
@@ -1807,7 +1822,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
                         env1.getConfig());
 
         DataStream<Tuple2<Integer, Integer>> fromKafka =
-                env1.addSource(kafkaServer.getConsumer(topic, schema, standardProps));
+                getStream(env1, topic, schema, standardProps);
         fromKafka.flatMap(
                 new FlatMapFunction<Tuple2<Integer, Integer>, Void>() {
                     @Override
@@ -2026,20 +2041,35 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
         // create the consumer
         cc.putAll(secureProps);
-        FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> consumer =
-                kafkaServer.getConsumer(topicName, deser, cc);
-        setKafkaConsumerOffset(startupMode, consumer, specificStartupOffsets, startupTimestamp);
+        DataStreamSource<Tuple2<Integer, Integer>> source;
+        if (useNewSource) {
+            KafkaSourceBuilder<Tuple2<Integer, Integer>> sourceBuilder =
+                    kafkaServer.getSourceBuilder(topicName, deser, cc);
+            Map<TopicPartition, Long> startOffsets = new HashMap<>();
+            if (specificStartupOffsets != null) {
+                specificStartupOffsets.forEach(
+                        (ktp, offset) ->
+                                startOffsets.put(
+                                        new TopicPartition(ktp.getTopic(), ktp.getPartition()),
+                                        offset));
+            }
+            setKafkaSourceOffset(startupMode, sourceBuilder, startOffsets, startupTimestamp);
+            source =
+                    env.fromSource(
+                            sourceBuilder.build(), WatermarkStrategy.noWatermarks(), "KafkaSource");
+        } else {
+            FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> consumer =
+                    kafkaServer.getConsumer(topicName, deser, cc);
+            setKafkaConsumerOffset(startupMode, consumer, specificStartupOffsets, startupTimestamp);
 
-        DataStream<Tuple2<Integer, Integer>> source =
-                env.addSource(consumer)
-                        .setParallelism(sourceParallelism)
-                        .map(new ThrottledMapper<Tuple2<Integer, Integer>>(20))
-                        .setParallelism(sourceParallelism);
+            source = env.addSource(consumer);
+        }
 
-        // verify data
-        source.flatMap(
+        source.setParallelism(sourceParallelism)
+                .map(new ThrottledMapper<>(20))
+                .setParallelism(sourceParallelism)
+                .flatMap(
                         new RichFlatMapFunction<Tuple2<Integer, Integer>, Integer>() {
-
                             private HashMap<Integer, BitSet> partitionsToValueCheck;
                             private int count = 0;
 
@@ -2163,6 +2193,33 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
                 break;
             case TIMESTAMP:
                 consumer.setStartFromTimestamp(startupTimestamp);
+                break;
+        }
+    }
+
+    protected void setKafkaSourceOffset(
+            final StartupMode startupMode,
+            final KafkaSourceBuilder<?> kafkaSourceBuilder,
+            final Map<TopicPartition, Long> specificStartupOffsets,
+            final Long startupTimestamp) {
+        switch (startupMode) {
+            case EARLIEST:
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.earliest());
+                break;
+            case LATEST:
+                kafkaSourceBuilder.setStartingOffsets(OffsetsInitializer.latest());
+                break;
+            case SPECIFIC_OFFSETS:
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.offsets(specificStartupOffsets));
+                break;
+            case GROUP_OFFSETS:
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.committedOffsets(OffsetResetStrategy.EARLIEST));
+                break;
+            case TIMESTAMP:
+                kafkaSourceBuilder.setStartingOffsets(
+                        OffsetsInitializer.timestamp(startupTimestamp));
                 break;
         }
     }
@@ -2390,11 +2447,24 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         Properties readProps = (Properties) standardProps.clone();
         readProps.setProperty("group.id", "flink-tests-validator");
         readProps.putAll(secureProps);
-        FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> consumer =
-                kafkaServer.getConsumer(topic, deserSchema, readProps);
-        consumer.setStartFromEarliest();
+        DataStreamSource<Tuple2<Integer, Integer>> dataStreamSource;
 
-        readEnv.addSource(consumer)
+        if (useNewSource) {
+            KafkaSource<Tuple2<Integer, Integer>> source =
+                    kafkaServer
+                            .getSourceBuilder(topic, deserSchema, readProps)
+                            .setStartingOffsets(OffsetsInitializer.earliest())
+                            .build();
+            dataStreamSource =
+                    readEnv.fromSource(source, WatermarkStrategy.noWatermarks(), "KafkaSource");
+        } else {
+            FlinkKafkaConsumerBase<Tuple2<Integer, Integer>> consumer =
+                    kafkaServer.getConsumer(topic, deserSchema, readProps);
+            consumer.setStartFromEarliest();
+            dataStreamSource = readEnv.addSource(consumer);
+        }
+
+        dataStreamSource
                 .map(
                         new RichMapFunction<Tuple2<Integer, Integer>, Tuple2<Integer, Integer>>() {
 
@@ -2462,6 +2532,54 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         waitUntilNoJobIsRunning(client);
 
         return success;
+    }
+
+    private <T> DataStreamSource<T> getStream(
+            StreamExecutionEnvironment env,
+            String topic,
+            DeserializationSchema<T> schema,
+            Properties props) {
+        return getStream(env, Collections.singletonList(topic), schema, props);
+    }
+
+    private <T> DataStreamSource<T> getStream(
+            StreamExecutionEnvironment env,
+            String topic,
+            KafkaDeserializationSchema<T> schema,
+            Properties props) {
+        return getStream(env, Collections.singletonList(topic), schema, props);
+    }
+
+    private <T> DataStreamSource<T> getStream(
+            StreamExecutionEnvironment env,
+            List<String> topics,
+            DeserializationSchema<T> schema,
+            Properties props) {
+        if (useNewSource) {
+            KafkaSource<T> kafkaSource =
+                    kafkaServer.getSourceBuilder(topics, schema, props).build();
+            return env.fromSource(kafkaSource, WatermarkStrategy.noWatermarks(), "KafkaSource");
+        } else {
+            FlinkKafkaConsumerBase<T> flinkKafkaConsumer =
+                    kafkaServer.getConsumer(topics, schema, props);
+            return env.addSource(flinkKafkaConsumer);
+        }
+    }
+
+    private <T> DataStreamSource<T> getStream(
+            StreamExecutionEnvironment env,
+            List<String> topics,
+            KafkaDeserializationSchema<T> schema,
+            Properties props) {
+        if (useNewSource) {
+            KafkaSource<T> kafkaSource =
+                    kafkaServer.getSourceBuilder(topics, schema, props).build();
+            return env.fromSource(kafkaSource, WatermarkStrategy.noWatermarks(), "KafkaSource");
+        } else {
+            FlinkKafkaConsumerBase<T> flinkKafkaConsumer =
+                    kafkaServer.getConsumer(topics, schema, props);
+            return env.addSource(flinkKafkaConsumer);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
 import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -147,6 +148,25 @@ public abstract class KafkaTestEnvironment {
     }
 
     public abstract <T> FlinkKafkaConsumerBase<T> getConsumer(
+            List<String> topics, KafkaDeserializationSchema<T> readSchema, Properties props);
+
+    public <T> KafkaSourceBuilder<T> getSourceBuilder(
+            List<String> topics, DeserializationSchema<T> deserializationSchema, Properties props) {
+        return getSourceBuilder(
+                topics, new KafkaDeserializationSchemaWrapper<T>(deserializationSchema), props);
+    }
+
+    public <T> KafkaSourceBuilder<T> getSourceBuilder(
+            String topic, KafkaDeserializationSchema<T> readSchema, Properties props) {
+        return getSourceBuilder(Collections.singletonList(topic), readSchema, props);
+    }
+
+    public <T> KafkaSourceBuilder<T> getSourceBuilder(
+            String topic, DeserializationSchema<T> deserializationSchema, Properties props) {
+        return getSourceBuilder(Collections.singletonList(topic), deserializationSchema, props);
+    }
+
+    public abstract <T> KafkaSourceBuilder<T> getSourceBuilder(
             List<String> topics, KafkaDeserializationSchema<T> readSchema, Properties props);
 
     public abstract <K, V> Collection<ConsumerRecord<K, V>> getAllRecordsFromTopic(

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -110,7 +110,7 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
     /**
      * Invoke the given callable periodically and handover the return value to the handler which
      * will be executed by the source coordinator. When this method is invoked multiple times, The
-     * <code>Coallble</code>s may be executed in a thread pool concurrently.
+     * <code>Callable</code>s may be executed in a thread pool concurrently.
      *
      * <p>It is important to make sure that the callable does not modify any shared state,
      * especially the states that will be a part of the {@link SplitEnumerator#snapshotState()}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -19,6 +19,7 @@ limitations under the License.
 package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -54,6 +55,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
@@ -94,6 +96,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     private final SourceCoordinatorProvider.CoordinatorExecutorThreadFactory
             coordinatorThreadFactory;
     private final String coordinatorThreadName;
+    private volatile boolean closed;
 
     public SourceCoordinatorContext(
             ExecutorService coordinatorExecutor,
@@ -103,18 +106,22 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
             SimpleVersionedSerializer<SplitT> splitSerializer) {
         this(
                 coordinatorExecutor,
+                Executors.newScheduledThreadPool(
+                        numWorkerThreads,
+                        new ExecutorThreadFactory(
+                                coordinatorThreadFactory.getCoordinatorThreadName() + "-worker")),
                 coordinatorThreadFactory,
-                numWorkerThreads,
                 operatorCoordinatorContext,
                 splitSerializer,
                 new SplitAssignmentTracker<>());
     }
 
     // Package private method for unit test.
+    @VisibleForTesting
     SourceCoordinatorContext(
             ExecutorService coordinatorExecutor,
+            ScheduledExecutorService workerExecutor,
             SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory,
-            int numWorkerThreads,
             OperatorCoordinator.Context operatorCoordinatorContext,
             SimpleVersionedSerializer<SplitT> splitSerializer,
             SplitAssignmentTracker<SplitT> splitAssignmentTracker) {
@@ -132,12 +139,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                                 new ThrowableCatchingRunnable(
                                         this::handleUncaughtExceptionFromAsyncCall, runnable));
 
-        this.notifier =
-                new ExecutorNotifier(
-                        Executors.newScheduledThreadPool(
-                                numWorkerThreads,
-                                new ExecutorThreadFactory(coordinatorThreadName + "-worker")),
-                        errorHandlingCoordinatorExecutor);
+        this.notifier = new ExecutorNotifier(workerExecutor, errorHandlingCoordinatorExecutor);
     }
 
     @Override
@@ -250,6 +252,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     @Override
     public void close() throws InterruptedException {
+        closed = true;
         notifier.close();
         coordinatorExecutor.shutdown();
         coordinatorExecutor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
@@ -267,6 +270,10 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     }
 
     void handleUncaughtExceptionFromAsyncCall(Throwable t) {
+        if (closed) {
+            return;
+        }
+
         ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
         LOG.error(
                 "Exception while handling result from async call in {}. Triggering job failover.",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumerator;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 
 import org.junit.After;
 import org.junit.Before;
@@ -65,8 +66,12 @@ public abstract class SourceCoordinatorTestBase {
         context =
                 new SourceCoordinatorContext<>(
                         coordinatorExecutor,
+                        Executors.newScheduledThreadPool(
+                                1,
+                                new ExecutorThreadFactory(
+                                        coordinatorThreadFactory.getCoordinatorThreadName()
+                                                + "-worker")),
                         coordinatorThreadFactory,
-                        1,
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),
                         splitSplitAssignmentTracker);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -351,7 +351,7 @@ public class StreamMultipleInputProcessorFactory {
                 WatermarkGauge inputWatermarkGauge,
                 MultiStreamStreamStatusTracker streamStatusTracker,
                 int inputIndex) {
-            super(chainedSourceOutput, streamStatusMaintainer, inputWatermarkGauge);
+            super(chainedSourceOutput, streamStatusMaintainer, new SimpleCounter(), inputWatermarkGauge);
             this.streamStatusTracker = streamStatusTracker;
             this.inputIndex = inputIndex;
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -351,7 +351,11 @@ public class StreamMultipleInputProcessorFactory {
                 WatermarkGauge inputWatermarkGauge,
                 MultiStreamStreamStatusTracker streamStatusTracker,
                 int inputIndex) {
-            super(chainedSourceOutput, streamStatusMaintainer, new SimpleCounter(), inputWatermarkGauge);
+            super(
+                    chainedSourceOutput,
+                    streamStatusMaintainer,
+                    new SimpleCounter(),
+                    inputWatermarkGauge);
             this.streamStatusTracker = streamStatusTracker;
             this.inputIndex = inputIndex;
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -21,10 +21,12 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
 import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
@@ -72,7 +74,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         // input processors
         sourceOperator.initReader();
 
-        final SourceReader<T, ?> sourceReader = mainOperator.getSourceReader();
+        final SourceReader<T, ?> sourceReader = sourceOperator.getSourceReader();
         final StreamTaskInput<T> input;
 
         if (sourceReader instanceof ExternallyInducedSourceReader) {
@@ -88,11 +90,19 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
             input = new StreamTaskSourceInput<>(sourceOperator, 0, 0);
         }
 
+        Counter numRecordsOut =
+                ((OperatorMetricGroup) sourceOperator.getMetricGroup())
+                        .getIOMetricGroup()
+                        .getNumRecordsOutCounter();
+
         // The SourceOperatorStreamTask doesn't have any inputs, so there is no need for
         // a WatermarkGauge on the input.
         output =
                 new AsyncDataOutputToOutput<>(
-                        operatorChain.getMainOperatorOutput(), getStreamStatusMaintainer(), null);
+                        operatorChain.getMainOperatorOutput(),
+                        getStreamStatusMaintainer(),
+                        numRecordsOut,
+                        null);
 
         inputProcessor = new StreamOneInputProcessor<>(input, output, operatorChain);
     }
@@ -144,20 +154,24 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
     public static class AsyncDataOutputToOutput<T> extends AbstractDataOutput<T> {
 
         private final Output<StreamRecord<T>> output;
+        private final Counter numRecordsOut;
         @Nullable private final WatermarkGauge inputWatermarkGauge;
 
         public AsyncDataOutputToOutput(
                 Output<StreamRecord<T>> output,
                 StreamStatusMaintainer streamStatusMaintainer,
+                Counter numRecordsOut,
                 @Nullable WatermarkGauge inputWatermarkGauge) {
             super(streamStatusMaintainer);
 
             this.output = checkNotNull(output);
+            this.numRecordsOut = numRecordsOut;
             this.inputWatermarkGauge = inputWatermarkGauge;
         }
 
         @Override
         public void emitRecord(StreamRecord<T> streamRecord) {
+            numRecordsOut.inc();
             output.collect(streamRecord);
         }
 


### PR DESCRIPTION
This PR is co-authored with @becketqin.

## What is the purpose of the change

This PR fixed a few bugs related to `KafkaSource`. See "Brief change log" for the list of bug fixes made in this PR.

## Brief change log

Bug fixes:
- `KafkaSourceReader` should not commit offsets for partitions whose offsets have not been initialized.
- `SourceCoordinatorContext` should not log and fail job again if it receives InterruptedException after it is closed.
- `PartitionOffsetsRetrieverImpl.committedOffsets()` should handle the case without committed offsets.
- `SourceOperatorStreamTask` should check the committed offset first before using OffsetResetStrategy.

Usability improvements:
- Reduce the offset commit logging verbosity from INFO to DEBUG.
- `SourceOperatorStreamTask` should update the numRecordsOutCount metric
- `KafkaSourceEnumerator` should close the admin client early if periodic partition discovery is disabled.
- Remove the unused `close.timeout.ms` config.
- Remove duplicated warning related to the partition.discovery.interval.ms default value.

Tests:
- Added IT cases for KafkaSource by migrating IT cases from FlinkKafkaConsumer.

## Verifying this change

The following bug-fix related commits are verified with new tests added in the same commit:
- Every commit which fixes a bug comes with a new unit test to verify the bug fix
- `KafkaSourceReader` should not commit offsets for partitions whose offsets have not been initialized
- `SourceCoordinatorContext` should not log and fail job again if it receives InterruptedException after it is closed.
- `PartitionOffsetsRetrieverImpl.committedOffsets()` should handle the case without committed offsets
- `SourceOperatorStreamTask` should check the committed offset first before using OffsetResetStrategy
- Auto offset commit should be disabled by default

The "Auto offset commit should be disabled by default" commit is trivial and no test needs to be added.

Verified that the numRecordsOutCount metric has reasonable value in the WebUI.

In addition, this PR added tests in `KafkaSourceITCase` to provide better coverage for KafkaSource.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)