### PR TITLE
 [FLINK-21596] Increase time out for the CheckpointFailureManagerITCase 

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
@@ -53,9 +52,8 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
@@ -68,27 +66,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /** Tests to verify end-to-end logic of checkpoint failure manager. */
 public class CheckpointFailureManagerITCase extends TestLogger {
-    private static MiniClusterWithClientResource cluster;
 
-    @Before
-    public void setup() throws Exception {
-        Configuration configuration = new Configuration();
-
-        cluster =
-                new MiniClusterWithClientResource(
-                        new MiniClusterResourceConfiguration.Builder()
-                                .setConfiguration(configuration)
-                                .build());
-        cluster.before();
-    }
-
-    @AfterClass
-    public static void shutDownExistingCluster() {
-        if (cluster != null) {
-            cluster.after();
-            cluster = null;
-        }
-    }
+    @ClassRule
+    public static MiniClusterWithClientResource cluster =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder().build());
 
     @Test(timeout = 20_000)
     public void testAsyncCheckpointFailureTriggerJobFailed() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -90,10 +90,10 @@ public class CheckpointFailureManagerITCase extends TestLogger {
         }
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 20_000)
     public void testAsyncCheckpointFailureTriggerJobFailed() throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.enableCheckpointing(100);
+        env.enableCheckpointing(500);
         env.setRestartStrategy(RestartStrategies.noRestart());
         env.setStateBackend(new AsyncFailureStateBackend());
         env.addSource(new StringGeneratingSourceFunction()).addSink(new DiscardingSink<>());


### PR DESCRIPTION
## What is the purpose of the change
Make the test more stable. The logs show that the cluster (task managers) cannot start in time and the test fails occasionally. You can see in the logs that the job switches to RUNNING just before the test times out.

## Brief change log
* Use `@ClassRule` instead of `AfterClass`, `BeforeClass`
* Increase time out
* Increase checkpointing interval to perform less actions when the cluster comes up.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
