### PR TITLE
[FLINK-21649] Refactor CopyOnWrite state classes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -285,6 +285,11 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
                     }
                     e.stateVersion = stateMapVersion;
                     e.state = getStateSerializer().copy(e.state);
+                } else if (e.stateVersion < stateMapVersion) {
+                    // the entry is not used by any active snapshot;
+                    // if it WAS used then it should NOT be included into the next one if it takes
+                    // versioning into account
+                    e.stateVersion = stateMapVersion;
                 }
 
                 return e.state;
@@ -424,6 +429,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
                     if (prev.entryVersion < highestRequiredSnapshotVersion) {
                         prev = handleChainedEntryCopyOnWrite(tab, index, prev);
                     }
+                    prev.entryVersion = stateMapVersion;
                     prev.next = e.next;
                 }
                 ++modCount;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -172,7 +172,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     private int rehashIndex;
 
     /** The current version of this map. Used for copy-on-write mechanics. */
-    private int stateMapVersion;
+    protected int stateMapVersion;
 
     /** The highest version of this map that is still required by any unreleased snapshot. */
     private int highestRequiredSnapshotVersion;
@@ -201,7 +201,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
      *
      * @param stateSerializer the serializer of the key.
      */
-    CopyOnWriteStateMap(TypeSerializer<S> stateSerializer) {
+    protected CopyOnWriteStateMap(TypeSerializer<S> stateSerializer) {
         this(DEFAULT_CAPACITY, stateSerializer);
     }
 
@@ -386,7 +386,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     // ---------------------------------------------------------------
 
     /** Helper method that is the basis for operations that add mappings. */
-    private StateMapEntry<K, N, S> putEntry(K key, N namespace) {
+    protected StateMapEntry<K, N, S> putEntry(K key, N namespace) {
 
         final int hash = computeHashForOperationAndDoIncrementalRehash(key, namespace);
         final StateMapEntry<K, N, S>[] tab = selectActiveTable(hash);
@@ -413,7 +413,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     }
 
     /** Helper method that is the basis for operations that remove mappings. */
-    private StateMapEntry<K, N, S> removeEntry(K key, N namespace) {
+    protected StateMapEntry<K, N, S> removeEntry(K key, N namespace) {
 
         final int hash = computeHashForOperationAndDoIncrementalRehash(key, namespace);
         final StateMapEntry<K, N, S>[] tab = selectActiveTable(hash);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMap.java
@@ -281,13 +281,9 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
                     if (e.entryVersion < requiredVersion) {
                         e = handleChainedEntryCopyOnWrite(tab, hash & (tab.length - 1), e);
                     }
-                    e.stateVersion = stateMapVersion;
-                    e.state = getStateSerializer().copy(e.state);
+                    setStateBeforeRead(e);
                 } else if (e.stateVersion < stateMapVersion) {
-                    // the entry is not used by any active snapshot;
-                    // if it WAS used then it should NOT be included into the next one if it takes
-                    // versioning into account
-                    e.stateVersion = stateMapVersion;
+                    beforeFirstReadAfterSnapshot(e);
                 }
 
                 return e.state;
@@ -295,6 +291,18 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         }
 
         return null;
+    }
+
+    protected void setStateBeforeRead(StateMapEntry<K, N, S> e) {
+        e.stateVersion = stateMapVersion;
+        e.state = copyState(e);
+    }
+
+    protected void beforeFirstReadAfterSnapshot(StateMapEntry<K, N, S> e) {
+        // the entry is not used by any active snapshot;
+        // if it WAS used then it should NOT be included into the next one if it takes
+        // versioning into account
+        e.stateVersion = stateMapVersion;
     }
 
     @Override
@@ -318,6 +326,10 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     public void put(K key, N namespace, S value) {
         final StateMapEntry<K, N, S> e = putEntry(key, namespace);
 
+        setStateOnWrite(e, value);
+    }
+
+    protected void setStateOnWrite(StateMapEntry<K, N, S> e, S value) {
         e.state = value;
         e.stateVersion = stateMapVersion;
     }
@@ -326,16 +338,19 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
     public S putAndGetOld(K key, N namespace, S state) {
         final StateMapEntry<K, N, S> e = putEntry(key, namespace);
 
-        // copy-on-write check for state
-        S oldState =
-                (e.stateVersion < highestRequiredSnapshotVersion)
-                        ? getStateSerializer().copy(e.state)
-                        : e.state;
+        S oldState = getStateAndCopyIfNeeded(e);
 
-        e.state = state;
-        e.stateVersion = stateMapVersion;
+        setStateOnWrite(e, state);
 
         return oldState;
+    }
+
+    private S getStateAndCopyIfNeeded(StateMapEntry<K, N, S> e) {
+        return e.stateVersion < highestRequiredSnapshotVersion ? copyState(e) : e.state;
+    }
+
+    protected S copyState(StateMapEntry<K, N, S> e) {
+        return e.state == null ? null : getStateSerializer().copy(e.state);
     }
 
     @Override
@@ -345,16 +360,9 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
 
     @Override
     public S removeAndGetOld(K key, N namespace) {
-
         final StateMapEntry<K, N, S> e = removeEntry(key, namespace);
 
-        return e != null
-                ?
-                // copy-on-write check for state
-                (e.stateVersion < highestRequiredSnapshotVersion
-                        ? getStateSerializer().copy(e.state)
-                        : e.state)
-                : null;
+        return e == null ? null : getStateAndCopyIfNeeded(e);
     }
 
     @Override
@@ -371,14 +379,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
 
         final StateMapEntry<K, N, S> entry = putEntry(key, namespace);
 
-        // copy-on-write check for state
-        entry.state =
-                transformation.apply(
-                        (entry.stateVersion < highestRequiredSnapshotVersion)
-                                ? getStateSerializer().copy(entry.state)
-                                : entry.state,
-                        value);
-        entry.stateVersion = stateMapVersion;
+        setStateOnWrite(entry, transformation.apply(getStateAndCopyIfNeeded(entry), value));
     }
 
     // Private implementation details of the API methods
@@ -584,9 +585,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         }
 
         int index = hash & (table.length - 1);
-        StateMapEntry<K, N, S> newEntry =
-                new StateMapEntry<>(
-                        key, namespace, null, hash, table[index], stateMapVersion, stateMapVersion);
+        StateMapEntry<K, N, S> newEntry = createEntry(namespace, key, hash, table[index]);
         table[index] = newEntry;
 
         if (table == primaryTable) {
@@ -673,7 +672,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
             while (e != null) {
                 // copy-on-write check for entry
                 if (e.entryVersion < requiredVersion) {
-                    e = new StateMapEntry<>(e, stateMapVersion);
+                    e = copyEntry(e);
                 }
                 StateMapEntry<K, N, S> n = e.next;
                 int pos = e.hash & newMask;
@@ -714,7 +713,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         StateMapEntry<K, N, S> copy;
 
         if (current.entryVersion < required) {
-            copy = new StateMapEntry<>(current, stateMapVersion);
+            copy = copyEntry(current);
             tab[mapIdx] = copy;
         } else {
             // nothing to do, just advance copy to current
@@ -729,7 +728,7 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
 
             if (current.entryVersion < required) {
                 // copy and advance the current's copy
-                copy.next = new StateMapEntry<>(current, stateMapVersion);
+                copy.next = copyEntry(current);
                 copy = copy.next;
             } else {
                 // nothing to do, just advance copy to current
@@ -965,5 +964,15 @@ public class CopyOnWriteStateMap<K, N, S> extends StateMap<K, N, S> {
         public void update(StateEntry<K, N, S> stateEntry, S newValue) {
             CopyOnWriteStateMap.this.put(stateEntry.getKey(), stateEntry.getNamespace(), newValue);
         }
+    }
+
+    protected StateMapEntry<K, N, S> createEntry(
+            N namespace, K key, int hash, StateMapEntry<K, N, S> next) {
+        return new StateMapEntry<>(
+                key, namespace, null, hash, next, stateMapVersion, stateMapVersion);
+    }
+
+    protected StateMapEntry<K, N, S> copyEntry(StateMapEntry<K, N, S> e) {
+        return new StateMapEntry<>(e, stateMapVersion);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapSnapshot.java
@@ -66,7 +66,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
      * this snapshot. This depends for each entry on whether or not it was subject to copy-on-write
      * operations by the {@link CopyOnWriteStateMap}.
      */
-    @Nonnull private final StateMapEntry<K, N, S>[] snapshotData;
+    @Nonnull protected final StateMapEntry<K, N, S>[] snapshotData;
 
     /** The number of (non-null) entries in snapshotData. */
     @Nonnegative private final int numberOfEntriesInSnapshotData;
@@ -80,7 +80,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
      * @param owningStateMap the {@link CopyOnWriteStateMap} for which this object represents a
      *     snapshot.
      */
-    CopyOnWriteStateMapSnapshot(CopyOnWriteStateMap<K, N, S> owningStateMap) {
+    protected CopyOnWriteStateMapSnapshot(CopyOnWriteStateMap<K, N, S> owningStateMap) {
         super(owningStateMap);
 
         this.snapshotData = owningStateMap.snapshotMapArrays();
@@ -106,7 +106,7 @@ public class CopyOnWriteStateMapSnapshot<K, N, S>
      * created. This value must be used to tell the {@link CopyOnWriteStateMap} when to release this
      * snapshot.
      */
-    int getSnapshotVersion() {
+    public int getSnapshotVersion() {
         return snapshotVersion;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTable.java
@@ -43,7 +43,7 @@ public class CopyOnWriteStateTable<K, N, S> extends StateTable<K, N, S> {
      * @param metaInfo the meta information, including the type serializer for state copy-on-write.
      * @param keySerializer the serializer of the key.
      */
-    CopyOnWriteStateTable(
+    protected CopyOnWriteStateTable(
             InternalKeyContext<K> keyContext,
             RegisteredKeyValueStateBackendMetaInfo<N, S> metaInfo,
             TypeSerializer<K> keySerializer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateTableSnapshot.java
@@ -41,8 +41,17 @@ public class CopyOnWriteStateTableSnapshot<K, N, S> extends AbstractStateTableSn
     /** The offset to the contiguous key groups. */
     private final int keyGroupOffset;
 
+    public int getKeyGroupOffset() {
+        return keyGroupOffset;
+    }
+
     /** Snapshots of state partitioned by key-group. */
     @Nonnull private final List<CopyOnWriteStateMapSnapshot<K, N, S>> stateMapSnapshots;
+
+    @Nonnull
+    public List<CopyOnWriteStateMapSnapshot<K, N, S>> getStateMapSnapshots() {
+        return stateMapSnapshots;
+    }
 
     /**
      * Creates a new {@link CopyOnWriteStateTableSnapshot}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMapEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMapEntry.java
@@ -96,15 +96,6 @@ public class StateMapEntry<K, N, S> implements StateEntry<K, N, S> {
         this.stateVersion = stateVersion;
     }
 
-    public final void setState(@Nullable S value, int mapVersion) {
-        // naturally, we can update the state version every time we replace the old state with a
-        // different object
-        if (value != state) {
-            this.state = value;
-            this.stateVersion = mapVersion;
-        }
-    }
-
     @Nonnull
     @Override
     public K getKey() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMapEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMapEntry.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.runtime.state.StateEntry;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * One entry in the {@link CopyOnWriteStateMap}. This is a triplet of key, namespace, and state.
+ * Thereby, key and namespace together serve as a composite key for the state. This class also
+ * contains some management meta data for copy-on-write, a pointer to link other {@link
+ * StateMapEntry}s to a list, and cached hash code.
+ *
+ * @param <K> type of key.
+ * @param <N> type of namespace.
+ * @param <S> type of state.
+ */
+public class StateMapEntry<K, N, S> implements StateEntry<K, N, S> {
+
+    /** The key. Assumed to be immumap and not null. */
+    @Nonnull final K key;
+
+    /** The namespace. Assumed to be immumap and not null. */
+    @Nonnull final N namespace;
+
+    /**
+     * The state. This is not final to allow exchanging the object for copy-on-write. Can be null.
+     */
+    @Nullable S state;
+
+    /**
+     * Link to another {@link StateMapEntry}. This is used to resolve collisions in the {@link
+     * CopyOnWriteStateMap} through chaining.
+     */
+    @Nullable StateMapEntry<K, N, S> next;
+
+    /**
+     * The version of this {@link StateMapEntry}. This is meta data for copy-on-write of the map
+     * structure.
+     */
+    int entryVersion;
+
+    /**
+     * The version of the state object in this entry. This is meta data for copy-on-write of the
+     * state object itself.
+     */
+    int stateVersion;
+
+    /** The computed secondary hash for the composite of key and namespace. */
+    final int hash;
+
+    StateMapEntry(StateMapEntry<K, N, S> other, int entryVersion) {
+        this(
+                other.key,
+                other.namespace,
+                other.state,
+                other.hash,
+                other.next,
+                entryVersion,
+                other.stateVersion);
+    }
+
+    StateMapEntry(
+            @Nonnull K key,
+            @Nonnull N namespace,
+            @Nullable S state,
+            int hash,
+            @Nullable StateMapEntry<K, N, S> next,
+            int entryVersion,
+            int stateVersion) {
+        this.key = key;
+        this.namespace = namespace;
+        this.hash = hash;
+        this.next = next;
+        this.entryVersion = entryVersion;
+        this.state = state;
+        this.stateVersion = stateVersion;
+    }
+
+    public final void setState(@Nullable S value, int mapVersion) {
+        // naturally, we can update the state version every time we replace the old state with a
+        // different object
+        if (value != state) {
+            this.state = value;
+            this.stateVersion = mapVersion;
+        }
+    }
+
+    @Nonnull
+    @Override
+    public K getKey() {
+        return key;
+    }
+
+    @Nonnull
+    @Override
+    public N getNamespace() {
+        return namespace;
+    }
+
+    @Nullable
+    @Override
+    public S getState() {
+        return state;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof StateMapEntry)) {
+            return false;
+        }
+
+        StateEntry<?, ?, ?> e = (StateEntry<?, ?, ?>) o;
+        return e.getKey().equals(key)
+                && e.getNamespace().equals(namespace)
+                && Objects.equals(e.getState(), state);
+    }
+
+    @Override
+    public final int hashCode() {
+        return (key.hashCode() ^ namespace.hashCode()) ^ Objects.hashCode(state);
+    }
+
+    @Override
+    public final String toString() {
+        return "(" + key + "|" + namespace + ")=" + state;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMapEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMapEntry.java
@@ -45,30 +45,30 @@ public class StateMapEntry<K, N, S> implements StateEntry<K, N, S> {
     /**
      * The state. This is not final to allow exchanging the object for copy-on-write. Can be null.
      */
-    @Nullable S state;
+    @Nullable protected S state;
 
     /**
      * Link to another {@link StateMapEntry}. This is used to resolve collisions in the {@link
      * CopyOnWriteStateMap} through chaining.
      */
-    @Nullable StateMapEntry<K, N, S> next;
+    @Nullable protected StateMapEntry<K, N, S> next;
 
     /**
      * The version of this {@link StateMapEntry}. This is meta data for copy-on-write of the map
      * structure.
      */
-    int entryVersion;
+    protected int entryVersion;
 
     /**
      * The version of the state object in this entry. This is meta data for copy-on-write of the
      * state object itself.
      */
-    int stateVersion;
+    protected int stateVersion;
 
     /** The computed secondary hash for the composite of key and namespace. */
     final int hash;
 
-    StateMapEntry(StateMapEntry<K, N, S> other, int entryVersion) {
+    protected StateMapEntry(StateMapEntry<K, N, S> other, int entryVersion) {
         this(
                 other.key,
                 other.namespace,
@@ -79,7 +79,7 @@ public class StateMapEntry<K, N, S> implements StateEntry<K, N, S> {
                 other.stateVersion);
     }
 
-    StateMapEntry(
+    protected StateMapEntry(
             @Nonnull K key,
             @Nonnull N namespace,
             @Nullable S state,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/CopyOnWriteStateMapTest.java
@@ -157,7 +157,7 @@ public class CopyOnWriteStateMapTest extends TestLogger {
         final Random random = new Random(42);
 
         // holds snapshots from the map under test
-        CopyOnWriteStateMap.StateMapEntry<Integer, Integer, ArrayList<Integer>>[] snapshot = null;
+        StateMapEntry<Integer, Integer, ArrayList<Integer>>[] snapshot = null;
         int snapshotSize = 0;
 
         // holds a reference snapshot from our reference map that we compare against
@@ -511,11 +511,11 @@ public class CopyOnWriteStateMapTest extends TestLogger {
 
     @SuppressWarnings("unchecked")
     private static <K, N, S> Tuple3<K, N, S>[] convert(
-            CopyOnWriteStateMap.StateMapEntry<K, N, S>[] snapshot, int mapSize) {
+            StateMapEntry<K, N, S>[] snapshot, int mapSize) {
 
         Tuple3<K, N, S>[] result = new Tuple3[mapSize];
         int pos = 0;
-        for (CopyOnWriteStateMap.StateMapEntry<K, N, S> entry : snapshot) {
+        for (StateMapEntry<K, N, S> entry : snapshot) {
             while (null != entry) {
                 result[pos++] =
                         new Tuple3<>(entry.getKey(), entry.getNamespace(), entry.getState());


### PR DESCRIPTION
## What is the purpose of the change

Trivial refactorings to `CopyOnWriteStateMap` and
related classes to allow extension and customization.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
