### PR TITLE
[FLINK-21783] Allow extension of HeapBackend SnapshotStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointableKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointableKeyedStateBackend.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 
 import javax.annotation.Nonnull;
 
@@ -45,5 +46,6 @@ public interface CheckpointableKeyedStateBackend<K>
      * write out a savepoint in the common/unified format.
      */
     @Nonnull
-    SavepointResources<K> savepoint() throws Exception;
+    SavepointResources<K> savepoint(long checkpointId, CheckpointOptions checkpointOptions)
+            throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
@@ -52,7 +52,8 @@ class DefaultOperatorStateBackendSnapshotStrategy
     }
 
     @Override
-    public DefaultOperatorStateBackendSnapshotResources syncPrepareResources(long checkpointId) {
+    public DefaultOperatorStateBackendSnapshotResources syncPrepareResources(
+            long checkpointId, CheckpointOptions checkpointOptions) {
         if (registeredOperatorStates.isEmpty() && registeredBroadcastStates.isEmpty()) {
             return new DefaultOperatorStateBackendSnapshotResources(
                     Collections.emptyMap(), Collections.emptyMap());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SavepointSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SavepointSnapshotStrategy.java
@@ -53,7 +53,8 @@ public class SavepointSnapshotStrategy<K>
     }
 
     @Override
-    public FullSnapshotResources<K> syncPrepareResources(long checkpointId) throws Exception {
+    public FullSnapshotResources<K> syncPrepareResources(
+            long checkpointId, CheckpointOptions checkpointOptions) throws Exception {
         return savepointResources;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategy.java
@@ -45,9 +45,11 @@ public interface SnapshotStrategy<S extends StateObject, SR extends SnapshotReso
      * used in the asynchronous part.
      *
      * @param checkpointId The ID of the checkpoint.
+     * @param checkpointOptions
      * @return Resources needed to finish the snapshot.
      */
-    SR syncPrepareResources(long checkpointId) throws Exception;
+    SR syncPrepareResources(long checkpointId, CheckpointOptions checkpointOptions)
+            throws Exception;
 
     /**
      * Operation that writes a snapshot into a stream that is provided by the given {@link

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategyRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategyRunner.java
@@ -74,7 +74,8 @@ public final class SnapshotStrategyRunner<T extends StateObject, SR extends Snap
             @Nonnull CheckpointOptions checkpointOptions)
             throws Exception {
         long startTime = System.currentTimeMillis();
-        SR snapshotResources = snapshotStrategy.syncPrepareResources(checkpointId);
+        SR snapshotResources =
+                snapshotStrategy.syncPrepareResources(checkpointId, checkpointOptions);
         logCompletedInternal(LOG_SYNC_COMPLETED_TEMPLATE, streamFactory, startTime);
         SnapshotStrategy.SnapshotResultSupplier<T> asyncSnapshot =
                 snapshotStrategy.asyncSnapshot(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -318,10 +318,12 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() {
+    public SavepointResources<K> savepoint(long checkpointId, CheckpointOptions checkpointOptions) {
 
         HeapSnapshotResources<K> snapshotResources =
                 HeapSnapshotResources.create(
+                        checkpointId,
+                        checkpointOptions,
                         registeredKVStates,
                         priorityQueuesManager.getRegisteredPQStates(),
                         keyGroupCompressionDecorator,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
@@ -137,11 +137,15 @@ public final class HeapSnapshotResources<K> implements FullSnapshotResources<K> 
             stateNamesToId.put(stateUid, stateNamesToId.size());
             StateSnapshotRestore state = kvState.getValue();
             if (null != state) {
-                final StateSnapshot stateSnapshot = state.stateSnapshot();
+                StateSnapshot stateSnapshot = snapshot(state);
                 metaInfoSnapshots.add(stateSnapshot.getMetaInfoSnapshot());
                 cowStateStableSnapshots.put(stateUid, stateSnapshot);
             }
         }
+    }
+
+    protected static StateSnapshot snapshot(StateSnapshotRestore state) {
+        return state.stateSnapshot();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResources.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * HeapKeyedStateBackend}.
  */
 @Internal
-final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
+public final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
     private final List<StateMetaInfoSnapshot> metaInfoSnapshots;
     private final Map<StateUID, StateSnapshot> cowStateStableSnapshots;
     private final StreamCompressionDecorator streamCompressionDecorator;
@@ -50,7 +50,7 @@ final class HeapSnapshotResources<K> implements FullSnapshotResources<K> {
     private final TypeSerializer<K> keySerializer;
     private final int totalKeyGroups;
 
-    private HeapSnapshotResources(
+    protected HeapSnapshotResources(
             List<StateMetaInfoSnapshot> metaInfoSnapshots,
             Map<StateUID, StateSnapshot> cowStateStableSnapshots,
             StreamCompressionDecorator streamCompressionDecorator,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResultSupplier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResultSupplier.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.SnapshotStrategy;
+import org.apache.flink.runtime.state.StateSnapshot;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+import static org.apache.flink.runtime.state.CheckpointStreamWithResultProvider.toKeyedStateHandleSnapshotResult;
+
+class HeapSnapshotResultSupplier<K>
+        implements SnapshotStrategy.SnapshotResultSupplier<KeyedStateHandle> {
+    private final HeapSnapshotResources<K> syncPartResource;
+    private final SupplierWithException<CheckpointStreamWithResultProvider, Exception>
+            checkpointStreamSupplier;
+    private final KeyedBackendSerializationProxy<K> serializationProxy;
+    private final KeyGroupRange keyGroupRange;
+    private final StreamCompressionDecorator keyGroupCompressionDecorator;
+
+    public HeapSnapshotResultSupplier(
+            HeapSnapshotResources<K> syncPartResource,
+            SupplierWithException<CheckpointStreamWithResultProvider, Exception>
+                    checkpointStreamSupplier,
+            KeyedBackendSerializationProxy<K> serializationProxy,
+            KeyGroupRange keyGroupRange,
+            StreamCompressionDecorator keyGroupCompressionDecorator) {
+        this.syncPartResource = syncPartResource;
+        this.checkpointStreamSupplier = checkpointStreamSupplier;
+        this.serializationProxy = serializationProxy;
+        this.keyGroupRange = keyGroupRange;
+        this.keyGroupCompressionDecorator = keyGroupCompressionDecorator;
+    }
+
+    @Override
+    public SnapshotResult<KeyedStateHandle> get(CloseableRegistry snapshotCloseableRegistry)
+            throws Exception {
+        final Map<StateUID, Integer> stateNamesToId = syncPartResource.getStateNamesToId();
+        final Map<StateUID, StateSnapshot> cowStateStableSnapshots =
+                syncPartResource.getCowStateStableSnapshots();
+        final CheckpointStreamWithResultProvider streamWithResultProvider =
+                checkpointStreamSupplier.get();
+
+        snapshotCloseableRegistry.registerCloseable(streamWithResultProvider);
+
+        final CheckpointStreamFactory.CheckpointStateOutputStream localStream =
+                streamWithResultProvider.getCheckpointOutputStream();
+
+        final DataOutputViewStreamWrapper outView = new DataOutputViewStreamWrapper(localStream);
+        serializationProxy.write(outView);
+
+        final long[] keyGroupRangeOffsets = new long[keyGroupRange.getNumberOfKeyGroups()];
+
+        for (int keyGroupPos = 0;
+                keyGroupPos < keyGroupRange.getNumberOfKeyGroups();
+                ++keyGroupPos) {
+            int keyGroupId = keyGroupRange.getKeyGroupId(keyGroupPos);
+            keyGroupRangeOffsets[keyGroupPos] = localStream.getPos();
+            outView.writeInt(keyGroupId);
+
+            for (Map.Entry<StateUID, StateSnapshot> stateSnapshot :
+                    cowStateStableSnapshots.entrySet()) {
+                StateSnapshot.StateKeyGroupWriter partitionedSnapshot =
+                        stateSnapshot.getValue().getKeyGroupWriter();
+                try (OutputStream kgCompressionOut =
+                        keyGroupCompressionDecorator.decorateWithCompression(localStream)) {
+                    DataOutputViewStreamWrapper kgCompressionView =
+                            new DataOutputViewStreamWrapper(kgCompressionOut);
+                    kgCompressionView.writeShort(stateNamesToId.get(stateSnapshot.getKey()));
+                    partitionedSnapshot.writeStateInKeyGroup(kgCompressionView, keyGroupId);
+                } // this will just close the outer compression stream
+            }
+        }
+
+        if (snapshotCloseableRegistry.unregisterCloseable(streamWithResultProvider)) {
+            KeyGroupRangeOffsets kgOffs =
+                    new KeyGroupRangeOffsets(keyGroupRange, keyGroupRangeOffsets);
+            SnapshotResult<StreamStateHandle> result =
+                    streamWithResultProvider.closeAndFinalizeCheckpointStreamResult();
+            return toKeyedStateHandleSnapshotResult(result, kgOffs, KeyGroupsStateHandle::new);
+        } else {
+            throw new IOException("Stream already unregistered.");
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResultSupplier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotResultSupplier.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -39,16 +40,22 @@ import java.util.Map;
 
 import static org.apache.flink.runtime.state.CheckpointStreamWithResultProvider.toKeyedStateHandleSnapshotResult;
 
-class HeapSnapshotResultSupplier<K>
+/**
+ * Writes out HeapState snapshot.
+ *
+ * @param <K> key type.
+ */
+@Internal
+public class HeapSnapshotResultSupplier<K>
         implements SnapshotStrategy.SnapshotResultSupplier<KeyedStateHandle> {
-    private final HeapSnapshotResources<K> syncPartResource;
-    private final SupplierWithException<CheckpointStreamWithResultProvider, Exception>
+    protected final HeapSnapshotResources<K> syncPartResource;
+    protected final SupplierWithException<CheckpointStreamWithResultProvider, Exception>
             checkpointStreamSupplier;
-    private final KeyedBackendSerializationProxy<K> serializationProxy;
-    private final KeyGroupRange keyGroupRange;
-    private final StreamCompressionDecorator keyGroupCompressionDecorator;
+    protected final KeyedBackendSerializationProxy<K> serializationProxy;
+    protected final KeyGroupRange keyGroupRange;
+    protected final StreamCompressionDecorator keyGroupCompressionDecorator;
 
-    public HeapSnapshotResultSupplier(
+    protected HeapSnapshotResultSupplier(
             HeapSnapshotResources<K> syncPartResource,
             SupplierWithException<CheckpointStreamWithResultProvider, Exception>
                     checkpointStreamSupplier,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -76,8 +76,11 @@ public class HeapSnapshotStrategy<K>
     }
 
     @Override
-    public HeapSnapshotResources<K> syncPrepareResources(long checkpointId) {
+    public HeapSnapshotResources<K> syncPrepareResources(
+            long checkpointId, CheckpointOptions checkpointOptions) {
         return HeapSnapshotResources.create(
+                checkpointId,
+                checkpointOptions,
                 registeredKVStates,
                 registeredPQStates,
                 keyGroupCompressionDecorator,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -45,18 +46,19 @@ import static org.apache.flink.runtime.state.CheckpointStreamWithResultProvider.
 import static org.apache.flink.runtime.state.CheckpointStreamWithResultProvider.createSimpleStream;
 
 /** A strategy how to perform a snapshot of a {@link HeapKeyedStateBackend}. */
-class HeapSnapshotStrategy<K>
+@Internal
+public class HeapSnapshotStrategy<K>
         implements SnapshotStrategy<KeyedStateHandle, HeapSnapshotResources<K>> {
 
-    private final Map<String, StateTable<K, ?, ?>> registeredKVStates;
-    private final Map<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates;
-    private final StreamCompressionDecorator keyGroupCompressionDecorator;
-    private final LocalRecoveryConfig localRecoveryConfig;
-    private final KeyGroupRange keyGroupRange;
-    private final StateSerializerProvider<K> keySerializerProvider;
-    private final int totalKeyGroups;
+    protected final Map<String, StateTable<K, ?, ?>> registeredKVStates;
+    protected final Map<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates;
+    protected final StreamCompressionDecorator keyGroupCompressionDecorator;
+    protected final LocalRecoveryConfig localRecoveryConfig;
+    protected final KeyGroupRange keyGroupRange;
+    protected final StateSerializerProvider<K> keySerializerProvider;
+    protected final int totalKeyGroups;
 
-    HeapSnapshotStrategy(
+    protected HeapSnapshotStrategy(
             Map<String, StateTable<K, ?, ?>> registeredKVStates,
             Map<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
             StreamCompressionDecorator keyGroupCompressionDecorator,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -117,14 +117,28 @@ public class HeapSnapshotStrategy<K>
                                 ? () ->
                                         createDuplicatingStream(
                                                 checkpointId,
-                                                CheckpointedStateScope.EXCLUSIVE,
+                                                getCheckpointedStateScope(),
                                                 streamFactory,
                                                 localRecoveryConfig
                                                         .getLocalStateDirectoryProvider())
                                 : () ->
                                         createSimpleStream(
-                                                CheckpointedStateScope.EXCLUSIVE, streamFactory);
+                                                getCheckpointedStateScope(), streamFactory);
 
+        return getSnapshotResultSupplier(
+                checkpointId, syncPartResource, serializationProxy, checkpointStreamSupplier);
+    }
+
+    protected CheckpointedStateScope getCheckpointedStateScope() {
+        return CheckpointedStateScope.EXCLUSIVE;
+    }
+
+    protected SnapshotResultSupplier<KeyedStateHandle> getSnapshotResultSupplier(
+            long checkpointId,
+            HeapSnapshotResources<K> syncPartResource,
+            KeyedBackendSerializationProxy<K> serializationProxy,
+            SupplierWithException<CheckpointStreamWithResultProvider, Exception>
+                    checkpointStreamSupplier) {
         return new HeapSnapshotResultSupplier<>(
                 syncPartResource,
                 checkpointStreamSupplier,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateUID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateUID.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 
 import javax.annotation.Nonnull;
@@ -25,7 +26,8 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 /** Unique identifier for registered state in this backend. */
-final class StateUID {
+@Internal
+public final class StateUID {
 
     @Nonnull private final String stateName;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -228,7 +228,8 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
+    public SavepointResources<K> savepoint(long checkpointId, CheckpointOptions checkpointOptions)
+            throws Exception {
         throw new UnsupportedOperationException(
                 "Unified savepoints are not supported on this testing StateBackend.");
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -263,8 +263,9 @@ class ChangelogKeyedStateBackend<K>
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
-        return keyedStateBackend.savepoint();
+    public SavepointResources<K> savepoint(long checkpointId, CheckpointOptions checkpointOptions)
+            throws Exception {
+        return keyedStateBackend.savepoint(checkpointId, checkpointOptions);
     }
 
     // -------------------- CheckpointListener --------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -555,7 +555,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
+    public SavepointResources<K> savepoint(long checkpointId, CheckpointOptions checkpointOptions)
+            throws Exception {
 
         // flush everything into db before taking a snapshot
         writeBatchWrapper.flush();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksFullSnapshotStrategy.java
@@ -91,7 +91,8 @@ public class RocksFullSnapshotStrategy<K>
     }
 
     @Override
-    public FullSnapshotResources<K> syncPrepareResources(long checkpointId) throws Exception {
+    public FullSnapshotResources<K> syncPrepareResources(
+            long checkpointId, CheckpointOptions checkpointOptions) throws Exception {
         return RocksDBFullSnapshotResources.create(
                 kvStateInformation,
                 registeredPQStates,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -143,8 +143,8 @@ public class RocksIncrementalSnapshotStrategy<K>
     }
 
     @Override
-    public IncrementalRocksDBSnapshotResources syncPrepareResources(long checkpointId)
-            throws Exception {
+    public IncrementalRocksDBSnapshotResources syncPrepareResources(
+            long checkpointId, CheckpointOptions checkpointOptions) throws Exception {
 
         final SnapshotDirectory snapshotDirectory = prepareLocalSnapshotDirectory(checkpointId);
         LOG.trace("Local RocksDB checkpoint goes to backup path {}.", snapshotDirectory);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -230,7 +230,12 @@ public class StreamOperatorStateHandler {
             if (null != keyedStateBackend) {
                 if (checkpointOptions.getCheckpointType().isSavepoint()) {
                     SnapshotStrategyRunner<KeyedStateHandle, ? extends FullSnapshotResources<?>>
-                            snapshotRunner = prepareSavepoint(keyedStateBackend, closeableRegistry);
+                            snapshotRunner =
+                                    prepareSavepoint(
+                                            checkpointId,
+                                            checkpointOptions,
+                                            keyedStateBackend,
+                                            closeableRegistry);
 
                     snapshotInProgress.setKeyedStateManagedFuture(
                             snapshotRunner.snapshot(
@@ -271,10 +276,13 @@ public class StreamOperatorStateHandler {
     @Nonnull
     public static SnapshotStrategyRunner<KeyedStateHandle, ? extends FullSnapshotResources<?>>
             prepareSavepoint(
+                    long checkpointId,
+                    CheckpointOptions checkpointOptions,
                     CheckpointableKeyedStateBackend<?> keyedStateBackend,
                     CloseableRegistry closeableRegistry)
                     throws Exception {
-        SavepointResources<?> savepointResources = keyedStateBackend.savepoint();
+        SavepointResources<?> savepointResources =
+                keyedStateBackend.savepoint(checkpointId, checkpointOptions);
 
         SavepointSnapshotStrategy<?> savepointSnapshotStrategy =
                 new SavepointSnapshotStrategy<>(savepointResources.getSnapshotResources());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -281,7 +281,8 @@ class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedStateBack
 
     @Nonnull
     @Override
-    public SavepointResources<K> savepoint() throws Exception {
+    public SavepointResources<K> savepoint(long checkpointId, CheckpointOptions checkpointOptions)
+            throws Exception {
         throw new UnsupportedOperationException(
                 "Savepoints are not supported in BATCH runtime mode.");
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -382,7 +382,8 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
                 FAILING_STRATEGY =
                         new SnapshotStrategy<OperatorStateHandle, SnapshotResources>() {
                             @Override
-                            public SnapshotResources syncPrepareResources(long checkpointId)
+                            public SnapshotResources syncPrepareResources(
+                                    long checkpointId, CheckpointOptions checkpointOptions)
                                     throws Exception {
                                 return null;
                             }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -165,7 +165,8 @@ public class CheckpointFailureManagerITCase extends TestLogger {
                 ASYNC_DECLINING_SNAPSHOT_STRATEGY =
                         new SnapshotStrategy<OperatorStateHandle, SnapshotResources>() {
                             @Override
-                            public SnapshotResources syncPrepareResources(long checkpointId)
+                            public SnapshotResources syncPrepareResources(
+                                    long checkpointId, CheckpointOptions checkpointOptions)
                                     throws Exception {
                                 return null;
                             }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -322,7 +322,8 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
             implements SnapshotStrategy<OperatorStateHandle, SnapshotResources> {
 
         @Override
-        public SnapshotResources syncPrepareResources(long checkpointId) {
+        public SnapshotResources syncPrepareResources(
+                long checkpointId, CheckpointOptions checkpointOptions) {
             return null;
         }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/state/SavepointStateBackendSwitchTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/SavepointStateBackendSwitchTestBase.java
@@ -231,19 +231,17 @@ public abstract class SavepointStateBackendSwitchTestBase {
         priorityQueue.add(new TimerHeapInternalTimer<>(2345L, "mno", namespace2));
         priorityQueue.add(new TimerHeapInternalTimer<>(3456L, "mno", namespace3));
 
+        CheckpointOptions checkpointOptions =
+                new CheckpointOptions(
+                        CheckpointType.SAVEPOINT, CheckpointStorageLocationReference.getDefault());
         SnapshotStrategyRunner<KeyedStateHandle, ? extends FullSnapshotResources<?>>
                 savepointRunner =
                         StreamOperatorStateHandler.prepareSavepoint(
-                                keyedBackend, new CloseableRegistry());
+                                0L, checkpointOptions, keyedBackend, new CloseableRegistry());
 
         RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                 savepointRunner.snapshot(
-                        0L,
-                        0L,
-                        new MemCheckpointStreamFactory(4 * 1024 * 1024),
-                        new CheckpointOptions(
-                                CheckpointType.SAVEPOINT,
-                                CheckpointStorageLocationReference.getDefault()));
+                        0L, 0L, new MemCheckpointStreamFactory(4 * 1024 * 1024), checkpointOptions);
 
         snapshot.run();
 


### PR DESCRIPTION
## What is the purpose of the change

Trivial refactorings to `HeapSnapshotStrategy` and
related classes to allow extension and customization.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
