### PR TITLE
[FLINK-21558][coordination] Skip check if slotreport indicates no change

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -355,8 +355,9 @@ public class DeclarativeSlotManager implements SlotManager {
         LOG.debug("Received slot report from instance {}: {}.", instanceId, slotReport);
 
         if (taskExecutorManager.isTaskManagerRegistered(instanceId)) {
-            slotTracker.notifySlotStatus(slotReport);
-            checkResourceRequirements();
+            if (slotTracker.notifySlotStatus(slotReport)) {
+                checkResourceRequirements();
+            }
             return true;
         } else {
             LOG.debug(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotTracker.java
@@ -89,8 +89,9 @@ interface SlotTracker {
      * Notifies the tracker about the slot statuses.
      *
      * @param slotStatuses slot statues
+     * @return whether any slot status has changed
      */
-    void notifySlotStatus(Iterable<SlotStatus> slotStatuses);
+    boolean notifySlotStatus(Iterable<SlotStatus> slotStatuses);
 
     /**
      * Returns a view over free slots. The returned collection cannot be modified directly, but

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -1200,6 +1200,11 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             assertThat(
                     notification.f1,
                     hasItem(ResourceRequirement.create(ResourceProfile.ANY, numExistingSlots)));
+
+            // another slot report that does not indicate any changes should not trigger another
+            // notification
+            slotManager.reportSlotStatus(taskExecutionConnection.getInstanceID(), slotReport);
+            assertThat(notEnoughResourceNotifications, hasSize(1));
         }
     }
 


### PR DESCRIPTION
Skips unnecessary resource checks if a slot report was received but no change in the set of resources was determined.
This is a performance optimization and results in less noise in the logs.