### PR TITLE
[FLINK-21673] Add extension points to snapshot reading/wr…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTable.java
@@ -311,7 +311,7 @@ public abstract class StateTable<K, N, S>
     }
 
     @VisibleForTesting
-    StateMap<K, N, S> getMapForKeyGroup(int keyGroupIndex) {
+    public StateMap<K, N, S> getMapForKeyGroup(int keyGroupIndex) {
         final int pos = indexToOffset(keyGroupIndex);
         if (pos >= 0 && pos < keyGroupedStateMaps.length) {
             return keyGroupedStateMaps[pos];

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateTableByKeyGroupReaders.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.memory.DataInputView;
@@ -35,7 +36,8 @@ import java.io.IOException;
  *
  * <p>The implementations are also located here as inner classes.
  */
-class StateTableByKeyGroupReaders {
+@Internal
+public class StateTableByKeyGroupReaders {
 
     /**
      * Creates a new StateTableByKeyGroupReader that inserts de-serialized mappings into the given
@@ -48,7 +50,7 @@ class StateTableByKeyGroupReaders {
      * @param version version for the de-serialization algorithm.
      * @return the appropriate reader.
      */
-    static <K, N, S> StateSnapshotKeyGroupReader readerForVersion(
+    public static <K, N, S> StateSnapshotKeyGroupReader readerForVersion(
             StateTable<K, N, S> stateTable, int version) {
         switch (version) {
             case 1:


### PR DESCRIPTION
## What is the purpose of the change

Trivial refactorings to allow customization
of readers and writers of heap state snapshots.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
