### PR TITLE
[FLINK-21650] Skip KGs not belonging to this backend on restore (instead of failing)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -200,12 +200,13 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
             int keyGroupIndex = groupOffset.f0;
             long offset = groupOffset.f1;
 
-            // Check that restored key groups all belong to the backend.
-            Preconditions.checkState(
-                    keyGroupRange.contains(keyGroupIndex),
-                    "Key group %s doesn't belong to this backend with key group range: %s",
-                    keyGroupIndex,
-                    keyGroupRange);
+            if (!keyGroupRange.contains(keyGroupIndex)) {
+                LOG.debug(
+                        "Key group {} doesn't belong to this backend with key group range: {}",
+                        keyGroupIndex,
+                        keyGroupRange);
+                continue;
+            }
 
             fsDataInputStream.seek(offset);
 


### PR DESCRIPTION
## What is the purpose of the change

```
In the new incremental mode, heap backend wraps KeyGroupsStateHandle
into IncrementalRemoteKeyedStateHandle. The latter don't compute
intersection because it is not directly aware of the offsets. So it just
returns a full keyrange if there is SOME intersection.
On recovery, unused keyGroups are filtered out by RocksDB state backend.
With this change, Heap state backend does the same.
```

## Verifying this change

The change is covered by existing IT cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
