### PR TITLE
[FLINK-21396][table-planner-blink] Use ResolvedCatalogTable within the planner

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -160,6 +161,9 @@ public abstract class ElasticsearchUpsertTableSinkFactoryBase
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+
+        // comment
+        properties.add(COMMENT);
 
         // format wildcard
         properties.add(FORMAT + ".*");

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1TableFactory.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1TableFactory.java
@@ -62,6 +62,7 @@ import static org.apache.flink.connector.hbase1.HBaseValidator.CONNECTOR_ZK_QUOR
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -194,6 +195,9 @@ public class HBase1TableFactory
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+
+        // comment
+        properties.add(COMMENT);
 
         // HBase properties
         properties.add(CONNECTOR_PROPERTIES + ".*");

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2TableFactory.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2TableFactory.java
@@ -62,6 +62,7 @@ import static org.apache.flink.connector.hbase2.HBaseValidator.CONNECTOR_ZK_QUOR
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -192,6 +193,9 @@ public class HBase2TableFactory
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+
+        // comment
+        properties.add(COMMENT);
 
         // HBase properties
         properties.add(CONNECTOR_PROPERTIES + ".*");

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -131,6 +132,9 @@ public class JdbcTableSourceSinkFactory
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+
+        // comment
+        properties.add(COMMENT);
 
         return properties;
     }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -53,6 +53,7 @@ import java.util.Properties;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -155,6 +156,9 @@ public abstract class KafkaTableSourceSinkFactoryBase
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+
+        // comment
+        properties.add(COMMENT);
 
         // format wildcard
         properties.add(FORMAT + ".*");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -90,6 +91,8 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+        // comment
+        properties.add(COMMENT);
 
         return properties;
     }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactoryBase.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -94,6 +95,8 @@ public abstract class TestTableSourceFactoryBase implements StreamTableSourceFac
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+        // comment
+        properties.add(COMMENT);
 
         return properties;
     }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSinkFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSinkFactoryBase.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_PATH;
 import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_TYPE_VALUE;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT_PROPERTY_VERSION;
@@ -90,6 +91,8 @@ public abstract class CsvTableSinkFactoryBase implements TableFactory {
         properties.add(SCHEMA + ".#." + DescriptorProperties.EXPR);
         // schema watermark
         properties.add(SCHEMA + "." + DescriptorProperties.WATERMARK + ".*");
+        // comment
+        properties.add(COMMENT);
         return properties;
     }
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
@@ -100,6 +101,8 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
         // table constraint
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+        // comment
+        properties.add(COMMENT);
 
         return properties;
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -854,7 +854,8 @@ public final class CatalogManager {
         return String.format("Could not execute %s in path %s", commandName, objectIdentifier);
     }
 
-    private ResolvedCatalogBaseTable<?> resolveCatalogBaseTable(CatalogBaseTable baseTable) {
+    /** Resolves a {@link CatalogBaseTable} to a validated {@link ResolvedCatalogBaseTable}. */
+    public ResolvedCatalogBaseTable<?> resolveCatalogBaseTable(CatalogBaseTable baseTable) {
         Preconditions.checkState(schemaResolver != null, "Schema resolver is not initialized.");
         if (baseTable instanceof CatalogTable) {
             return resolveCatalogTable((CatalogTable) baseTable);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -46,6 +46,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -138,7 +139,13 @@ public class ExpressionResolver {
                 localReferences.stream()
                         .collect(
                                 Collectors.toMap(
-                                        LocalReferenceExpression::getName, Function.identity()));
+                                        LocalReferenceExpression::getName,
+                                        Function.identity(),
+                                        (u, v) -> {
+                                            throw new IllegalStateException(
+                                                    "Duplicate local reference: " + u);
+                                        },
+                                        LinkedHashMap::new));
         this.localOverWindows = prepareOverWindows(localOverWindows);
     }
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import static org.apache.flink.table.api.Expressions.callSql;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isProctimeAttribute;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRowtimeAttribute;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isTimeAttribute;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
@@ -305,7 +306,11 @@ public class SchemaResolutionTest {
                                 DataTypes.FIELD("orig_ts", DataTypes.TIMESTAMP(3)),
                                 DataTypes.FIELD("proctime", DataTypes.TIMESTAMP(3).notNull()))
                         .notNull();
-        assertThat(resolvedSchema.toSourceRowDataType(), equalTo(expectedDataType));
+        final DataType sourceRowDataType = resolvedSchema.toSourceRowDataType();
+        assertThat(sourceRowDataType, equalTo(expectedDataType));
+
+        assertFalse(isTimeAttribute(sourceRowDataType.getChildren().get(4).getLogicalType()));
+        assertFalse(isTimeAttribute(sourceRowDataType.getChildren().get(6).getLogicalType()));
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/CatalogManagerMocks.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/CatalogManagerMocks.java
@@ -32,7 +32,9 @@ public final class CatalogManagerMocks {
     public static final String DEFAULT_DATABASE = EnvironmentSettings.DEFAULT_BUILTIN_DATABASE;
 
     public static CatalogManager createEmptyCatalogManager() {
-        return preparedCatalogManager().build();
+        final CatalogManager catalogManager = preparedCatalogManager().build();
+        catalogManager.initSchemaResolver(true, ExpressionResolverMocks.dummyResolver());
+        return catalogManager;
     }
 
     public static CatalogManager.Builder preparedCatalogManager() {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableSourceFactoryMock.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.table.descriptors.DescriptorProperties.COMMENT;
 import static org.apache.flink.table.descriptors.DescriptorProperties.EXPR;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
 import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
@@ -89,6 +90,8 @@ public class TableSourceFactoryMock implements TableSourceFactory<Row> {
         // table constraint
         supportedProperties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
         supportedProperties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+        // comment
+        supportedProperties.add(COMMENT);
 
         return supportedProperties;
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -74,7 +74,10 @@ public final class CatalogPropertiesUtil {
 
             serializeResolvedSchema(properties, resolvedTable.getResolvedSchema());
 
-            properties.put(COMMENT, resolvedTable.getComment());
+            final String comment = resolvedTable.getComment();
+            if (comment != null && comment.length() > 0) {
+                properties.put(COMMENT, comment);
+            }
 
             serializePartitionKeys(properties, resolvedTable.getPartitionKeys());
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogTable.java
@@ -108,7 +108,7 @@ public final class ResolvedCatalogTable
     }
 
     @Override
-    public CatalogTable copy(Map<String, String> options) {
+    public ResolvedCatalogTable copy(Map<String, String> options) {
         return new ResolvedCatalogTable(origin.copy(options), resolvedSchema);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/DescriptorProperties.java
@@ -112,6 +112,8 @@ public class DescriptorProperties {
 
     public static final String PRIMARY_KEY_COLUMNS = "primary-key.columns";
 
+    public static final String COMMENT = "comment";
+
     private static final Pattern SCHEMA_COLUMN_NAME_SUFFIX = Pattern.compile("\\d+\\.name");
 
     private static final Consumer<String> EMPTY_CONSUMER = (value) -> {};

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/DataTypeUtils.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
@@ -61,9 +62,11 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.table.types.extraction.ExtractionUtils.primitiveToWrapper;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldNames;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isCompositeType;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeUtils.getAtomicName;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeUtils.removeTimeAttributes;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeUtils.toInternalConversionClass;
 
 /** Utilities for handling {@link DataType}s. */
@@ -206,6 +209,18 @@ public final class DataTypeUtils {
     public static DataType replaceLogicalType(DataType dataType, LogicalType replacement) {
         return LogicalTypeDataTypeConverter.toDataType(replacement)
                 .bridgedTo(dataType.getConversionClass());
+    }
+
+    /**
+     * Removes time attributes from the {@link DataType}. As everywhere else in the code base, this
+     * method does not support nested time attributes for now.
+     */
+    public static DataType removeTimeAttribute(DataType dataType) {
+        final LogicalType type = dataType.getLogicalType();
+        if (hasFamily(type, LogicalTypeFamily.TIMESTAMP)) {
+            return replaceLogicalType(dataType, removeTimeAttributes(type));
+        }
+        return dataType;
     }
 
     /**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.catalog.CatalogManager.TableLookupResult;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
 import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
@@ -105,8 +106,8 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
         return tableIdentifier;
     }
 
-    public CatalogBaseTable getCatalogTable() {
-        return lookupResult.getTable();
+    public ResolvedCatalogBaseTable<?> getResolvedCatalogTable() {
+        return lookupResult.getResolvedTable();
     }
 
     public boolean isTemporary() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/CatalogTableSpecBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/CatalogTableSpecBase.java
@@ -20,8 +20,8 @@ package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.planner.plan.nodes.exec.serde.CatalogTableJsonDeserializer;
 import org.apache.flink.table.planner.plan.nodes.exec.serde.CatalogTableJsonSerializer;
 import org.apache.flink.table.planner.plan.nodes.exec.serde.ObjectIdentifierJsonDeserializer;
@@ -51,13 +51,14 @@ public class CatalogTableSpecBase {
     @JsonProperty(value = FIELD_NAME_CATALOG_TABLE, required = true)
     @JsonSerialize(using = CatalogTableJsonSerializer.class)
     @JsonDeserialize(using = CatalogTableJsonDeserializer.class)
-    protected final CatalogTable catalogTable;
+    protected final ResolvedCatalogTable catalogTable;
 
     @JsonIgnore protected ClassLoader classLoader;
 
     @JsonIgnore protected ReadableConfig configuration;
 
-    protected CatalogTableSpecBase(ObjectIdentifier objectIdentifier, CatalogTable catalogTable) {
+    protected CatalogTableSpecBase(
+            ObjectIdentifier objectIdentifier, ResolvedCatalogTable catalogTable) {
         this.objectIdentifier = checkNotNull(objectIdentifier);
         this.catalogTable = checkNotNull(catalogTable);
     }
@@ -76,7 +77,7 @@ public class CatalogTableSpecBase {
     }
 
     @JsonIgnore
-    public CatalogTable getCatalogTable() {
+    public ResolvedCatalogTable getCatalogTable() {
         return catalogTable;
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec;
@@ -52,7 +52,7 @@ public class DynamicTableSinkSpec extends CatalogTableSpecBase {
     @JsonCreator
     public DynamicTableSinkSpec(
             @JsonProperty(FIELD_NAME_IDENTIFIER) ObjectIdentifier objectIdentifier,
-            @JsonProperty(FIELD_NAME_CATALOG_TABLE) CatalogTable catalogTable,
+            @JsonProperty(FIELD_NAME_CATALOG_TABLE) ResolvedCatalogTable catalogTable,
             @Nullable @JsonProperty(FIELD_NAME_SINK_ABILITY_SPECS)
                     List<SinkAbilitySpec> sinkAbilitySpecs) {
         super(objectIdentifier, catalogTable);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
 import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -60,7 +60,7 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
     @JsonCreator
     public DynamicTableSourceSpec(
             @JsonProperty(FIELD_NAME_IDENTIFIER) ObjectIdentifier objectIdentifier,
-            @JsonProperty(FIELD_NAME_CATALOG_TABLE) CatalogTable catalogTable,
+            @JsonProperty(FIELD_NAME_CATALOG_TABLE) ResolvedCatalogTable catalogTable,
             @Nullable @JsonProperty(FIELD_NAME_SOURCE_ABILITY_SPECS)
                     List<SourceAbilitySpec> sourceAbilitySpecs) {
         super(objectIdentifier, catalogTable);
@@ -83,7 +83,11 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
 
             if (sourceAbilitySpecs != null) {
                 RowType newProducedType =
-                        (RowType) catalogTable.getSchema().toRowDataType().getLogicalType();
+                        (RowType)
+                                catalogTable
+                                        .getResolvedSchema()
+                                        .toSourceRowDataType()
+                                        .getLogicalType();
                 for (SourceAbilitySpec spec : sourceAbilitySpecs) {
                     SourceAbilityContext context =
                             new SourceAbilityContext(planner.getFlinkContext(), newProducedType);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
-import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
@@ -89,7 +89,7 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
 
         final int[] refFields = RexNodeExtractor.extractRefInputFields(project.getProjects());
         TableSourceTable oldTableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
-        final TableSchema oldSchema = oldTableSourceTable.catalogTable().getSchema();
+        final ResolvedSchema oldSchema = oldTableSourceTable.catalogTable().getResolvedSchema();
         final DynamicTableSource oldSource = oldTableSourceTable.tableSource();
         final TableConfig config = ShortcutUtils.unwrapContext(scan).getTableConfig();
 
@@ -114,12 +114,12 @@ public class PushProjectIntoTableSourceScanRule extends RelOptRule {
                             pks -> {
                                 for (String name : pks.getColumns()) {
                                     int index = fieldNames.indexOf(name);
-                                    TableColumn col = oldSchema.getTableColumn(index).get();
+                                    Column col = oldSchema.getColumn(index).get();
                                     oldProjectsWithPK.add(
                                             new RexInputRef(
                                                     index,
                                                     flinkTypeFactory.createFieldTypeFromLogicalType(
-                                                            col.getType().getLogicalType())));
+                                                            col.getDataType().getLogicalType())));
                                 }
                             });
         }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/sinks/DynamicSinkUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
@@ -82,7 +83,7 @@ public final class DynamicSinkUtils {
             RelNode input,
             CatalogSinkModifyOperation sinkOperation,
             DynamicTableSink sink,
-            CatalogTable table) {
+            ResolvedCatalogTable table) {
         final FlinkTypeFactory typeFactory = ShortcutUtils.unwrapTypeFactory(relBuilder);
         final TableSchema schema = table.getSchema();
 
@@ -279,7 +280,7 @@ public final class DynamicSinkUtils {
      * SupportsWritingMetadata#listWritableMetadata()}.
      *
      * <p>This method assumes that sink and schema have been validated via {@link
-     * #prepareDynamicSink(CatalogSinkModifyOperation, DynamicTableSink, CatalogTable)}.
+     * #prepareDynamicSink(CatalogSinkModifyOperation, DynamicTableSink, CatalogTable, List)}.
      */
     private static List<String> createRequiredMetadataKeys(
             TableSchema schema, DynamicTableSink sink) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -334,33 +334,39 @@ abstract class PlannerBase(
   private def getTableSink(
       objectIdentifier: ObjectIdentifier,
       dynamicOptions: JMap[String, String])
-    : Option[(CatalogTable, Any)] = {
-    val lookupResult = JavaScalaConversionUtil.toScala(catalogManager.getTable(objectIdentifier))
-    lookupResult
-      .map(_.getTable) match {
-      case Some(table: ConnectorCatalogTable[_, _]) =>
-        JavaScalaConversionUtil.toScala(table.getTableSink) match {
-          case Some(sink) => Some(table, sink)
+    : Option[(ResolvedCatalogTable, Any)] = {
+    val optionalLookupResult =
+      JavaScalaConversionUtil.toScala(catalogManager.getTable(objectIdentifier))
+    if (optionalLookupResult.isEmpty) {
+      return None
+    }
+    val lookupResult = optionalLookupResult.get
+    lookupResult.getTable match {
+      case connectorTable: ConnectorCatalogTable[_, _] =>
+        val resolvedTable = lookupResult.getResolvedTable.asInstanceOf[ResolvedCatalogTable]
+        JavaScalaConversionUtil.toScala(connectorTable.getTableSink) match {
+          case Some(sink) => Some(resolvedTable, sink)
           case None => None
         }
 
-      case Some(table: CatalogTable) =>
-        val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
+      case regularTable: CatalogTable =>
+        val resolvedTable = lookupResult.getResolvedTable.asInstanceOf[ResolvedCatalogTable]
         val tableToFind = if (dynamicOptions.nonEmpty) {
-          table.copy(FlinkHints.mergeTableOptions(dynamicOptions, table.getOptions))
+          resolvedTable.copy(FlinkHints.mergeTableOptions(dynamicOptions, resolvedTable.getOptions))
         } else {
-          table
+          resolvedTable
         }
-        val isTemporary = lookupResult.get.isTemporary
-        if (isLegacyConnectorOptions(objectIdentifier, table, isTemporary)) {
+        val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
+        val isTemporary = lookupResult.isTemporary
+        if (isLegacyConnectorOptions(objectIdentifier, resolvedTable.getOrigin, isTemporary)) {
           val tableSink = TableFactoryUtil.findAndCreateTableSink(
             catalog.orElse(null),
             objectIdentifier,
-            tableToFind,
+            tableToFind.getOrigin,
             getTableConfig.getConfiguration,
             isStreamingMode,
             isTemporary)
-          Option(table, tableSink)
+          Option(resolvedTable, tableSink)
         } else {
           val tableSink = FactoryUtil.createTableSink(
             catalog.orElse(null),
@@ -369,7 +375,7 @@ abstract class PlannerBase(
             getTableConfig.getConfiguration,
             getClassLoader,
             isTemporary)
-          Option(table, tableSink)
+          Option(resolvedTable, tableSink)
         }
 
       case _ => None

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalSink.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.calcite
 
-import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
 
@@ -39,7 +39,7 @@ final class LogicalSink(
     traitSet: RelTraitSet,
     input: RelNode,
     tableIdentifier: ObjectIdentifier,
-    catalogTable: CatalogTable,
+    catalogTable: ResolvedCatalogTable,
     tableSink: DynamicTableSink,
     val staticPartitions: Map[String, String],
     val abilitySpecs: Array[SinkAbilitySpec])
@@ -63,7 +63,7 @@ object LogicalSink {
   def create(
       input: RelNode,
       tableIdentifier: ObjectIdentifier,
-      catalogTable: CatalogTable,
+      catalogTable: ResolvedCatalogTable,
       tableSink: DynamicTableSink,
       staticPartitions: util.Map[String, String],
       abilitySpecs: Array[SinkAbilitySpec]): LogicalSink = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.calcite
 
-import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
@@ -36,7 +36,7 @@ import scala.collection.JavaConversions._
   * @param traitSet the traits of this rel
   * @param input    input relational expression
  *  @param tableIdentifier the full path of the table to retrieve.
- *  @param catalogTable Catalog table where this table source table comes from
+ *  @param catalogTable Resolved catalog table where this table source table comes from
  *  @param tableSink the [[DynamicTableSink]] for which to write into
   */
 abstract class Sink(
@@ -44,7 +44,7 @@ abstract class Sink(
     traitSet: RelTraitSet,
     input: RelNode,
     val tableIdentifier: ObjectIdentifier,
-    val catalogTable: CatalogTable,
+    val catalogTable: ResolvedCatalogTable,
     val tableSink: DynamicTableSink)
   extends SingleRel(cluster, traitSet, input) {
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalSink.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.logical
 
-import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
@@ -41,7 +41,7 @@ class FlinkLogicalSink(
     traitSet: RelTraitSet,
     input: RelNode,
     tableIdentifier: ObjectIdentifier,
-    catalogTable: CatalogTable,
+    catalogTable: ResolvedCatalogTable,
     tableSink: DynamicTableSink,
     val staticPartitions: Map[String, String],
     val abilitySpecs: Array[SinkAbilitySpec])
@@ -88,7 +88,7 @@ object FlinkLogicalSink {
   def create(
       input: RelNode,
       tableIdentifier: ObjectIdentifier,
-      catalogTable: CatalogTable,
+      catalogTable: ResolvedCatalogTable,
       tableSink: DynamicTableSink,
       staticPartitions: Map[String, String] = Map(),
       abilitySpecs: Array[SinkAbilitySpec] = Array.empty): FlinkLogicalSink = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
-import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
@@ -42,7 +42,7 @@ class BatchPhysicalSink(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     tableIdentifier: ObjectIdentifier,
-    catalogTable: CatalogTable,
+    catalogTable: ResolvedCatalogTable,
     tableSink: DynamicTableSink,
     abilitySpecs: Array[SinkAbilitySpec])
   extends Sink(cluster, traitSet, inputRel, tableIdentifier, catalogTable, tableSink)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
@@ -42,7 +42,7 @@ class StreamPhysicalSink(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     tableIdentifier: ObjectIdentifier,
-    catalogTable: CatalogTable,
+    catalogTable: ResolvedCatalogTable,
     tableSink: DynamicTableSink,
     abilitySpecs: Array[SinkAbilitySpec])
   extends Sink(cluster, traitSet, inputRel, tableIdentifier, catalogTable, tableSink)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSinkRule.scala
@@ -60,7 +60,7 @@ class BatchPhysicalSinkRule extends ConverterRule(
           val dynamicPartFields = sinkNode.catalogTable.getPartitionKeys
               .filter(!sinkNode.staticPartitions.contains(_))
           val fieldNames = sinkNode.catalogTable
-            .getSchema
+            .getResolvedSchema
             .toPhysicalRowDataType
             .getLogicalType.asInstanceOf[RowType]
             .getFieldNames

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.schema
 
-import org.apache.flink.table.catalog.{CatalogTable, ObjectIdentifier}
+import org.apache.flink.table.catalog.{ObjectIdentifier, ResolvedCatalogTable}
 import org.apache.flink.table.connector.source.DynamicTableSource
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
@@ -40,7 +40,7 @@ import java.util
  * @param statistic The table statistics
  * @param tableSource The [[DynamicTableSource]] for which is converted to a Calcite Table
  * @param isStreamingMode A flag that tells if the current table is in stream mode
- * @param catalogTable Catalog table where this table source table comes from
+ * @param catalogTable Resolved catalog table where this table source table comes from
  * @param extraDigests The extra digests which will be added into `getQualifiedName`
  *                     as a part of table digest
  */
@@ -51,7 +51,7 @@ class TableSourceTable(
     statistic: FlinkStatistic,
     val tableSource: DynamicTableSource,
     val isStreamingMode: Boolean,
-    val catalogTable: CatalogTable,
+    val catalogTable: ResolvedCatalogTable,
     val extraDigests: Array[String] = Array.empty,
     val abilitySpecs: Array[SourceAbilitySpec] = Array.empty)
   extends FlinkPreparingTableBase(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -19,9 +19,13 @@
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
@@ -32,6 +36,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -63,7 +68,11 @@ public class DynamicTableSinkSpecSerdeTest {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         SerdeContext serdeCtx =
                 new SerdeContext(
-                        new FlinkContextImpl(TableConfig.getDefault(), null, null, null),
+                        new FlinkContextImpl(
+                                TableConfig.getDefault(),
+                                null,
+                                CatalogManagerMocks.createEmptyCatalogManager(),
+                                null),
                         classLoader,
                         FlinkTypeFactory.INSTANCE(),
                         FlinkSqlOperatorTable.instance());
@@ -91,10 +100,18 @@ public class DynamicTableSinkSpecSerdeTest {
         properties1.put("schema.0.name", "a");
         properties1.put("schema.0.data-type", "BIGINT");
 
+        final CatalogTable catalogTable1 = CatalogTable.fromProperties(properties1);
+
+        final ResolvedSchema resolvedSchema1 =
+                new ResolvedSchema(
+                        Collections.singletonList(Column.physical("a", DataTypes.BIGINT())),
+                        Collections.emptyList(),
+                        null);
+
         DynamicTableSinkSpec spec1 =
                 new DynamicTableSinkSpec(
                         ObjectIdentifier.of("default_catalog", "default_db", "MyTable"),
-                        CatalogTableImpl.fromProperties(properties1),
+                        new ResolvedCatalogTable(catalogTable1, resolvedSchema1),
                         Collections.emptyList());
         spec1.setReadableConfig(new Configuration());
 
@@ -107,12 +124,23 @@ public class DynamicTableSinkSpecSerdeTest {
         properties2.put("schema.1.name", "b");
         properties2.put("schema.1.data-type", "INT");
         properties2.put("schema.2.name", "p");
-        properties2.put("schema.2.data-type", "VARCHAR");
+        properties2.put("schema.2.data-type", "STRING");
+
+        final CatalogTable catalogTable2 = CatalogTable.fromProperties(properties2);
+
+        final ResolvedSchema resolvedSchema2 =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT()),
+                                Column.physical("b", DataTypes.INT()),
+                                Column.physical("p", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        null);
 
         DynamicTableSinkSpec spec2 =
                 new DynamicTableSinkSpec(
                         ObjectIdentifier.of("default_catalog", "default_db", "MyTable"),
-                        CatalogTableImpl.fromProperties(properties2),
+                        new ResolvedCatalogTable(catalogTable2, resolvedSchema2),
                         Arrays.asList(
                                 new OverwriteSpec(true),
                                 new PartitioningSpec(
@@ -130,13 +158,24 @@ public class DynamicTableSinkSpecSerdeTest {
         properties3.put("schema.1.name", "b");
         properties3.put("schema.1.data-type", "INT");
         properties3.put("schema.2.name", "m");
-        properties3.put("schema.2.data-type", "VARCHAR");
-        properties3.put("writable-metadata", "m:VARCHAR");
+        properties3.put("schema.2.data-type", "STRING");
+        properties3.put("writable-metadata", "m:STRING");
+
+        final CatalogTable catalogTable3 = CatalogTable.fromProperties(properties3);
+
+        final ResolvedSchema resolvedSchema3 =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT()),
+                                Column.physical("b", DataTypes.INT()),
+                                Column.physical("m", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        null);
 
         DynamicTableSinkSpec spec3 =
                 new DynamicTableSinkSpec(
                         ObjectIdentifier.of("default_catalog", "default_db", "MyTable"),
-                        CatalogTableImpl.fromProperties(properties3),
+                        new ResolvedCatalogTable(catalogTable3, resolvedSchema3),
                         Collections.singletonList(
                                 new WritingMetadataSpec(
                                         Collections.singletonList("m"),

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeCumulateWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeCumulateWindow.out
@@ -290,9 +290,9 @@
         "tableName" : "MySink"
       },
       "catalogTable" : {
-        "schema.1.name" : "cnt",
         "connector" : "values",
         "schema.0.data-type" : "BIGINT",
+        "schema.1.name" : "cnt",
         "schema.0.name" : "b",
         "schema.1.data-type" : "BIGINT"
       }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
@@ -289,9 +289,9 @@
         "tableName" : "MySink"
       },
       "catalogTable" : {
-        "schema.1.name" : "sum_a",
         "connector" : "values",
         "schema.0.data-type" : "BIGINT",
+        "schema.1.name" : "sum_a",
         "schema.0.name" : "b",
         "schema.1.data-type" : "INT"
       }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
@@ -147,6 +147,8 @@ class InMemoryTableFactory(terminationCount: Int)
     // table constraint
     properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_NAME);
     properties.add(SCHEMA + "." + DescriptorProperties.PRIMARY_KEY_COLUMNS);
+    // comment
+    properties.add(COMMENT);
 
     properties
   }


### PR DESCRIPTION
## What is the purpose of the change

This updates the planner to only use instances of `ResolvedCatalogTable` with `ResolvedSchema`. It ensures that all existing tests still pass.

## Brief change log

- Use `ResolvedCatalogTable` instead of `CatalogTableImpl`
- Do not use time attributes in data types derived from a `ResolvedSchema`

## Verifying this change

This change is already covered by existing tests, such as `TableScanTest`, `DynamicTableSinkSpecSerdeTest` and more.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
