### PR TITLE
[FLINK-16829] Refactored Prometheus Metric Reporters to Use Constructor Initialization

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -56,42 +56,41 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
     private boolean deleteOnShutdown;
     private Map<String, String> groupingKey;
 
-    @Override
-    public void open(MetricConfig config) {
-        super.open(config);
+    PrometheusPushGatewayReporter(
+        @Nullable final String hostConfig,
+        @Nullable final int portConfig,
+        @Nullable final String jobNameConfig,
+        @Nullable final boolean randomJobSuffixConfig,
+        @Nullable final boolean deleteOnShutdownConfig,
+        @Nullable final Map<String, String> groupingKeyConfig
+    ) {
+        deleteOnShutdown = deleteOnShutdownConfig
+        groupingKey = parseGroupingKey(groupingKeyConfig)
 
-        String host = config.getString(HOST.key(), HOST.defaultValue());
-        int port = config.getInteger(PORT.key(), PORT.defaultValue());
-        String configuredJobName = config.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
-        boolean randomSuffix =
-                config.getBoolean(
-                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
-        deleteOnShutdown =
-                config.getBoolean(DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
-        groupingKey =
-                parseGroupingKey(config.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
-
-        if (host == null || host.isEmpty() || port < 1) {
+        if (hostConfig == null || hostConfig.isEmpty() || portConfig < 1) {
             throw new IllegalArgumentException(
-                    "Invalid host/port configuration. Host: " + host + " Port: " + port);
+                    "Invalid host/port configuration. Host: " + hostConfig + " Port: " + portConfig);
         }
 
-        if (randomSuffix) {
-            this.jobName = configuredJobName + new AbstractID();
+        if (randomJobSuffixConfig) {
+            this.jobName = jobNameConfig + new AbstractID();
         } else {
-            this.jobName = configuredJobName;
+            this.jobName = jobNameConfig;
         }
 
-        pushGateway = new PushGateway(host + ':' + port);
+        pushGateway = new PushGateway(hostConfig + ':' + portConfig);
         log.info(
                 "Configured PrometheusPushGatewayReporter with {host:{}, port:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
-                host,
-                port,
-                jobName,
-                randomSuffix,
+                hostConfig,
+                portConfig,
+                jobNameConfig,
+                randomJobSuffixConfig,
                 deleteOnShutdown,
                 groupingKey);
     }
+
+    @Override
+    public void open(MetricConfig config) { }
 
     Map<String, String> parseGroupingKey(final String groupingKeyConfig) {
         if (!groupingKeyConfig.isEmpty()) {

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -22,6 +22,13 @@ import org.apache.flink.metrics.reporter.MetricReporterFactory;
 
 import java.util.Properties;
 
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.DELETE_ON_SHUTDOWN;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.JOB_NAME;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PORT;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
+
 /** {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}. */
 @InterceptInstantiationViaReflection(
         reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter")
@@ -29,6 +36,24 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
 
     @Override
     public PrometheusPushGatewayReporter createMetricReporter(Properties properties) {
-        return new PrometheusPushGatewayReporter();
+        String hostConfig = properties.getString(HOST.key(), HOST.defaultValue());
+        int portConfig = properties.getInteger(PORT.key(), PORT.defaultValue());
+        String jobNameConfig = properties.getString(JOB_NAME.key(), JOB_NAME.defaultValue())
+        boolean randomJobSuffixConfig =
+                config.getBoolean(
+                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
+        boolean deleteOnShutdownConfig =
+                config.getBoolean(DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
+        Map<String, String> groupingKeyConfig =
+                parseGroupingKey(config.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
+
+        return new PrometheusPushGatewayReporter(
+            hostConfig,
+            portConfig,
+            jobNameConfig,
+            randomJobSuffixConfig,
+            deleteOnShutdownConfig,
+            groupingKeyConfig
+        );
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -38,9 +38,6 @@ import java.util.Iterator;
         factoryClassName = "org.apache.flink.metrics.prometheus.PrometheusReporterFactory")
 public class PrometheusReporter extends AbstractPrometheusReporter {
 
-    static final String ARG_PORT = "port";
-    private static final String DEFAULT_PORT = "9249";
-
     private HTTPServer httpServer;
     private int port;
 
@@ -50,11 +47,7 @@ public class PrometheusReporter extends AbstractPrometheusReporter {
         return port;
     }
 
-    @Override
-    public void open(MetricConfig config) {
-        super.open(config);
-
-        String portsConfig = config.getString(ARG_PORT, DEFAULT_PORT);
+    PrometheusReporter(@Nullable final String portsConfig) {
         Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
 
         while (ports.hasNext()) {
@@ -75,6 +68,9 @@ public class PrometheusReporter extends AbstractPrometheusReporter {
                             + portsConfig);
         }
     }
+
+    @Override
+    public void open(MetricConfig config) { }
 
     @Override
     public void close() {

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
@@ -27,8 +27,12 @@ import java.util.Properties;
         reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusReporter")
 public class PrometheusReporterFactory implements MetricReporterFactory {
 
+    static final String ARG_PORT = "port";
+    private static final String DEFAULT_PORT = "9249";
+
     @Override
     public PrometheusReporter createMetricReporter(Properties properties) {
-        return new PrometheusReporter();
+        String portsConfig = properties.getString(ARG_PORT, DEFAULT_PORT);
+        return new PrometheusReporter(portsConfig);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Clean-up for the initialization of the two Prometheus Metric Reporters (`PrometheusReporter` and `PrometheusPushGatewayReporter`) by explicitly passing in arguments to the constructors as opposed to relying on resolving these values via the internal configuration properties.

## Brief change log

- Removed argument resolution against defaults from the `open()` functions and instead resolved those within the factories and passed them into the respective reporter instances (roughly modeled after the `JmxReporter` implementation)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
