### PR TITLE
[FLINK-21784] Allow extension of HeapBackend RestoreOperation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyValueStateBackendMetaInfo.java
@@ -43,9 +43,9 @@ import java.util.Objects;
  */
 public class RegisteredKeyValueStateBackendMetaInfo<N, S> extends RegisteredStateMetaInfoBase {
 
-    @Nonnull private final StateDescriptor.Type stateType;
+    @Nonnull protected final StateDescriptor.Type stateType;
     @Nonnull private final StateSerializerProvider<N> namespaceSerializerProvider;
-    @Nonnull private final StateSerializerProvider<S> stateSerializerProvider;
+    @Nonnull protected final StateSerializerProvider<S> stateSerializerProvider;
     @Nonnull private StateSnapshotTransformFactory<S> stateSnapshotTransformFactory;
 
     public RegisteredKeyValueStateBackendMetaInfo(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMetaInfoRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMetaInfoRestoreOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.heap;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyExtractorFunction;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.Keyed;
@@ -42,7 +43,8 @@ import java.util.Map;
  *
  * @param <K> The key by which state is keyed.
  */
-class HeapMetaInfoRestoreOperation<K> {
+@Internal
+public class HeapMetaInfoRestoreOperation<K> {
     private final StateSerializerProvider<K> keySerializerProvider;
     private final HeapPriorityQueueSetFactory priorityQueueSetFactory;
     @Nonnull private final KeyGroupRange keyGroupRange;
@@ -50,7 +52,7 @@ class HeapMetaInfoRestoreOperation<K> {
     private final StateTableFactory<K> stateTableFactory;
     private final InternalKeyContext<K> keyContext;
 
-    HeapMetaInfoRestoreOperation(
+    protected HeapMetaInfoRestoreOperation(
             StateSerializerProvider<K> keySerializerProvider,
             HeapPriorityQueueSetFactory priorityQueueSetFactory,
             @Nonnull KeyGroupRange keyGroupRange,
@@ -78,15 +80,11 @@ class HeapMetaInfoRestoreOperation<K> {
                 case KEY_VALUE:
                     registeredState = registeredKVStates.get(metaInfoSnapshot.getName());
                     if (registeredState == null) {
-                        RegisteredKeyValueStateBackendMetaInfo<?, ?>
-                                registeredKeyedBackendStateMetaInfo =
-                                        new RegisteredKeyValueStateBackendMetaInfo<>(
-                                                metaInfoSnapshot);
                         registeredKVStates.put(
                                 metaInfoSnapshot.getName(),
                                 stateTableFactory.newStateTable(
                                         keyContext,
-                                        registeredKeyedBackendStateMetaInfo,
+                                        createMetaInfo(metaInfoSnapshot),
                                         keySerializerProvider.currentSchemaSerializer()));
                     }
                     break;
@@ -113,6 +111,11 @@ class HeapMetaInfoRestoreOperation<K> {
         }
 
         return kvStatesById;
+    }
+
+    protected RegisteredKeyValueStateBackendMetaInfo<?, ?> createMetaInfo(
+            StateMetaInfoSnapshot snapshot) {
+        return new RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
## What is the purpose of the change

Trivial refactorings to `HeapRestoreOperation` and
related classes to allow extension and customization.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
