### PR TITLE
[FLINK-21744][table-planner-blink]Support StreamExecDeduplicate json serialization/deserialization

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -52,15 +52,26 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Stream {@link ExecNode} which deduplicate on keys and keeps only first row or last row. This node
  * is an optimization of {@link StreamExecRank} for some special cases. Compared to {@link
  * StreamExecRank}, this node could use mini-batch and access less state.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecDeduplicate extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    public static final String FIELD_NAME_UNIQUE_KEYS = "uniqueKeys";
+    public static final String FIELD_NAME_IS_ROWTIME = "isRowtime";
+    public static final String FIELD_NAME_KEEP_LAST_ROW = "keepLastRow";
+    public static final String FIELD_NAME_GENERATE_UPDATE_BEFORE = "generateUpdateBefore";
 
     @Experimental
     public static final ConfigOption<Boolean> TABLE_EXEC_INSERT_AND_UPDATE_AFTER_SENSITIVE =
@@ -76,9 +87,16 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                                     + "but there will be additional overhead."
                                     + "Default is true.");
 
+    @JsonProperty(FIELD_NAME_UNIQUE_KEYS)
     private final int[] uniqueKeys;
+
+    @JsonProperty(FIELD_NAME_IS_ROWTIME)
     private final boolean isRowtime;
+
+    @JsonProperty(FIELD_NAME_KEEP_LAST_ROW)
     private final boolean keepLastRow;
+
+    @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE)
     private final boolean generateUpdateBefore;
 
     public StreamExecDeduplicate(
@@ -89,7 +107,28 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
             InputProperty inputProperty,
             RowType outputType,
             String description) {
-        super(Collections.singletonList(inputProperty), outputType, description);
+        this(
+                uniqueKeys,
+                isRowtime,
+                keepLastRow,
+                generateUpdateBefore,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
+                outputType,
+                description);
+    }
+
+    @JsonCreator
+    public StreamExecDeduplicate(
+            @JsonProperty(FIELD_NAME_UNIQUE_KEYS) int[] uniqueKeys,
+            @JsonProperty(FIELD_NAME_IS_ROWTIME) boolean isRowtime,
+            @JsonProperty(FIELD_NAME_KEEP_LAST_ROW) boolean keepLastRow,
+            @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE) boolean generateUpdateBefore,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(id, inputProperties, outputType, description);
         this.uniqueKeys = uniqueKeys;
         this.isRowtime = isRowtime;
         this.keepLastRow = keepLastRow;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization/deserialization for deduplicate. */
+public class DeduplicationJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+    }
+
+    @Test
+    public void testDeduplication() {
+        String srcTableDdl =
+                "CREATE TABLE srcValuesTable (\n"
+                        + "  order_id bigint,\n"
+                        + "  `user` varchar,\n"
+                        + "  product varchar,\n"
+                        + "  order_time timestamp(3),\n"
+                        + "  proctime AS PROCTIME()\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false',"
+                        + "  'disable-lookup' = 'true')";
+        tEnv.executeSql(srcTableDdl);
+        String sinkTableDdl =
+                "CREATE TABLE sink (\n"
+                        + "  order_id bigint,\n"
+                        + "  `user` varchar,\n"
+                        + "  product varchar,\n"
+                        + "  order_time timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan(
+                "insert into sink "
+                        + "select order_id, user, product, order_time \n"
+                        + "FROM (\n"
+                        + "  SELECT *,\n"
+                        + "    ROW_NUMBER() OVER (PARTITION BY product ORDER BY proctime ASC) AS row_num\n"
+                        + "  FROM srcValuesTable)\n"
+                        + "WHERE row_num = 1 \n");
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -68,8 +68,7 @@ public class JsonSerdeCoverageTest {
                     "StreamExecExpand",
                     "StreamExecMultipleInput",
                     "StreamExecMatch",
-                    "StreamExecValues",
-                    "StreamExecDeduplicate");
+                    "StreamExecValues");
 
     @SuppressWarnings({"rawtypes"})
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Test for watermark assigner json plan. */
+public class DeduplicationJsonPlanITCase extends JsonPlanTestBase {
+
+    @Test
+    public void testDeduplication() throws Exception {
+        List<Row> data =
+                Arrays.asList(
+                        Row.of(1L, "terry", "pen", 1000L),
+                        Row.of(2L, "alice", "pen", 2000L),
+                        Row.of(3L, "bob", "pen", 3000L),
+                        Row.of(4L, "bob", "apple", 4000L),
+                        Row.of(5L, "fish", "apple", 5000L));
+        createTestValuesSourceTable(
+                "MyTable",
+                data,
+                "order_id bigint",
+                "`user` varchar",
+                "product varchar",
+                "order_time bigint ",
+                "event_time as TO_TIMESTAMP(FROM_UNIXTIME(order_time)) ",
+                "watermark for event_time as event_time - INTERVAL '5' second ");
+
+        createTestNonInsertOnlyValuesSinkTable(
+                "MySink",
+                "order_id bigint",
+                "`user` varchar",
+                "product varchar",
+                "order_time bigint",
+                "primary key(product) not enforced");
+
+        String jsonPlan =
+                tableEnv.getJsonPlan(
+                        "insert into MySink "
+                                + "select order_id, user, product, order_time \n"
+                                + "FROM (\n"
+                                + "  SELECT *,\n"
+                                + "    ROW_NUMBER() OVER (PARTITION BY product ORDER BY event_time ASC) AS row_num\n"
+                                + "  FROM MyTable)\n"
+                                + "WHERE row_num = 1 \n");
+        tableEnv.getConfig()
+                .getConfiguration()
+                .setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+        tableEnv.executeJsonPlan(jsonPlan).await();
+
+        assertResult(
+                Arrays.asList("+I[1, terry, pen, 1000]", "+I[4, bob, apple, 4000]"),
+                TestValuesTableFactory.getRawResults("MySink"));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/DeduplicationJsonPlanITCase.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
-/** Test for watermark assigner json plan. */
+/** Test for deduplication json plan. */
 public class DeduplicationJsonPlanITCase extends JsonPlanTestBase {
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest_jsonplan/testDeduplication.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest_jsonplan/testDeduplication.out
@@ -1,0 +1,355 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "srcValuesTable"
+      },
+      "catalogTable" : {
+        "disable-lookup" : "true",
+        "schema.4.expr" : "PROCTIME()",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "product",
+        "schema.1.name" : "user",
+        "bounded" : "false",
+        "schema.4.name" : "proctime",
+        "schema.1.data-type" : "VARCHAR(2147483647)",
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "order_time",
+        "connector" : "values",
+        "schema.4.data-type" : "TIMESTAMP(3) NOT NULL",
+        "schema.0.name" : "order_id"
+      }
+    },
+    "id" : 1,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "order_id" : "BIGINT"
+      }, {
+        "user" : "VARCHAR(2147483647)"
+      }, {
+        "product" : "VARCHAR(2147483647)"
+      }, {
+        "order_time" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, srcValuesTable]], fields=[order_id, user, product, order_time])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ ],
+      "type" : {
+        "timestampKind" : "PROCTIME",
+        "nullable" : false
+      }
+    } ],
+    "condition" : null,
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "order_id" : "BIGINT"
+      }, {
+        "user" : "VARCHAR(2147483647)"
+      }, {
+        "product" : "VARCHAR(2147483647)"
+      }, {
+        "order_time" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "$4" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[order_id, user, product, order_time, PROCTIME() AS $4])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 2 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "order_id" : "BIGINT"
+      }, {
+        "user" : "VARCHAR(2147483647)"
+      }, {
+        "product" : "VARCHAR(2147483647)"
+      }, {
+        "order_time" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "$4" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[hash[product]])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecDeduplicate",
+    "uniqueKeys" : [ 2 ],
+    "isRowtime" : false,
+    "keepLastRow" : false,
+    "generateUpdateBefore" : false,
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "order_id" : "BIGINT"
+      }, {
+        "user" : "VARCHAR(2147483647)"
+      }, {
+        "product" : "VARCHAR(2147483647)"
+      }, {
+        "order_time" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      }, {
+        "$4" : {
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
+    "description" : "Deduplicate(keep=[FirstRow], key=[product], order=[PROCTIME])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    } ],
+    "condition" : null,
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "order_id" : "BIGINT"
+      }, {
+        "user" : "VARCHAR(2147483647)"
+      }, {
+        "product" : "VARCHAR(2147483647)"
+      }, {
+        "order_time" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[order_id, user, product, order_time])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "sink"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "order_time",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "product",
+        "schema.1.name" : "user",
+        "schema.0.name" : "order_id",
+        "schema.1.data-type" : "VARCHAR(2147483647)"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 6,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "order_id" : "BIGINT"
+      }, {
+        "user" : "VARCHAR(2147483647)"
+      }, {
+        "product" : "VARCHAR(2147483647)"
+      }, {
+        "order_time" : {
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR",
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+        }
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.sink], fields=[order_id, user, product, order_time])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 5,
+    "target" : 6,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest_jsonplan/testDeduplication.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest_jsonplan/testDeduplication.out
@@ -37,10 +37,10 @@
         "product" : "VARCHAR(2147483647)"
       }, {
         "order_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -112,17 +112,17 @@
         "product" : "VARCHAR(2147483647)"
       }, {
         "order_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "$4" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -149,17 +149,17 @@
         "product" : "VARCHAR(2147483647)"
       }, {
         "order_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "$4" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -189,17 +189,17 @@
         "product" : "VARCHAR(2147483647)"
       }, {
         "order_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       }, {
         "$4" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : false,
           "precision" : 3,
-          "kind" : "PROCTIME",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "PROCTIME"
         }
       } ]
     },
@@ -258,10 +258,10 @@
         "product" : "VARCHAR(2147483647)"
       }, {
         "order_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },
@@ -307,10 +307,10 @@
         "product" : "VARCHAR(2147483647)"
       }, {
         "order_time" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
           "nullable" : true,
           "precision" : 3,
-          "kind" : "REGULAR",
-          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE"
+          "kind" : "REGULAR"
         }
       } ]
     },


### PR DESCRIPTION
## What is the purpose of the change

*Support StreamExecDeduplicate json serialization/deserialization so that we can serialize the whole exec nodes graph *


## Brief change log
  - 1e37067 pre-request for this pr test work, should remove after https://github.com/apache/flink/pull/15219 merged
  - 67a1a86 Support StreamExecDeduplicate json serialization/deserialization

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test `DeduplicationJsonPlanTest.java ` to ensure the plan as expected.*
  - *Added test `DeduplicationJsonPlanITCase.java` that validates that serialized exec node can be executed*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
