### PR TITLE
[FLINK-16829] Refactored Prometheus Metric Reporters to use construct…

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -28,8 +28,6 @@ import org.apache.flink.util.Preconditions;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.Map;
 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -48,12 +48,13 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
     private final boolean deleteOnShutdown;
 
     PrometheusPushGatewayReporter(
-        @Nullable PushGateway pushGateway,
-        @Nullable String jobName,
-        @Nullable Map<String, String> groupingKey,
+        String host,
+        int port,
+        String jobName,
+        Map<String, String> groupingKey,
         final boolean deleteOnShutdown
         ) {
-        this.pushGateway = Preconditions.checkNotNull(pushGateway);
+        this.pushGateway = new PushGateway(host + ':' + port);
         this.jobName = Preconditions.checkNotNull(jobName);
         this.groupingKey = Preconditions.checkNotNull(groupingKey);
         this.deleteOnShutdown = deleteOnShutdown;

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -46,12 +46,11 @@ public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter im
     private final boolean deleteOnShutdown;
 
     PrometheusPushGatewayReporter(
-        String host,
-        int port,
-        String jobName,
-        Map<String, String> groupingKey,
-        final boolean deleteOnShutdown
-        ) {
+            String host,
+            int port,
+            String jobName,
+            Map<String, String> groupingKey,
+            final boolean deleteOnShutdown) {
         this.pushGateway = new PushGateway(host + ':' + port);
         this.jobName = Preconditions.checkNotNull(jobName);
         this.groupingKey = Preconditions.checkNotNull(groupingKey);

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporter.java
@@ -20,27 +20,18 @@ package org.apache.flink.metrics.prometheus;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.Metric;
-import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
-import org.apache.flink.util.AbstractID;
-import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.Preconditions;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import javax.annotation.Nullable;
 
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.DELETE_ON_SHUTDOWN;
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST;
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.JOB_NAME;
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PORT;
-import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus {@link PushGateway}.
@@ -51,75 +42,21 @@ import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterO
                 "org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterFactory")
 public class PrometheusPushGatewayReporter extends AbstractPrometheusReporter implements Scheduled {
 
-    private PushGateway pushGateway;
-    private String jobName;
-    private boolean deleteOnShutdown;
-    private Map<String, String> groupingKey;
+    private final PushGateway pushGateway;
+    private final String jobName;
+    private final Map<String, String> groupingKey;
+    private final boolean deleteOnShutdown;
 
-    @Override
-    public void open(MetricConfig config) {
-        super.open(config);
-
-        String host = config.getString(HOST.key(), HOST.defaultValue());
-        int port = config.getInteger(PORT.key(), PORT.defaultValue());
-        String configuredJobName = config.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
-        boolean randomSuffix =
-                config.getBoolean(
-                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
-        deleteOnShutdown =
-                config.getBoolean(DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
-        groupingKey =
-                parseGroupingKey(config.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
-
-        if (host == null || host.isEmpty() || port < 1) {
-            throw new IllegalArgumentException(
-                    "Invalid host/port configuration. Host: " + host + " Port: " + port);
-        }
-
-        if (randomSuffix) {
-            this.jobName = configuredJobName + new AbstractID();
-        } else {
-            this.jobName = configuredJobName;
-        }
-
-        pushGateway = new PushGateway(host + ':' + port);
-        log.info(
-                "Configured PrometheusPushGatewayReporter with {host:{}, port:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
-                host,
-                port,
-                jobName,
-                randomSuffix,
-                deleteOnShutdown,
-                groupingKey);
-    }
-
-    Map<String, String> parseGroupingKey(final String groupingKeyConfig) {
-        if (!groupingKeyConfig.isEmpty()) {
-            Map<String, String> groupingKey = new HashMap<>();
-            String[] kvs = groupingKeyConfig.split(";");
-            for (String kv : kvs) {
-                int idx = kv.indexOf("=");
-                if (idx < 0) {
-                    log.warn("Invalid prometheusPushGateway groupingKey:{}, will be ignored", kv);
-                    continue;
-                }
-
-                String labelKey = kv.substring(0, idx);
-                String labelValue = kv.substring(idx + 1);
-                if (StringUtils.isNullOrWhitespaceOnly(labelKey)
-                        || StringUtils.isNullOrWhitespaceOnly(labelValue)) {
-                    log.warn(
-                            "Invalid groupingKey {labelKey:{}, labelValue:{}} must not be empty",
-                            labelKey,
-                            labelValue);
-                    continue;
-                }
-                groupingKey.put(labelKey, labelValue);
-            }
-
-            return groupingKey;
-        }
-        return Collections.emptyMap();
+    PrometheusPushGatewayReporter(
+        @Nullable PushGateway pushGateway,
+        @Nullable String jobName,
+        @Nullable Map<String, String> groupingKey,
+        final boolean deleteOnShutdown
+        ) {
+        this.pushGateway = Preconditions.checkNotNull(pushGateway);
+        this.jobName = Preconditions.checkNotNull(jobName);
+        this.groupingKey = Preconditions.checkNotNull(groupingKey);
+        this.deleteOnShutdown = deleteOnShutdown;
     }
 
     @Override

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -57,9 +57,11 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
                 metricConfig.getBoolean(
                         RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
         boolean deleteOnShutdown =
-                metricConfig.getBoolean(DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
+                metricConfig.getBoolean(
+                        DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
         Map<String, String> groupingKey =
-                parseGroupingKey(metricConfig.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
+                parseGroupingKey(
+                        metricConfig.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
 
         if (host == null || host.isEmpty() || port < 1) {
             throw new IllegalArgumentException(
@@ -80,7 +82,8 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
                 deleteOnShutdown,
                 groupingKey);
 
-        return new PrometheusPushGatewayReporter(host, port, jobName, groupingKey, deleteOnShutdown);
+        return new PrometheusPushGatewayReporter(
+                host, port, jobName, groupingKey, deleteOnShutdown);
     }
 
     @VisibleForTesting

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -17,18 +17,102 @@
 
 package org.apache.flink.metrics.prometheus;
 
+import io.prometheus.client.exporter.PushGateway;
+
+import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.StringUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.DELETE_ON_SHUTDOWN;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.GROUPING_KEY;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.HOST;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.JOB_NAME;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.PORT;
+import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterOptions.RANDOM_JOB_NAME_SUFFIX;
 
 /** {@link MetricReporterFactory} for {@link PrometheusPushGatewayReporter}. */
 @InterceptInstantiationViaReflection(
         reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporter")
 public class PrometheusPushGatewayReporterFactory implements MetricReporterFactory {
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PrometheusPushGatewayReporterFactory.class);
+
     @Override
     public PrometheusPushGatewayReporter createMetricReporter(Properties properties) {
-        return new PrometheusPushGatewayReporter();
+        MetricConfig metricConfig = (MetricConfig)properties;
+
+        String host = metricConfig.getString(HOST.key(), HOST.defaultValue());
+        int port = metricConfig.getInteger(PORT.key(), PORT.defaultValue());
+        String configuredJobName = metricConfig.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
+        boolean randomSuffix =
+                metricConfig.getBoolean(
+                        RANDOM_JOB_NAME_SUFFIX.key(), RANDOM_JOB_NAME_SUFFIX.defaultValue());
+        boolean deleteOnShutdown =
+                metricConfig.getBoolean(DELETE_ON_SHUTDOWN.key(), DELETE_ON_SHUTDOWN.defaultValue());
+        Map<String, String> groupingKey =
+                parseGroupingKey(metricConfig.getString(GROUPING_KEY.key(), GROUPING_KEY.defaultValue()));
+
+        if (host == null || host.isEmpty() || port < 1) {
+            throw new IllegalArgumentException(
+                    "Invalid host/port configuration. Host: " + host + " Port: " + port);
+        }
+
+        String jobName = configuredJobName;
+        if (randomSuffix) {
+            jobName = configuredJobName + new AbstractID();
+        } 
+
+        PushGateway pushGateway = new PushGateway(host + ':' + port);
+        LOG.info(
+                "Configured PrometheusPushGatewayReporter with {host:{}, port:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
+                host,
+                port,
+                jobName,
+                randomSuffix,
+                deleteOnShutdown,
+                groupingKey);
+
+        return new PrometheusPushGatewayReporter(pushGateway, jobName, groupingKey, deleteOnShutdown);
+    }
+
+    static Map<String, String> parseGroupingKey(final String groupingKeyConfig) {
+        if (!groupingKeyConfig.isEmpty()) {
+            Map<String, String> groupingKey = new HashMap<>();
+            String[] kvs = groupingKeyConfig.split(";");
+            for (String kv : kvs) {
+                int idx = kv.indexOf("=");
+                if (idx < 0) {
+                    LOG.warn("Invalid prometheusPushGateway groupingKey:{}, will be ignored", kv);
+                    continue;
+                }
+
+                String labelKey = kv.substring(0, idx);
+                String labelValue = kv.substring(idx + 1);
+                if (StringUtils.isNullOrWhitespaceOnly(labelKey)
+                        || StringUtils.isNullOrWhitespaceOnly(labelValue)) {
+                    LOG.warn(
+                            "Invalid groupingKey {labelKey:{}, labelValue:{}} must not be empty",
+                            labelKey,
+                            labelValue);
+                    continue;
+                }
+                groupingKey.put(labelKey, labelValue);
+            }
+
+            return groupingKey;
+        }
+
+        return Collections.emptyMap();
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -17,8 +17,7 @@
 
 package org.apache.flink.metrics.prometheus;
 
-import io.prometheus.client.exporter.PushGateway;
-
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
@@ -50,8 +49,7 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
 
     @Override
     public PrometheusPushGatewayReporter createMetricReporter(Properties properties) {
-        MetricConfig metricConfig = (MetricConfig)properties;
-
+        MetricConfig metricConfig = (MetricConfig) properties;
         String host = metricConfig.getString(HOST.key(), HOST.defaultValue());
         int port = metricConfig.getInteger(PORT.key(), PORT.defaultValue());
         String configuredJobName = metricConfig.getString(JOB_NAME.key(), JOB_NAME.defaultValue());
@@ -71,7 +69,7 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
         String jobName = configuredJobName;
         if (randomSuffix) {
             jobName = configuredJobName + new AbstractID();
-        } 
+        }
 
         LOG.info(
                 "Configured PrometheusPushGatewayReporter with {host:{}, port:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
@@ -85,6 +83,7 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
         return new PrometheusPushGatewayReporter(host, port, jobName, groupingKey, deleteOnShutdown);
     }
 
+    @VisibleForTesting
     static Map<String, String> parseGroupingKey(final String groupingKeyConfig) {
         if (!groupingKeyConfig.isEmpty()) {
             Map<String, String> groupingKey = new HashMap<>();

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterFactory.java
@@ -73,7 +73,6 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
             jobName = configuredJobName + new AbstractID();
         } 
 
-        PushGateway pushGateway = new PushGateway(host + ':' + port);
         LOG.info(
                 "Configured PrometheusPushGatewayReporter with {host:{}, port:{}, jobName:{}, randomJobNameSuffix:{}, deleteOnShutdown:{}, groupingKey:{}}",
                 host,
@@ -83,7 +82,7 @@ public class PrometheusPushGatewayReporterFactory implements MetricReporterFacto
                 deleteOnShutdown,
                 groupingKey);
 
-        return new PrometheusPushGatewayReporter(pushGateway, jobName, groupingKey, deleteOnShutdown);
+        return new PrometheusPushGatewayReporter(host, port, jobName, groupingKey, deleteOnShutdown);
     }
 
     static Map<String, String> parseGroupingKey(final String groupingKeyConfig) {

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -49,11 +49,24 @@ public class PrometheusReporter extends AbstractPrometheusReporter {
         return port;
     }
 
-    PrometheusReporter(
-        final int port, 
-        @Nullable HTTPServer httpServer) {
-        this.httpServer = Preconditions.checkNotNull(httpServer);
-        this.port = port;
+    PrometheusReporter(Iterator<Integer> ports) {
+        while (ports.hasNext()) {
+            port = ports.next();
+            try {
+                // internally accesses CollectorRegistry.defaultRegistry
+                httpServer = new HTTPServer(port);
+                log.info("Started PrometheusReporter HTTP server on port {}.", port);
+                break;
+            } catch (IOException ioe) { // assume port conflict
+                log.debug("Could not start PrometheusReporter HTTP server on port {}.", port, ioe);
+            }
+        }
+
+        if (httpServer == null) {
+            throw new RuntimeException(
+                    "Could not start PrometheusReporter HTTP server on any configured port. Ports: "
+                            + ports);
+        }
     }
 
     @Override

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -21,18 +21,14 @@ package org.apache.flink.metrics.prometheus;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Metric;
-import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
-import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import io.prometheus.client.exporter.HTTPServer;
 
 import java.io.IOException;
 import java.util.Iterator;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus. */
 @PublicEvolving

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -32,14 +32,13 @@ import io.prometheus.client.exporter.HTTPServer;
 import java.io.IOException;
 import java.util.Iterator;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /** {@link MetricReporter} that exports {@link Metric Metrics} via Prometheus. */
 @PublicEvolving
 @InstantiateViaFactory(
         factoryClassName = "org.apache.flink.metrics.prometheus.PrometheusReporterFactory")
 public class PrometheusReporter extends AbstractPrometheusReporter {
-
-    static final String ARG_PORT = "port";
-    private static final String DEFAULT_PORT = "9249";
 
     private HTTPServer httpServer;
     private int port;
@@ -50,30 +49,11 @@ public class PrometheusReporter extends AbstractPrometheusReporter {
         return port;
     }
 
-    @Override
-    public void open(MetricConfig config) {
-        super.open(config);
-
-        String portsConfig = config.getString(ARG_PORT, DEFAULT_PORT);
-        Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
-
-        while (ports.hasNext()) {
-            int port = ports.next();
-            try {
-                // internally accesses CollectorRegistry.defaultRegistry
-                httpServer = new HTTPServer(port);
-                this.port = port;
-                log.info("Started PrometheusReporter HTTP server on port {}.", port);
-                break;
-            } catch (IOException ioe) { // assume port conflict
-                log.debug("Could not start PrometheusReporter HTTP server on port {}.", port, ioe);
-            }
-        }
-        if (httpServer == null) {
-            throw new RuntimeException(
-                    "Could not start PrometheusReporter HTTP server on any configured port. Ports: "
-                            + portsConfig);
-        }
+    PrometheusReporter(
+        final int port, 
+        @Nullable HTTPServer httpServer) {
+        this.httpServer = Preconditions.checkNotNull(httpServer);
+        this.port = port;
     }
 
     @Override

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
@@ -39,8 +39,6 @@ import java.util.Properties;
         reporterClassName = "org.apache.flink.metrics.prometheus.PrometheusReporter")
 public class PrometheusReporterFactory implements MetricReporterFactory {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PrometheusReporterFactory.class);
-
     static final String ARG_PORT = "port";
     private static final String DEFAULT_PORT = "9249";
 
@@ -49,26 +47,7 @@ public class PrometheusReporterFactory implements MetricReporterFactory {
         MetricConfig metricConfig = (MetricConfig)properties;
         String portsConfig = metricConfig.getString(ARG_PORT, DEFAULT_PORT);
         Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
-        Integer port = null;
-        HTTPServer httpServer = null;
-        while (ports.hasNext()) {
-            port = ports.next();
-            try {
-                // internally accesses CollectorRegistry.defaultRegistry
-                httpServer = new HTTPServer(port);
-                LOG.info("Started PrometheusReporter HTTP server on port {}.", port);
-                break;
-            } catch (IOException ioe) { // assume port conflict
-                LOG.debug("Could not start PrometheusReporter HTTP server on port {}.", port, ioe);
-            }
-        }
-        
-        if (httpServer == null) {
-            throw new RuntimeException(
-                    "Could not start PrometheusReporter HTTP server on any configured port. Ports: "
-                            + portsConfig);
-        }
 
-        return new PrometheusReporter(port, httpServer);
+        return new PrometheusReporter(ports);
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
@@ -17,20 +17,11 @@
 
 package org.apache.flink.metrics.prometheus;
 
-import io.prometheus.client.exporter.HTTPServer;
-
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.util.NetUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -44,7 +35,7 @@ public class PrometheusReporterFactory implements MetricReporterFactory {
 
     @Override
     public PrometheusReporter createMetricReporter(Properties properties) {
-        MetricConfig metricConfig = (MetricConfig)properties;
+        MetricConfig metricConfig = (MetricConfig) properties;
         String portsConfig = metricConfig.getString(ARG_PORT, DEFAULT_PORT);
         Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -30,7 +30,8 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 
     @Test
     public void testParseGroupingKey() {
-        Map<String, String> groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=v1;k2=v2");
+        Map<String, String> groupingKey =
+                PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=v1;k2=v2");
         Assert.assertNotNull(groupingKey);
         Assert.assertEquals("v1", groupingKey.get("k1"));
         Assert.assertEquals("v2", groupingKey.get("k2"));
@@ -38,7 +39,8 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 
     @Test
     public void testParseIncompleteGroupingKey() {
-        Map<String, String> groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=");
+        Map<String, String> groupingKey =
+                PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=");
         Assert.assertTrue(groupingKey.isEmpty());
 
         groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("=v1");

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusPushGatewayReporterTest.java
@@ -30,8 +30,7 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 
     @Test
     public void testParseGroupingKey() {
-        PrometheusPushGatewayReporter reporter = new PrometheusPushGatewayReporter();
-        Map<String, String> groupingKey = reporter.parseGroupingKey("k1=v1;k2=v2");
+        Map<String, String> groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=v1;k2=v2");
         Assert.assertNotNull(groupingKey);
         Assert.assertEquals("v1", groupingKey.get("k1"));
         Assert.assertEquals("v2", groupingKey.get("k2"));
@@ -39,14 +38,13 @@ public class PrometheusPushGatewayReporterTest extends TestLogger {
 
     @Test
     public void testParseIncompleteGroupingKey() {
-        PrometheusPushGatewayReporter reporter = new PrometheusPushGatewayReporter();
-        Map<String, String> groupingKey = reporter.parseGroupingKey("k1=");
+        Map<String, String> groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1=");
         Assert.assertTrue(groupingKey.isEmpty());
 
-        groupingKey = reporter.parseGroupingKey("=v1");
+        groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("=v1");
         Assert.assertTrue(groupingKey.isEmpty());
 
-        groupingKey = reporter.parseGroupingKey("k1");
+        groupingKey = PrometheusPushGatewayReporterFactory.parseGroupingKey("k1");
         Assert.assertTrue(groupingKey.isEmpty());
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -52,11 +52,12 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import static org.apache.flink.metrics.prometheus.PrometheusReporter.ARG_PORT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
+
+import static org.apache.flink.metrics.prometheus.PrometheusReporterFactory.ARG_PORT;
 
 /** Basic test for {@link PrometheusReporter}. */
 public class PrometheusReporterTest extends TestLogger {
@@ -71,6 +72,8 @@ public class PrometheusReporterTest extends TestLogger {
     private static final String DEFAULT_LABELS = "{" + DIMENSIONS + ",}";
     private static final String SCOPE_PREFIX = "flink_taskmanager_";
 
+    private static final PrometheusReporterFactory prometheusReporterFactory =
+            new PrometheusReporterFactory();
     private static final PortRangeProvider portRangeProvider = new PortRangeProvider();
 
     @Rule public ExpectedException thrown = ExpectedException.none();
@@ -373,7 +376,10 @@ public class PrometheusReporterTest extends TestLogger {
         MetricConfig metricConfig = new MetricConfig();
         metricConfig.setProperty(ARG_PORT, portString);
 
-        return ReporterSetup.forReporter(reporterName, metricConfig, new PrometheusReporter());
+        PrometheusReporter metricReporter = prometheusReporterFactory
+                .createMetricReporter(metricConfig);
+
+        return ReporterSetup.forReporter(reporterName, metricConfig, metricReporter);
     }
 
     @After

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -52,12 +52,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import static org.apache.flink.metrics.prometheus.PrometheusReporterFactory.ARG_PORT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
-
-import static org.apache.flink.metrics.prometheus.PrometheusReporterFactory.ARG_PORT;
 
 /** Basic test for {@link PrometheusReporter}. */
 public class PrometheusReporterTest extends TestLogger {

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -375,8 +375,8 @@ public class PrometheusReporterTest extends TestLogger {
         MetricConfig metricConfig = new MetricConfig();
         metricConfig.setProperty(ARG_PORT, portString);
 
-        PrometheusReporter metricReporter = prometheusReporterFactory
-                .createMetricReporter(metricConfig);
+        PrometheusReporter metricReporter =
+                prometheusReporterFactory.createMetricReporter(metricConfig);
 
         return ReporterSetup.forReporter(reporterName, metricConfig, metricReporter);
     }


### PR DESCRIPTION
## What is the purpose of the change

Clean-up for the initialization of the two Prometheus Metric Reporters (`PrometheusReporter` and `PrometheusPushGatewayReporter`) by explicitly passing in arguments to the constructors as opposed to relying on resolving these values via the internal configuration properties.

## Brief change log

- Removed argument resolution against defaults from the `open()` functions and instead resolved those within the factories and passed them into the respective reporter instances (roughly modeled after the `JmxReporter` implementation)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
