### PR TITLE
[FLINK-21757][metrics] Add LogicalScopeProvider interface

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/LogicalScopeProvider.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/LogicalScopeProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics;
+
+/**
+ * Extension for metric groups that support logical scopes.
+ *
+ * <p>ATTENTION: This interface is *not* meant for the long-term; it merely removes the need for
+ * reporters to depend on flink-runtime in order to access the logical scope. Once the logical scope
+ * is properly exposed this interface *will* be removed.
+ */
+public interface LogicalScopeProvider {
+    /**
+     * Returns the logical scope for the metric group, for example {@code "taskmanager.job.task"},
+     * with the given filter being applied to all scope components.
+     *
+     * @param filter filter to apply to all scope components
+     * @return logical scope
+     */
+    String getLogicalScope(CharacterFilter filter);
+
+    /**
+     * Returns the logical scope for the metric group, for example {@code "taskmanager.job.task"},
+     * with the given filter being applied to all scope components and the given delimiter being
+     * used to concatenate scope components.
+     *
+     * @param filter filter to apply to all scope components
+     * @param delimiter delimiter to use for concatenating scope components
+     * @return logical scope
+     */
+    String getLogicalScope(CharacterFilter filter, char delimiter);
+
+    /**
+     * Casts the given metric group to a {@link LogicalScopeProvider}, if it implements the
+     * interface.
+     *
+     * @param metricGroup metric group to cast
+     * @return cast metric group
+     * @throws IllegalStateException if the metric group did not implement the LogicalScopeProvider
+     *     interface
+     */
+    static LogicalScopeProvider castFrom(MetricGroup metricGroup) throws IllegalStateException {
+        if (metricGroup instanceof LogicalScopeProvider) {
+            return (LogicalScopeProvider) metricGroup;
+        } else {
+            throw new IllegalStateException(
+                    "The given metric group does not implement the LogicalScopeProvider interface.");
+        }
+    }
+}

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/MeasurementInfoProvider.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/MeasurementInfoProvider.java
@@ -20,9 +20,8 @@ package org.apache.flink.metrics.influxdb;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.LogicalScopeProvider;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
-import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -63,7 +62,7 @@ class MeasurementInfoProvider implements MetricInfoProvider<MeasurementInfo> {
     }
 
     private static String getLogicalScope(MetricGroup group) {
-        return ((FrontMetricGroup<AbstractMetricGroup<?>>) group)
+        return LogicalScopeProvider.castFrom(group)
                 .getLogicalScope(CHARACTER_FILTER, SCOPE_SEPARATOR);
     }
 }

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -24,14 +24,13 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.LogicalScopeProvider;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
-import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
-import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,8 +197,7 @@ public class JMXReporter implements MetricReporter {
 
     static String generateJmxDomain(String metricName, MetricGroup group) {
         return JMX_DOMAIN_PREFIX
-                + ((FrontMetricGroup<AbstractMetricGroup<?>>) group)
-                        .getLogicalScope(CHARACTER_FILTER, '.')
+                + LogicalScopeProvider.castFrom(group).getLogicalScope(CHARACTER_FILTER, '.')
                 + '.'
                 + metricName;
     }

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -25,13 +25,12 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.LogicalScopeProvider;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
-import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
-import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
@@ -251,7 +250,7 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
     @SuppressWarnings("unchecked")
     private static String getLogicalScope(MetricGroup group) {
-        return ((FrontMetricGroup<AbstractMetricGroup<?>>) group)
+        return LogicalScopeProvider.castFrom(group)
                 .getLogicalScope(CHARACTER_FILTER, SCOPE_SEPARATOR);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.LogicalScopeProvider;
 
 import java.util.Map;
 
@@ -32,7 +33,8 @@ import java.util.Map;
  *
  * @param <P> parentMetricGroup to {@link AbstractMetricGroup AbstractMetricGroup}
  */
-public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMetricGroup<P> {
+public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMetricGroup<P>
+        implements LogicalScopeProvider {
 
     @VisibleForTesting static final char DEFAULT_REPLACEMENT = '_';
     @VisibleForTesting static final char DEFAULT_REPLACEMENT_ALTERNATIVE = '-';
@@ -68,11 +70,17 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
                 this.settings.getReporterIndex(), this.settings.getExcludedVariables());
     }
 
+    /** @deprecated work against the LogicalScopeProvider interface instead. */
+    @Override
+    @Deprecated
     public String getLogicalScope(CharacterFilter filter) {
         return parentMetricGroup.getLogicalScope(
                 getDelimiterFilter(this.settings, filter), this.settings.getDelimiter());
     }
 
+    /** @deprecated work against the LogicalScopeProvider interface instead. */
+    @Override
+    @Deprecated
     public String getLogicalScope(CharacterFilter filter, char delimiter) {
         return parentMetricGroup.getLogicalScope(
                 getDelimiterFilter(this.settings, filter),


### PR DESCRIPTION
Extracts the logical scope methods from the FrontMetricGroup into a separate interface living in flink-metrics-core, so that reporters wanting to make use of do not need a dependency on flink-runtime.