### PR TITLE
[FLINK-21778][network] Use heap memory instead of direct memory as index entry cache for sort-merge shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriter.java
@@ -111,7 +111,7 @@ public class PartitionedFileWriter implements AutoCloseable {
         this.dataFilePath = new File(basePath + PartitionedFile.DATA_FILE_SUFFIX).toPath();
         this.indexFilePath = new File(basePath + PartitionedFile.INDEX_FILE_SUFFIX).toPath();
 
-        this.indexBuffer = ByteBuffer.allocateDirect(MIN_INDEX_BUFFER_SIZE);
+        this.indexBuffer = ByteBuffer.allocate(MIN_INDEX_BUFFER_SIZE);
         BufferReaderWriterUtil.configureByteBuffer(indexBuffer);
 
         // allocate 4M unmanaged direct memory for caching of data before writing
@@ -173,7 +173,7 @@ public class PartitionedFileWriter implements AutoCloseable {
         }
 
         int newIndexBufferSize = Math.min(maxIndexBufferSize, 2 * indexBuffer.capacity());
-        ByteBuffer newIndexBuffer = ByteBuffer.allocateDirect(newIndexBufferSize);
+        ByteBuffer newIndexBuffer = ByteBuffer.allocate(newIndexBufferSize);
         indexBuffer.flip();
         newIndexBuffer.put(indexBuffer);
         BufferReaderWriterUtil.configureByteBuffer(newIndexBuffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -112,7 +112,7 @@ public class SortMergeResultPartition extends ResultPartition {
 
         PartitionedFileWriter fileWriter = null;
         try {
-            // allocate at most 4M direct memory for caching of index entries
+            // allocate at most 4M heap memory for caching of index entries
             fileWriter = new PartitionedFileWriter(numSubpartitions, 4194304, resultFileBasePath);
         } catch (Throwable throwable) {
             ExceptionUtils.rethrow(throwable);


### PR DESCRIPTION
## What is the purpose of the change

Currently, the sort-merge shuffle implementation uses a piece of direct memory as index entry cache for acceleration. This patch switches to heap memory instead to reduce the consumption of direct memory which can further reduce the possibility of OutOfMemoryError.


## Brief change log

  - Use heap memory instead of direct memory as index entry cache for sort-merge shuffle.


## Verifying this change

This change is already covered by existing tests, such as PartitionedFileWriteReadTest, SortMergeResultPartitionTest and BlockingShuffleITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
