### PR TITLE
 [FLINK-21802][table-planner-blink]LogicalTypeJsonDeserializer/Serializer support custom RowType/MapType/ArrayType/MultisetType 

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
@@ -53,10 +53,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ARRAY_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTES;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_COMPARISION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_DESCRIPTION;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ELEMENT_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_FIELDS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_FINAL;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_IDENTIFIER;
@@ -65,7 +65,6 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJs
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_KEY_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_LENGTH;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_LOGICAL_TYPE;
-import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_MULTI_SET_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_NAME;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_NULLABLE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_PRECISION;
@@ -173,14 +172,15 @@ public class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
 
     private ArrayType deserializeArrayType(JsonNode logicalTypeNode, SerdeContext serdeCtx) {
         boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
-        LogicalType elementType = deserialize(logicalTypeNode.get(FIELD_NAME_ARRAY_TYPE), serdeCtx);
+        LogicalType elementType =
+                deserialize(logicalTypeNode.get(FIELD_NAME_ELEMENT_TYPE), serdeCtx);
         return new ArrayType(nullable, elementType);
     }
 
     private MultisetType deserializeMultisetType(JsonNode logicalTypeNode, SerdeContext serdeCtx) {
         boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
         LogicalType elementType =
-                deserialize(logicalTypeNode.get(FIELD_NAME_MULTI_SET_TYPE), serdeCtx);
+                deserialize(logicalTypeNode.get(FIELD_NAME_ELEMENT_TYPE), serdeCtx);
         return new MultisetType(nullable, elementType);
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonDeserializer.java
@@ -21,16 +21,24 @@ package org.apache.flink.table.planner.plan.nodes.exec.serde;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.SymbolType;
+import org.apache.flink.table.types.logical.TimestampKind;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
 import org.apache.flink.table.utils.EncodingUtils;
 
@@ -42,24 +50,32 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ARRAY_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_ATTRIBUTES;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_COMPARISION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_DESCRIPTION;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_FIELDS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_FINAL;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_IDENTIFIER;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_IMPLEMENTATION_CLASS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_INSTANTIABLE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_KEY_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_LENGTH;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_LOGICAL_TYPE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_MULTI_SET_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_NAME;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_NULLABLE;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_PRECISION;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_SOURCE_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_SUPPER_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_SYMBOL_CLASS;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_TIMESTAMP_KIND;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_TYPE_INFO;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_TYPE_NAME;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.LogicalTypeJsonSerializer.FIELD_NAME_VALUE_TYPE;
 
 /**
  * JSON deserializer for {@link LogicalType}. refer to {@link LogicalTypeJsonSerializer} for
@@ -101,6 +117,20 @@ public class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
                     return deserializeDistinctType(logicalTypeNode, serdeCtx);
                 case STRUCTURED_TYPE:
                     return deserializeStructuredType(logicalTypeNode, serdeCtx);
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                    return deserializeTimestampType(logicalTypeNode);
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    return deserializeZonedTimestampType(logicalTypeNode);
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                    return deserializeLocalZonedTimestampType(logicalTypeNode);
+                case ROW:
+                    return deserializeRowType(logicalTypeNode, serdeCtx);
+                case MAP:
+                    return deserializeMapType(logicalTypeNode, serdeCtx);
+                case ARRAY:
+                    return deserializeArrayType(logicalTypeNode, serdeCtx);
+                case MULTISET:
+                    return deserializeMultisetType(logicalTypeNode, serdeCtx);
                 default:
                     throw new TableException("Unsupported type name:" + typeName);
             }
@@ -111,6 +141,47 @@ public class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
         } else {
             return LogicalTypeParser.parse(logicalTypeNode.asText());
         }
+    }
+
+    private RowType deserializeRowType(JsonNode logicalTypeNode, SerdeContext serdeCtx) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        List<RowType.RowField> rowFields = new ArrayList<>();
+        Iterator<JsonNode> elements = logicalTypeNode.get(FIELD_NAME_FIELDS).elements();
+        while (elements.hasNext()) {
+            JsonNode node = elements.next();
+            String filedName = node.fieldNames().next();
+            LogicalType fieldType = deserialize(node.get(filedName), serdeCtx);
+            if (node.has(FIELD_NAME_DESCRIPTION)) {
+                rowFields.add(
+                        new RowType.RowField(
+                                filedName, fieldType, node.get(FIELD_NAME_DESCRIPTION).asText()));
+            } else {
+                rowFields.add(new RowType.RowField(filedName, fieldType));
+            }
+        }
+        return new RowType(nullable, rowFields);
+    }
+
+    private MapType deserializeMapType(JsonNode logicalTypeNode, SerdeContext serdeCtx) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        LogicalType keyLogicalType =
+                deserialize(logicalTypeNode.get(FIELD_NAME_KEY_TYPE), serdeCtx);
+        LogicalType valueLogicalType =
+                deserialize(logicalTypeNode.get(FIELD_NAME_VALUE_TYPE), serdeCtx);
+        return new MapType(nullable, keyLogicalType, valueLogicalType);
+    }
+
+    private ArrayType deserializeArrayType(JsonNode logicalTypeNode, SerdeContext serdeCtx) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        LogicalType elementType = deserialize(logicalTypeNode.get(FIELD_NAME_ARRAY_TYPE), serdeCtx);
+        return new ArrayType(nullable, elementType);
+    }
+
+    private MultisetType deserializeMultisetType(JsonNode logicalTypeNode, SerdeContext serdeCtx) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        LogicalType elementType =
+                deserialize(logicalTypeNode.get(FIELD_NAME_MULTI_SET_TYPE), serdeCtx);
+        return new MultisetType(nullable, elementType);
     }
 
     private CharType deserializeCharType(JsonNode logicalTypeNode) {
@@ -259,5 +330,29 @@ public class LogicalTypeJsonDeserializer extends StdDeserializer<LogicalType> {
             builder.description(description);
         }
         return builder.build();
+    }
+
+    private TimestampType deserializeTimestampType(JsonNode logicalTypeNode) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        int precision = logicalTypeNode.get(FIELD_NAME_PRECISION).asInt();
+        TimestampKind timestampKind =
+                TimestampKind.valueOf(logicalTypeNode.get(FIELD_NAME_TIMESTAMP_KIND).asText());
+        return new TimestampType(nullable, timestampKind, precision);
+    }
+
+    private ZonedTimestampType deserializeZonedTimestampType(JsonNode logicalTypeNode) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        int precision = logicalTypeNode.get(FIELD_NAME_PRECISION).asInt();
+        TimestampKind timestampKind =
+                TimestampKind.valueOf(logicalTypeNode.get(FIELD_NAME_TIMESTAMP_KIND).asText());
+        return new ZonedTimestampType(nullable, timestampKind, precision);
+    }
+
+    private LocalZonedTimestampType deserializeLocalZonedTimestampType(JsonNode logicalTypeNode) {
+        boolean nullable = logicalTypeNode.get(FIELD_NAME_NULLABLE).asBoolean();
+        int precision = logicalTypeNode.get(FIELD_NAME_PRECISION).asInt();
+        TimestampKind timestampKind =
+                TimestampKind.valueOf(logicalTypeNode.get(FIELD_NAME_TIMESTAMP_KIND).asText());
+        return new LocalZonedTimestampType(nullable, timestampKind, precision);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
@@ -81,12 +81,10 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
     // RowType
     public static final String FIELD_NAME_FIELDS = "fields";
     // MapType
-    public static final String FIELD_NAME_KEY_TYPE = "mapKeyType";
-    public static final String FIELD_NAME_VALUE_TYPE = "mapValueType";
-    // ArrayType
-    public static final String FIELD_NAME_ARRAY_TYPE = "arrayElementType";
-    // MultiSetType
-    public static final String FIELD_NAME_MULTI_SET_TYPE = "multiSetElementType";
+    public static final String FIELD_NAME_KEY_TYPE = "keyType";
+    public static final String FIELD_NAME_VALUE_TYPE = "valueType";
+    // ArrayType/MultiSetType
+    public static final String FIELD_NAME_ELEMENT_TYPE = "elementType";
 
     public LogicalTypeJsonSerializer() {
         super(LogicalType.class);
@@ -189,7 +187,7 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, arrayType.getTypeRoot().name());
         jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, arrayType.isNullable());
-        jsonGenerator.writeFieldName(FIELD_NAME_ARRAY_TYPE);
+        jsonGenerator.writeFieldName(FIELD_NAME_ELEMENT_TYPE);
         serialize(arrayType.getElementType(), jsonGenerator, serializerProvider);
         jsonGenerator.writeEndObject();
     }
@@ -202,7 +200,7 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, multisetType.getTypeRoot().name());
         jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, multisetType.isNullable());
-        jsonGenerator.writeFieldName(FIELD_NAME_MULTI_SET_TYPE);
+        jsonGenerator.writeFieldName(FIELD_NAME_ELEMENT_TYPE);
         serialize(multisetType.getElementType(), jsonGenerator, serializerProvider);
         jsonGenerator.writeEndObject();
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
@@ -209,9 +209,9 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         // Zero-length character strings have no serializable string representation.
         if (charType.getLength() == CharType.EMPTY_LITERAL_LENGTH) {
             jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, charType.getTypeRoot().name());
             jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, charType.isNullable());
             jsonGenerator.writeNumberField(FIELD_NAME_LENGTH, charType.getLength());
-            jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, charType.getTypeRoot().name());
             jsonGenerator.writeEndObject();
         } else {
             jsonGenerator.writeObject(charType.asSerializableString());
@@ -223,9 +223,9 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         // Zero-length character strings have no serializable string representation.
         if (varCharType.getLength() == VarCharType.EMPTY_LITERAL_LENGTH) {
             jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, varCharType.getTypeRoot().name());
             jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, varCharType.isNullable());
             jsonGenerator.writeNumberField(FIELD_NAME_LENGTH, varCharType.getLength());
-            jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, varCharType.getTypeRoot().name());
             jsonGenerator.writeEndObject();
         } else {
             jsonGenerator.writeObject(varCharType.asSerializableString());
@@ -236,9 +236,9 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         // Zero-length binary strings have no serializable string representation.
         if (binaryType.getLength() == BinaryType.EMPTY_LITERAL_LENGTH) {
             jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, binaryType.getTypeRoot().name());
             jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, binaryType.isNullable());
             jsonGenerator.writeNumberField(FIELD_NAME_LENGTH, binaryType.getLength());
-            jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, binaryType.getTypeRoot().name());
             jsonGenerator.writeEndObject();
         } else {
             jsonGenerator.writeObject(binaryType.asSerializableString());
@@ -250,10 +250,10 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         // Zero-length binary strings have no serializable string representation.
         if (varBinaryType.getLength() == VarBinaryType.EMPTY_LITERAL_LENGTH) {
             jsonGenerator.writeStartObject();
-            jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, varBinaryType.isNullable());
-            jsonGenerator.writeNumberField(FIELD_NAME_LENGTH, varBinaryType.getLength());
             jsonGenerator.writeStringField(
                     FIELD_NAME_TYPE_NAME, varBinaryType.getTypeRoot().name());
+            jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, varBinaryType.isNullable());
+            jsonGenerator.writeNumberField(FIELD_NAME_LENGTH, varBinaryType.getLength());
             jsonGenerator.writeEndObject();
         } else {
             jsonGenerator.writeObject(varBinaryType.asSerializableString());
@@ -340,30 +340,30 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
     private void serialize(TimestampType timestampType, JsonGenerator jsonGenerator)
             throws IOException {
         jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, timestampType.getTypeRoot().name());
         jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, timestampType.isNullable());
         jsonGenerator.writeNumberField(FIELD_NAME_PRECISION, timestampType.getPrecision());
         jsonGenerator.writeObjectField(FIELD_NAME_TIMESTAMP_KIND, timestampType.getKind());
-        jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, timestampType.getTypeRoot().name());
         jsonGenerator.writeEndObject();
     }
 
     private void serialize(ZonedTimestampType timestampType, JsonGenerator jsonGenerator)
             throws IOException {
         jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, timestampType.getTypeRoot().name());
         jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, timestampType.isNullable());
         jsonGenerator.writeNumberField(FIELD_NAME_PRECISION, timestampType.getPrecision());
         jsonGenerator.writeObjectField(FIELD_NAME_TIMESTAMP_KIND, timestampType.getKind());
-        jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, timestampType.getTypeRoot().name());
         jsonGenerator.writeEndObject();
     }
 
     private void serialize(LocalZonedTimestampType timestampType, JsonGenerator jsonGenerator)
             throws IOException {
         jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, timestampType.getTypeRoot().name());
         jsonGenerator.writeBooleanField(FIELD_NAME_NULLABLE, timestampType.isNullable());
         jsonGenerator.writeNumberField(FIELD_NAME_PRECISION, timestampType.getPrecision());
         jsonGenerator.writeObjectField(FIELD_NAME_TIMESTAMP_KIND, timestampType.getKind());
-        jsonGenerator.writeStringField(FIELD_NAME_TYPE_NAME, timestampType.getTypeRoot().name());
         jsonGenerator.writeEndObject();
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeJsonSerializer.java
@@ -131,10 +131,6 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
         } else if (logicalType instanceof LocalZonedTimestampType) {
             // LocalZonedTimestampType does not consider `TimestampKind`
             serialize((LocalZonedTimestampType) logicalType, jsonGenerator);
-        } else if (logicalType instanceof UnresolvedUserDefinedType) {
-            throw new TableException(
-                    "Can not serialize an UnresolvedUserDefinedType instance. \n"
-                            + "It needs to be resolved into a proper user-defined type.\"");
         } else if (logicalType instanceof RowType) {
             serializeRowType((RowType) logicalType, jsonGenerator, serializerProvider);
         } else if (logicalType instanceof MapType) {
@@ -143,6 +139,10 @@ public class LogicalTypeJsonSerializer extends StdSerializer<LogicalType> {
             serializeArrayType((ArrayType) logicalType, jsonGenerator, serializerProvider);
         } else if (logicalType instanceof MultisetType) {
             serializeMultisetType((MultisetType) logicalType, jsonGenerator, serializerProvider);
+        } else if (logicalType instanceof UnresolvedUserDefinedType) {
+            throw new TableException(
+                    "Can not serialize an UnresolvedUserDefinedType instance. \n"
+                            + "It needs to be resolved into a proper user-defined type.\"");
         } else {
             jsonGenerator.writeObject(logicalType.asSerializableString());
         }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
@@ -105,7 +105,7 @@ public class LogicalTypeSerdeTest {
         }
         String json = writer.toString();
         LogicalType actual = mapper.readValue(json, LogicalType.class);
-        assertEquals(logicalType, actual);
+        assertEquals(logicalType.asSerializableString(), actual.asSerializableString());
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
@@ -106,55 +106,7 @@ public class LogicalTypeSerdeTest {
         String json = writer.toString();
         LogicalType actual = mapper.readValue(json, LogicalType.class);
         assertEquals(logicalType, actual);
-        if (canSerializableString(logicalType)) {
-            assertEquals(logicalType.asSerializableString(), actual.asSerializableString());
-        }
-    }
-
-    private boolean canSerializableString(LogicalType logicalType) {
-        if (logicalType instanceof RawType
-                || logicalType instanceof SymbolType
-                || logicalType instanceof TypeInformationRawType) {
-            return false;
-        }
-        if (CharType.ofEmptyLiteral().copy(true).equals(logicalType)
-                || CharType.ofEmptyLiteral().copy(false).equals(logicalType)) {
-            return false;
-        }
-        if (VarCharType.ofEmptyLiteral().copy(true).equals(logicalType)
-                || VarCharType.ofEmptyLiteral().copy(false).equals(logicalType)) {
-            return false;
-        }
-        if (BinaryType.ofEmptyLiteral().copy(true).equals(logicalType)
-                || BinaryType.ofEmptyLiteral().copy(false).equals(logicalType)) {
-            return false;
-        }
-        if (VarBinaryType.ofEmptyLiteral().copy(true).equals(logicalType)
-                || VarBinaryType.ofEmptyLiteral().copy(false).equals(logicalType)) {
-            return false;
-        }
-        if (logicalType instanceof ArrayType) {
-            return canSerializableString(((ArrayType) logicalType).getElementType());
-        }
-        if (logicalType instanceof MultisetType) {
-            return canSerializableString(((MultisetType) logicalType).getElementType());
-        }
-        if (logicalType instanceof MapType) {
-            return canSerializableString(((MapType) logicalType).getKeyType())
-                    && canSerializableString(((MapType) logicalType).getValueType());
-        }
-        if (logicalType instanceof RowType) {
-            RowType rowType = (RowType) logicalType;
-            List<RowType.RowField> fields = rowType.getFields();
-            boolean canSerializableString = true;
-            for (RowType.RowField field : fields) {
-                canSerializableString = canSerializableString(field.getType());
-                if (!canSerializableString) {
-                    return false;
-                }
-            }
-        }
-        return true;
+        assertEquals(logicalType.asSummaryString(), actual.asSummaryString());
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalTypeSerdeTest.java
@@ -105,7 +105,13 @@ public class LogicalTypeSerdeTest {
         }
         String json = writer.toString();
         LogicalType actual = mapper.readValue(json, LogicalType.class);
-        assertEquals(logicalType.asSerializableString(), actual.asSerializableString());
+        assertEquals(logicalType, actual);
+
+        if (logicalType instanceof TimestampType
+                || logicalType instanceof ZonedTimestampType
+                || logicalType instanceof LocalZonedTimestampType) {
+            assertEquals(logicalType.asSummaryString(), actual.asSummaryString());
+        }
     }
 
     @Parameterized.Parameters(name = "{0}")

--- a/flink-table/flink-table-planner-blink/src/test/resources/jsonplan/testGetJsonPlan.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/jsonplan/testGetJsonPlan.out
@@ -1,74 +1,104 @@
 {
-    "flinkVersion": "",
-    "nodes": [
-        {
-            "class": "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
-            "scanTableSource": {
-                "identifier": {
-                    "catalogName": "default_catalog",
-                    "databaseName": "default_database",
-                    "tableName": "MyTable"
-                },
-                "catalogTable": {
-                    "schema.2.data-type": "VARCHAR(2147483647)",
-                    "connector": "values",
-                    "schema.0.data-type": "BIGINT",
-                    "schema.2.name": "c",
-                    "schema.1.name": "b",
-                    "bounded": "false",
-                    "schema.0.name": "a",
-                    "schema.1.data-type": "INT"
-                }
+   "flinkVersion":"",
+   "nodes":[
+      {
+         "class":"org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+         "scanTableSource":{
+            "identifier":{
+               "catalogName":"default_catalog",
+               "databaseName":"default_database",
+               "tableName":"MyTable"
             },
-            "id": 1,
-            "outputType": "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
-            "description": "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
-            "inputProperties": []
-        },
-        {
-            "class": "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
-            "dynamicTableSink": {
-                "identifier": {
-                    "catalogName": "default_catalog",
-                    "databaseName": "default_database",
-                    "tableName": "MySink"
-                },
-                "catalogTable": {
-                    "table-sink-class": "DEFAULT",
-                    "schema.2.data-type": "VARCHAR(2147483647)",
-                    "connector": "values",
-                    "schema.0.data-type": "BIGINT",
-                    "schema.2.name": "c",
-                    "schema.1.name": "b",
-                    "schema.0.name": "a",
-                    "schema.1.data-type": "INT"
-                }
+            "catalogTable":{
+               "schema.2.data-type":"VARCHAR(2147483647)",
+               "connector":"values",
+               "schema.0.data-type":"BIGINT",
+               "schema.2.name":"c",
+               "schema.1.name":"b",
+               "bounded":"false",
+               "schema.0.name":"a",
+               "schema.1.data-type":"INT"
+            }
+         },
+         "id":1,
+         "outputType":{
+            "type":"ROW",
+            "nullable":true,
+            "fields":[
+               {
+                  "a":"BIGINT"
+               },
+               {
+                  "b":"INT"
+               },
+               {
+                  "c":"VARCHAR(2147483647)"
+               }
+            ]
+         },
+         "description":"TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+         "inputProperties":[
+
+         ]
+      },
+      {
+         "class":"org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+         "dynamicTableSink":{
+            "identifier":{
+               "catalogName":"default_catalog",
+               "databaseName":"default_database",
+               "tableName":"MySink"
             },
-            "inputChangelogMode": [
-                "INSERT"
-            ],
-            "id": 2,
-            "inputProperties": [
-                {
-                    "requiredDistribution": {
-                        "type": "UNKNOWN"
-                    },
-                    "damBehavior": "PIPELINED",
-                    "priority": 0
-                }
-            ],
-            "outputType": "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
-            "description": "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
-        }
-    ],
-    "edges": [
-        {
-            "source": 1,
-            "target": 2,
-            "shuffle": {
-                "type": "FORWARD"
-            },
-            "shuffleMode": "PIPELINED"
-        }
-    ]
+            "catalogTable":{
+               "table-sink-class":"DEFAULT",
+               "schema.2.data-type":"VARCHAR(2147483647)",
+               "connector":"values",
+               "schema.0.data-type":"BIGINT",
+               "schema.2.name":"c",
+               "schema.1.name":"b",
+               "schema.0.name":"a",
+               "schema.1.data-type":"INT"
+            }
+         },
+         "inputChangelogMode":[
+            "INSERT"
+         ],
+         "id":2,
+         "inputProperties":[
+            {
+               "requiredDistribution":{
+                  "type":"UNKNOWN"
+               },
+               "damBehavior":"PIPELINED",
+               "priority":0
+            }
+         ],
+         "outputType":{
+            "type":"ROW",
+            "nullable":true,
+            "fields":[
+               {
+                  "a":"BIGINT"
+               },
+               {
+                  "b":"INT"
+               },
+               {
+                  "c":"VARCHAR(2147483647)"
+               }
+            ]
+         },
+         "description":"Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
+      }
+   ],
+   "edges":[
+      {
+         "source":1,
+         "target":2,
+         "shuffle":{
+            "type":"FORWARD"
+         },
+         "shuffleMode":"PIPELINED"
+      }
+   ]
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
@@ -37,10 +37,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "d" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -396,10 +396,10 @@
         "c2" : "VARCHAR(2147483647)"
       }, {
         "d1" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -457,10 +457,10 @@
         "c2" : "VARCHAR(2147483647)"
       }, {
         "d1" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
@@ -25,8 +25,25 @@
         "predicates" : [ ]
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "id" : 6,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[a, b, c, d])",
     "inputProperties" : [ ]
   }, {
@@ -354,7 +371,7 @@
         "nullable" : true
       }
     },
-    "id" : 2,
+    "id" : 7,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -362,7 +379,30 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `a1` VARCHAR(2147483647), `b` INT NOT NULL, `b1` VARCHAR(2147483647), `c1` VARCHAR(2147483647), `c2` VARCHAR(2147483647), `d1` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "a1" : "VARCHAR(2147483647)"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "b1" : "VARCHAR(2147483647)"
+      }, {
+        "c1" : "VARCHAR(2147483647)"
+      }, {
+        "c2" : "VARCHAR(2147483647)"
+      }, {
+        "d1" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, CAST(a) AS a1, b, udf2(b, b, d) AS b1, udf3(c, b) AS c1, udf4(SUBSTRING(c, 1, 5)) AS c2, udf5(d, 1000) AS d1], where=[(((org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$JavaFunc0$ea91f94853664692cdbdcd38ac065769(a) > 0) OR ((a * b) < 100)) AND (b > 10))])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -392,7 +432,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 3,
+    "id" : 8,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -400,19 +440,42 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `a1` VARCHAR(2147483647), `b` INT NOT NULL, `b1` VARCHAR(2147483647), `c1` VARCHAR(2147483647), `c2` VARCHAR(2147483647), `d1` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "a1" : "VARCHAR(2147483647)"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "b1" : "VARCHAR(2147483647)"
+      }, {
+        "c1" : "VARCHAR(2147483647)"
+      }, {
+        "c2" : "VARCHAR(2147483647)"
+      }, {
+        "d1" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, a1, b, b1, c1, c2, d1])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 6,
+    "target" : 7,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 7,
+    "target" : 8,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleFilter.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleFilter.out
@@ -26,7 +26,24 @@
       } ]
     },
     "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[a, b, c, d])",
     "inputProperties" : [ ]
   }, {
@@ -97,7 +114,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, d], where=[(b > 0)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -129,7 +163,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c, d])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleFilter.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleFilter.out
@@ -37,10 +37,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "d" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -125,10 +125,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "d" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -174,10 +174,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "d" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleProject.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testSimpleProject.out
@@ -23,11 +23,27 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "id" : 4,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
@@ -48,7 +64,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 2,
+    "id" : 5,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -56,12 +72,20 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 4,
+    "target" : 5,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testChangelogSource.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testChangelogSource.out
@@ -26,16 +26,32 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT NOT NULL"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
-    "id" : 55,
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "id" : 1,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecDropUpdateBefore",
-    "id" : 56,
+    "id" : 2,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -43,11 +59,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "DropUpdateBefore"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 57,
+    "id" : 3,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",
@@ -56,13 +80,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[a, b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecChangelogNormalize",
     "uniqueKeys" : [ 0, 1 ],
     "generateUpdateBefore" : true,
-    "id" : 58,
+    "id" : 4,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -70,7 +102,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "ChangelogNormalize(key=[a, b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -91,7 +131,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
-    "id" : 59,
+    "id" : 5,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -99,33 +139,41 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
   } ],
   "edges" : [ {
-    "source" : 55,
-    "target" : 56,
+    "source" : 1,
+    "target" : 2,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 56,
-    "target" : 57,
+    "source" : 2,
+    "target" : 3,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 57,
-    "target" : 58,
+    "source" : 3,
+    "target" : 4,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 58,
-    "target" : 59,
+    "source" : 4,
+    "target" : 5,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testUpsertSource.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testUpsertSource.out
@@ -26,16 +26,32 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT NOT NULL"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
-    "id" : 60,
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "id" : 6,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 61,
+    "id" : 7,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",
@@ -44,13 +60,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[a, b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecChangelogNormalize",
     "uniqueKeys" : [ 0, 1 ],
     "generateUpdateBefore" : true,
-    "id" : 62,
+    "id" : 8,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -58,7 +82,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "ChangelogNormalize(key=[a, b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -79,7 +111,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
-    "id" : 63,
+    "id" : 9,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -87,26 +119,34 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
   } ],
   "edges" : [ {
-    "source" : 60,
-    "target" : 61,
+    "source" : 6,
+    "target" : 7,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 61,
-    "target" : 62,
+    "source" : 7,
+    "target" : 8,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 62,
-    "target" : 63,
+    "source" : 8,
+    "target" : 9,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=false].out
@@ -23,11 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 2 ], [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "c" : "VARCHAR(2147483647)"
+          }, {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `b` INT NOT NULL>",
+    "id" : 43,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[c, a, b]]], fields=[c, a, b])",
     "inputProperties" : [ ]
   }, {
@@ -82,7 +102,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 2,
+    "id" : 44,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -90,11 +110,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `$f2` BOOLEAN NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[c, a, (b > 10) AS $f2, b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 3,
+    "id" : 45,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",
@@ -103,7 +135,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `$f2` BOOLEAN NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[c]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -192,7 +236,7 @@
     "aggCallNeedRetractions" : [ false, false, false, false, false ],
     "generateUpdateBefore" : true,
     "needRetraction" : false,
-    "id" : 4,
+    "id" : 46,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -200,7 +244,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `cnt_a1` BIGINT NOT NULL, `cnt_a2` BIGINT NOT NULL, `sum_a` BIGINT, `sum_b` INT NOT NULL, `avg_b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "cnt_a1" : "BIGINT NOT NULL"
+      }, {
+        "cnt_a2" : "BIGINT NOT NULL"
+      }, {
+        "sum_a" : "BIGINT"
+      }, {
+        "sum_b" : "INT NOT NULL"
+      }, {
+        "avg_b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "GroupAggregate(groupBy=[c], select=[c, COUNT(DISTINCT a) FILTER $f2 AS cnt_a1, COUNT(DISTINCT a) AS cnt_a2, SUM(DISTINCT a) AS sum_a, SUM(DISTINCT b) AS sum_b, AVG(b) AS avg_b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -305,7 +365,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `cnt_a1` BIGINT, `cnt_a2` BIGINT, `sum_a` BIGINT, `sum_b` INT, `avg_b` DOUBLE>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "cnt_a1" : "BIGINT"
+      }, {
+        "cnt_a2" : "BIGINT"
+      }, {
+        "sum_a" : "BIGINT"
+      }, {
+        "sum_b" : "INT"
+      }, {
+        "avg_b" : "DOUBLE"
+      } ]
+    },
     "description" : "Calc(select=[c, CAST(cnt_a1) AS cnt_a1, CAST(cnt_a2) AS cnt_a2, sum_a, CAST(sum_b) AS sum_b, CAST(avg_b) AS avg_b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -334,7 +410,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER" ],
-    "id" : 6,
+    "id" : 48,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -342,40 +418,56 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `cnt_a1` BIGINT, `cnt_a2` BIGINT, `sum_a` BIGINT, `sum_b` INT, `avg_b` DOUBLE>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "cnt_a1" : "BIGINT"
+      }, {
+        "cnt_a2" : "BIGINT"
+      }, {
+        "sum_a" : "BIGINT"
+      }, {
+        "sum_b" : "INT"
+      }, {
+        "avg_b" : "DOUBLE"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[c, cnt_a1, cnt_a2, sum_a, sum_b, avg_b])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 43,
+    "target" : 44,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 44,
+    "target" : 45,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 45,
+    "target" : 46,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 46,
+    "target" : 47,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 5,
-    "target" : 6,
+    "source" : 47,
+    "target" : 48,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
@@ -23,11 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 2 ], [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "c" : "VARCHAR(2147483647)"
+          }, {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
     "id" : 19,
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[c, a, b]]], fields=[c, a, b])",
     "inputProperties" : [ ]
   }, {
@@ -90,7 +110,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `$f2` BOOLEAN NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[c, a, (b > 10) AS $f2, b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -103,7 +135,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `a` BIGINT, `$f2` BOOLEAN NOT NULL, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[c]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -200,7 +244,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `cnt_a1` BIGINT NOT NULL, `cnt_a2` BIGINT NOT NULL, `sum_a` BIGINT, `sum_b` INT NOT NULL, `avg_b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "cnt_a1" : "BIGINT NOT NULL"
+      }, {
+        "cnt_a2" : "BIGINT NOT NULL"
+      }, {
+        "sum_a" : "BIGINT"
+      }, {
+        "sum_b" : "INT NOT NULL"
+      }, {
+        "avg_b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "GroupAggregate(groupBy=[c], select=[c, COUNT(DISTINCT a) FILTER $f2 AS cnt_a1, COUNT(DISTINCT a) AS cnt_a2, SUM(DISTINCT a) AS sum_a, SUM(DISTINCT b) AS sum_b, AVG(b) AS avg_b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -305,7 +365,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `cnt_a1` BIGINT, `cnt_a2` BIGINT, `sum_a` BIGINT, `sum_b` INT, `avg_b` DOUBLE>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "cnt_a1" : "BIGINT"
+      }, {
+        "cnt_a2" : "BIGINT"
+      }, {
+        "sum_a" : "BIGINT"
+      }, {
+        "sum_b" : "INT"
+      }, {
+        "avg_b" : "DOUBLE"
+      } ]
+    },
     "description" : "Calc(select=[c, CAST(cnt_a1) AS cnt_a1, CAST(cnt_a2) AS cnt_a2, sum_a, CAST(sum_b) AS sum_b, CAST(avg_b) AS avg_b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -342,7 +418,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`c` VARCHAR(2147483647), `cnt_a1` BIGINT, `cnt_a2` BIGINT, `sum_a` BIGINT, `sum_b` INT, `avg_b` DOUBLE>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "cnt_a1" : "BIGINT"
+      }, {
+        "cnt_a2" : "BIGINT"
+      }, {
+        "sum_a" : "BIGINT"
+      }, {
+        "sum_b" : "INT"
+      }, {
+        "avg_b" : "DOUBLE"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[c, cnt_a1, cnt_a2, sum_a, sum_b, avg_b])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=false].out
@@ -23,11 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 1 ], [ 0 ], [ 2 ] ],
-        "producedType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `c` VARCHAR(2147483647)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "b" : "INT NOT NULL"
+          }, {
+            "a" : "BIGINT"
+          }, {
+            "c" : "VARCHAR(2147483647)"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `c` VARCHAR(2147483647)>",
+    "id" : 25,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, a, c]]], fields=[b, a, c])",
     "inputProperties" : [ ]
   }, {
@@ -82,7 +102,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 2,
+    "id" : 26,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -90,11 +110,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `$f2` BOOLEAN NOT NULL, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[b, a, (b > 1) AS $f2, c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 3,
+    "id" : 27,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",
@@ -103,7 +135,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `$f2` BOOLEAN NOT NULL, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -161,7 +205,7 @@
     "aggCallNeedRetractions" : [ false, false, false ],
     "generateUpdateBefore" : true,
     "needRetraction" : false,
-    "id" : 4,
+    "id" : 28,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -169,7 +213,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `cnt_a` BIGINT NOT NULL, `max_b` INT, `min_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "cnt_a" : "BIGINT NOT NULL"
+      }, {
+        "max_b" : "INT"
+      }, {
+        "min_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "GroupAggregate(groupBy=[b], select=[b, COUNT(a) AS cnt_a, MAX(b) FILTER $f2 AS max_b, MIN(c) AS min_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -240,7 +296,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 5,
+    "id" : 29,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -248,7 +304,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `cnt_a` BIGINT, `max_b` BIGINT, `min_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "cnt_a" : "BIGINT"
+      }, {
+        "max_b" : "BIGINT"
+      }, {
+        "min_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[CAST(b) AS b, CAST(cnt_a) AS cnt_a, CAST(max_b) AS max_b, min_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -273,7 +341,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER" ],
-    "id" : 6,
+    "id" : 30,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -281,40 +349,52 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `cnt_a` BIGINT, `max_b` BIGINT, `min_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "cnt_a" : "BIGINT"
+      }, {
+        "max_b" : "BIGINT"
+      }, {
+        "min_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, cnt_a, max_b, min_c])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 25,
+    "target" : 26,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 26,
+    "target" : 27,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 27,
+    "target" : 28,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 28,
+    "target" : 29,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 5,
-    "target" : 6,
+    "source" : 29,
+    "target" : 30,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=true].out
@@ -23,11 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 1 ], [ 0 ], [ 2 ] ],
-        "producedType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `c` VARCHAR(2147483647)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "b" : "INT NOT NULL"
+          }, {
+            "a" : "BIGINT"
+          }, {
+            "c" : "VARCHAR(2147483647)"
+          } ]
+        }
       } ]
     },
     "id" : 1,
-    "outputType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[b, a, c]]], fields=[b, a, c])",
     "inputProperties" : [ ]
   }, {
@@ -90,7 +110,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `$f2` BOOLEAN NOT NULL, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[b, a, (b > 1) AS $f2, c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -103,7 +135,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `a` BIGINT, `$f2` BOOLEAN NOT NULL, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "$f2" : "BOOLEAN NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -169,7 +213,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `cnt_a` BIGINT NOT NULL, `max_b` INT, `min_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "cnt_a" : "BIGINT NOT NULL"
+      }, {
+        "max_b" : "INT"
+      }, {
+        "min_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "GroupAggregate(groupBy=[b], select=[b, COUNT(a) AS cnt_a, MAX(b) FILTER $f2 AS max_b, MIN(c) AS min_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -248,7 +304,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `cnt_a` BIGINT, `max_b` BIGINT, `min_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "cnt_a" : "BIGINT"
+      }, {
+        "max_b" : "BIGINT"
+      }, {
+        "min_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[CAST(b) AS b, CAST(cnt_a) AS cnt_a, CAST(max_b) AS max_b, min_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -281,7 +349,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `cnt_a` BIGINT, `max_b` BIGINT, `min_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "cnt_a" : "BIGINT"
+      }, {
+        "max_b" : "BIGINT"
+      }, {
+        "min_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, cnt_a, max_b, min_c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=false].out
@@ -23,11 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ], [ 2 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          }, {
+            "c" : "VARCHAR(2147483647)"
+          } ]
+        }
       } ]
     },
-    "id" : 7,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647)>",
+    "id" : 31,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, c]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -94,7 +114,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 8,
+    "id" : 32,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -102,11 +122,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `$f3` BOOLEAN NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "$f3" : "BOOLEAN NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, (a > 1) IS TRUE AS $f3])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 9,
+    "id" : 33,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "SINGLETON"
@@ -114,7 +146,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `$f3` BOOLEAN NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "$f3" : "BOOLEAN NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[single])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -188,7 +232,7 @@
     "aggCallNeedRetractions" : [ false, false, false, false ],
     "generateUpdateBefore" : true,
     "needRetraction" : false,
-    "id" : 10,
+    "id" : 34,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -196,7 +240,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`avg_a` BIGINT, `cnt` BIGINT NOT NULL, `min_b` INT, `max_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "avg_a" : "BIGINT"
+      }, {
+        "cnt" : "BIGINT NOT NULL"
+      }, {
+        "min_b" : "INT"
+      }, {
+        "max_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "GroupAggregate(select=[AVG(a) AS avg_a, COUNT(*) AS cnt, MIN(b) AS min_b, MAX(c) FILTER $f3 AS max_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -286,7 +342,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 11,
+    "id" : 35,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -294,7 +350,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`avg_a` DOUBLE, `cnt` BIGINT, `cnt_b` BIGINT, `min_b` BIGINT, `max_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "avg_a" : "DOUBLE"
+      }, {
+        "cnt" : "BIGINT"
+      }, {
+        "cnt_b" : "BIGINT"
+      }, {
+        "min_b" : "BIGINT"
+      }, {
+        "max_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[CAST(avg_a) AS avg_a, CAST(cnt) AS cnt, CAST(cnt) AS cnt_b, CAST(min_b) AS min_b, max_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -321,7 +391,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER" ],
-    "id" : 12,
+    "id" : 36,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -329,40 +399,54 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`avg_a` DOUBLE, `cnt` BIGINT, `cnt_b` BIGINT, `min_b` BIGINT, `max_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "avg_a" : "DOUBLE"
+      }, {
+        "cnt" : "BIGINT"
+      }, {
+        "cnt_b" : "BIGINT"
+      }, {
+        "min_b" : "BIGINT"
+      }, {
+        "max_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[avg_a, cnt, cnt_b, min_b, max_c])"
   } ],
   "edges" : [ {
-    "source" : 7,
-    "target" : 8,
+    "source" : 31,
+    "target" : 32,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 8,
-    "target" : 9,
+    "source" : 32,
+    "target" : 33,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 9,
-    "target" : 10,
+    "source" : 33,
+    "target" : 34,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 10,
-    "target" : 11,
+    "source" : 34,
+    "target" : 35,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 11,
-    "target" : 12,
+    "source" : 35,
+    "target" : 36,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggWithoutGroupBy[isMiniBatchEnabled=true].out
@@ -23,11 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ], [ 2 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          }, {
+            "c" : "VARCHAR(2147483647)"
+          } ]
+        }
       } ]
     },
     "id" : 7,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b, c]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -102,7 +122,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `$f3` BOOLEAN NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "$f3" : "BOOLEAN NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, (a > 1) IS TRUE AS $f3])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -114,7 +146,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `$f3` BOOLEAN NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "$f3" : "BOOLEAN NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[single])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -196,7 +240,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`avg_a` BIGINT, `cnt` BIGINT NOT NULL, `min_b` INT, `max_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "avg_a" : "BIGINT"
+      }, {
+        "cnt" : "BIGINT NOT NULL"
+      }, {
+        "min_b" : "INT"
+      }, {
+        "max_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "GroupAggregate(select=[AVG(a) AS avg_a, COUNT(*) AS cnt, MIN(b) AS min_b, MAX(c) FILTER $f3 AS max_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -294,7 +350,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`avg_a` DOUBLE, `cnt` BIGINT, `cnt_b` BIGINT, `min_b` BIGINT, `max_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "avg_a" : "DOUBLE"
+      }, {
+        "cnt" : "BIGINT"
+      }, {
+        "cnt_b" : "BIGINT"
+      }, {
+        "min_b" : "BIGINT"
+      }, {
+        "max_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[CAST(avg_a) AS avg_a, CAST(cnt) AS cnt, CAST(cnt) AS cnt_b, CAST(min_b) AS min_b, max_c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -329,7 +399,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`avg_a` DOUBLE, `cnt` BIGINT, `cnt_b` BIGINT, `min_b` BIGINT, `max_c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "avg_a" : "DOUBLE"
+      }, {
+        "cnt" : "BIGINT"
+      }, {
+        "cnt_b" : "BIGINT"
+      }, {
+        "min_b" : "BIGINT"
+      }, {
+        "max_c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[avg_a, cnt, cnt_b, min_b, max_c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=false].out
@@ -21,8 +21,20 @@
         "schema.1.data-type" : "INT NOT NULL"
       }
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` BIGINT>",
+    "id" : 37,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : "BIGINT"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
     "inputProperties" : [ ]
   }, {
@@ -72,7 +84,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 2,
+    "id" : 38,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -80,11 +92,27 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `$f1` INT NOT NULL, `$f2` INT NOT NULL, `d` BIGINT, `a` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "$f1" : "INT NOT NULL"
+      }, {
+        "$f2" : "INT NOT NULL"
+      }, {
+        "d" : "BIGINT"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[b, 10 AS $f1, 5 AS $f2, d, a, c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 3,
+    "id" : 39,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",
@@ -93,7 +121,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `$f1` INT NOT NULL, `$f2` INT NOT NULL, `d` BIGINT, `a` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "$f1" : "INT NOT NULL"
+      }, {
+        "$f2" : "INT NOT NULL"
+      }, {
+        "d" : "BIGINT"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -178,7 +222,7 @@
     "aggCallNeedRetractions" : [ false, false, false, false ],
     "generateUpdateBefore" : true,
     "needRetraction" : false,
-    "id" : 4,
+    "id" : 40,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -186,7 +230,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a1" : "BIGINT"
+      }, {
+        "a2" : "BIGINT"
+      }, {
+        "a3" : "BIGINT"
+      }, {
+        "c1" : "BIGINT"
+      } ]
+    },
     "description" : "GroupAggregate(groupBy=[b], select=[b, my_sum1(b, $f1) AS a1, my_sum2($f2, b) AS a2, my_avg(d, a) AS a3, my_count(c) AS c1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -239,7 +297,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 5,
+    "id" : 41,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -247,7 +305,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a1" : "BIGINT"
+      }, {
+        "a2" : "BIGINT"
+      }, {
+        "a3" : "BIGINT"
+      }, {
+        "c1" : "BIGINT"
+      } ]
+    },
     "description" : "Calc(select=[CAST(b) AS b, a1, a2, a3, c1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -274,7 +346,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER" ],
-    "id" : 6,
+    "id" : 42,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -282,40 +354,54 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a1" : "BIGINT"
+      }, {
+        "a2" : "BIGINT"
+      }, {
+        "a3" : "BIGINT"
+      }, {
+        "c1" : "BIGINT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, a1, a2, a3, c1])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 37,
+    "target" : 38,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 38,
+    "target" : 39,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 39,
+    "target" : 40,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 40,
+    "target" : 41,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 5,
-    "target" : 6,
+    "source" : 41,
+    "target" : 42,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=true].out
@@ -22,7 +22,19 @@
       }
     },
     "id" : 13,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : "BIGINT"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
     "inputProperties" : [ ]
   }, {
@@ -80,7 +92,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `$f1` INT NOT NULL, `$f2` INT NOT NULL, `d` BIGINT, `a` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "$f1" : "INT NOT NULL"
+      }, {
+        "$f2" : "INT NOT NULL"
+      }, {
+        "d" : "BIGINT"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[b, 10 AS $f1, 5 AS $f2, d, a, c])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -93,7 +121,23 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `$f1` INT NOT NULL, `$f2` INT NOT NULL, `d` BIGINT, `a` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "$f1" : "INT NOT NULL"
+      }, {
+        "$f2" : "INT NOT NULL"
+      }, {
+        "d" : "BIGINT"
+      }, {
+        "a" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecGroupAggregate",
@@ -186,7 +230,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` INT NOT NULL, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "INT NOT NULL"
+      }, {
+        "a1" : "BIGINT"
+      }, {
+        "a2" : "BIGINT"
+      }, {
+        "a3" : "BIGINT"
+      }, {
+        "c1" : "BIGINT"
+      } ]
+    },
     "description" : "GroupAggregate(groupBy=[b], select=[b, my_sum1(b, $f1) AS a1, my_sum2($f2, b) AS a2, my_avg(d, a) AS a3, my_count(c) AS c1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -247,7 +305,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a1" : "BIGINT"
+      }, {
+        "a2" : "BIGINT"
+      }, {
+        "a3" : "BIGINT"
+      }, {
+        "c1" : "BIGINT"
+      } ]
+    },
     "description" : "Calc(select=[CAST(b) AS b, a1, a2, a3, c1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -282,7 +354,21 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a1" : "BIGINT"
+      }, {
+        "a2" : "BIGINT"
+      }, {
+        "a3" : "BIGINT"
+      }, {
+        "c1" : "BIGINT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, a1, a2, a3, c1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testOverwrite.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testOverwrite.out
@@ -20,7 +20,17 @@
       }
     },
     "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -56,7 +66,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testPartitioning.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testPartitioning.out
@@ -21,11 +21,27 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT>",
+    "id" : 5,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
@@ -54,7 +70,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 2,
+    "id" : 6,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -62,7 +78,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `EXPR$2` VARCHAR(2147483647) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "EXPR$2" : "VARCHAR(2147483647) NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[a, b, _UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET \"UTF-16LE\" AS EXPR$2])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -92,7 +118,7 @@
       } ]
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 3,
+    "id" : 7,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -100,19 +126,29 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `EXPR$2` VARCHAR(2147483647) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "EXPR$2" : "VARCHAR(2147483647) NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, EXPR$2])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 5,
+    "target" : 6,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 6,
+    "target" : 7,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testWritingMetadata.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testWritingMetadata.out
@@ -19,8 +19,18 @@
         "schema.1.data-type" : "INT"
       }
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "id" : 3,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -46,11 +56,21 @@
       "sinkAbilitySpecs" : [ {
         "type" : "WritingMetadata",
         "metadataKeys" : [ "m" ],
-        "consumedType" : "ROW<`a` BIGINT, `b` INT, `m` VARCHAR(2147483647)> NOT NULL"
+        "consumedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          }, {
+            "m" : "VARCHAR(2147483647)"
+          } ]
+        }
       } ]
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 2,
+    "id" : 4,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -58,12 +78,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 3,
+    "target" : 4,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testFilterPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testFilterPushDown.out
@@ -50,8 +50,18 @@
         } ]
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "id" : 6,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, src, filter=[greaterThan(a, 0)]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -74,7 +84,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 2,
+    "id" : 7,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -82,12 +92,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 6,
+    "target" : 7,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testPartitionPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testPartitionPushDown.out
@@ -31,11 +31,27 @@
       }, {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          } ]
+        }
       } ]
     },
     "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, PartitionTable, filter=[], partitions=[{p=A}], project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
@@ -85,7 +101,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `p` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "p" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[a, b, CAST(_UTF-16LE'A':VARCHAR(2147483647) CHARACTER SET \"UTF-16LE\") AS p])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -115,7 +141,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `p` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "p" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, p])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testProjectPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testProjectPushDown.out
@@ -21,11 +21,27 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT>",
+    "id" : 8,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
@@ -46,7 +62,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 2,
+    "id" : 9,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -54,12 +70,20 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.sink], fields=[a, b])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 8,
+    "target" : 9,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testReadingMetadata.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testReadingMetadata.out
@@ -26,15 +26,45 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT, `m` VARCHAR(2147483647)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          }, {
+            "m" : "VARCHAR(2147483647)"
+          } ]
+        }
       }, {
         "type" : "ReadingMetadata",
         "metadataKeys" : [ "m" ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT, `m` VARCHAR(2147483647)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          }, {
+            "m" : "VARCHAR(2147483647)"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `m` VARCHAR(2147483647)>",
+    "id" : 4,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "m" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable2, project=[a, b, m]]], fields=[a, b, m])",
     "inputProperties" : [ ]
   }, {
@@ -57,7 +87,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 2,
+    "id" : 5,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -65,12 +95,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `m` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "m" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.sink], fields=[a, b, m])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 4,
+    "target" : 5,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -57,11 +57,41 @@
           }
         },
         "idleTimeoutMillis" : -1,
-        "producedType" : "ROW<`a` BIGINT, `b` INT, `c` TIMESTAMP(3)> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT"
+          }, {
+            "c" : {
+              "nullable" : true,
+              "precision" : 3,
+              "kind" : "ROWTIME",
+              "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            }
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` TIMESTAMP(3)>",
+    "id" : 10,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable, watermark=[-($2, 5000:INTERVAL SECOND)]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -84,7 +114,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 2,
+    "id" : 11,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -92,12 +122,27 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.sink], fields=[a, b, c])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 10,
+    "target" : 11,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testWatermarkPushDown.out
@@ -66,10 +66,10 @@
             "b" : "INT"
           }, {
             "c" : {
+              "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
               "nullable" : true,
               "precision" : 3,
-              "kind" : "ROWTIME",
-              "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+              "kind" : "ROWTIME"
             }
           } ]
         }
@@ -85,10 +85,10 @@
         "b" : "INT"
       }, {
         "c" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -131,10 +131,10 @@
         "b" : "INT"
       }, {
         "c" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/UnionJsonPlanTest_jsonplan/testUnion.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/UnionJsonPlanTest_jsonplan/testUnion.out
@@ -23,11 +23,27 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
     "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
@@ -48,12 +64,20 @@
       }
     },
     "id" : 2,
-    "outputType" : "ROW<`d` BIGINT, `e` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "d" : "BIGINT"
+      }, {
+        "e" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[d, e])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecUnion",
-    "id" : 4,
+    "id" : 3,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -67,7 +91,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Union(all=[true], union=[a, b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -87,7 +119,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 5,
+    "id" : 4,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -95,26 +127,34 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
   } ],
   "edges" : [ {
     "source" : 1,
-    "target" : 4,
+    "target" : 3,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
     "source" : 2,
-    "target" : 4,
+    "target" : 3,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 3,
+    "target" : 4,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WatermarkAssignerJsonPlanTest_jsonplan/testWatermarkAssigner.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WatermarkAssignerJsonPlanTest_jsonplan/testWatermarkAssigner.out
@@ -34,10 +34,10 @@
         "b" : "INT"
       }, {
         "c" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -94,10 +94,10 @@
         "b" : "INT"
       }, {
         "c" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -139,10 +139,10 @@
         "b" : "INT"
       }, {
         "c" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WatermarkAssignerJsonPlanTest_jsonplan/testWatermarkAssigner.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WatermarkAssignerJsonPlanTest_jsonplan/testWatermarkAssigner.out
@@ -25,7 +25,22 @@
       }
     },
     "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, WatermarkTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -70,7 +85,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[c], watermark=[(c - 5000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -100,7 +130,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.sink], fields=[a, b, c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeCumulateWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeCumulateWindow.out
@@ -119,17 +119,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -187,17 +187,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -254,10 +254,10 @@
         "a" : "INT"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -284,10 +284,10 @@
         "a" : "INT"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -336,10 +336,10 @@
         "step" : "PT5S"
       },
       "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
         "nullable" : true,
         "precision" : 3,
-        "kind" : "ROWTIME",
-        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        "kind" : "ROWTIME"
       },
       "timeAttributeIndex" : 3,
       "isRowtime" : true
@@ -351,10 +351,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : true,
             "precision" : 3,
-            "kind" : "ROWTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "ROWTIME"
           }
         }
       }
@@ -365,10 +365,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : true,
             "precision" : 3,
-            "kind" : "ROWTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "ROWTIME"
           }
         }
       }
@@ -392,17 +392,17 @@
         "EXPR$3" : "INT"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -455,10 +455,10 @@
         "b" : "BIGINT"
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "EXPR$2" : "BIGINT NOT NULL"
@@ -503,10 +503,10 @@
         "b" : "BIGINT"
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "EXPR$2" : "BIGINT NOT NULL"

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeCumulateWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeCumulateWindow.out
@@ -28,7 +28,17 @@
       }
     },
     "id" : 41,
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -98,7 +108,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
@@ -142,7 +176,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -185,7 +243,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `c` VARCHAR(2147483647), `a` INT, `rowtime` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "INT"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[b, c, a, rowtime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -198,7 +273,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `c` VARCHAR(2147483647), `a` INT, `rowtime` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "INT"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowAggregate",
@@ -243,7 +335,12 @@
         "maxSize" : "PT15S",
         "step" : "PT5S"
       },
-      "timeAttributeType" : "TIMESTAMP(3)",
+      "timeAttributeType" : {
+        "nullable" : true,
+        "precision" : 3,
+        "kind" : "ROWTIME",
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+      },
       "timeAttributeIndex" : 3,
       "isRowtime" : true
     },
@@ -253,7 +350,12 @@
         "kind" : "WindowStart",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3)"
+          "type" : {
+            "nullable" : true,
+            "precision" : 3,
+            "kind" : "ROWTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     }, {
@@ -262,7 +364,12 @@
         "kind" : "WindowEnd",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3)"
+          "type" : {
+            "nullable" : true,
+            "precision" : 3,
+            "kind" : "ROWTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     } ],
@@ -274,7 +381,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$2` BIGINT NOT NULL, `EXPR$3` INT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$2" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$3" : "INT"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WindowAggregate(groupBy=[b], window=[CUMULATE(time_col=[rowtime], max_size=[15 s], step=[5 s])], select=[b, COUNT(c) AS EXPR$2, SUM(a) AS EXPR$3, start('w$) AS window_start, end('w$) AS window_end])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -317,7 +448,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$2` BIGINT NOT NULL, `EXPR$3` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "EXPR$2" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$3" : "INT"
+      } ]
+    },
     "description" : "Calc(select=[b, window_end, EXPR$2, EXPR$3])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -348,7 +496,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$2` BIGINT NOT NULL, `EXPR$3` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "EXPR$2" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$3" : "INT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, window_end, EXPR$2, EXPR$3])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeHopWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeHopWindow.out
@@ -119,17 +119,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -187,17 +187,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -254,10 +254,10 @@
         "a" : "INT"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -284,10 +284,10 @@
         "a" : "INT"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -336,10 +336,10 @@
         "slide" : "PT5S"
       },
       "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
         "nullable" : true,
         "precision" : 3,
-        "kind" : "ROWTIME",
-        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        "kind" : "ROWTIME"
       },
       "timeAttributeIndex" : 3,
       "isRowtime" : true
@@ -351,10 +351,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : true,
             "precision" : 3,
-            "kind" : "ROWTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "ROWTIME"
           }
         }
       }
@@ -365,10 +365,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : true,
             "precision" : 3,
-            "kind" : "ROWTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "ROWTIME"
           }
         }
       }
@@ -392,17 +392,17 @@
         "EXPR$2" : "INT"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeHopWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeHopWindow.out
@@ -28,7 +28,17 @@
       }
     },
     "id" : 25,
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -98,7 +108,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
@@ -142,7 +176,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -185,7 +243,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `c` VARCHAR(2147483647), `a` INT, `rowtime` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "INT"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[b, c, a, rowtime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -198,7 +273,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `c` VARCHAR(2147483647), `a` INT, `rowtime` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "a" : "INT"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowAggregate",
@@ -243,7 +335,12 @@
         "size" : "PT10S",
         "slide" : "PT5S"
       },
-      "timeAttributeType" : "TIMESTAMP(3)",
+      "timeAttributeType" : {
+        "nullable" : true,
+        "precision" : 3,
+        "kind" : "ROWTIME",
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+      },
       "timeAttributeIndex" : 3,
       "isRowtime" : true
     },
@@ -253,7 +350,12 @@
         "kind" : "WindowStart",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3)"
+          "type" : {
+            "nullable" : true,
+            "precision" : 3,
+            "kind" : "ROWTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     }, {
@@ -262,7 +364,12 @@
         "kind" : "WindowEnd",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3)"
+          "type" : {
+            "nullable" : true,
+            "precision" : 3,
+            "kind" : "ROWTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     } ],
@@ -274,7 +381,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` BIGINT NOT NULL, `EXPR$2` INT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$2" : "INT"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WindowAggregate(groupBy=[b], window=[HOP(time_col=[rowtime], size=[10 s], slide=[5 s])], select=[b, COUNT(c) AS EXPR$1, SUM(a) AS EXPR$2, start('w$) AS window_start, end('w$) AS window_end])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -309,7 +440,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` BIGINT NOT NULL, `EXPR$2` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$2" : "INT"
+      } ]
+    },
     "description" : "Calc(select=[b, EXPR$1, EXPR$2])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -338,7 +479,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` BIGINT NOT NULL, `EXPR$2` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$2" : "INT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, EXPR$1, EXPR$2])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -119,17 +119,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -187,17 +187,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -254,10 +254,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -284,10 +284,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       } ]
     },
@@ -371,10 +371,10 @@
         "size" : "PT5S"
       },
       "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
         "nullable" : true,
         "precision" : 3,
-        "kind" : "ROWTIME",
-        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        "kind" : "ROWTIME"
       },
       "timeAttributeIndex" : 3,
       "isRowtime" : true
@@ -386,10 +386,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : true,
             "precision" : 3,
-            "kind" : "ROWTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "ROWTIME"
           }
         }
       }
@@ -400,10 +400,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : true,
             "precision" : 3,
-            "kind" : "ROWTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "ROWTIME"
           }
         }
       }
@@ -431,17 +431,17 @@
         "EXPR$6" : "VARCHAR(2147483647)"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -517,17 +517,17 @@
         "b" : "BIGINT"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "EXPR$3" : "BIGINT NOT NULL"
@@ -582,17 +582,17 @@
         "b" : "BIGINT"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "EXPR$3" : "BIGINT NOT NULL"

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -28,7 +28,17 @@
       }
     },
     "id" : 1,
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -98,7 +108,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
@@ -142,7 +176,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -185,7 +243,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a` INT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[b, a, c, rowtime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -198,7 +273,24 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a` INT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowAggregate",
@@ -278,7 +370,12 @@
         "type" : "TumblingWindow",
         "size" : "PT5S"
       },
-      "timeAttributeType" : "TIMESTAMP(3)",
+      "timeAttributeType" : {
+        "nullable" : true,
+        "precision" : 3,
+        "kind" : "ROWTIME",
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+      },
       "timeAttributeIndex" : 3,
       "isRowtime" : true
     },
@@ -288,7 +385,12 @@
         "kind" : "WindowStart",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3)"
+          "type" : {
+            "nullable" : true,
+            "precision" : 3,
+            "kind" : "ROWTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     }, {
@@ -297,7 +399,12 @@
         "kind" : "WindowEnd",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3)"
+          "type" : {
+            "nullable" : true,
+            "precision" : 3,
+            "kind" : "ROWTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     } ],
@@ -309,7 +416,35 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$3` BIGINT NOT NULL, `EXPR$4` INT, `EXPR$5` BIGINT NOT NULL, `EXPR$6` VARCHAR(2147483647), `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$3" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$4" : "INT"
+      }, {
+        "EXPR$5" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$6" : "VARCHAR(2147483647)"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WindowAggregate(groupBy=[b], window=[TUMBLE(time_col=[rowtime], size=[5 s])], select=[b, COUNT(*) AS EXPR$3, SUM(a) AS EXPR$4, COUNT(DISTINCT c) AS EXPR$5, concat_distinct_agg(c) AS EXPR$6, start('w$) AS window_start, end('w$) AS window_end])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -375,7 +510,35 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$3` BIGINT NOT NULL, `EXPR$4` INT, `EXPR$5` BIGINT NOT NULL, `EXPR$6` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "EXPR$3" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$4" : "INT"
+      }, {
+        "EXPR$5" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$6" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Calc(select=[b, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, EXPR$6])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -412,7 +575,35 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$3` BIGINT NOT NULL, `EXPR$4` INT, `EXPR$5` BIGINT NOT NULL, `EXPR$6` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "EXPR$3" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$4" : "INT"
+      }, {
+        "EXPR$5" : "BIGINT NOT NULL"
+      }, {
+        "EXPR$6" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, EXPR$6])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeCumulateWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeCumulateWindow.out
@@ -119,17 +119,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -187,17 +187,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -245,10 +245,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -273,10 +273,10 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -309,10 +309,10 @@
         "step" : "PT5S"
       },
       "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
         "nullable" : false,
         "precision" : 3,
-        "kind" : "PROCTIME",
-        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        "kind" : "PROCTIME"
       },
       "timeAttributeIndex" : 2,
       "isRowtime" : false
@@ -324,10 +324,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : false,
             "precision" : 3,
-            "kind" : "PROCTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "PROCTIME"
           }
         }
       }
@@ -338,10 +338,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : false,
             "precision" : 3,
-            "kind" : "PROCTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "PROCTIME"
           }
         }
       }
@@ -363,17 +363,17 @@
         "EXPR$1" : "BIGINT NOT NULL"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeCumulateWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeCumulateWindow.out
@@ -28,7 +28,17 @@
       }
     },
     "id" : 9,
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -98,7 +108,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
@@ -142,7 +176,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -178,7 +236,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `c` VARCHAR(2147483647), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[b, c, proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -191,7 +264,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `c` VARCHAR(2147483647), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowAggregate",
@@ -220,7 +308,12 @@
         "maxSize" : "PT15S",
         "step" : "PT5S"
       },
-      "timeAttributeType" : "TIMESTAMP(3) NOT NULL",
+      "timeAttributeType" : {
+        "nullable" : false,
+        "precision" : 3,
+        "kind" : "PROCTIME",
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+      },
       "timeAttributeIndex" : 2,
       "isRowtime" : false
     },
@@ -230,7 +323,12 @@
         "kind" : "WindowStart",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3) NOT NULL"
+          "type" : {
+            "nullable" : false,
+            "precision" : 3,
+            "kind" : "PROCTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     }, {
@@ -239,7 +337,12 @@
         "kind" : "WindowEnd",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3) NOT NULL"
+          "type" : {
+            "nullable" : false,
+            "precision" : 3,
+            "kind" : "PROCTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     } ],
@@ -251,7 +354,29 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` BIGINT NOT NULL, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "BIGINT NOT NULL"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WindowAggregate(groupBy=[b], window=[CUMULATE(time_col=[proctime], max_size=[15 s], step=[5 s])], select=[b, COUNT(c) AS EXPR$1, start('w$) AS window_start, end('w$) AS window_end])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -279,7 +404,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[b, EXPR$1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -306,7 +439,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, EXPR$1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
@@ -119,17 +119,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -187,17 +187,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -244,10 +244,10 @@
         "a" : "INT"
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -272,10 +272,10 @@
         "a" : "INT"
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -308,10 +308,10 @@
         "slide" : "PT5M"
       },
       "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
         "nullable" : false,
         "precision" : 3,
-        "kind" : "PROCTIME",
-        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        "kind" : "PROCTIME"
       },
       "timeAttributeIndex" : 2,
       "isRowtime" : false
@@ -323,10 +323,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : false,
             "precision" : 3,
-            "kind" : "PROCTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "PROCTIME"
           }
         }
       }
@@ -337,10 +337,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : false,
             "precision" : 3,
-            "kind" : "PROCTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "PROCTIME"
           }
         }
       }
@@ -362,17 +362,17 @@
         "EXPR$1" : "INT"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeHopWindow.out
@@ -28,7 +28,17 @@
       }
     },
     "id" : 33,
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -98,7 +108,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
@@ -142,7 +176,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -177,7 +235,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a` INT, `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a" : "INT"
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[b, a, proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -190,7 +263,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `a` INT, `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "a" : "INT"
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowAggregate",
@@ -219,7 +307,12 @@
         "size" : "PT10M",
         "slide" : "PT5M"
       },
-      "timeAttributeType" : "TIMESTAMP(3) NOT NULL",
+      "timeAttributeType" : {
+        "nullable" : false,
+        "precision" : 3,
+        "kind" : "PROCTIME",
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+      },
       "timeAttributeIndex" : 2,
       "isRowtime" : false
     },
@@ -229,7 +322,12 @@
         "kind" : "WindowStart",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3) NOT NULL"
+          "type" : {
+            "nullable" : false,
+            "precision" : 3,
+            "kind" : "PROCTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     }, {
@@ -238,7 +336,12 @@
         "kind" : "WindowEnd",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3) NOT NULL"
+          "type" : {
+            "nullable" : false,
+            "precision" : 3,
+            "kind" : "PROCTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     } ],
@@ -250,7 +353,29 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` INT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "INT"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WindowAggregate(groupBy=[b], window=[HOP(time_col=[proctime], size=[10 min], slide=[5 min])], select=[b, SUM(a) AS EXPR$1, start('w$) AS window_start, end('w$) AS window_end])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -278,7 +403,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "INT"
+      } ]
+    },
     "description" : "Calc(select=[b, EXPR$1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -305,7 +438,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$1` INT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$1" : "INT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, EXPR$1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
@@ -119,17 +119,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -187,17 +187,17 @@
         "c" : "VARCHAR(2147483647)"
       }, {
         "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "ROWTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "ROWTIME"
         }
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -235,10 +235,10 @@
         "b" : "BIGINT"
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -261,10 +261,10 @@
         "b" : "BIGINT"
       }, {
         "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -296,10 +296,10 @@
         "size" : "PT15M"
       },
       "timeAttributeType" : {
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
         "nullable" : false,
         "precision" : 3,
-        "kind" : "PROCTIME",
-        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        "kind" : "PROCTIME"
       },
       "timeAttributeIndex" : 1,
       "isRowtime" : false
@@ -311,10 +311,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : false,
             "precision" : 3,
-            "kind" : "PROCTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "PROCTIME"
           }
         }
       }
@@ -325,10 +325,10 @@
         "reference" : {
           "name" : "w$",
           "type" : {
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
             "nullable" : false,
             "precision" : 3,
-            "kind" : "PROCTIME",
-            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+            "kind" : "PROCTIME"
           }
         }
       }
@@ -350,17 +350,17 @@
         "EXPR$2" : "BIGINT NOT NULL"
       }, {
         "window_start" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -406,10 +406,10 @@
         "b" : "BIGINT"
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "EXPR$2" : "BIGINT NOT NULL"
@@ -450,10 +450,10 @@
         "b" : "BIGINT"
       }, {
         "window_end" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "EXPR$2" : "BIGINT NOT NULL"

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/WindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
@@ -28,7 +28,17 @@
       }
     },
     "id" : 17,
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
@@ -98,7 +108,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[a, b, c, TO_TIMESTAMP(c) AS rowtime, PROCTIME() AS proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
@@ -142,7 +176,31 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` INT, `b` BIGINT, `c` VARCHAR(2147483647), `rowtime` TIMESTAMP(3), `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "rowtime" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -170,7 +228,20 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Calc(select=[b, proctime])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
@@ -183,7 +254,20 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `proctime` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "proctime" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowAggregate",
@@ -211,7 +295,12 @@
         "type" : "TumblingWindow",
         "size" : "PT15M"
       },
-      "timeAttributeType" : "TIMESTAMP(3) NOT NULL",
+      "timeAttributeType" : {
+        "nullable" : false,
+        "precision" : 3,
+        "kind" : "PROCTIME",
+        "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+      },
       "timeAttributeIndex" : 1,
       "isRowtime" : false
     },
@@ -221,7 +310,12 @@
         "kind" : "WindowStart",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3) NOT NULL"
+          "type" : {
+            "nullable" : false,
+            "precision" : 3,
+            "kind" : "PROCTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     }, {
@@ -230,7 +324,12 @@
         "kind" : "WindowEnd",
         "reference" : {
           "name" : "w$",
-          "type" : "TIMESTAMP(3) NOT NULL"
+          "type" : {
+            "nullable" : false,
+            "precision" : 3,
+            "kind" : "PROCTIME",
+            "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          }
         }
       }
     } ],
@@ -242,7 +341,29 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `EXPR$2` BIGINT NOT NULL, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "EXPR$2" : "BIGINT NOT NULL"
+      }, {
+        "window_start" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
     "description" : "WindowAggregate(groupBy=[b], window=[TUMBLE(time_col=[proctime], size=[15 min])], select=[b, COUNT(*) AS EXPR$2, start('w$) AS window_start, end('w$) AS window_end])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -278,7 +399,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$2` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "EXPR$2" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[b, window_end, EXPR$2])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -307,7 +443,22 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`b` BIGINT, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$2` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "b" : "BIGINT"
+      }, {
+        "window_end" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "EXPR$2" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, window_end, EXPR$2])"
   } ],
   "edges" : [ {


### PR DESCRIPTION
## What is the purpose of the change

*We should custom RowType/MapType/ArrayType/MultiSetType deserialize/serializer method to allow some special LogicalType such as TimestampType's kind field.*


## Brief change log

  - 8a320ad LogicalTypeJsonDeserializer/Serializer add corresponding method to support RowType/MapType/ArrayType/MultisetType


## Verifying this change

*(Please pick either of the following options)*

This change is already covered by existing tests, such as *LogicalTypeSerdeTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
