### PR TITLE
[FLINK-21610][tests] Do not attempt to cancel the job

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -243,7 +243,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                 null);
     }
 
-    private void printOutput(String processName, String logContents) {
+    private static void printOutput(String processName, String logContents) {
         if (logContents == null || logContents.length() == 0) {
             return;
         }
@@ -251,7 +251,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
         System.out.println("-----------------------------------------");
         System.out.println(" BEGIN SPAWNED PROCESS LOG FOR " + processName);
         System.out.println("-----------------------------------------");
-        System.out.println(log);
+        System.out.println(logContents);
         System.out.println("-----------------------------------------");
         System.out.println("		END SPAWNED PROCESS LOG");
         System.out.println("-----------------------------------------");

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -233,10 +233,14 @@ public class ProcessFailureCancelingITCase extends TestLogger {
             assertTrue(error instanceof ProgramInvocationException);
             // all seems well :-)
         } catch (Exception e) {
-            printProcessLog("TaskManager", taskManagerProcess.getErrorOutput().toString());
+            if (taskManagerProcess != null) {
+                printProcessLog("TaskManager", taskManagerProcess.getErrorOutput().toString());
+            }
             throw e;
         } catch (Error e) {
-            printProcessLog("TaskManager 1", taskManagerProcess.getErrorOutput().toString());
+            if (taskManagerProcess != null) {
+                printProcessLog("TaskManager 1", taskManagerProcess.getErrorOutput().toString());
+            }
             throw e;
         } finally {
             if (taskManagerProcess != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -204,14 +204,9 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
             assertTrue(error instanceof ProgramInvocationException);
             // all seems well :-)
-        } catch (Exception e) {
+        } catch (Exception | Error e) {
             if (taskManagerProcess != null) {
                 printProcessLog("TaskManager", taskManagerProcess.getErrorOutput().toString());
-            }
-            throw e;
-        } catch (Error e) {
-            if (taskManagerProcess != null) {
-                printProcessLog("TaskManager 1", taskManagerProcess.getErrorOutput().toString());
             }
             throw e;
         } finally {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -210,14 +210,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
             final Collection<JobID> jobIds = waitForRunningJobs(clusterClient, timeout);
 
             assertThat(jobIds, hasSize(1));
-            final JobID jobId = jobIds.iterator().next();
 
             // kill the TaskManager after the job started to run
             taskManagerProcess.destroy();
             taskManagerProcess = null;
-
-            // try to cancel the job
-            clusterClient.cancel(jobId).get();
 
             // we should see a failure within reasonable time (10s is the ask timeout).
             // since the CI environment is often slow, we conservatively give it up to 2 minutes,

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -79,7 +79,7 @@ import static org.junit.Assert.assertTrue;
 public class ProcessFailureCancelingITCase extends TestLogger {
 
     private static final String TASK_DEPLOYED_MARKER = "deployed";
-    private static final Duration TIMEOUT = Duration.ofMinutes(1);
+    private static final Duration TIMEOUT = Duration.ofMinutes(2);
 
     @Rule public final BlobServerResource blobServerResource = new BlobServerResource();
 


### PR DESCRIPTION
The cancellation of the job may fail if the job termination finishes so quickly that the job has been cleaned up before the cancellation has been processed.
The cancellation is unnecessary anyway because the TM failure causes the job to fail and we explicitly forbid restarts.
As such we can just remove the cancel call.