### PR TITLE
[FLINK-20740][network] Introduce a separated buffer pool and a separated thread pool for sort-merge blocking shuffle

### DIFF
--- a/docs/layouts/shortcodes/generated/common_memory_section.html
+++ b/docs/layouts/shortcodes/generated/common_memory_section.html
@@ -75,6 +75,12 @@
             <td>Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for TaskExecutor framework, which will not be allocated to task slots.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.framework.off-heap.batch-shuffle.size</h5></td>
+            <td style="word-wrap: break-word;">32 mb</td>
+            <td>MemorySize</td>
+            <td>Size of memory used by blocking shuffle for shuffle data read (currently only used by sort-merge shuffle). Notes: 1) The memory is cut from 'taskmanager.memory.framework.off-heap.size' so must be smaller than that, which means you may also need to increase 'taskmanager.memory.framework.off-heap.size' after you increase this config value; 2) This memory size can influence the shuffle performance and you can increase this config value for large-scale batch jobs (for example, to 128M or 256M).</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>

--- a/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
@@ -21,6 +21,12 @@
             <td>Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for TaskExecutor framework, which will not be allocated to task slots.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.framework.off-heap.batch-shuffle.size</h5></td>
+            <td style="word-wrap: break-word;">32 mb</td>
+            <td>MemorySize</td>
+            <td>Size of memory used by blocking shuffle for shuffle data read (currently only used by sort-merge shuffle). Notes: 1) The memory is cut from 'taskmanager.memory.framework.off-heap.size' so must be smaller than that, which means you may also need to increase 'taskmanager.memory.framework.off-heap.size' after you increase this config value; 2) This memory size can influence the shuffle performance and you can increase this config value for large-scale batch jobs (for example, to 128M or 256M).</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>
             <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -513,6 +513,28 @@ public class TaskManagerOptions {
                                     + " the configured min/max size, the min/max size will be used. The exact size of Network Memory can be"
                                     + " explicitly specified by setting the min/max size to the same value.");
 
+    /**
+     * Size of direct memory used by blocking shuffle for shuffle data read (currently only used by
+     * sort-merge shuffle).
+     */
+    @Documentation.Section(Documentation.Sections.COMMON_MEMORY)
+    public static final ConfigOption<MemorySize> NETWORK_BATCH_SHUFFLE_READ_MEMORY =
+            key("taskmanager.memory.framework.off-heap.batch-shuffle.size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("32m"))
+                    .withDescription(
+                            String.format(
+                                    "Size of memory used by blocking shuffle for shuffle data read "
+                                            + "(currently only used by sort-merge shuffle). Notes: "
+                                            + "1) The memory is cut from '%s' so must be smaller than"
+                                            + " that, which means you may also need to increase '%s' "
+                                            + "after you increase this config value; 2) This memory"
+                                            + " size can influence the shuffle performance and you "
+                                            + "can increase this config value for large-scale batch"
+                                            + " jobs (for example, to 128M or 256M).",
+                                    FRAMEWORK_OFF_HEAP_MEMORY.key(),
+                                    FRAMEWORK_OFF_HEAP_MEMORY.key()));
+
     /** JVM Metaspace Size for the TaskExecutors. */
     @Documentation.Section(Documentation.Sections.COMMON_MEMORY)
     public static final ConfigOption<MemorySize> JVM_METASPACE =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPool.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.disk;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A fixed-size {@link MemorySegment} pool used by batch shuffle for shuffle data read (currently
+ * only used by sort-merge blocking shuffle).
+ */
+public class BatchShuffleReadBufferPool {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BatchShuffleReadBufferPool.class);
+
+    /**
+     * Memory size in bytes can be allocated from this buffer pool for a single request (8M is for
+     * better sequential read).
+     */
+    private static final int NUM_BYTES_PER_REQUEST = 8 * 1024 * 1024;
+
+    /** Total direct memory size in bytes can can be allocated and used by this buffer pool. */
+    private final long totalBytes;
+
+    /**
+     * Maximum time to wait when requesting read buffers from this buffer pool before throwing an
+     * exception.
+     */
+    private final Duration requestTimeout;
+
+    /** The number of total buffers in this buffer pool. */
+    private final int numTotalBuffers;
+
+    /** Size of each buffer in bytes in this buffer pool. */
+    private final int bufferSize;
+
+    /** The number of buffers to be returned for a single request. */
+    private final int numBuffersPerRequest;
+
+    /** All available buffers in this buffer pool currently. */
+    @GuardedBy("buffers")
+    private final Queue<MemorySegment> buffers = new ArrayDeque<>();
+
+    /** Whether this buffer pool has been destroyed or not. */
+    @GuardedBy("buffers")
+    private boolean destroyed;
+
+    /** Whether this buffer pool has been initialized or not. */
+    @GuardedBy("buffers")
+    private boolean initialized;
+
+    public BatchShuffleReadBufferPool(long totalBytes, int bufferSize, Duration requestTimeout) {
+        checkArgument(totalBytes > 0, "Total memory size must be positive.");
+        checkArgument(bufferSize > 0, "Size of buffer must be positive.");
+        checkArgument(
+                totalBytes >= bufferSize,
+                String.format(
+                        "Illegal configuration, config value for '%s' must be no smaller than '%s',"
+                                + " please increase '%s' to at least %d bytes.",
+                        TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key(),
+                        TaskManagerOptions.MEMORY_SEGMENT_SIZE.key(),
+                        TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key(),
+                        bufferSize));
+
+        this.totalBytes = totalBytes;
+        this.bufferSize = bufferSize;
+        this.requestTimeout = checkNotNull(requestTimeout);
+
+        this.numTotalBuffers = (int) Math.min(totalBytes / bufferSize, Integer.MAX_VALUE);
+        this.numBuffersPerRequest =
+                Math.min(numTotalBuffers, Math.max(1, NUM_BYTES_PER_REQUEST / bufferSize));
+    }
+
+    @VisibleForTesting
+    long getTotalBytes() {
+        return totalBytes;
+    }
+
+    @VisibleForTesting
+    int getNumBuffersPerRequest() {
+        return numBuffersPerRequest;
+    }
+
+    @VisibleForTesting
+    int getNumTotalBuffers() {
+        return numTotalBuffers;
+    }
+
+    @VisibleForTesting
+    int getAvailableBuffers() {
+        synchronized (buffers) {
+            return buffers.size();
+        }
+    }
+
+    public int getMaxConcurrentRequests() {
+        return numBuffersPerRequest > 0 ? numTotalBuffers / numBuffersPerRequest : 0;
+    }
+
+    /** Initializes this buffer pool which allocates all the buffers. */
+    private void initialize() {
+        LOG.info(
+                "Initializing batch shuffle IO buffer pool: numBuffers={}, bufferSize={}.",
+                numTotalBuffers,
+                bufferSize);
+
+        synchronized (buffers) {
+            checkState(!destroyed, "Buffer pool is already destroyed.");
+
+            if (initialized) {
+                return;
+            }
+            initialized = true;
+
+            try {
+                for (int i = 0; i < numTotalBuffers; ++i) {
+                    buffers.add(MemorySegmentFactory.allocateUnpooledOffHeapMemory(bufferSize));
+                }
+            } catch (OutOfMemoryError outOfMemoryError) {
+                int allocated = buffers.size();
+                buffers.forEach(MemorySegment::free);
+                buffers.clear();
+                throw new OutOfMemoryError(
+                        String.format(
+                                "Can't allocate enough direct buffer for batch shuffle read buffer "
+                                        + "pool (bytes allocated: %d, bytes still needed: %d). To "
+                                        + "avoid the exception, you need to do one of the following"
+                                        + " adjustments: 1) If you have ever decreased %s, you need"
+                                        + " to undo the decrement; 2) If you ever increased %s, you"
+                                        + " should also increase %s; 3) If neither the above cases,"
+                                        + " it usually means some other parts of your application "
+                                        + "have consumed too many direct memory and the value of %s"
+                                        + " should be increased.",
+                                allocated * bufferSize,
+                                (numTotalBuffers - allocated) * bufferSize,
+                                TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key(),
+                                TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key(),
+                                TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key(),
+                                TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key()));
+            }
+        }
+    }
+
+    /**
+     * Requests a collection of buffers (determined by {@link #numBuffersPerRequest}) from this
+     * buffer pool. Exception will be thrown if no enough buffers can be allocated in the given
+     * timeout.
+     */
+    public List<MemorySegment> requestBuffers() throws Exception {
+        List<MemorySegment> allocated = new ArrayList<>(numBuffersPerRequest);
+        synchronized (buffers) {
+            checkState(!destroyed, "Buffer pool is already destroyed.");
+
+            if (!initialized) {
+                initialize();
+            }
+
+            Deadline deadline = Deadline.fromNow(requestTimeout);
+            while (buffers.size() < numBuffersPerRequest) {
+                checkState(!destroyed, "Buffer pool is already destroyed.");
+
+                buffers.wait(requestTimeout.toMillis());
+                if (!deadline.hasTimeLeft()) {
+                    throw new TimeoutException(
+                            String.format(
+                                    "Can't allocate enough buffers in the given timeout, which means"
+                                            + " there is a fierce contention for read buffers, please"
+                                            + " increase '%s'.",
+                                    TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key()));
+                }
+            }
+
+            while (allocated.size() < numBuffersPerRequest) {
+                allocated.add(buffers.poll());
+            }
+        }
+        return allocated;
+    }
+
+    /**
+     * Recycles the target buffer to this buffer pool. This method should never throw any exception.
+     */
+    public void recycle(MemorySegment segment) {
+        checkArgument(segment != null, "Buffer must be not null.");
+
+        recycle(Collections.singletonList(segment));
+    }
+
+    /**
+     * Recycles a collection of buffers to this buffer pool. This method should never throw any
+     * exception.
+     */
+    public void recycle(Collection<MemorySegment> segments) {
+        checkArgument(segments != null, "Buffer list must be not null.");
+
+        if (segments.isEmpty()) {
+            return;
+        }
+
+        synchronized (buffers) {
+            checkState(initialized, "Recycling a buffer before initialization.");
+
+            if (destroyed) {
+                segments.forEach(MemorySegment::free);
+                return;
+            }
+
+            buffers.addAll(segments);
+            if (buffers.size() >= numBuffersPerRequest) {
+                buffers.notifyAll();
+            }
+        }
+    }
+
+    /** Destroys this buffer pool and after which, no buffer can be allocated any more. */
+    public void destroy() {
+        synchronized (buffers) {
+            destroyed = true;
+
+            buffers.clear();
+            buffers.notifyAll();
+        }
+    }
+
+    public boolean isDestroyed() {
+        synchronized (buffers) {
+            return destroyed;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
@@ -37,8 +38,13 @@ import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.runtime.util.Hardware;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.registerShuffleMetrics;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -119,6 +125,27 @@ public class NettyShuffleServiceFactory
                         config.networkBufferSize(),
                         config.getRequestSegmentsTimeout());
 
+        // we create a separated buffer pool here for batch shuffle instead of reusing the network
+        // buffer pool directly to avoid potential side effects of memory contention, for example,
+        // dead lock or "insufficient network buffer" error
+        BatchShuffleReadBufferPool batchShuffleReadBufferPool =
+                new BatchShuffleReadBufferPool(
+                        config.batchShuffleReadMemoryBytes(),
+                        config.networkBufferSize(),
+                        Duration.ofMinutes(5)); // 5 min buffer request timeout by default
+
+        // we create a separated IO executor pool here for batch shuffle instead of reusing the
+        // TaskManager IO executor pool directly to avoid the potential side effects of execution
+        // contention, for example, too long IO or waiting time leading to starvation or timeout
+        ExecutorService batchShuffleReadIOExecutor =
+                Executors.newFixedThreadPool(
+                        Math.max(
+                                1,
+                                Math.min(
+                                        batchShuffleReadBufferPool.getMaxConcurrentRequests(),
+                                        4 * Hardware.getNumberCPUCores())),
+                        new ExecutorThreadFactory("blocking-shuffle-io"));
+
         registerShuffleMetrics(metricGroup, networkBufferPool);
 
         ResultPartitionFactory resultPartitionFactory =
@@ -126,6 +153,8 @@ public class NettyShuffleServiceFactory
                         resultPartitionManager,
                         fileChannelManager,
                         networkBufferPool,
+                        batchShuffleReadBufferPool,
+                        batchShuffleReadIOExecutor,
                         config.getBlockingSubpartitionType(),
                         config.networkBuffersPerChannel(),
                         config.floatingNetworkBuffersPerGate(),
@@ -155,6 +184,8 @@ public class NettyShuffleServiceFactory
                 fileChannelManager,
                 resultPartitionFactory,
                 singleInputGateFactory,
-                ioExecutor);
+                ioExecutor,
+                batchShuffleReadBufferPool,
+                batchShuffleReadIOExecutor);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 
 /** Factory for {@link ResultPartition} to use in {@link NettyShuffleEnvironment}. */
@@ -47,6 +49,10 @@ public class ResultPartitionFactory {
     private final FileChannelManager channelManager;
 
     private final BufferPoolFactory bufferPoolFactory;
+
+    private final BatchShuffleReadBufferPool batchShuffleReadBufferPool;
+
+    private final ExecutorService batchShuffleReadIOExecutor;
 
     private final BoundedBlockingSubpartitionType blockingSubpartitionType;
 
@@ -72,6 +78,8 @@ public class ResultPartitionFactory {
             ResultPartitionManager partitionManager,
             FileChannelManager channelManager,
             BufferPoolFactory bufferPoolFactory,
+            BatchShuffleReadBufferPool batchShuffleReadBufferPool,
+            ExecutorService batchShuffleReadIOExecutor,
             BoundedBlockingSubpartitionType blockingSubpartitionType,
             int networkBuffersPerChannel,
             int floatingNetworkBuffersPerGate,
@@ -88,6 +96,8 @@ public class ResultPartitionFactory {
         this.networkBuffersPerChannel = networkBuffersPerChannel;
         this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
         this.bufferPoolFactory = bufferPoolFactory;
+        this.batchShuffleReadBufferPool = batchShuffleReadBufferPool;
+        this.batchShuffleReadIOExecutor = batchShuffleReadIOExecutor;
         this.blockingSubpartitionType = blockingSubpartitionType;
         this.networkBufferSize = networkBufferSize;
         this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPoolTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2012 The Netty Project
+ * Copy from netty 4.1.32.Final
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.io.disk;
+
+import org.apache.flink.core.memory.MemorySegment;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link BatchShuffleReadBufferPool}. */
+public class BatchShuffleReadBufferPoolTest {
+
+    @Rule public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalTotalBytes() {
+        createBufferPool(0, 1024);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalBufferSize() {
+        createBufferPool(32 * 1024 * 1024, 0);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testIllegalRequestTimeout() {
+        createBufferPool(null);
+    }
+
+    @Test
+    public void testLargeTotalBytes() {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool(Long.MAX_VALUE, 1024);
+        assertEquals(Integer.MAX_VALUE, bufferPool.getNumTotalBuffers());
+        bufferPool.destroy();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTotalBytesSmallerThanBufferSize() {
+        createBufferPool(4096, 32 * 1024);
+    }
+
+    @Test
+    public void testBufferCalculation() {
+        long totalBytes = 32 * 1024 * 1024;
+        for (int bufferSize = 4 * 1024; bufferSize <= totalBytes; bufferSize += 1024) {
+            BatchShuffleReadBufferPool bufferPool = createBufferPool(totalBytes, bufferSize);
+
+            assertEquals(totalBytes, bufferPool.getTotalBytes());
+            assertEquals(totalBytes / bufferSize, bufferPool.getNumTotalBuffers());
+            assertTrue(bufferPool.getNumBuffersPerRequest() <= bufferPool.getNumTotalBuffers());
+            assertTrue(bufferPool.getNumBuffersPerRequest() > 0);
+        }
+    }
+
+    @Test
+    public void testRequestBuffers() throws Exception {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+        List<MemorySegment> buffers = new ArrayList<>();
+
+        try {
+            buffers.addAll(bufferPool.requestBuffers());
+            assertEquals(bufferPool.getNumBuffersPerRequest(), buffers.size());
+        } finally {
+            bufferPool.recycle(buffers);
+            bufferPool.destroy();
+        }
+    }
+
+    @Test
+    public void testRecycle() throws Exception {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+        List<MemorySegment> buffers = bufferPool.requestBuffers();
+
+        bufferPool.recycle(buffers);
+        assertEquals(bufferPool.getNumTotalBuffers(), bufferPool.getAvailableBuffers());
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testRequestBuffersTimeout() throws Exception {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool(Duration.ofSeconds(1));
+        List<MemorySegment> buffers = new ArrayList<>();
+
+        try {
+            while (true) {
+                buffers.addAll(bufferPool.requestBuffers());
+            }
+        } finally {
+            bufferPool.recycle(buffers);
+            bufferPool.destroy();
+        }
+    }
+
+    @Test
+    public void testBufferFulfilledByRecycledBuffers() throws Exception {
+        int numRequestThreads = 2;
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+        Map<Object, List<MemorySegment>> buffers = new ConcurrentHashMap<>();
+
+        try {
+            Object[] owners = new Object[] {new Object(), new Object(), new Object(), new Object()};
+            for (int i = 0; i < 4; ++i) {
+                buffers.put(owners[i], bufferPool.requestBuffers());
+            }
+            assertEquals(0, bufferPool.getAvailableBuffers());
+
+            Thread[] requestThreads = new Thread[numRequestThreads];
+            for (int i = 0; i < numRequestThreads; ++i) {
+                requestThreads[i] =
+                        new Thread(
+                                () -> {
+                                    try {
+                                        Object owner = new Object();
+                                        buffers.put(owner, bufferPool.requestBuffers());
+                                    } catch (Throwable throwable) {
+                                        exception.set(throwable);
+                                    }
+                                });
+                requestThreads[i].start();
+            }
+
+            // recycle one by one
+            for (MemorySegment segment : buffers.remove(owners[0])) {
+                bufferPool.recycle(segment);
+            }
+
+            // bulk recycle
+            bufferPool.recycle(buffers.remove(owners[1]));
+
+            for (Thread requestThread : requestThreads) {
+                requestThread.join();
+            }
+
+            assertNull(exception.get());
+            assertEquals(0, bufferPool.getAvailableBuffers());
+            assertEquals(4, buffers.size());
+        } finally {
+            for (Object owner : buffers.keySet()) {
+                bufferPool.recycle(buffers.remove(owner));
+            }
+            assertEquals(bufferPool.getNumTotalBuffers(), bufferPool.getAvailableBuffers());
+            bufferPool.destroy();
+        }
+    }
+
+    @Test
+    public void testMultipleThreadRequestAndRecycle() throws Exception {
+        int numRequestThreads = 10;
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+
+        try {
+            Thread[] requestThreads = new Thread[numRequestThreads];
+            for (int i = 0; i < numRequestThreads; ++i) {
+                requestThreads[i] =
+                        new Thread(
+                                () -> {
+                                    try {
+                                        for (int j = 0; j < 100; ++j) {
+                                            List<MemorySegment> buffers =
+                                                    bufferPool.requestBuffers();
+                                            Thread.sleep(10);
+                                            if (j % 2 == 0) {
+                                                bufferPool.recycle(buffers);
+                                            } else {
+                                                for (MemorySegment segment : buffers) {
+                                                    bufferPool.recycle(segment);
+                                                }
+                                            }
+                                        }
+                                    } catch (Throwable throwable) {
+                                        exception.set(throwable);
+                                    }
+                                });
+                requestThreads[i].start();
+            }
+
+            for (Thread requestThread : requestThreads) {
+                requestThread.join();
+            }
+
+            assertNull(exception.get());
+            assertEquals(bufferPool.getNumTotalBuffers(), bufferPool.getAvailableBuffers());
+        } finally {
+            bufferPool.destroy();
+        }
+    }
+
+    @Test
+    public void testDestroy() throws Exception {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+        List<MemorySegment> buffers = bufferPool.requestBuffers();
+        bufferPool.recycle(buffers);
+
+        assertFalse(bufferPool.isDestroyed());
+        assertEquals(bufferPool.getNumTotalBuffers(), bufferPool.getAvailableBuffers());
+
+        buffers = bufferPool.requestBuffers();
+        assertEquals(
+                bufferPool.getNumTotalBuffers() - buffers.size(), bufferPool.getAvailableBuffers());
+
+        bufferPool.destroy();
+        assertTrue(bufferPool.isDestroyed());
+        assertEquals(0, bufferPool.getAvailableBuffers());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRequestBuffersAfterDestroyed() throws Exception {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+        bufferPool.requestBuffers();
+
+        bufferPool.destroy();
+        bufferPool.requestBuffers();
+    }
+
+    @Test
+    public void testRecycleAfterDestroyed() throws Exception {
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+        List<MemorySegment> buffers = bufferPool.requestBuffers();
+        bufferPool.destroy();
+
+        bufferPool.recycle(buffers);
+        assertEquals(0, bufferPool.getAvailableBuffers());
+    }
+
+    @Test
+    public void testDestroyWhileBlockingRequest() throws Exception {
+        AtomicReference<Throwable> exception = new AtomicReference<>();
+        BatchShuffleReadBufferPool bufferPool = createBufferPool();
+
+        Thread requestThread =
+                new Thread(
+                        () -> {
+                            try {
+                                while (true) {
+                                    bufferPool.requestBuffers();
+                                }
+                            } catch (Throwable throwable) {
+                                exception.set(throwable);
+                            }
+                        });
+        requestThread.start();
+
+        Thread.sleep(1000);
+        bufferPool.destroy();
+        requestThread.join();
+
+        assertTrue(exception.get() instanceof IllegalStateException);
+    }
+
+    private BatchShuffleReadBufferPool createBufferPool(long totalBytes, int bufferSize) {
+        return new BatchShuffleReadBufferPool(totalBytes, bufferSize, Duration.ofMinutes(5));
+    }
+
+    private BatchShuffleReadBufferPool createBufferPool() {
+        return createBufferPool(32 * 1024 * 1024, 32 * 1024);
+    }
+
+    private BatchShuffleReadBufferPool createBufferPool(Duration requestTimeout) {
+        return new BatchShuffleReadBufferPool(64 * 32 * 1024, 32 * 1024, requestTimeout);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -58,6 +58,8 @@ public class NettyShuffleEnvironmentBuilder {
 
     private int sortShuffleMinParallelism = Integer.MAX_VALUE;
 
+    private long batchShuffleReadMemoryBytes = 64 * DEFAULT_NETWORK_BUFFER_SIZE;
+
     private int maxBuffersPerChannel = Integer.MAX_VALUE;
 
     private boolean blockingShuffleCompressionEnabled = false;
@@ -130,6 +132,12 @@ public class NettyShuffleEnvironmentBuilder {
         return this;
     }
 
+    public NettyShuffleEnvironmentBuilder setBatchShuffleReadMemoryBytes(
+            long batchShuffleReadMemoryBytes) {
+        this.batchShuffleReadMemoryBytes = batchShuffleReadMemoryBytes;
+        return this;
+    }
+
     public NettyShuffleEnvironmentBuilder setBlockingShuffleCompressionEnabled(
             boolean blockingShuffleCompressionEnabled) {
         this.blockingShuffleCompressionEnabled = blockingShuffleCompressionEnabled;
@@ -179,6 +187,7 @@ public class NettyShuffleEnvironmentBuilder {
                         blockingShuffleCompressionEnabled,
                         compressionCodec,
                         maxBuffersPerChannel,
+                        batchShuffleReadMemoryBytes,
                         sortShuffleMinBuffers,
                         sortShuffleMinParallelism),
                 taskManagerLocation,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -26,7 +28,9 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.util.function.SupplierWithException;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
 
 /** Utility class to encapsulate the logic of building a {@link ResultPartition} instance. */
 public class ResultPartitionBuilder {
@@ -49,6 +53,11 @@ public class ResultPartitionBuilder {
     private FileChannelManager channelManager = NoOpFileChannelManager.INSTANCE;
 
     private NetworkBufferPool networkBufferPool = new NetworkBufferPool(2, 1);
+
+    private BatchShuffleReadBufferPool batchShuffleReadBufferPool =
+            new BatchShuffleReadBufferPool(64 * 32 * 1024, 32 * 1024, Duration.ofMinutes(5));
+
+    private ExecutorService batchShuffleReadIOExecutor = Executors.newDirectExecutorService();
 
     private int networkBuffersPerChannel = 1;
 
@@ -116,6 +125,8 @@ public class ResultPartitionBuilder {
                         environment.getConfiguration().floatingNetworkBuffersPerGate())
                 .setNetworkBufferSize(environment.getConfiguration().networkBufferSize())
                 .setNetworkBufferPool(environment.getNetworkBufferPool())
+                .setBatchShuffleReadBufferPool(environment.getBatchShuffleReadBufferPool())
+                .setBatchShuffleReadIOExecutor(environment.getBatchShuffleReadIOExecutor())
                 .setSortShuffleMinBuffers(environment.getConfiguration().sortShuffleMinBuffers())
                 .setSortShuffleMinParallelism(
                         environment.getConfiguration().sortShuffleMinParallelism());
@@ -123,6 +134,18 @@ public class ResultPartitionBuilder {
 
     public ResultPartitionBuilder setNetworkBufferPool(NetworkBufferPool networkBufferPool) {
         this.networkBufferPool = networkBufferPool;
+        return this;
+    }
+
+    public ResultPartitionBuilder setBatchShuffleReadBufferPool(
+            BatchShuffleReadBufferPool batchShuffleReadBufferPool) {
+        this.batchShuffleReadBufferPool = batchShuffleReadBufferPool;
+        return this;
+    }
+
+    public ResultPartitionBuilder setBatchShuffleReadIOExecutor(
+            ExecutorService batchShuffleReadIOExecutor) {
+        this.batchShuffleReadIOExecutor = batchShuffleReadIOExecutor;
         return this;
     }
 
@@ -187,6 +210,8 @@ public class ResultPartitionBuilder {
                         partitionManager,
                         channelManager,
                         networkBufferPool,
+                        batchShuffleReadBufferPool,
+                        batchShuffleReadIOExecutor,
                         blockingSubpartitionType,
                         networkBuffersPerChannel,
                         floatingNetworkBuffersPerGate,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
@@ -30,6 +32,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -122,6 +125,9 @@ public class ResultPartitionFactoryTest extends TestLogger {
                         manager,
                         fileChannelManager,
                         new NetworkBufferPool(1, SEGMENT_SIZE),
+                        new BatchShuffleReadBufferPool(
+                                10 * SEGMENT_SIZE, SEGMENT_SIZE, Duration.ofMinutes(5)),
+                        Executors.newDirectExecutorService(),
                         BoundedBlockingSubpartitionType.AUTO,
                         1,
                         1,


### PR DESCRIPTION
## What is the purpose of the change

Currently, sort-merge blocking shuffle implementation uses some unmanaged direct memory and the netty thread for shuffle data read which can lead to direct memory OOM and stress the netty thread with file IO. This patch introduces a separated buffer pool and a separated thread pool for data read. In the following patch, the problem will be totally solved by the IO scheduling mechanism leveraging the introduced buffer pool and thread pool.

## Brief change log

  - Introduce a separated buffer pool and a separated thread pool for sort-merge blocking shuffle.


## Verifying this change

This change added tests BatchReadBufferPoolTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
