### PR TITLE
[FLINK-21793][k8s] Use RM generated JVM memory options.

### DIFF
--- a/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-taskmanager.sh
@@ -38,9 +38,7 @@ fi
 
 # Add TaskManager specific JVM options
 export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_TM}"
-parseTmArgsAndExportLogs "${ARGS[@]}"
-
-# Do not need to add ${DYNAMIC_PARAMETERS[@]} to ${ARGS[@]} since it is already done in native Kubernetes integration.
+export JVM_ARGS="$JVM_ARGS $FLINK_TM_JVM_MEM_OPTS"
 
 ARGS=("--configDir" "${FLINK_CONF_DIR}" "${ARGS[@]}")
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.externalresource.ExternalResourceUtils;
 import org.apache.flink.runtime.resourcemanager.active.AbstractResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.active.ResourceManagerDriver;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
@@ -259,11 +260,13 @@ public class KubernetesResourceManagerDriver
 
         final String dynamicProperties =
                 BootstrapTools.getDynamicPropertiesAsString(flinkClientConfig, taskManagerConfig);
-
+        final String jvmMemOpts =
+                ProcessMemoryUtils.generateJvmParametersStr(taskExecutorProcessSpec);
         return new KubernetesTaskManagerParameters(
                 flinkConfig,
                 podName,
                 dynamicProperties,
+                jvmMemOpts,
                 taskManagerParameters,
                 ExternalResourceUtils.getExternalResources(
                         flinkConfig,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecorator.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 
 import java.util.List;
 
@@ -47,6 +48,12 @@ public class CmdTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                 new ContainerBuilder(flinkPod.getMainContainer())
                         .withCommand(kubernetesTaskManagerParameters.getContainerEntrypoint())
                         .withArgs(getTaskManagerStartCommand())
+                        .addToEnv(
+                                new EnvVarBuilder()
+                                        .withName(Constants.ENV_TM_JVM_MEM_OPTS)
+                                        .withValue(
+                                                kubernetesTaskManagerParameters.getJvmMemOptsEnv())
+                                        .build())
                         .build();
 
         return new FlinkPod.Builder(flinkPod).withMainContainer(mainContainerWithStartCmd).build();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -42,6 +42,8 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
     private final String dynamicProperties;
 
+    private final String jvmMemOptsEnv;
+
     private final ContaineredTaskManagerParameters containeredTaskManagerParameters;
 
     private final Map<String, Long> taskManagerExternalResources;
@@ -50,11 +52,13 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
             Configuration flinkConfig,
             String podName,
             String dynamicProperties,
+            String jvmMemOptsEnv,
             ContaineredTaskManagerParameters containeredTaskManagerParameters,
             Map<String, Long> taskManagerExternalResources) {
         super(flinkConfig);
         this.podName = checkNotNull(podName);
         this.dynamicProperties = checkNotNull(dynamicProperties);
+        this.jvmMemOptsEnv = checkNotNull(jvmMemOptsEnv);
         this.containeredTaskManagerParameters = checkNotNull(containeredTaskManagerParameters);
         this.taskManagerExternalResources = checkNotNull(taskManagerExternalResources);
     }
@@ -134,6 +138,10 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
     public String getDynamicProperties() {
         return dynamicProperties;
+    }
+
+    public String getJvmMemOptsEnv() {
+        return jvmMemOptsEnv;
     }
 
     public ContaineredTaskManagerParameters getContaineredTaskManagerParameters() {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -107,4 +107,6 @@ public class Constants {
     // Kubernetes start scripts
     public static final String KUBERNETES_JOB_MANAGER_SCRIPT_PATH = "kubernetes-jobmanager.sh";
     public static final String KUBERNETES_TASK_MANAGER_SCRIPT_PATH = "kubernetes-taskmanager.sh";
+
+    public static final String ENV_TM_JVM_MEM_OPTS = "FLINK_TM_JVM_MEM_OPTS";
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
@@ -58,6 +58,11 @@ public class KubernetesTestUtils {
                 ContaineredTaskManagerParameters.create(
                         flinkConfig, TaskExecutorProcessUtils.processSpecFromConfig(flinkConfig));
         return new KubernetesTaskManagerParameters(
-                flinkConfig, podName, "", containeredTaskManagerParameters, Collections.emptyMap());
+                flinkConfig,
+                podName,
+                "",
+                "",
+                containeredTaskManagerParameters,
+                Collections.emptyMap());
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -35,6 +35,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
 
     protected static final String POD_NAME = "taskmanager-pod-1";
     protected static final String DYNAMIC_PROPERTIES = "";
+    protected static final String JVM_MEM_OPTS_ENV = "-Xmx512m";
 
     protected static final int TOTAL_PROCESS_MEMORY = 1184;
     protected static final double TASK_MANAGER_CPU = 2.0;
@@ -73,6 +74,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
                         flinkConfig,
                         POD_NAME,
                         DYNAMIC_PROPERTIES,
+                        JVM_MEM_OPTS_ENV,
                         containeredTaskManagerParameters,
                         ExternalResourceUtils.getExternalResources(
                                 flinkConfig,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecoratorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import org.junit.Test;
 
 import java.util.List;
@@ -78,5 +79,17 @@ public class CmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
                                 + " "
                                 + mainClassArgs);
         assertThat(resultFlinkPod.getMainContainer().getArgs(), contains(flinkCommands.toArray()));
+    }
+
+    @Test
+    public void testTaskManagerJvmMemOptsEnv() {
+        final FlinkPod resultFlinkPod = cmdTaskManagerDecorator.decorateFlinkPod(baseFlinkPod);
+        assertThat(
+                resultFlinkPod.getMainContainer().getEnv(),
+                contains(
+                        new EnvVarBuilder()
+                                .withName(Constants.ENV_TM_JVM_MEM_OPTS)
+                                .withValue(JVM_MEM_OPTS_ENV)
+                                .build()));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -86,7 +86,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
         assertEquals(CONTAINER_IMAGE, resultMainContainer.getImage());
         assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), resultMainContainer.getImagePullPolicy());
 
-        assertEquals(3, resultMainContainer.getEnv().size());
+        assertEquals(4, resultMainContainer.getEnv().size());
         assertTrue(
                 resultMainContainer.getEnv().stream()
                         .anyMatch(envVar -> envVar.getName().equals("key1")));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -49,6 +49,7 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
 
     private static final String POD_NAME = "task-manager-pod-1";
     private static final String DYNAMIC_PROPERTIES = "-Dkey.b='b2'";
+    private static final String JVM_MEM_OPTS_ENV = "-Xmx512m";
 
     private final Map<String, String> customizedEnvs =
             new HashMap<String, String>() {
@@ -91,6 +92,7 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
                         flinkConfig,
                         POD_NAME,
                         DYNAMIC_PROPERTIES,
+                        JVM_MEM_OPTS_ENV,
                         containeredTaskManagerParameters,
                         Collections.emptyMap());
     }
@@ -145,6 +147,11 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
     @Test
     public void testGetDynamicProperties() {
         assertEquals(DYNAMIC_PROPERTIES, kubernetesTaskManagerParameters.getDynamicProperties());
+    }
+
+    @Test
+    public void testGetJvmMemOptsEnv() {
+        assertThat(kubernetesTaskManagerParameters.getJvmMemOptsEnv(), is(JVM_MEM_OPTS_ENV));
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
