### PR TITLE
[FLINK-21777][network] Replace the 4M data writing cache of sort-merge shuffle with writev system call

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWithChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWithChannel.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Buffer and the corresponding channel index. */
+public class BufferWithChannel {
+
+    private final Buffer buffer;
+
+    private final int channelIndex;
+
+    BufferWithChannel(Buffer buffer, int channelIndex) {
+        this.buffer = checkNotNull(buffer);
+        this.channelIndex = channelIndex;
+    }
+
+    public Buffer getBuffer() {
+        return buffer;
+    }
+
+    public int getChannelIndex() {
+        return channelIndex;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortBuffer.java
@@ -24,8 +24,6 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * Data of different channels can be appended to a {@link SortBuffer} and after the {@link
  * SortBuffer} is finished, the appended data can be copied from it in channel index order.
@@ -67,25 +65,4 @@ public interface SortBuffer {
 
     /** Whether this {@link SortBuffer} is released or not. */
     boolean isReleased();
-
-    /** Buffer and the corresponding channel index returned to reader. */
-    class BufferWithChannel {
-
-        private final Buffer buffer;
-
-        private final int channelIndex;
-
-        BufferWithChannel(Buffer buffer, int channelIndex) {
-            this.buffer = checkNotNull(buffer);
-            this.channelIndex = channelIndex;
-        }
-
-        public Buffer getBuffer() {
-            return buffer;
-        }
-
-        public int getChannelIndex() {
-            return channelIndex;
-        }
-    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
@@ -38,13 +38,17 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
-import static org.apache.flink.runtime.io.network.partition.SortBuffer.BufferWithChannel;
 import static org.apache.flink.util.Preconditions.checkElementIndex;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -56,6 +60,12 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @NotThreadSafe
 public class SortMergeResultPartition extends ResultPartition {
+
+    /**
+     * Number of expected buffer size to allocate for data writing. Currently, it is an empirical
+     * value (8M) which can not be configured.
+     */
+    private static final int NUM_WRITE_BUFFER_BYTES = 8 * 1024 * 1024;
 
     private final Object lock = new Object();
 
@@ -70,14 +80,18 @@ public class SortMergeResultPartition extends ResultPartition {
     /** Number of data buffers (excluding events) written for each subpartition. */
     private final int[] numDataBuffers;
 
-    /** A piece of unmanaged memory for data writing. */
-    private final MemorySegment writeBuffer;
+    /** Buffers cut from the network buffer pool for data writing. */
+    @GuardedBy("lock")
+    private final List<MemorySegment> writeBuffers = new ArrayList<>();
 
     /** Size of network buffer and write buffer. */
     private final int networkBufferSize;
 
     /** File writer for this result partition. */
     private final PartitionedFileWriter fileWriter;
+
+    /** Number of guaranteed network buffers can be used by {@link #currentSortBuffer}. */
+    private int numBuffersForSort;
 
     /** Current {@link SortBuffer} to append records to. */
     private SortBuffer currentSortBuffer;
@@ -108,7 +122,6 @@ public class SortMergeResultPartition extends ResultPartition {
 
         this.networkBufferSize = networkBufferSize;
         this.numDataBuffers = new int[numSubpartitions];
-        this.writeBuffer = MemorySegmentFactory.allocateUnpooledOffHeapMemory(networkBufferSize);
 
         PartitionedFileWriter fileWriter = null;
         try {
@@ -118,6 +131,45 @@ public class SortMergeResultPartition extends ResultPartition {
             ExceptionUtils.rethrow(throwable);
         }
         this.fileWriter = fileWriter;
+    }
+
+    @Override
+    public void setup() throws IOException {
+        super.setup();
+
+        int expectedWriteBuffers = NUM_WRITE_BUFFER_BYTES / networkBufferSize;
+        if (networkBufferSize > NUM_WRITE_BUFFER_BYTES) {
+            expectedWriteBuffers = 1;
+        }
+
+        int numRequiredBuffer = bufferPool.getNumberOfRequiredMemorySegments();
+        String errorMessage =
+                String.format(
+                        "Too few sort buffers, please increase %s to a larger value (more than %d).",
+                        NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS,
+                        2 * expectedWriteBuffers);
+        if (numRequiredBuffer < 2 * expectedWriteBuffers) {
+            LOG.warn(errorMessage);
+        }
+
+        int numWriteBuffers = Math.min(numRequiredBuffer / 2, expectedWriteBuffers);
+        if (numWriteBuffers < 1) {
+            throw new IOException(errorMessage);
+        }
+        numBuffersForSort = numRequiredBuffer - numWriteBuffers;
+
+        synchronized (lock) {
+            try {
+                for (int i = 0; i < numWriteBuffers; ++i) {
+                    MemorySegment segment =
+                            bufferPool.requestBufferBuilderBlocking().getMemorySegment();
+                    writeBuffers.add(segment);
+                }
+            } catch (InterruptedException exception) {
+                // the setup method does not allow InterruptedException
+                throw new IOException(exception);
+            }
+        }
     }
 
     @Override
@@ -199,7 +251,12 @@ public class SortMergeResultPartition extends ResultPartition {
 
         currentSortBuffer =
                 new PartitionSortedBuffer(
-                        lock, bufferPool, numSubpartitions, networkBufferSize, null);
+                        lock,
+                        bufferPool,
+                        numSubpartitions,
+                        networkBufferSize,
+                        numBuffersForSort,
+                        null);
         return currentSortBuffer;
     }
 
@@ -212,38 +269,51 @@ public class SortMergeResultPartition extends ResultPartition {
         if (currentSortBuffer.hasRemaining()) {
             fileWriter.startNewRegion();
 
-            while (currentSortBuffer.hasRemaining()) {
-                BufferWithChannel bufferWithChannel =
-                        currentSortBuffer.copyIntoSegment(writeBuffer);
-                Buffer buffer = bufferWithChannel.getBuffer();
-                int subpartitionIndex = bufferWithChannel.getChannelIndex();
+            List<BufferWithChannel> toWrite = new ArrayList<>();
+            Queue<MemorySegment> segments = getWriteBuffers();
 
-                writeCompressedBufferIfPossible(buffer, subpartitionIndex);
+            while (currentSortBuffer.hasRemaining()) {
+                if (segments.isEmpty()) {
+                    fileWriter.writeBuffers(toWrite);
+                    toWrite.clear();
+                    segments = getWriteBuffers();
+                }
+
+                BufferWithChannel bufferWithChannel =
+                        currentSortBuffer.copyIntoSegment(checkNotNull(segments.poll()));
+                updateStatistics(bufferWithChannel);
+                toWrite.add(compressBufferIfPossible(bufferWithChannel));
             }
+
+            fileWriter.writeBuffers(toWrite);
         }
 
         currentSortBuffer.release();
     }
 
-    private void writeCompressedBufferIfPossible(Buffer buffer, int targetSubpartition)
-            throws IOException {
-        updateStatistics(buffer, targetSubpartition);
-
-        try {
-            if (canBeCompressed(buffer)) {
-                buffer = bufferCompressor.compressToIntermediateBuffer(buffer);
-            }
-            fileWriter.writeBuffer(buffer, targetSubpartition);
-        } finally {
-            buffer.recycleBuffer();
+    private Queue<MemorySegment> getWriteBuffers() {
+        synchronized (lock) {
+            checkState(!writeBuffers.isEmpty(), "Task has been canceled.");
+            return new ArrayDeque<>(writeBuffers);
         }
     }
 
-    private void updateStatistics(Buffer buffer, int subpartitionIndex) {
+    private BufferWithChannel compressBufferIfPossible(BufferWithChannel bufferWithChannel) {
+        Buffer buffer = bufferWithChannel.getBuffer();
+        if (!canBeCompressed(buffer)) {
+            return bufferWithChannel;
+        }
+
+        buffer = checkNotNull(bufferCompressor).compressToOriginalBuffer(buffer);
+        return new BufferWithChannel(buffer, bufferWithChannel.getChannelIndex());
+    }
+
+    private void updateStatistics(BufferWithChannel bufferWithChannel) {
+        Buffer buffer = bufferWithChannel.getBuffer();
         numBuffersOut.inc();
         numBytesOut.inc(buffer.readableBytes());
         if (buffer.isBuffer()) {
-            ++numDataBuffers[subpartitionIndex];
+            ++numDataBuffers[bufferWithChannel.getChannelIndex()];
         }
     }
 
@@ -254,13 +324,27 @@ public class SortMergeResultPartition extends ResultPartition {
             throws IOException {
         fileWriter.startNewRegion();
 
-        while (record.hasRemaining()) {
-            int toCopy = Math.min(record.remaining(), writeBuffer.size());
-            writeBuffer.put(0, record, toCopy);
-            NetworkBuffer buffer = new NetworkBuffer(writeBuffer, (buf) -> {}, dataType, toCopy);
+        List<BufferWithChannel> toWrite = new ArrayList<>();
+        Queue<MemorySegment> segments = getWriteBuffers();
 
-            writeCompressedBufferIfPossible(buffer, targetSubpartition);
+        while (record.hasRemaining()) {
+            if (segments.isEmpty()) {
+                fileWriter.writeBuffers(toWrite);
+                toWrite.clear();
+                segments = getWriteBuffers();
+            }
+
+            int toCopy = Math.min(record.remaining(), networkBufferSize);
+            MemorySegment writeBuffer = checkNotNull(segments.poll());
+            writeBuffer.put(0, record, toCopy);
+
+            NetworkBuffer buffer = new NetworkBuffer(writeBuffer, (buf) -> {}, dataType, toCopy);
+            BufferWithChannel bufferWithChannel = new BufferWithChannel(buffer, targetSubpartition);
+            updateStatistics(bufferWithChannel);
+            toWrite.add(compressBufferIfPossible(bufferWithChannel));
         }
+
+        fileWriter.writeBuffers(toWrite);
     }
 
     void releaseReader(SortMergeSubpartitionReader reader) {
@@ -289,8 +373,22 @@ public class SortMergeResultPartition extends ResultPartition {
         super.finish();
     }
 
+    private void releaseWriteBuffers() {
+        synchronized (lock) {
+            if (bufferPool != null) {
+                for (MemorySegment segment : writeBuffers) {
+                    bufferPool.recycle(segment);
+                }
+                writeBuffers.clear();
+            }
+        }
+    }
+
     @Override
     public void close() {
+        releaseWriteBuffers();
+        // the close method will be always called by the task thread, so there is need to make
+        // the currentSortBuffer filed volatile and visible to the cancel thread intermediately
         releaseCurrentSortBuffer();
         super.close();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionSortedBufferTest.java
@@ -99,7 +99,7 @@ public class PartitionSortedBufferTest {
         // read all data from the sort buffer
         while (sortBuffer.hasRemaining()) {
             MemorySegment readBuffer = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
-            SortBuffer.BufferWithChannel bufferAndChannel = sortBuffer.copyIntoSegment(readBuffer);
+            BufferWithChannel bufferAndChannel = sortBuffer.copyIntoSegment(readBuffer);
             int subpartition = bufferAndChannel.getChannelIndex();
             buffersRead[subpartition].add(bufferAndChannel.getBuffer());
             numBytesRead[subpartition] += bufferAndChannel.getBuffer().readableBytes();
@@ -192,7 +192,7 @@ public class PartitionSortedBufferTest {
     private void checkReadResult(
             SortBuffer sortBuffer, ByteBuffer expectedBuffer, int expectedChannel, int bufferSize) {
         MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
-        SortBuffer.BufferWithChannel bufferWithChannel = sortBuffer.copyIntoSegment(segment);
+        BufferWithChannel bufferWithChannel = sortBuffer.copyIntoSegment(segment);
         assertEquals(expectedChannel, bufferWithChannel.getChannelIndex());
         assertEquals(expectedBuffer, bufferWithChannel.getBuffer().getNioBufferReadable());
     }
@@ -319,7 +319,8 @@ public class PartitionSortedBufferTest {
         BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
 
         SortBuffer sortBuffer =
-                new PartitionSortedBuffer(new Object(), bufferPool, 1, bufferSize, null);
+                new PartitionSortedBuffer(
+                        new Object(), bufferPool, 1, bufferSize, bufferPoolSize, null);
         sortBuffer.append(ByteBuffer.allocate(recordSize), 0, Buffer.DataType.DATA_BUFFER);
 
         assertEquals(bufferPoolSize, bufferPool.bestEffortGetNumOfUsedBuffers());
@@ -347,7 +348,12 @@ public class PartitionSortedBufferTest {
         BufferPool bufferPool = globalPool.createBufferPool(bufferPoolSize, bufferPoolSize);
 
         return new PartitionSortedBuffer(
-                new Object(), bufferPool, numSubpartitions, bufferSize, customReadOrder);
+                new Object(),
+                bufferPool,
+                numSubpartitions,
+                bufferSize,
+                bufferPoolSize,
+                customReadOrder);
     }
 
     public static int[] getRandomSubpartitionOrder(int numSubpartitions) {


### PR DESCRIPTION
## What is the purpose of the change

Currently, the sort-merge shuffle implementation uses 4M unmanaged direct memory as cache for data writing. This patch replaces the cache with writev system call which can reduce the unmanaged direct memory usage without any performance loss.


## Brief change log

  - Remove the data writing cache in PartitionedFileWriter;
  - Allocate a collection of network buffers as write buffer;
  - Bulk write the data out when the write buffer is full.


## Verifying this change

This change is already covered by existing tests, such as PartitionedFileWriteReadTest, SortMergeResultPartitionTest and BlockingShuffleITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
