### PR TITLE
[FLINK-21753][runtime] Don't cycle reference between memory manager and gc cleaner action

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemorySegmentFactory.java
@@ -168,15 +168,15 @@ public final class MemorySegmentFactory {
      *
      * @param size The size of the off-heap unsafe memory segment to allocate.
      * @param owner The owner to associate with the off-heap unsafe memory segment.
-     * @param customCleanupAction A custom action to run upon calling GC cleaner.
+     * @param gcCleanupAction A custom action to run upon calling GC cleaner.
      * @return A new memory segment, backed by off-heap unsafe memory.
      */
     public static MemorySegment allocateOffHeapUnsafeMemory(
-            int size, Object owner, Runnable customCleanupAction) {
+            int size, Object owner, Runnable gcCleanupAction) {
         long address = MemoryUtils.allocateUnsafe(size);
         ByteBuffer offHeapBuffer = MemoryUtils.wrapUnsafeMemoryWithByteBuffer(address, size);
         Runnable cleaner =
-                MemoryUtils.createMemoryGcCleaner(offHeapBuffer, address, customCleanupAction);
+                MemoryUtils.createMemoryGcCleaner(offHeapBuffer, address, gcCleanupAction);
         return new HybridMemorySegment(offHeapBuffer, owner, false, cleaner);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -241,7 +241,7 @@ public class MemoryManager {
                     String.format("Could not allocate %d pages", numberOfPages), e);
         }
 
-        Runnable gcCleanup = memoryBudget.cleanupMemory(getPageSize());
+        Runnable gcCleanup = memoryBudget.getReleaseMemoryAction(getPageSize());
         allocatedSegments.compute(
                 owner,
                 (o, currentSegmentsForOwner) -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -157,6 +157,12 @@ public class MemoryManager {
         }
     }
 
+    /** Gets memory budget. */
+    @VisibleForTesting
+    public UnsafeMemoryBudget getMemoryBudget() {
+        return memoryBudget;
+    }
+
     /**
      * Checks whether the MemoryManager has been shut down.
      *
@@ -235,7 +241,7 @@ public class MemoryManager {
                     String.format("Could not allocate %d pages", numberOfPages), e);
         }
 
-        Runnable pageCleanup = this::releasePage;
+        Runnable gcCleanup = memoryBudget.cleanupMemory(getPageSize());
         allocatedSegments.compute(
                 owner,
                 (o, currentSegmentsForOwner) -> {
@@ -245,7 +251,7 @@ public class MemoryManager {
                                     : currentSegmentsForOwner;
                     for (long i = numberOfPages; i > 0; i--) {
                         MemorySegment segment =
-                                allocateOffHeapUnsafeMemory(getPageSize(), owner, pageCleanup);
+                                allocateOffHeapUnsafeMemory(getPageSize(), owner, gcCleanup);
                         target.add(segment);
                         segmentsForOwner.add(segment);
                     }
@@ -253,10 +259,6 @@ public class MemoryManager {
                 });
 
         Preconditions.checkState(!isShutDown, "Memory manager has been concurrently shut down.");
-    }
-
-    private void releasePage() {
-        memoryBudget.releaseMemory(getPageSize());
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
@@ -215,12 +215,12 @@ class UnsafeMemoryBudget {
     }
 
     /**
-     * Return an runnable to postpone memory release.
+     * Generates an release memory action that can be performed later
      *
-     * <p>The returned runnable could be safely referenced by possible gc cleaner action without
+     * <p>The generated runnable could be safely referenced by possible gc cleaner action without
      * worrying about cycle reference back to memory manager.
      */
-    Runnable cleanupMemory(@Nonnegative long size) {
+    Runnable getReleaseMemoryAction(@Nonnegative long size) {
         return () -> {
             releaseMemory(size);
         };

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/UnsafeMemoryBudget.java
@@ -213,4 +213,16 @@ class UnsafeMemoryBudget {
                             size, currentAvailableMemorySize, totalMemorySize));
         }
     }
+
+    /**
+     * Return an runnable to postpone memory release.
+     *
+     * <p>The returned runnable could be safely referenced by possible gc cleaner action without
+     * worrying about cycle reference back to memory manager.
+     */
+    Runnable cleanupMemory(@Nonnegative long size) {
+        return () -> {
+            releaseMemory(size);
+        };
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -353,7 +353,8 @@ public class MemoryManagerTest {
         }
     }
 
-    private UnsafeMemoryBudget allocateLeakingPages() throws MemoryAllocationException {
+    private UnsafeMemoryBudget allocateLeakingPagesAndGetBudget() throws MemoryAllocationException {
+        // We create a new memory manager here since we want it and all its segments to be leaking.
         MemoryManager memoryManager =
                 MemoryManagerBuilder.newBuilder()
                         .setMemorySize(MEMORY_SIZE)
@@ -366,7 +367,7 @@ public class MemoryManagerTest {
 
     @Test
     public void testGcCleanup() throws Exception {
-        UnsafeMemoryBudget memoryBudget = allocateLeakingPages();
+        UnsafeMemoryBudget memoryBudget = allocateLeakingPagesAndGetBudget();
         for (int i = 0;
                 i < 20 && memoryBudget.getAvailableMemorySize() < memoryBudget.getTotalMemorySize();
                 i++) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Tests for the memory manager. */
@@ -350,5 +351,28 @@ public class MemoryManagerTest {
         } catch (MemoryReservationException maex) {
             // expected
         }
+    }
+
+    private UnsafeMemoryBudget allocateLeakingPages() throws MemoryAllocationException {
+        MemoryManager memoryManager =
+                MemoryManagerBuilder.newBuilder()
+                        .setMemorySize(MEMORY_SIZE)
+                        .setPageSize(PAGE_SIZE)
+                        .build();
+        memoryManager.allocatePages(new Object(), (int) memoryManager.getMemorySize() / PAGE_SIZE);
+
+        return memoryManager.getMemoryBudget();
+    }
+
+    @Test
+    public void testGcCleanup() throws Exception {
+        UnsafeMemoryBudget memoryBudget = allocateLeakingPages();
+        for (int i = 0;
+                i < 20 && memoryBudget.getAvailableMemorySize() < memoryBudget.getTotalMemorySize();
+                i++) {
+            System.gc();
+            Thread.sleep(50);
+        }
+        assertTrue(memoryBudget.verifyEmpty());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Break cycle reference between memory manager and gc cleaner action in the first place.


## Brief change log
* Creates an runnable that does not reference `MemoryManager`.
* Uses that runnable as gc cleanup action.

## Verifying this change
This change added tests and can be verified as follows:
* `MemoryManagerTest.testGcCleanup`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## Worth to fix ?
* Is there anywhere memory segment was freed but not released ?
