### PR TITLE
[FLINK-21774][sql-client] Do not display column names when return set is emtpy in SQL Client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.utils.PrintUtils;
-import org.apache.flink.types.Row;
-import org.apache.flink.util.CollectionUtil;
 
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
@@ -51,13 +49,9 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** SQL CLI client. */
@@ -294,31 +288,15 @@ public class CliClient implements AutoCloseable {
                 callHelp();
                 break;
             case SHOW_CATALOGS:
-                callShowCatalogs();
-                break;
-            case SHOW_CURRENT_CATALOG:
-                callShowCurrentCatalog();
-                break;
             case SHOW_DATABASES:
-                callShowDatabases();
-                break;
-            case SHOW_CURRENT_DATABASE:
-                callShowCurrentDatabase();
-                break;
             case SHOW_TABLES:
-                callShowTables();
-                break;
             case SHOW_VIEWS:
-                callShowViews();
-                break;
             case SHOW_FUNCTIONS:
-                callShowFunctions(cmdCall);
-                break;
             case SHOW_MODULES:
-                callShowModules(cmdCall);
-                break;
             case SHOW_PARTITIONS:
-                callShowPartitions(cmdCall);
+            case SHOW_CURRENT_CATALOG:
+            case SHOW_CURRENT_DATABASE:
+                callShow(cmdCall);
                 break;
             case USE_CATALOG:
                 callUseCatalog(cmdCall);
@@ -478,145 +456,9 @@ public class CliClient implements AutoCloseable {
         terminal.flush();
     }
 
-    private void callShowCatalogs() {
-        final List<String> catalogs;
-        try {
-            catalogs = getShowResult("CATALOGS");
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        if (catalogs.isEmpty()) {
-            terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
-        } else {
-            catalogs.forEach((v) -> terminal.writer().println(v));
-        }
-        terminal.flush();
-    }
-
-    private void callShowCurrentCatalog() {
-        String currentCatalog;
-        try {
-            Row result = executor.executeSql(sessionId, "SHOW CURRENT CATALOG").collect().next();
-            currentCatalog = checkNotNull(result.getField(0)).toString();
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        terminal.writer().println(currentCatalog);
-        terminal.flush();
-    }
-
-    private void callShowDatabases() {
-        final List<String> dbs;
-        try {
-            dbs = getShowResult("DATABASES");
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        if (dbs.isEmpty()) {
-            terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
-        } else {
-            dbs.forEach((v) -> terminal.writer().println(v));
-        }
-        terminal.flush();
-    }
-
-    private void callShowCurrentDatabase() {
-        String currentDatabase;
-        try {
-            Row result = executor.executeSql(sessionId, "SHOW CURRENT DATABASE").collect().next();
-            currentDatabase = checkNotNull(result.getField(0)).toString();
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        terminal.writer().println(currentDatabase);
-        terminal.flush();
-    }
-
-    private void callShowTables() {
-        final List<String> tables;
-        try {
-            tables = getShowResult("TABLES");
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        if (tables.isEmpty()) {
-            terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
-        } else {
-            tables.forEach((v) -> terminal.writer().println(v));
-        }
-        terminal.flush();
-    }
-
-    private void callShowViews() {
-        final List<String> views;
-        try {
-            views = getShowResult("VIEWS");
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        if (views.isEmpty()) {
-            terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
-        } else {
-            views.forEach((v) -> terminal.writer().println(v));
-        }
-        terminal.flush();
-    }
-
-    private void callShowFunctions(SqlCommandCall cmdCall) {
-        final List<String> functions;
-        try {
-            functions = getShowResult(cmdCall);
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        if (functions.isEmpty()) {
-            terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
-        } else {
-            Collections.sort(functions);
-            functions.forEach((v) -> terminal.writer().println(v));
-        }
-        terminal.flush();
-    }
-
-    private List<String> getShowResult(String objectToShow) {
-        TableResult tableResult = executor.executeSql(sessionId, "SHOW " + objectToShow);
-        return CollectionUtil.iteratorToList(tableResult.collect()).stream()
-                .map(r -> checkNotNull(r.getField(0)).toString())
-                .collect(Collectors.toList());
-    }
-
-    private List<String> getShowResult(SqlCommandCall cmdCall) {
-        TableResult tableResult = executor.executeSql(sessionId, cmdCall.operands[0]);
-        return CollectionUtil.iteratorToList(tableResult.collect()).stream()
-                .map(r -> checkNotNull(r.getField(0)).toString())
-                .collect(Collectors.toList());
-    }
-
-    private void callShowModules(SqlCommandCall cmdCall) {
-        getResultAsTableauForm(cmdCall.operands[0]);
-    }
-
-    private void callShowPartitions(SqlCommandCall cmdCall) {
-        final List<String> partitions;
-        try {
-            partitions = getShowResult(cmdCall);
-        } catch (SqlExecutionException e) {
-            printExecutionException(e);
-            return;
-        }
-        if (partitions.isEmpty()) {
-            terminal.writer().println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
-        } else {
-            partitions.forEach((v) -> terminal.writer().println(v));
-        }
-        terminal.flush();
+    private void callShow(SqlCommandCall cmdCall) {
+        getResultAsTableauForm(
+                cmdCall.operands.length == 0 ? cmdCall.command.toString() : cmdCall.operands[0]);
     }
 
     private void callUseCatalog(SqlCommandCall cmdCall) {

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -52,12 +52,22 @@ create catalog c1 with ('type'='generic_in_memory');
 !info
 
 show catalogs;
-c1
-default_catalog
++-----------------+
+|    catalog name |
++-----------------+
+|              c1 |
+| default_catalog |
++-----------------+
+2 rows in set
 !ok
 
 show current catalog;
-default_catalog
++----------------------+
+| current catalog name |
++----------------------+
+|      default_catalog |
++----------------------+
+1 row in set
 !ok
 
 use catalog c1;
@@ -65,7 +75,12 @@ use catalog c1;
 !info
 
 show current catalog;
-c1
++----------------------+
+| current catalog name |
++----------------------+
+|                   c1 |
++----------------------+
+1 row in set
 !ok
 
 drop catalog default_catalog;
@@ -81,12 +96,22 @@ create database db1;
 !info
 
 show databases;
-default
-db1
++---------------+
+| database name |
++---------------+
+|       default |
+|           db1 |
++---------------+
+2 rows in set
 !ok
 
 show current database;
-default
++-----------------------+
+| current database name |
++-----------------------+
+|               default |
++-----------------------+
+1 row in set
 !ok
 
 use db1;
@@ -94,7 +119,12 @@ use db1;
 !info
 
 show current database;
-db1
++-----------------------+
+| current database name |
++-----------------------+
+|                   db1 |
++-----------------------+
+1 row in set
 !ok
 
 create database db2 comment 'db2_comment' with ('k1' = 'v1');
@@ -108,9 +138,14 @@ alter database db2 set ('k1' = 'a', 'k2' = 'b');
 # TODO: show database properties when we support DESCRIBE DATABSE
 
 show databases;
-default
-db1
-db2
++---------------+
+| database name |
++---------------+
+|       default |
+|           db1 |
+|           db2 |
++---------------+
+3 rows in set
 !ok
 
 drop database if exists db2;
@@ -118,8 +153,13 @@ drop database if exists db2;
 !info
 
 show databases;
-default
-db1
++---------------+
+| database name |
++---------------+
+|       default |
+|           db1 |
++---------------+
+2 rows in set
 !ok
 
 # ==========================================================================
@@ -163,16 +203,31 @@ use catalog hivecatalog;
 !info
 
 show current catalog;
-hivecatalog
++----------------------+
+| current catalog name |
++----------------------+
+|          hivecatalog |
++----------------------+
+1 row in set
 !ok
 
 show databases;
-additional_test_database
-default
++--------------------------+
+|            database name |
++--------------------------+
+| additional_test_database |
+|                  default |
++--------------------------+
+2 rows in set
 !ok
 
 show tables;
-param_types_table
++-------------------+
+|        table name |
++-------------------+
+| param_types_table |
++-------------------+
+1 row in set
 !ok
 
 use additional_test_database;
@@ -180,11 +235,21 @@ use additional_test_database;
 !info
 
 show tables;
-test_table
++------------+
+| table name |
++------------+
+| test_table |
++------------+
+1 row in set
 !ok
 
 show current database;
-additional_test_database
++--------------------------+
+|    current database name |
++--------------------------+
+| additional_test_database |
++--------------------------+
+1 row in set
 !ok
 
 # ==========================================================================
@@ -236,9 +301,14 @@ create table MyTable2 (a int, b string);
 
 # hive catalog is case-insensitive
 show tables;
-mytable1
-mytable2
-test_table
++------------+
+| table name |
++------------+
+|   mytable1 |
+|   mytable2 |
+| test_table |
++------------+
+3 rows in set
 !ok
 
 # test create with full qualified name
@@ -259,8 +329,13 @@ use db1;
 !info
 
 show tables;
-MyTable3
-MyTable4
++------------+
+| table name |
++------------+
+|   MyTable3 |
+|   MyTable4 |
++------------+
+2 rows in set
 !ok
 
 # test create with database name
@@ -277,8 +352,13 @@ use `default`;
 !info
 
 show tables;
-MyTable5
-MyTable6
++------------+
+| table name |
++------------+
+|   MyTable5 |
+|   MyTable6 |
++------------+
+2 rows in set
 !ok
 
 drop table db1.MyTable3;
@@ -290,7 +370,12 @@ use db1;
 !info
 
 show tables;
-MyTable4
++------------+
+| table name |
++------------+
+|   MyTable4 |
++------------+
+1 row in set
 !ok
 
 drop table c1.`default`.MyTable6;
@@ -302,7 +387,12 @@ use `default`;
 !info
 
 show tables;
-MyTable5
++------------+
+| table name |
++------------+
+|   MyTable5 |
++------------+
+1 row in set
 !ok
 
 # ==========================================================================
@@ -318,8 +408,13 @@ create table MyTable7 (a int, b string);
 !info
 
 show tables;
-MyTable5
-MyTable7
++------------+
+| table name |
++------------+
+|   MyTable5 |
+|   MyTable7 |
++------------+
+2 rows in set
 !ok
 
 reset;
@@ -331,5 +426,10 @@ drop table MyTable5;
 !info
 
 show tables;
-MyTable7
++------------+
+| table name |
++------------+
+|   MyTable7 |
++------------+
+1 row in set
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -21,7 +21,12 @@ create function func1 as 'LowerUDF' LANGUAGE JAVA;
 !info
 
 show user functions;
-func1
++---------------+
+| function name |
++---------------+
+|         func1 |
++---------------+
+1 row in set
 !ok
 
 SET execution.result-mode=tableau;
@@ -46,8 +51,13 @@ create temporary function if not exists func2 as 'LowerUDF' LANGUAGE JAVA;
 !info
 
 show user functions;
-func1
-func2
++---------------+
+| function name |
++---------------+
+|         func1 |
+|         func2 |
++---------------+
+2 rows in set
 !ok
 
 # ====== test function with full qualified name ======
@@ -78,8 +88,13 @@ create temporary function if not exists c1.db.func4 as 'LowerUDF' LANGUAGE JAVA;
 
 # no func3 and func4 because we are not under catalog c1
 show user functions;
-func1
-func2
++---------------+
+| function name |
++---------------+
+|         func1 |
+|         func2 |
++---------------+
+2 rows in set
 !ok
 
 use catalog c1;
@@ -92,8 +107,13 @@ use db;
 
 # should show func3 and func4 now
 show user functions;
-func3
-func4
++---------------+
+| function name |
++---------------+
+|         func4 |
+|         func3 |
++---------------+
+2 rows in set
 !ok
 
 # test create function with database name
@@ -111,8 +131,13 @@ use `default`;
 
 # should show func5 and func6
 show user functions;
-func5
-func6
++---------------+
+| function name |
++---------------+
+|         func5 |
+|         func6 |
++---------------+
+2 rows in set
 !ok
 
 # ==========================================================================
@@ -145,9 +170,14 @@ drop function if exists non_func;
 
 # should contain func11, not contain func10
 show user functions;
-func11
-func3
-func4
++---------------+
+| function name |
++---------------+
+|         func4 |
+|        func11 |
+|         func3 |
++---------------+
+3 rows in set
 !ok
 
 # ==========================================================================
@@ -188,5 +218,10 @@ create function lowerudf AS 'LowerUDF';
 !info
 
 show user functions;
-lowerudf
++---------------+
+| function name |
++---------------+
+|      lowerudf |
++---------------+
+1 row in set
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -110,8 +110,8 @@ show user functions;
 +---------------+
 | function name |
 +---------------+
-|         func4 |
 |         func3 |
+|         func4 |
 +---------------+
 2 rows in set
 !ok
@@ -173,9 +173,9 @@ show user functions;
 +---------------+
 | function name |
 +---------------+
-|         func4 |
 |        func11 |
 |         func3 |
+|         func4 |
 +---------------+
 3 rows in set
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/module.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/module.q
@@ -183,10 +183,7 @@ UNLOAD MODULE core;
 !info
 
 SHOW MODULES;
-+-------------+
-| module name |
-+-------------+
-0 row in set
+Empty set
 !ok
 
 SHOW FULL MODULES;

--- a/flink-table/flink-sql-client/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/table.q
@@ -60,7 +60,12 @@ CREATE TABLE IF NOT EXISTS orders (
 
 # test SHOW TABLES
 show tables;
-orders
++------------+
+| table name |
++------------+
+|     orders |
++------------+
+1 row in set
 !ok
 
 # ==========================================================================
@@ -103,8 +108,8 @@ drop table orders2;
 
 # verify table is dropped
 show tables;
-[INFO] Result was empty.
-!info
+Empty set
+!ok
 
 # ==========================================================================
 # test temporary table
@@ -133,7 +138,12 @@ create temporary table if not exists tbl1 (
 
 # list permanent and temporary tables together
 show tables;
-tbl1
++------------+
+| table name |
++------------+
+|       tbl1 |
++------------+
+1 row in set
 !ok
 
 drop temporary table tbl1;
@@ -173,5 +183,5 @@ drop table `mod`;
 !info
 
 show tables;
-[INFO] Result was empty.
-!info
+Empty set
+!ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/view.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/view.q
@@ -52,14 +52,24 @@ create temporary view if not exists v2 as select * from v1;
 !info
 
 show tables;
-orders
-v1
-v2
++------------+
+| table name |
++------------+
+|     orders |
+|         v1 |
+|         v2 |
++------------+
+3 rows in set
 !ok
 
 show views;
-v1
-v2
++-----------+
+| view name |
++-----------+
+|        v1 |
+|        v2 |
++-----------+
+2 rows in set
 !ok
 
 # ==== test permanent view =====
@@ -77,8 +87,13 @@ org.apache.flink.table.catalog.exceptions.TableAlreadyExistException: Table (or 
 
 # we didn't distinguish the temporary v1 and permanent v1 for now
 show views;
-v1
-v2
++-----------+
+| view name |
++-----------+
+|        v1 |
+|        v2 |
++-----------+
+2 rows in set
 !ok
 
 # test describe view
@@ -154,6 +169,11 @@ drop view `mod`;
 !info
 
 show tables;
-orders
-v2
++------------+
+| table name |
++------------+
+|     orders |
+|         v2 |
++------------+
+2 rows in set
 !ok

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -628,18 +628,15 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public String[] listUserDefinedFunctions() {
-        return sortFunctions(functionCatalog.getUserDefinedFunctions());
+        String[] functions = functionCatalog.getUserDefinedFunctions();
+        Arrays.sort(functions);
+        return functions;
     }
 
     @Override
     public String[] listFunctions() {
-        return sortFunctions(functionCatalog.getFunctions());
-    }
-
-    private String[] sortFunctions(String[] functions) {
-        if (functions != null && functions.length > 0) {
-            Arrays.sort(functions);
-        }
+        String[] functions = functionCatalog.getFunctions();
+        Arrays.sort(functions);
         return functions;
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -628,12 +628,19 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public String[] listUserDefinedFunctions() {
-        return functionCatalog.getUserDefinedFunctions();
+        return sortFunctions(functionCatalog.getUserDefinedFunctions());
     }
 
     @Override
     public String[] listFunctions() {
-        return functionCatalog.getFunctions();
+        return sortFunctions(functionCatalog.getFunctions());
+    }
+
+    private String[] sortFunctions(String[] functions) {
+        if (functions != null && functions.length > 0) {
+            Arrays.sort(functions);
+        }
+        return functions;
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -116,60 +116,61 @@ public class PrintUtils {
             String nullColumn,
             boolean deriveColumnWidthByType,
             boolean printRowKind) {
-        if (it.hasNext()) {
-            final List<TableColumn> columns = tableSchema.getTableColumns();
-            String[] columnNames =
-                    columns.stream().map(TableColumn::getName).toArray(String[]::new);
-            if (printRowKind) {
-                columnNames =
-                        Stream.concat(Stream.of(ROW_KIND_COLUMN), Arrays.stream(columnNames))
-                                .toArray(String[]::new);
-            }
-
-            final int[] colWidths;
-            if (deriveColumnWidthByType) {
-                colWidths =
-                        columnWidthsByType(
-                                columns,
-                                maxColumnWidth,
-                                nullColumn,
-                                printRowKind ? ROW_KIND_COLUMN : null);
-            } else {
-                final List<Row> rows = new ArrayList<>();
-                final List<String[]> content = new ArrayList<>();
-                content.add(columnNames);
-                while (it.hasNext()) {
-                    Row row = it.next();
-                    rows.add(row);
-                    content.add(rowToString(row, nullColumn, printRowKind));
-                }
-                colWidths = columnWidthsByContent(columnNames, content, maxColumnWidth);
-                it = rows.iterator();
-            }
-
-            final String borderline = PrintUtils.genBorderLine(colWidths);
-            // print border line
-            printWriter.println(borderline);
-            // print field names
-            PrintUtils.printSingleRow(colWidths, columnNames, printWriter);
-            // print border line
-            printWriter.println(borderline);
-
-            long numRows = 0;
-            while (it.hasNext()) {
-                String[] cols = rowToString(it.next(), nullColumn, printRowKind);
-                // print content
-                printSingleRow(colWidths, cols, printWriter);
-                numRows++;
-            }
-
-            // print border line
-            printWriter.println(borderline);
-            final String rowTerm = numRows > 1 ? "rows" : "row";
-            printWriter.println(numRows + " " + rowTerm + " in set");
-        } else {
+        if (!it.hasNext()) {
             printWriter.println("Empty set");
+            printWriter.flush();
+            return;
         }
+        final List<TableColumn> columns = tableSchema.getTableColumns();
+        String[] columnNames = columns.stream().map(TableColumn::getName).toArray(String[]::new);
+        if (printRowKind) {
+            columnNames =
+                    Stream.concat(Stream.of(ROW_KIND_COLUMN), Arrays.stream(columnNames))
+                            .toArray(String[]::new);
+        }
+
+        final int[] colWidths;
+        if (deriveColumnWidthByType) {
+            colWidths =
+                    columnWidthsByType(
+                            columns,
+                            maxColumnWidth,
+                            nullColumn,
+                            printRowKind ? ROW_KIND_COLUMN : null);
+        } else {
+            final List<Row> rows = new ArrayList<>();
+            final List<String[]> content = new ArrayList<>();
+            content.add(columnNames);
+            while (it.hasNext()) {
+                Row row = it.next();
+                rows.add(row);
+                content.add(rowToString(row, nullColumn, printRowKind));
+            }
+            colWidths = columnWidthsByContent(columnNames, content, maxColumnWidth);
+            it = rows.iterator();
+        }
+
+        final String borderline = PrintUtils.genBorderLine(colWidths);
+        // print border line
+        printWriter.println(borderline);
+        // print field names
+        PrintUtils.printSingleRow(colWidths, columnNames, printWriter);
+        // print border line
+        printWriter.println(borderline);
+
+        long numRows = 0;
+        while (it.hasNext()) {
+            String[] cols = rowToString(it.next(), nullColumn, printRowKind);
+
+            // print content
+            printSingleRow(colWidths, cols, printWriter);
+            numRows++;
+        }
+
+        // print border line
+        printWriter.println(borderline);
+        final String rowTerm = numRows > 1 ? "rows" : "row";
+        printWriter.println(numRows + " " + rowTerm + " in set");
         printWriter.flush();
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -116,36 +116,37 @@ public class PrintUtils {
             String nullColumn,
             boolean deriveColumnWidthByType,
             boolean printRowKind) {
-        final List<TableColumn> columns = tableSchema.getTableColumns();
-        String[] columnNames = columns.stream().map(TableColumn::getName).toArray(String[]::new);
-        if (printRowKind) {
-            columnNames =
-                    Stream.concat(Stream.of(ROW_KIND_COLUMN), Arrays.stream(columnNames))
-                            .toArray(String[]::new);
-        }
-
-        final int[] colWidths;
-        if (deriveColumnWidthByType) {
-            colWidths =
-                    columnWidthsByType(
-                            columns,
-                            maxColumnWidth,
-                            nullColumn,
-                            printRowKind ? ROW_KIND_COLUMN : null);
-        } else {
-            final List<Row> rows = new ArrayList<>();
-            final List<String[]> content = new ArrayList<>();
-            content.add(columnNames);
-            while (it.hasNext()) {
-                Row row = it.next();
-                rows.add(row);
-                content.add(rowToString(row, nullColumn, printRowKind));
-            }
-            colWidths = columnWidthsByContent(columnNames, content, maxColumnWidth);
-            it = rows.iterator();
-        }
-
         if (it.hasNext()) {
+            final List<TableColumn> columns = tableSchema.getTableColumns();
+            String[] columnNames =
+                    columns.stream().map(TableColumn::getName).toArray(String[]::new);
+            if (printRowKind) {
+                columnNames =
+                        Stream.concat(Stream.of(ROW_KIND_COLUMN), Arrays.stream(columnNames))
+                                .toArray(String[]::new);
+            }
+
+            final int[] colWidths;
+            if (deriveColumnWidthByType) {
+                colWidths =
+                        columnWidthsByType(
+                                columns,
+                                maxColumnWidth,
+                                nullColumn,
+                                printRowKind ? ROW_KIND_COLUMN : null);
+            } else {
+                final List<Row> rows = new ArrayList<>();
+                final List<String[]> content = new ArrayList<>();
+                content.add(columnNames);
+                while (it.hasNext()) {
+                    Row row = it.next();
+                    rows.add(row);
+                    content.add(rowToString(row, nullColumn, printRowKind));
+                }
+                colWidths = columnWidthsByContent(columnNames, content, maxColumnWidth);
+                it = rows.iterator();
+            }
+
             final String borderline = PrintUtils.genBorderLine(colWidths);
             // print border line
             printWriter.println(borderline);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -145,36 +145,30 @@ public class PrintUtils {
             it = rows.iterator();
         }
 
-        final String borderline = PrintUtils.genBorderLine(colWidths);
-        // print border line
-        printWriter.println(borderline);
-        // print field names
-        PrintUtils.printSingleRow(colWidths, columnNames, printWriter);
-        // print border line
-        printWriter.println(borderline);
-        printWriter.flush();
-
-        long numRows = 0;
-        while (it.hasNext()) {
-            String[] cols = rowToString(it.next(), nullColumn, printRowKind);
-
-            // print content
-            printSingleRow(colWidths, cols, printWriter);
-            numRows++;
-        }
-
-        if (numRows > 0) {
+        if (it.hasNext()) {
+            final String borderline = PrintUtils.genBorderLine(colWidths);
             // print border line
             printWriter.println(borderline);
-        }
+            // print field names
+            PrintUtils.printSingleRow(colWidths, columnNames, printWriter);
+            // print border line
+            printWriter.println(borderline);
 
-        final String rowTerm;
-        if (numRows > 1) {
-            rowTerm = "rows";
+            long numRows = 0;
+            while (it.hasNext()) {
+                String[] cols = rowToString(it.next(), nullColumn, printRowKind);
+                // print content
+                printSingleRow(colWidths, cols, printWriter);
+                numRows++;
+            }
+
+            // print border line
+            printWriter.println(borderline);
+            final String rowTerm = numRows > 1 ? "rows" : "row";
+            printWriter.println(numRows + " " + rowTerm + " in set");
         } else {
-            rowTerm = "row";
+            printWriter.println("Empty set");
         }
-        printWriter.println(numRows + " " + rowTerm + " in set");
         printWriter.flush();
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -82,16 +82,7 @@ public class PrintUtilsTest {
         PrintUtils.printAsTableauForm(
                 getSchema(), Collections.<Row>emptyList().iterator(), new PrintWriter(outContent));
 
-        assertEquals(
-                "+---------+-----+--------+---------+----------------+-----------+"
-                        + System.lineSeparator()
-                        + "| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |"
-                        + System.lineSeparator()
-                        + "+---------+-----+--------+---------+----------------+-----------+"
-                        + System.lineSeparator()
-                        + "0 row in set"
-                        + System.lineSeparator(),
-                outContent.toString());
+        assertEquals("Empty set" + System.lineSeparator(), outContent.toString());
     }
 
     @Test
@@ -105,16 +96,7 @@ public class PrintUtilsTest {
                 true, // derive column width by type
                 true);
 
-        assertEquals(
-                "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
-                        + System.lineSeparator()
-                        + "| op | boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |"
-                        + System.lineSeparator()
-                        + "+----+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+"
-                        + System.lineSeparator()
-                        + "0 row in set"
-                        + System.lineSeparator(),
-                outContent.toString());
+        assertEquals("Empty set" + System.lineSeparator(), outContent.toString());
     }
 
     @Test
@@ -128,16 +110,7 @@ public class PrintUtilsTest {
                 false, // derive column width by content
                 false);
 
-        assertEquals(
-                "+---------+-----+--------+---------+----------------+-----------+"
-                        + System.lineSeparator()
-                        + "| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |"
-                        + System.lineSeparator()
-                        + "+---------+-----+--------+---------+----------------+-----------+"
-                        + System.lineSeparator()
-                        + "0 row in set"
-                        + System.lineSeparator(),
-                outContent.toString());
+        assertEquals("Empty set" + System.lineSeparator(), outContent.toString());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*Currently, SQL Client displays the column names when the return set of `SHOW MODULES` is empty:*
```
SHOW MODULES;
+-------------+
| module name |
+-------------+
0 row in set
!ok
```
*The output of `SHOW MODULES` could be improved by simply omit the column names header.*

## Brief change log

  - *`CliClient` add `callShowResult` and `callShowCurrentResult` method to unify the client execution of `SHOW` and `SHOW` statement.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)