### PR TITLE
[FLINK-17012][streaming] 'RUNNING' state split into 'RUNNING' and 'RE…

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -1558,7 +1558,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "status" : {
             "type" : "string",
-            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
           },
           "tasks" : {
             "type" : "object",
@@ -3536,7 +3536,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "status" : {
             "type" : "string",
-            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
           },
           "subtask" : {
             "type" : "integer"
@@ -4121,7 +4121,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "status" : {
       "type" : "string",
-      "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+      "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
     },
     "subtask" : {
       "type" : "integer"
@@ -4249,7 +4249,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "status" : {
       "type" : "string",
-      "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+      "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
     },
     "subtask" : {
       "type" : "integer"
@@ -4658,7 +4658,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "status" : {
             "type" : "string",
-            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
           },
           "status-counts" : {
             "type" : "object",
@@ -5281,6 +5281,22 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "type" : "object",
   "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerDetailsInfo",
   "properties" : {
+    "allocatedSlots" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:SlotInfo",
+        "properties" : {
+          "jobId" : {
+            "type" : "any"
+          },
+          "resource" : {
+            "type" : "object",
+            "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo"
+          }
+        }
+      }
+    },
     "dataPort" : {
       "type" : "integer"
     },

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -948,10 +948,10 @@ public class RestClusterClientTest extends TestLogger {
                 throws RestHandlerException {
             JobDetails running =
                     new JobDetails(
-                            new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[9], 0);
+                            new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[10], 0);
             JobDetails finished =
                     new JobDetails(
-                            new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0);
+                            new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[10], 0);
             return CompletableFuture.completedFuture(
                     new MultipleJobsDetails(Arrays.asList(running, finished)));
         }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -740,7 +740,7 @@
               },
               "status" : {
                 "type" : "string",
-                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
               },
               "start-time" : {
                 "type" : "integer"
@@ -1943,7 +1943,7 @@
               },
               "status" : {
                 "type" : "string",
-                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
               },
               "attempt" : {
                 "type" : "integer"
@@ -2255,7 +2255,7 @@
         },
         "status" : {
           "type" : "string",
-          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
         },
         "attempt" : {
           "type" : "integer"
@@ -2341,7 +2341,7 @@
         },
         "status" : {
           "type" : "string",
-          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
         },
         "attempt" : {
           "type" : "integer"
@@ -2576,7 +2576,7 @@
               },
               "status" : {
                 "type" : "string",
-                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
               },
               "start-time" : {
                 "type" : "integer"

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -740,7 +740,7 @@
               },
               "status" : {
                 "type" : "string",
-                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
               },
               "start-time" : {
                 "type" : "integer"
@@ -1943,7 +1943,7 @@
               },
               "status" : {
                 "type" : "string",
-                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
               },
               "attempt" : {
                 "type" : "integer"
@@ -2255,7 +2255,7 @@
         },
         "status" : {
           "type" : "string",
-          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
         },
         "attempt" : {
           "type" : "integer"
@@ -2341,7 +2341,7 @@
         },
         "status" : {
           "type" : "string",
-          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+          "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
         },
         "attempt" : {
           "type" : "integer"
@@ -2576,7 +2576,7 @@
               },
               "status" : {
                 "type" : "string",
-                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RECOVERING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING", "RECOVERING" ]
               },
               "start-time" : {
                 "type" : "integer"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -258,6 +258,7 @@ public class TaskDeploymentDescriptorFactory {
 
     private static boolean isProducerAvailable(ExecutionState producerState) {
         return producerState == ExecutionState.RUNNING
+                || producerState == ExecutionState.RECOVERING
                 || producerState == ExecutionState.FINISHED
                 || producerState == ExecutionState.SCHEDULED
                 || producerState == ExecutionState.DEPLOYING;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/ExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/ExecutionState.java
@@ -23,17 +23,17 @@ package org.apache.flink.runtime.execution;
  * the state {@code CREATED} and switch states according to this diagram:
  *
  * <pre>{@code
- *  CREATED  -> SCHEDULED -> DEPLOYING -> RUNNING -> FINISHED
- *     |            |            |          |
- *     |            |            |   +------+
- *     |            |            V   V
+ *  CREATED  -> SCHEDULED -> DEPLOYING -> RECOVERING -> RUNNING -> FINISHED
+ *     |            |            |          |              |
+ *     |            |            |    +-----+--------------+
+ *     |            |            V    V
  *     |            |         CANCELLING -----+----> CANCELED
  *     |            |                         |
  *     |            +-------------------------+
  *     |
  *     |                                   ... -> FAILED
  *     V
- * RECONCILING  -> RUNNING | FINISHED | CANCELED | FAILED
+ * RECONCILING  -> RECOVERING | RUNNING | FINISHED | CANCELED | FAILED
  *
  * }</pre>
  *
@@ -51,6 +51,9 @@ public enum ExecutionState {
     SCHEDULED,
 
     DEPLOYING,
+
+    /** Restoring last possible valid state of the task if it has it. */
+    RECOVERING,
 
     RUNNING,
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/ExecutionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/ExecutionState.java
@@ -52,9 +52,6 @@ public enum ExecutionState {
 
     DEPLOYING,
 
-    /** Restoring last possible valid state of the task if it has it. */
-    RECOVERING,
-
     RUNNING,
 
     /**
@@ -71,7 +68,10 @@ public enum ExecutionState {
 
     FAILED,
 
-    RECONCILING;
+    RECONCILING,
+
+    /** Restoring last possible valid state of the task if it has it. */
+    RECOVERING;
 
     public boolean isTerminal() {
         return this == FINISHED || this == CANCELED || this == FAILED;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1213,6 +1213,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         Map<String, Accumulator<?, ?>> accumulators;
 
         switch (state.getExecutionState()) {
+            case RECOVERING:
+                return attempt.switchToRecovering();
+
             case RUNNING:
                 return attempt.switchToRunning();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -721,9 +721,7 @@ public class Execution
             // Consumer is deploying => cache the partition info which would be
             // sent after switching to running
             // ----------------------------------------------------------------
-            if (consumerState == DEPLOYING
-                    || consumerState == RUNNING
-                    || consumerState == RECOVERING) {
+            if (consumerState == DEPLOYING || consumerState == RUNNING) {
                 final PartitionInfo partitionInfo = createPartitionInfo(partition);
 
                 if (consumerState == DEPLOYING) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -717,11 +717,13 @@ public class Execution
             final ExecutionState consumerState = consumer.getState();
 
             // ----------------------------------------------------------------
-            // Consumer is running => send update message now
+            // Consumer is recovering or running => send update message now
             // Consumer is deploying => cache the partition info which would be
             // sent after switching to running
             // ----------------------------------------------------------------
-            if (consumerState == DEPLOYING || consumerState == RUNNING) {
+            if (consumerState == DEPLOYING
+                    || consumerState == RUNNING
+                    || consumerState == RECOVERING) {
                 final PartitionInfo partitionInfo = createPartitionInfo(partition);
 
                 if (consumerState == DEPLOYING) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -555,6 +555,8 @@ public class ExecutionJobVertex
             return ExecutionState.CANCELING;
         } else if (verticesPerState[ExecutionState.CANCELED.ordinal()] > 0) {
             return ExecutionState.CANCELED;
+        } else if (verticesPerState[ExecutionState.RECOVERING.ordinal()] > 0) {
+            return ExecutionState.RECOVERING;
         } else if (verticesPerState[ExecutionState.RUNNING.ordinal()] > 0) {
             return ExecutionState.RUNNING;
         } else if (verticesPerState[ExecutionState.FINISHED.ordinal()] > 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteChannelStateChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteChannelStateChecker.java
@@ -67,6 +67,7 @@ public class RemoteChannelStateChecker {
     private static boolean isConsumerStateValidForConsumption(
             ExecutionState consumerExecutionState) {
         return consumerExecutionState == ExecutionState.RUNNING
+                || consumerExecutionState == ExecutionState.RECOVERING
                 || consumerExecutionState == ExecutionState.DEPLOYING;
     }
 
@@ -74,6 +75,7 @@ public class RemoteChannelStateChecker {
         ExecutionState producerState = getProducerState(responseHandle);
         return producerState == ExecutionState.SCHEDULED
                 || producerState == ExecutionState.DEPLOYING
+                || producerState == ExecutionState.RECOVERING
                 || producerState == ExecutionState.RUNNING
                 || producerState == ExecutionState.FINISHED;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -291,4 +291,16 @@ public abstract class AbstractInvokable {
         throw new UnsupportedOperationException(
                 "dispatchOperatorEvent not supported by " + getClass().getName());
     }
+
+    /**
+     * This method can be called before {@link #invoke()} to restore an invokable object for the
+     * last valid state, if it has it.
+     *
+     * <p>Every implementation determinate what should be restored by itself. (nothing happens by
+     * default).
+     *
+     * @throws Exception Tasks may forward their exceptions for the TaskManager to handle through
+     *     failure/recovery.
+     */
+    public void restore() throws Exception {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -505,8 +505,8 @@ public class Task
     public boolean isBackPressured() {
         if (invokable == null
                 || consumableNotifyingPartitionWriters.length == 0
-                || executionState != ExecutionState.RECOVERING
-                || executionState != ExecutionState.RUNNING) {
+                || (executionState != ExecutionState.RECOVERING
+                        && executionState != ExecutionState.RUNNING)) {
             return false;
         }
         for (int i = 0; i < consumableNotifyingPartitionWriters.length; ++i) {
@@ -833,11 +833,10 @@ public class Task
                     }
                 }
 
-                // transition into our final state. we should be either in DEPLOYING, RUNNING,
-                // CANCELING, or FAILED
+                // transition into our final state. we should be either in DEPLOYING, RECOVERING,
+                // RUNNING, CANCELING, or FAILED
                 // loop for multiple retries during concurrent state changes via calls to cancel()
-                // or
-                // to failExternally()
+                // or to failExternally()
                 while (true) {
                     ExecutionState current = this.executionState;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -505,6 +505,7 @@ public class Task
     public boolean isBackPressured() {
         if (invokable == null
                 || consumableNotifyingPartitionWriters.length == 0
+                || executionState != ExecutionState.RECOVERING
                 || executionState != ExecutionState.RUNNING) {
             return false;
         }
@@ -737,18 +738,33 @@ public class Task
             // by the time we switched to running.
             this.invokable = invokable;
 
-            // switch to the RUNNING state, if that fails, we have been canceled/failed in the
+            // switch to the RECOVERING state, if that fails, we have been canceled/failed in the
             // meantime
-            if (!transitionState(ExecutionState.DEPLOYING, ExecutionState.RUNNING)) {
+            if (!transitionState(ExecutionState.DEPLOYING, ExecutionState.RECOVERING)) {
+                throw new CancelTaskException();
+            }
+
+            taskManagerActions.updateTaskExecutionState(
+                    new TaskExecutionState(executionId, ExecutionState.RECOVERING));
+
+            // make sure the user code classloader is accessible thread-locally
+            executingThread.setContextClassLoader(userCodeClassLoader.asClassLoader());
+
+            FlinkSecurityManager.monitorUserSystemExitForCurrentThread();
+            try {
+                // Restore invokable data to the last valid state
+                invokable.restore();
+            } finally {
+                FlinkSecurityManager.unmonitorUserSystemExitForCurrentThread();
+            }
+
+            if (!transitionState(ExecutionState.RECOVERING, ExecutionState.RUNNING)) {
                 throw new CancelTaskException();
             }
 
             // notify everyone that we switched to running
             taskManagerActions.updateTaskExecutionState(
                     new TaskExecutionState(executionId, ExecutionState.RUNNING));
-
-            // make sure the user code classloader is accessible thread-locally
-            executingThread.setContextClassLoader(userCodeClassLoader.asClassLoader());
 
             // Monitor user codes from exiting JVM covering user function invocation. This can be
             // done in a finer-grained way like enclosing user callback functions individually,
@@ -825,7 +841,9 @@ public class Task
                 while (true) {
                     ExecutionState current = this.executionState;
 
-                    if (current == ExecutionState.RUNNING || current == ExecutionState.DEPLOYING) {
+                    if (current == ExecutionState.RUNNING
+                            || current == ExecutionState.RECOVERING
+                            || current == ExecutionState.DEPLOYING) {
                         if (t instanceof CancelTaskException) {
                             if (transitionState(current, ExecutionState.CANCELED)) {
                                 cancelInvokable(invokable);
@@ -1120,8 +1138,8 @@ public class Task
                     this.failureCause = cause;
                     return;
                 }
-            } else if (current == ExecutionState.RUNNING) {
-                if (transitionState(ExecutionState.RUNNING, targetState, cause)) {
+            } else if (current == ExecutionState.RECOVERING || current == ExecutionState.RUNNING) {
+                if (transitionState(current, targetState, cause)) {
                     // we are canceling / failing out of the running state
                     // we need to cancel the invokable
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
@@ -93,6 +93,7 @@ public class ShuffleDescriptorTest extends TestLogger {
 
             // These states are allowed
             if (state == ExecutionState.RUNNING
+                    || state == ExecutionState.RECOVERING
                     || state == ExecutionState.FINISHED
                     || state == ExecutionState.SCHEDULED
                     || state == ExecutionState.DEPLOYING) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -350,6 +350,9 @@ public class ArchivedExecutionGraphTest extends TestLogger {
                 runtimeVertex.getStateTimestamp(ExecutionState.DEPLOYING),
                 archivedVertex.getStateTimestamp(ExecutionState.DEPLOYING));
         assertEquals(
+                runtimeVertex.getStateTimestamp(ExecutionState.RECOVERING),
+                archivedVertex.getStateTimestamp(ExecutionState.RECOVERING));
+        assertEquals(
                 runtimeVertex.getStateTimestamp(ExecutionState.RUNNING),
                 archivedVertex.getStateTimestamp(ExecutionState.RUNNING));
         assertEquals(
@@ -404,6 +407,9 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         assertEquals(
                 runtimeExecution.getStateTimestamp(ExecutionState.DEPLOYING),
                 archivedExecution.getStateTimestamp(ExecutionState.DEPLOYING));
+        assertEquals(
+                runtimeExecution.getStateTimestamp(ExecutionState.RECOVERING),
+                archivedExecution.getStateTimestamp(ExecutionState.RECOVERING));
         assertEquals(
                 runtimeExecution.getStateTimestamp(ExecutionState.RUNNING),
                 archivedExecution.getStateTimestamp(ExecutionState.RUNNING));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -252,6 +252,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
                 assertNotNull(
                         "No assigned resource (test instability).",
                         vertex.getCurrentAssignedResource());
+                vertex.getCurrentExecutionAttempt().switchToRecovering();
                 vertex.getCurrentExecutionAttempt().switchToRunning();
             }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -235,6 +235,7 @@ public class ExecutionGraphTestUtils {
      */
     public static void switchAllVerticesToRunning(ExecutionGraph eg) {
         for (ExecutionVertex vertex : eg.getAllExecutionVertices()) {
+            vertex.getCurrentExecutionAttempt().switchToRecovering();
             vertex.getCurrentExecutionAttempt().switchToRunning();
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -293,6 +293,7 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
         execution = executionVertex.getCurrentExecutionAttempt();
 
         scheduler.startScheduling();
+        execution.switchToRecovering();
         execution.switchToRunning();
 
         final IntermediateResultPartitionID expectedIntermediateResultPartitionId =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/UpdatePartitionConsumersTest.java
@@ -155,9 +155,13 @@ public class UpdatePartitionConsumersTest extends TestLogger {
         assertThat(ev3.getExecutionState(), is(ExecutionState.DEPLOYING));
         assertThat(ev4.getExecutionState(), is(ExecutionState.DEPLOYING));
 
+        updateState(scheduler, ev1, ExecutionState.RECOVERING);
         updateState(scheduler, ev1, ExecutionState.RUNNING);
+        updateState(scheduler, ev2, ExecutionState.RECOVERING);
         updateState(scheduler, ev2, ExecutionState.RUNNING);
+        updateState(scheduler, ev3, ExecutionState.RECOVERING);
         updateState(scheduler, ev3, ExecutionState.RUNNING);
+        updateState(scheduler, ev4, ExecutionState.RECOVERING);
         updateState(scheduler, ev4, ExecutionState.RUNNING);
 
         final InputGateDeploymentDescriptor ev4Igdd2 =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1714,6 +1714,10 @@ public class JobMasterTest extends TestLogger {
 
             jobMasterGateway
                     .updateTaskExecutionState(
+                            new TaskExecutionState(executionAttemptId, ExecutionState.RECOVERING))
+                    .get();
+            jobMasterGateway
+                    .updateTaskExecutionState(
                             new TaskExecutionState(executionAttemptId, ExecutionState.RUNNING))
                     .get();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/JobDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/JobDetailsTest.java
@@ -46,7 +46,7 @@ public class JobDetailsTest extends TestLogger {
                         9L,
                         JobStatus.RUNNING,
                         8L,
-                        new int[] {1, 3, 3, 7, 4, 2, 7, 3, 3},
+                        new int[] {1, 3, 3, 4, 7, 4, 2, 7, 3, 3},
                         42);
 
         final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -86,6 +86,7 @@ import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.futureFailedWith;
 import static org.apache.flink.core.testutils.FlinkMatchers.futureWillCompleteExceptionally;
+import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.setExecutionToState;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -752,7 +753,8 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 
     private void failAndRestartTask(DefaultScheduler scheduler, int subtask) {
         failAndRedeployTask(scheduler, subtask);
-        SchedulerTestingUtils.setExecutionToRunning(scheduler, testVertexId, subtask);
+        setExecutionToState(ExecutionState.RECOVERING, scheduler, testVertexId, subtask);
+        setExecutionToState(ExecutionState.RUNNING, scheduler, testVertexId, subtask);
 
         // guard the test assumptions: This must bring the task back to RUNNING
         assertEquals(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBatchSchedulingTest.java
@@ -164,6 +164,9 @@ public class DefaultSchedulerBatchSchedulingTest extends TestLogger {
                         () -> {
                             scheduler.updateTaskExecutionState(
                                     new TaskExecutionState(
+                                            executionAttemptId, ExecutionState.RECOVERING));
+                            scheduler.updateTaskExecutionState(
+                                    new TaskExecutionState(
                                             executionAttemptId, ExecutionState.RUNNING));
                             scheduler.updateTaskExecutionState(
                                     new TaskExecutionState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -221,13 +221,13 @@ public class SchedulerTestingUtils {
                         attemptID, ExecutionState.CANCELED, new Exception("test task failure")));
     }
 
-    public static void setExecutionToRunning(
-            DefaultScheduler scheduler, JobVertexID jvid, int subtask) {
+    public static void setExecutionToState(
+            ExecutionState executionState,
+            DefaultScheduler scheduler,
+            JobVertexID jvid,
+            int subtask) {
         final ExecutionAttemptID attemptID = getAttemptId(scheduler, jvid, subtask);
-        scheduler.updateTaskExecutionState(
-                new TaskExecutionState(attemptID, ExecutionState.RECOVERING));
-        scheduler.updateTaskExecutionState(
-                new TaskExecutionState(attemptID, ExecutionState.RUNNING));
+        scheduler.updateTaskExecutionState(new TaskExecutionState(attemptID, executionState));
     }
 
     public static void setAllExecutionsToRunning(final DefaultScheduler scheduler) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -225,15 +225,20 @@ public class SchedulerTestingUtils {
             DefaultScheduler scheduler, JobVertexID jvid, int subtask) {
         final ExecutionAttemptID attemptID = getAttemptId(scheduler, jvid, subtask);
         scheduler.updateTaskExecutionState(
+                new TaskExecutionState(attemptID, ExecutionState.RECOVERING));
+        scheduler.updateTaskExecutionState(
                 new TaskExecutionState(attemptID, ExecutionState.RUNNING));
     }
 
     public static void setAllExecutionsToRunning(final DefaultScheduler scheduler) {
         getAllCurrentExecutionAttempts(scheduler)
                 .forEach(
-                        (attemptId) ->
-                                scheduler.updateTaskExecutionState(
-                                        new TaskExecutionState(attemptId, ExecutionState.RUNNING)));
+                        (attemptId) -> {
+                            scheduler.updateTaskExecutionState(
+                                    new TaskExecutionState(attemptId, ExecutionState.RECOVERING));
+                            scheduler.updateTaskExecutionState(
+                                    new TaskExecutionState(attemptId, ExecutionState.RUNNING));
+                        });
     }
 
     public static void setAllExecutionsToCancelled(final DefaultScheduler scheduler) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -100,7 +100,7 @@ public class TaskExecutorSlotLifetimeTest extends TestLogger {
                     return CompletableFuture.completedFuture(Acknowledge.get());
                 });
 
-        final BlockingQueue<TaskExecutionState> taskExecutionStates = new ArrayBlockingQueue<>(2);
+        final BlockingQueue<TaskExecutionState> taskExecutionStates = new ArrayBlockingQueue<>(3);
         final OneShotLatch slotsOfferedLatch = new OneShotLatch();
         final TestingJobMasterGateway jobMasterGateway =
                 new TestingJobMasterGatewayBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -342,7 +342,9 @@ public class TaskExecutorSubmissionTest extends TestLogger {
                         .setUpdateTaskExecutionStateFunction(
                                 taskExecutionState -> {
                                     if (taskExecutionState != null
-                                            && taskExecutionState.getID().equals(eid1)) {
+                                            && taskExecutionState.getID().equals(eid1)
+                                            && taskExecutionState.getExecutionState()
+                                                    == ExecutionState.RUNNING) {
                                         return FutureUtils.completedExceptionally(
                                                 new ExecutionGraphException(
                                                         "The execution attempt "

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -67,6 +67,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -88,6 +89,7 @@ import static org.mockito.Mockito.when;
  * correctly handled.
  */
 public class TaskTest extends TestLogger {
+    private static final String RESTORE_EXCEPTION_MSG = "TestExceptionInRestore";
 
     private static OneShotLatch awaitLatch;
     private static OneShotLatch triggerLatch;
@@ -135,6 +137,7 @@ public class TaskTest extends TestLogger {
         assertNull(task.getFailureCause());
         assertNull(task.getInvokable());
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.FINISHED, task, null);
     }
@@ -288,6 +291,28 @@ public class TaskTest extends TestLogger {
     }
 
     @Test
+    public void testExecutionFailsInRestore() throws Exception {
+        final QueuedNoOpTaskManagerActions taskManagerActions = new QueuedNoOpTaskManagerActions();
+        final Task task =
+                createTaskBuilder()
+                        .setInvokable(InvokableWithExceptionInRestore.class)
+                        .setTaskManagerActions(taskManagerActions)
+                        .build();
+
+        task.run();
+
+        assertEquals(ExecutionState.FAILED, task.getExecutionState());
+        assertTrue(task.isCanceledOrFailed());
+        assertNotNull(task.getFailureCause());
+        assertNotNull(task.getFailureCause().getMessage());
+        assertThat(task.getFailureCause().getMessage(), containsString(RESTORE_EXCEPTION_MSG));
+
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
+        taskManagerActions.validateListenerMessage(
+                ExecutionState.FAILED, task, new Exception(RESTORE_EXCEPTION_MSG));
+    }
+
+    @Test
     public void testExecutionFailsInInvoke() throws Exception {
         final QueuedNoOpTaskManagerActions taskManagerActions = new QueuedNoOpTaskManagerActions();
         final Task task =
@@ -304,6 +329,7 @@ public class TaskTest extends TestLogger {
         assertNotNull(task.getFailureCause().getMessage());
         assertTrue(task.getFailureCause().getMessage().contains("test"));
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(
                 ExecutionState.FAILED, task, new Exception("test"));
@@ -326,9 +352,40 @@ public class TaskTest extends TestLogger {
         final Throwable cause = task.getFailureCause();
         assertTrue(cause instanceof IOException);
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(
                 ExecutionState.FAILED, task, new IOException("test"));
+    }
+
+    @Test
+    public void testCancelDuringRestore() throws Exception {
+        final QueuedNoOpTaskManagerActions taskManagerActions = new QueuedNoOpTaskManagerActions();
+        final Task task =
+                createTaskBuilder()
+                        .setInvokable(InvokableBlockingInRestore.class)
+                        .setTaskManagerActions(taskManagerActions)
+                        .build();
+
+        // run the task asynchronous
+        task.startTaskThread();
+
+        // wait till the task is in restore
+        awaitLatch.await();
+
+        task.cancelExecution();
+        assertTrue(
+                task.getExecutionState() == ExecutionState.CANCELING
+                        || task.getExecutionState() == ExecutionState.CANCELED);
+
+        task.getExecutingThread().join();
+
+        assertEquals(ExecutionState.CANCELED, task.getExecutionState());
+        assertTrue(task.isCanceledOrFailed());
+        assertNull(task.getFailureCause());
+
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
+        taskManagerActions.validateListenerMessage(ExecutionState.CANCELED, task, null);
     }
 
     @Test
@@ -357,8 +414,37 @@ public class TaskTest extends TestLogger {
         assertTrue(task.isCanceledOrFailed());
         assertNull(task.getFailureCause());
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.CANCELED, task, null);
+    }
+
+    @Test
+    public void testFailExternallyDuringRestore() throws Exception {
+        final QueuedNoOpTaskManagerActions taskManagerActions = new QueuedNoOpTaskManagerActions();
+        final Task task =
+                createTaskBuilder()
+                        .setInvokable(InvokableBlockingInRestore.class)
+                        .setTaskManagerActions(taskManagerActions)
+                        .build();
+
+        // run the task asynchronous
+        task.startTaskThread();
+
+        // wait till the task is in invoke
+        awaitLatch.await();
+
+        task.failExternally(new Exception(RESTORE_EXCEPTION_MSG));
+
+        task.getExecutingThread().join();
+
+        assertEquals(ExecutionState.FAILED, task.getExecutionState());
+        assertTrue(task.isCanceledOrFailed());
+        assertThat(task.getFailureCause().getMessage(), containsString(RESTORE_EXCEPTION_MSG));
+
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
+        taskManagerActions.validateListenerMessage(
+                ExecutionState.FAILED, task, new Exception(RESTORE_EXCEPTION_MSG));
     }
 
     @Test
@@ -384,6 +470,7 @@ public class TaskTest extends TestLogger {
         assertTrue(task.isCanceledOrFailed());
         assertTrue(task.getFailureCause().getMessage().contains("test"));
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(
                 ExecutionState.FAILED, task, new Exception("test"));
@@ -407,6 +494,7 @@ public class TaskTest extends TestLogger {
         assertTrue(task.isCanceledOrFailed());
         assertTrue(task.getFailureCause().getMessage().contains("test"));
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(
                 ExecutionState.FAILED, task, new Exception("test"));
@@ -440,6 +528,7 @@ public class TaskTest extends TestLogger {
         assertTrue(task.isCanceledOrFailed());
         assertNull(task.getFailureCause());
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.CANCELED, task, null);
     }
@@ -471,6 +560,7 @@ public class TaskTest extends TestLogger {
         assertTrue(task.isCanceledOrFailed());
         assertTrue(task.getFailureCause().getMessage().contains("external"));
 
+        taskManagerActions.validateListenerMessage(ExecutionState.RECOVERING, task, null);
         taskManagerActions.validateListenerMessage(ExecutionState.RUNNING, task, null);
         taskManagerActions.validateListenerMessage(
                 ExecutionState.FAILED, task, new Exception("external"));
@@ -548,6 +638,7 @@ public class TaskTest extends TestLogger {
             expected.put(state, ExecutionState.FAILED);
         }
 
+        expected.put(ExecutionState.RECOVERING, initialTaskState);
         expected.put(ExecutionState.RUNNING, initialTaskState);
         expected.put(ExecutionState.SCHEDULED, initialTaskState);
         expected.put(ExecutionState.DEPLOYING, initialTaskState);
@@ -571,7 +662,7 @@ public class TaskTest extends TestLogger {
             assertEquals(expected.get(state), newTaskState);
         }
 
-        assertEquals(4, producingStateCounter);
+        assertEquals(5, producingStateCounter);
     }
 
     /** Tests the trigger partition state update future completions. */
@@ -1075,6 +1166,20 @@ public class TaskTest extends TestLogger {
         }
     }
 
+    static final class InvokableWithExceptionInRestore extends AbstractInvokable {
+        public InvokableWithExceptionInRestore(Environment environment) {
+            super(environment);
+        }
+
+        @Override
+        public void restore() throws Exception {
+            throw new Exception(RESTORE_EXCEPTION_MSG);
+        }
+
+        @Override
+        public void invoke() throws Exception {}
+    }
+
     private static final class FailingInvokableWithChainedException extends AbstractInvokable {
         public FailingInvokableWithChainedException(Environment environment) {
             super(environment);
@@ -1118,6 +1223,27 @@ public class TaskTest extends TestLogger {
                 }
             }
         }
+    }
+
+    private static final class InvokableBlockingInRestore extends AbstractInvokable {
+        public InvokableBlockingInRestore(Environment environment) {
+            super(environment);
+        }
+
+        @Override
+        public void restore() throws Exception {
+            awaitLatch.trigger();
+
+            // block forever
+            synchronized (this) {
+                while (true) {
+                    wait();
+                }
+            }
+        }
+
+        @Override
+        public void invoke() throws Exception {}
     }
 
     /** {@link AbstractInvokable} which throws {@link RuntimeException} on invoke. */


### PR DESCRIPTION
…COVERING' in order to distinguish when the task is really running

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request separates ExecutionState#RUNNING into two differents states RUNNING and RECOVERING. It needs to be done because right now when the task switch to RUUNING state it can do a recovery for some time but from the user side, it looks like the task does nothing.*


## Brief change log

  - *New state RECOVERING is added to ExecutionState*
  - *New method 'restore' without any implementation is added into AbstractInvokable*
  - *Support of new state is added to Execution graph*
  - *Sending partition infos moved from RUNNING to RECOVERING state*


## Verifying this change

This change is already covered by existing tests with minor changes, such as *TaskTest*, *ExecutionGraph\**.
This change added tests and can be verified as follows:

  - *Extended unit tests in TaskTests to be sure that task correctly from RECOVERING state to other states(CANCEL, RUNNING, FAILED)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / *don't know*)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no / **don't know**)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
