### PR TITLE
[FLINK-21651][sql-client] Migrate module related tests in LocalExecutorITCase to the new integration test framework

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -37,7 +37,6 @@ import org.apache.flink.table.client.gateway.local.result.DynamicResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.module.ModuleEntry;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
@@ -264,20 +263,6 @@ public class LocalExecutor implements Executor {
     @Override
     public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
         cancelQueryInternal(resultId);
-    }
-
-    @VisibleForTesting
-    List<String> listModules(String sessionId) throws SqlExecutionException {
-        final ExecutionContext context = getExecutionContext(sessionId);
-        final TableEnvironment tableEnv = context.getTableEnvironment();
-        return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listModules()));
-    }
-
-    @VisibleForTesting
-    List<ModuleEntry> listFullModules(String sessionId) throws SqlExecutionException {
-        final ExecutionContext context = getExecutionContext(sessionId);
-        final TableEnvironment tableEnv = context.getTableEnvironment();
-        return context.wrapClassLoader(() -> Arrays.asList(tableEnv.listFullModules()));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -27,23 +27,18 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.ExecutionEntry;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
-import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.client.gateway.context.DefaultContext;
 import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
 import org.apache.flink.table.client.gateway.utils.SimpleCatalogFactory;
 import org.apache.flink.table.client.gateway.utils.TestUserClassLoaderJar;
 import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.module.ModuleEntry;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
@@ -51,7 +46,6 @@ import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Matcher;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -77,11 +71,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
-import static org.apache.flink.table.client.gateway.context.ExecutionContextTest.MODULES_ENVIRONMENT_FILE;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -496,236 +487,6 @@ public class LocalExecutorITCase extends TestLogger {
         }
     }
 
-    @Test
-    public void testLoadModuleWithModuleConfEnabled() throws Exception {
-        // only blink planner supports LOAD MODULE syntax
-        Assume.assumeTrue(planner.equals("blink"));
-        final LocalExecutor executor =
-                createLocalExecutor(
-                        createModifiedEnvironment(
-                                MODULES_ENVIRONMENT_FILE, createModuleReplaceVars()),
-                        udfDependency);
-        String sessionId = executor.openSession("test-session");
-        assertEquals("test-session", sessionId);
-
-        assertThrows(
-                "Could not execute statement: load module core",
-                SqlExecutionException.class,
-                () -> executor.executeSql(sessionId, "load module core"));
-
-        executor.executeSql(sessionId, "load module hive");
-        assertEquals(
-                executor.listModules(sessionId),
-                Arrays.asList("core", "mymodule", "myhive", "myhive2", "hive"));
-    }
-
-    @Test
-    public void testUnloadModuleWithModuleConfEnabled() throws Exception {
-        // only blink planner supports UNLOAD MODULE syntax
-        Assume.assumeTrue(planner.equals("blink"));
-        final LocalExecutor executor =
-                createLocalExecutor(
-                        createModifiedEnvironment(
-                                MODULES_ENVIRONMENT_FILE, createModuleReplaceVars()),
-                        Collections.emptyList());
-        String sessionId = executor.openSession("test-session");
-        assertEquals("test-session", sessionId);
-
-        executor.executeSql(sessionId, "unload module mymodule");
-        assertEquals(executor.listModules(sessionId), Arrays.asList("core", "myhive", "myhive2"));
-
-        exception.expect(SqlExecutionException.class);
-        exception.expectMessage("Could not execute statement: unload module mymodule");
-        executor.executeSql(sessionId, "unload module mymodule");
-    }
-
-    @Test
-    public void testHiveBuiltInFunctionWithHiveModuleEnabled() throws Exception {
-        // only blink planner supports LOAD MODULE syntax
-        Assume.assumeTrue(planner.equals("blink"));
-
-        final URL url = getClass().getClassLoader().getResource("test-data.csv");
-        Objects.requireNonNull(url);
-        final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", planner);
-        replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
-        replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-        replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-        replaceVars.put("$VAR_MAX_ROWS", "100");
-        replaceVars.put("$VAR_RESULT_MODE", "table");
-
-        final LocalExecutor executor =
-                createLocalExecutor(
-                        createModifiedEnvironment(replaceVars), Collections.emptyList());
-        String sessionId = executor.openSession("test-session");
-        assertEquals("test-session", sessionId);
-
-        // cannot use hive built-in function without loading hive module
-        assertThrows(
-                "Could not execute statement: select substring_index('www.apache.org', '.', 2) from TableNumber1",
-                SqlExecutionException.class,
-                () ->
-                        executor.executeSql(
-                                sessionId,
-                                "select substring_index('www.apache.org', '.', 2) from TableNumber1"));
-
-        executor.executeSql(sessionId, "load module hive");
-        assertEquals(executor.listModules(sessionId), Arrays.asList("core", "hive"));
-
-        assertShowResult(
-                executor.executeSql(
-                        sessionId,
-                        "select substring_index('www.apache.org', '.', 2) from TableNumber1"),
-                hasItems("www.apache"));
-    }
-
-    @Test
-    public void testUseModulesWithModuleConfEnabled() throws Exception {
-        // only blink planner supports USE MODULES syntax
-        Assume.assumeTrue(planner.equals("blink"));
-        final LocalExecutor executor =
-                createLocalExecutor(
-                        createModifiedEnvironment(
-                                MODULES_ENVIRONMENT_FILE, createModuleReplaceVars()),
-                        Collections.emptyList());
-        String sessionId = executor.openSession("test-session");
-        assertEquals("test-session", sessionId);
-        assertEquals(
-                executor.listModules(sessionId),
-                Arrays.asList("core", "mymodule", "myhive", "myhive2"));
-        assertEquals(
-                executor.listFullModules(sessionId),
-                Arrays.asList(
-                        new ModuleEntry("core", true),
-                        new ModuleEntry("mymodule", true),
-                        new ModuleEntry("myhive", true),
-                        new ModuleEntry("myhive2", true)));
-
-        // change resolution order
-        executor.executeSql(sessionId, "use modules myhive2, core, mymodule, myhive");
-        assertEquals(
-                executor.listModules(sessionId),
-                Arrays.asList("myhive2", "core", "mymodule", "myhive"));
-        assertEquals(
-                executor.listFullModules(sessionId),
-                Arrays.asList(
-                        new ModuleEntry("myhive2", true),
-                        new ModuleEntry("core", true),
-                        new ModuleEntry("mymodule", true),
-                        new ModuleEntry("myhive", true)));
-
-        // disable modules by not using
-        executor.executeSql(sessionId, "use modules core, myhive");
-        assertEquals(executor.listModules(sessionId), Arrays.asList("core", "myhive"));
-        assertEquals(
-                executor.listFullModules(sessionId),
-                Arrays.asList(
-                        new ModuleEntry("core", true),
-                        new ModuleEntry("myhive", true),
-                        new ModuleEntry("mymodule", false),
-                        new ModuleEntry("myhive2", false)));
-
-        // use duplicate module names
-        assertThrows(
-                "Could not execute statement: use modules core, myhive, core",
-                SqlExecutionException.class,
-                () -> executor.executeSql(sessionId, "use modules core, myhive, core"));
-
-        // use non-existed module name
-        assertThrows(
-                "Could not execute statement: use modules core, dummy",
-                SqlExecutionException.class,
-                () -> executor.executeSql(sessionId, "use modules core, dummy"));
-    }
-
-    @Test
-    public void testHiveBuiltInFunctionWithoutUsingHiveModule() throws Exception {
-        // only blink planner supports USE MODULES syntax
-        Assume.assumeTrue(planner.equals("blink"));
-
-        final URL url = getClass().getClassLoader().getResource("test-data.csv");
-        Objects.requireNonNull(url);
-        final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", planner);
-        replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
-        replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-        replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-        replaceVars.put("$VAR_MAX_ROWS", "100");
-        replaceVars.put("$VAR_RESULT_MODE", "table");
-
-        final LocalExecutor executor =
-                createLocalExecutor(
-                        createModifiedEnvironment(replaceVars), Collections.emptyList());
-        String sessionId = executor.openSession("test-session");
-        assertEquals("test-session", sessionId);
-
-        executor.executeSql(sessionId, "load module hive");
-        assertEquals(executor.listModules(sessionId), Arrays.asList("core", "hive"));
-        assertEquals(
-                executor.listFullModules(sessionId),
-                Arrays.asList(new ModuleEntry("core", true), new ModuleEntry("hive", true)));
-
-        assertShowResult(
-                executor.executeSql(
-                        sessionId,
-                        "select substring_index('www.apache.org', '.', 2) from TableNumber1"),
-                hasItems("www.apache"));
-
-        // cannot use hive built-in function without using hive module
-        executor.executeSql(sessionId, "use modules core");
-        assertEquals(executor.listModules(sessionId), Collections.singletonList("core"));
-        assertEquals(
-                executor.listFullModules(sessionId),
-                Arrays.asList(new ModuleEntry("core", true), new ModuleEntry("hive", false)));
-        assertThrows(
-                "Could not execute statement: select substring_index('www.apache.org', '.', 2) from TableNumber1",
-                SqlExecutionException.class,
-                () ->
-                        executor.executeSql(
-                                sessionId,
-                                "select substring_index('www.apache.org', '.', 2) from TableNumber1"));
-    }
-
-    @Test
-    public void testShowModules() throws Exception {
-        // only blink planner supports SHOW [FULL] MODULES syntax
-        Assume.assumeTrue(planner.equals("blink"));
-
-        final LocalExecutor executor =
-                createLocalExecutor(
-                        createModifiedEnvironment(
-                                MODULES_ENVIRONMENT_FILE, createModuleReplaceVars()),
-                        Collections.emptyList());
-        String sessionId = executor.openSession("test-session");
-        assertEquals("test-session", sessionId);
-
-        verifyShowModules(
-                executor,
-                sessionId,
-                Arrays.asList(
-                        Row.of("core", true),
-                        Row.of("mymodule", true),
-                        Row.of("myhive", true),
-                        Row.of("myhive2", true)));
-
-        // check result after using modules
-        executor.executeSql(sessionId, "USE MODULES mymodule, core");
-        verifyShowModules(
-                executor,
-                sessionId,
-                Arrays.asList(
-                        Row.of("mymodule", true),
-                        Row.of("core", true),
-                        Row.of("myhive", false),
-                        Row.of("myhive2", false)));
-
-        // check result after unloading modules
-        executor.executeSql(sessionId, "UNLOAD MODULE mymodule");
-        executor.executeSql(sessionId, "UNLOAD MODULE myhive2");
-        verifyShowModules(
-                executor, sessionId, Arrays.asList(Row.of("core", true), Row.of("myhive", false)));
-    }
-
     // --------------------------------------------------------------------------------------------
     // Helper method
     // --------------------------------------------------------------------------------------------
@@ -874,38 +635,6 @@ public class LocalExecutorITCase extends TestLogger {
             }
         }
         return actualResults;
-    }
-
-    private static TableSchema getShowModulesTableSchema(boolean requireFull) {
-        return TableSchema.builder()
-                .fields(
-                        requireFull
-                                ? new String[] {"module name", "used"}
-                                : new String[] {"module name"},
-                        requireFull
-                                ? new DataType[] {DataTypes.STRING(), DataTypes.BOOLEAN()}
-                                : new DataType[] {DataTypes.STRING()})
-                .build();
-    }
-
-    private void verifyShowModules(
-            LocalExecutor executor, String sessionId, List<Row> rowOfEntries) {
-        TableSchema showModulesTableSchema = getShowModulesTableSchema(false);
-        TableSchema showFullModulesTableSchema = getShowModulesTableSchema(true);
-        List<Row> rowOfNames =
-                rowOfEntries.stream()
-                        .filter(row -> row.getFieldAs(1))
-                        .map(row -> Row.project(row, new int[] {0}))
-                        .collect(Collectors.toList());
-
-        TableResult showModules = executor.executeSql(sessionId, "SHOW MODULES");
-        TableResult showFullModules = executor.executeSql(sessionId, "SHOW FULL MODULES");
-
-        assertEquals(showModulesTableSchema, showModules.getTableSchema());
-        assertEquals(showFullModulesTableSchema, showFullModules.getTableSchema());
-
-        assertEquals(rowOfNames, CollectionUtil.iteratorToList(showModules.collect()));
-        assertEquals(rowOfEntries, CollectionUtil.iteratorToList(showFullModules.collect()));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -42,10 +42,8 @@ import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.TestLogger;
 
-import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -71,11 +69,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /** Contains basic tests for the {@link LocalExecutor}. */
@@ -502,16 +498,6 @@ public class LocalExecutorITCase extends TestLogger {
         return new LocalExecutor(defaultContext);
     }
 
-    private Map<String, String> createModuleReplaceVars() {
-        Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", "blink");
-        replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
-        replaceVars.put("$VAR_RESULT_MODE", "changelog");
-        replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
-        replaceVars.put("$VAR_MAX_ROWS", "100");
-        return replaceVars;
-    }
-
     private void executeStreamQueryTable(
             Map<String, String> replaceVars, String query, List<String> expectedResults)
             throws Exception {
@@ -537,14 +523,6 @@ public class LocalExecutorITCase extends TestLogger {
         } finally {
             executor.closeSession(sessionId);
         }
-    }
-
-    private void assertShowResult(TableResult showResult, Matcher<Iterable<String>> matcher) {
-        List<String> actual =
-                CollectionUtil.iteratorToList(showResult.collect()).stream()
-                        .map(r -> checkNotNull(r.getField(0)).toString())
-                        .collect(Collectors.toList());
-        assertThat(actual, matcher);
     }
 
     private void verifySinkResult(String path) throws IOException {

--- a/flink-table/flink-sql-client/src/test/resources/sql/module.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/module.q
@@ -1,0 +1,205 @@
+# module.q - LOAD/UNLOAD MODULE, USE/LIST/LIST FULL MODULES
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set tableau result mode
+SET execution.result-mode = tableau;
+[INFO] Session property has been set.
+!info
+
+# ==========================================================================
+# test load module
+# ==========================================================================
+
+# load core module twice
+LOAD MODULE core;
+[ERROR] Could not execute SQL statement. Load module failed! Reason:
+org.apache.flink.table.api.ValidationException: A module with name 'core' already exists
+!error
+
+# use hive built-in function without loading hive module
+SELECT SUBSTRING_INDEX('www.apache.org', '.', 2) FROM (VALUES (1, 'Hello World')) AS T(id, str);
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.calcite.sql.validate.SqlValidatorException: No match found for function signature SUBSTRING_INDEX(<CHARACTER>, <CHARACTER>, <NUMERIC>)
+!error
+
+# load hive module with module name as string literal
+LOAD MODULE 'hive';
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.sql.parser.impl.ParseException: Encountered "\'hive\'" at line 1, column 13.
+Was expecting one of:
+    <BRACKET_QUOTED_IDENTIFIER> ...
+    <QUOTED_IDENTIFIER> ...
+    <BACK_QUOTED_IDENTIFIER> ...
+    <HYPHENATED_IDENTIFIER> ...
+    <IDENTIFIER> ...
+    <UNICODE_QUOTED_IDENTIFIER> ...
+
+!error
+
+# load hive module with module name capitalized
+LOAD MODULE Hive;
+[ERROR] Could not execute SQL statement. Load module failed! Reason:
+org.apache.flink.table.api.NoMatchingTableFactoryException: Could not find a suitable table factory for 'org.apache.flink.table.factories.ModuleFactory' in
+the classpath.
+
+Reason: Required context properties mismatch.
+
+The following properties are requested:
+type=Hive
+
+The following factories have been considered:
+org.apache.flink.table.client.gateway.local.DependencyTest$TestModuleFactory
+org.apache.flink.table.module.CoreModuleFactory
+org.apache.flink.table.module.hive.HiveModuleFactory
+!error
+
+# load hive module with specifying type
+LOAD MODULE myhive WITH ('type' = 'hive');
+[ERROR] Could not execute SQL statement. Load module failed! Reason:
+org.apache.flink.table.api.ValidationException: Property 'type' = 'hive' is not supported since module name is used to find module
+!error
+
+LOAD MODULE hive;
+[INFO] Load module succeeded!
+!info
+
+# show enabled modules
+SHOW MODULES;
++-------------+
+| module name |
++-------------+
+|        core |
+|        hive |
++-------------+
+2 rows in set
+!ok
+
+# show all loaded modules
+SHOW FULL MODULES;
++-------------+------+
+| module name | used |
++-------------+------+
+|        core | true |
+|        hive | true |
++-------------+------+
+2 rows in set
+!ok
+
+# use hive built-in function after loading hive module
+SELECT SUBSTRING_INDEX('www.apache.org', '.', 2) FROM (VALUES (1, 'Hello World')) AS T(id, str);
++----+----------------------+
+| op |               EXPR$0 |
++----+----------------------+
+| +I |           www.apache |
++----+----------------------+
+Received a total of 1 row
+!ok
+
+# ==========================================================================
+# test use modules
+# ==========================================================================
+
+# use duplicate modules
+USE MODULES hive, core, hive;
+[ERROR] Could not execute SQL statement. Use modules failed! Reason:
+org.apache.flink.table.api.ValidationException: Module 'hive' appears more than once
+!error
+
+# change module resolution order
+USE MODULES hive, core;
+[INFO] Use modules succeeded!
+!info
+
+SHOW MODULES;
++-------------+
+| module name |
++-------------+
+|        hive |
+|        core |
++-------------+
+2 rows in set
+!ok
+
+SHOW FULL MODULES;
++-------------+------+
+| module name | used |
++-------------+------+
+|        hive | true |
+|        core | true |
++-------------+------+
+2 rows in set
+!ok
+
+# disable hive module
+USE MODULES core;
+[INFO] Use modules succeeded!
+!info
+
+SHOW MODULES;
++-------------+
+| module name |
++-------------+
+|        core |
++-------------+
+1 row in set
+!ok
+
+SHOW FULL MODULES;
++-------------+-------+
+| module name |  used |
++-------------+-------+
+|        core |  true |
+|        hive | false |
++-------------+-------+
+2 rows in set
+!ok
+
+# use hive built-in function without using hive module
+SELECT SUBSTRING_INDEX('www.apache.org', '.', 2) FROM (VALUES (1, 'Hello World')) AS T(id, str);
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.calcite.sql.validate.SqlValidatorException: No match found for function signature SUBSTRING_INDEX(<CHARACTER>, <CHARACTER>, <NUMERIC>)
+!error
+
+# ==========================================================================
+# test unload module
+# ==========================================================================
+
+UNLOAD MODULE core;
+[INFO] Unload module succeeded!
+!info
+
+SHOW MODULES;
++-------------+
+| module name |
++-------------+
+0 row in set
+!ok
+
+SHOW FULL MODULES;
++-------------+-------+
+| module name |  used |
++-------------+-------+
+|        hive | false |
++-------------+-------+
+1 row in set
+!ok
+
+# unload core module twice
+UNLOAD MODULE core;
+[ERROR] Could not execute SQL statement. Unload module failed! Reason:
+org.apache.flink.table.api.ValidationException: No module with name 'core' exists
+!error


### PR DESCRIPTION
## Brief change log

This PR migrates the tests in`LocalExecutorITCase` to `CliClientITCase`, and removes `#listModules` and `#listFullModules` in `LocalExecutor` since they are not needed anymore.


## Verifying this change

This change added  a `module.q` script under `test/resources/sql/` dir and can be verified by running `CliClientITCase`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
