### PR TITLE
[FLINK-21466][table] Add SQL Client default mode value embedded

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -45,10 +45,10 @@ The SQL Client is bundled in the regular Flink distribution and thus runnable ou
 
 ### Starting the SQL Client CLI
 
-The SQL Client scripts are also located in the binary directory of Flink. [In the future](sqlClient.html#limitations--future), a user will have two possibilities of starting the SQL Client CLI either by starting an embedded standalone process or by connecting to a remote SQL Client Gateway. At the moment only the `embedded` mode is supported，default mode value `embedded`. You can start the CLI by calling:
+The SQL Client scripts are also located in the binary directory of Flink. [In the future](sqlClient.html#limitations--future), a user will have two possibilities of starting the SQL Client CLI either by starting an embedded standalone process or by connecting to a remote SQL Client Gateway. At the moment only the `embedded` mode is supported，and default mode is `embedded`. You can start the CLI by calling:
 
 {% highlight bash %}
-./bin/sql-client.sh embedded(default mode value embedded)
+./bin/sql-client.sh
 {% endhighlight %}
 
 By default, the SQL Client will read its configuration from the environment file located in `./conf/sql-client-defaults.yaml`. See the [configuration part](sqlClient.html#environment-files) for more information about the structure of environment files.

--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -45,10 +45,10 @@ The SQL Client is bundled in the regular Flink distribution and thus runnable ou
 
 ### Starting the SQL Client CLI
 
-The SQL Client scripts are also located in the binary directory of Flink. [In the future](sqlClient.html#limitations--future), a user will have two possibilities of starting the SQL Client CLI either by starting an embedded standalone process or by connecting to a remote SQL Client Gateway. At the moment only the `embedded` mode is supported. You can start the CLI by calling:
+The SQL Client scripts are also located in the binary directory of Flink. [In the future](sqlClient.html#limitations--future), a user will have two possibilities of starting the SQL Client CLI either by starting an embedded standalone process or by connecting to a remote SQL Client Gateway. At the moment only the `embedded` mode is supported，default mode value `embedded`. You can start the CLI by calling:
 
 {% highlight bash %}
-./bin/sql-client.sh embedded
+./bin/sql-client.sh embedded(default mode value embedded)
 {% endhighlight %}
 
 By default, the SQL Client will read its configuration from the environment file located in `./conf/sql-client-defaults.yaml`. See the [configuration part](sqlClient.html#environment-files) for more information about the structure of environment files.
@@ -154,7 +154,7 @@ Configuration
 The SQL Client can be started with the following optional CLI commands. They are discussed in detail in the subsequent paragraphs.
 
 {% highlight text %}
-./bin/sql-client.sh embedded --help
+./bin/sql-client.sh --help
 
 Mode "embedded" submits Flink jobs from the local machine.
 

--- a/docs/dev/table/sqlClient.zh.md
+++ b/docs/dev/table/sqlClient.zh.md
@@ -47,7 +47,7 @@ SQL 客户端捆绑在常规 Flink 发行版中，因此可以直接运行。它
 SQL Client 脚本也位于 Flink 的 bin 目录中。[将来](sqlClient.html#limitations--future)，用户可以通过启动嵌入式 standalone 进程或通过连接到远程 SQL 客户端网关来启动 SQL 客户端命令行界面。目前仅支持 `embedded` 模式，默认模式`embedded`。可以通过以下方式启动 CLI：
 
 {% highlight bash %}
-./bin/sql-client.sh embedded（默认模式embedded，可以不填）
+./bin/sql-client.sh
 {% endhighlight %}
 
 默认情况下，SQL 客户端将从 `./conf/sql-client-defaults.yaml` 中读取配置。有关环境配置文件结构的更多信息，请参见[配置部分](sqlClient.html#environment-files)。

--- a/docs/dev/table/sqlClient.zh.md
+++ b/docs/dev/table/sqlClient.zh.md
@@ -44,10 +44,10 @@ SQL 客户端捆绑在常规 Flink 发行版中，因此可以直接运行。它
 
 ### 启动 SQL 客户端命令行界面
 
-SQL Client 脚本也位于 Flink 的 bin 目录中。[将来](sqlClient.html#limitations--future)，用户可以通过启动嵌入式 standalone 进程或通过连接到远程 SQL 客户端网关来启动 SQL 客户端命令行界面。目前仅支持 `embedded` 模式。可以通过以下方式启动 CLI：
+SQL Client 脚本也位于 Flink 的 bin 目录中。[将来](sqlClient.html#limitations--future)，用户可以通过启动嵌入式 standalone 进程或通过连接到远程 SQL 客户端网关来启动 SQL 客户端命令行界面。目前仅支持 `embedded` 模式，默认模式`embedded`。可以通过以下方式启动 CLI：
 
 {% highlight bash %}
-./bin/sql-client.sh embedded
+./bin/sql-client.sh embedded（默认模式embedded，可以不填）
 {% endhighlight %}
 
 默认情况下，SQL 客户端将从 `./conf/sql-client-defaults.yaml` 中读取配置。有关环境配置文件结构的更多信息，请参见[配置部分](sqlClient.html#environment-files)。
@@ -155,7 +155,7 @@ Received a total of 5 rows
 SQL 客户端启动时可以添加 CLI 选项，具体如下。
 
 {% highlight text %}
-./bin/sql-client.sh embedded --help
+./bin/sql-client.sh --help
 
 Mode "embedded" submits Flink jobs from the local machine.
 

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -198,7 +198,7 @@ EOF
 
 SQL_STATEMENT="insert into sink select add_one(a) from (VALUES (1), (2), (3)) as source (a)"
 
-JOB_ID=$($FLINK_DIR/bin/sql-client.sh embedded \
+JOB_ID=$($FLINK_DIR/bin/sql-client.sh \
   --environment $SQL_CONF \
   -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
   -pyreq "${REQUIREMENTS_PATH}" \

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -231,7 +231,7 @@ INSERT INTO ElasticsearchUpsertSinkTable
 EOF
 )
 
-JOB_ID=$($FLINK_DIR/bin/sql-client.sh embedded \
+JOB_ID=$($FLINK_DIR/bin/sql-client.sh \
   --jar $KAFKA_SQL_JAR \
   --jar $ELASTICSEARCH_SQL_JAR \
   --jar $SQL_TOOLBOX_JAR \
@@ -259,7 +259,7 @@ INSERT INTO ElasticsearchAppendSinkTable
 EOF
 )
 
-JOB_ID=$($FLINK_DIR/bin/sql-client.sh embedded \
+JOB_ID=$($FLINK_DIR/bin/sql-client.sh \
   --jar $KAFKA_SQL_JAR \
   --jar $ELASTICSEARCH_SQL_JAR \
   --jar $SQL_TOOLBOX_JAR \

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -83,7 +83,7 @@ EOF
         SQL_STATEMENT="INSERT INTO q$i $(cat "$ORIGIN_QUERY_DIR/q$i.sql")"
     fi
 
-    JOB_ID=$("$FLINK_DIR/bin/sql-client.sh" embedded \
+    JOB_ID=$("$FLINK_DIR/bin/sql-client.sh" \
         --environment "$SQL_CONF" \
         --update "$SQL_STATEMENT" | grep "Job ID:" | sed 's/.* //g')
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.client;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.client.cli.CliClient;
 import org.apache.flink.table.client.cli.CliOptions;
@@ -27,6 +26,8 @@ import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.local.LocalExecutor;
+
+import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.table.client.config.entries.ConfigurationEntry.create;
 import static org.apache.flink.table.client.config.entries.ConfigurationEntry.merge;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -187,12 +187,12 @@ public class SqlClient {
         } else {
             // mode is specified, extract the mode value and reaming args
             model = args[0];
+            // remove mode
             modeArgs = Arrays.copyOfRange(args, 1, args.length);
         }
 
         switch (model) {
             case MODE_EMBEDDED:
-                // remove mode
                 final CliOptions options = CliOptionsParser.parseEmbeddedModeClient(modeArgs);
                 if (options.isPrintHelp()) {
                     CliOptionsParser.printHelpEmbeddedModeClient();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.client.config.entries.ConfigurationEntry.create;
 import static org.apache.flink.table.client.config.entries.ConfigurationEntry.merge;
@@ -184,8 +185,14 @@ public class SqlClient {
 
     public static void main(String[] args) {
         if (args.length < 1) {
-            CliOptionsParser.printHelpClient();
-            return;
+            args = new String[]{MODE_EMBEDDED};
+        } else {
+            String mode = args[0];
+            if (!MODE_EMBEDDED.equals(mode)) {
+                List<String> params = Arrays.stream(args).collect(Collectors.toList());
+                params.add(0, MODE_EMBEDDED);
+                args = params.toArray(new String[params.size()]);
+            }
         }
 
         switch (args[0]) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.client;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.client.cli.CliClient;
 import org.apache.flink.table.client.cli.CliOptions;
@@ -26,8 +27,6 @@ import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.local.LocalExecutor;
-
-import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,12 +34,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.*;
 
 import static org.apache.flink.table.client.config.entries.ConfigurationEntry.create;
 import static org.apache.flink.table.client.config.entries.ConfigurationEntry.merge;
@@ -184,21 +178,21 @@ public class SqlClient {
     // --------------------------------------------------------------------------------------------
 
     public static void main(String[] args) {
-        if (args.length < 1) {
-            args = new String[]{MODE_EMBEDDED};
+        final String model;
+        final String[] modeArgs;
+        if (args.length < 1 || args[0].startsWith("-")) {
+            // mode is not specified, use the default `embedded` mode
+            model = MODE_EMBEDDED;
+            modeArgs = args;
         } else {
-            String mode = args[0];
-            if (!MODE_EMBEDDED.equals(mode)) {
-                List<String> params = Arrays.stream(args).collect(Collectors.toList());
-                params.add(0, MODE_EMBEDDED);
-                args = params.toArray(new String[params.size()]);
-            }
+            // mode is specified, extract the mode value and reaming args
+            model = args[0];
+            modeArgs = Arrays.copyOfRange(args, 1, args.length);
         }
 
-        switch (args[0]) {
+        switch (model) {
             case MODE_EMBEDDED:
                 // remove mode
-                final String[] modeArgs = Arrays.copyOfRange(args, 1, args.length);
                 final CliOptions options = CliOptionsParser.parseEmbeddedModeClient(modeArgs);
                 if (options.isPrintHelp()) {
                     CliOptionsParser.printHelpEmbeddedModeClient();


### PR DESCRIPTION
Users can use command
`>./sql-client.sh `
to start the sql client and don't need to add embedded.