### PR TITLE
[hotfix][docs] Add missing semicolons and remove unnecessary semicolo…

### DIFF
--- a/docs/content/docs/learn-flink/datastream_api.md
+++ b/docs/content/docs/learn-flink/datastream_api.md
@@ -73,7 +73,7 @@ public class Person {
     public Person() {};  
     public Person(String name, Integer age) {  
         . . .
-    };  
+    }
 }  
 
 Person person = new Person("Fred Flintstone", 35);
@@ -127,11 +127,11 @@ public class Example {
         public Person(String name, Integer age) {
             this.name = name;
             this.age = age;
-        };
+        }
 
         public String toString() {
             return this.name.toString() + ": age " + this.age.toString();
-        };
+        }
     }
 }
 ```
@@ -172,7 +172,7 @@ DataStream<Person> flintstones = env.fromCollection(people);
 Another convenient way to get some data into a stream while prototyping is to use a socket
 
 ```java
-DataStream<String> lines = env.socketTextStream("localhost", 9999)
+DataStream<String> lines = env.socketTextStream("localhost", 9999);
 ```
 
 or a file

--- a/docs/content/docs/learn-flink/etl.md
+++ b/docs/content/docs/learn-flink/etl.md
@@ -144,7 +144,7 @@ this would mean doing some sort of GROUP BY with the `startCell`, while in Flink
 ```java
 rides
     .flatMap(new NYCEnrichment())
-    .keyBy(enrichedRide -> enrichedRide.startCell)
+    .keyBy(enrichedRide -> enrichedRide.startCell);
 ```
 
 Every `keyBy` causes a network shuffle that repartitions the stream. In general this is pretty
@@ -168,13 +168,13 @@ For example, rather than creating a new `EnrichedRide` class with a `startCell` 
 as a key via 
 
 ```java
-keyBy(enrichedRide -> enrichedRide.startCell)
+keyBy(enrichedRide -> enrichedRide.startCell);
 ```
 
 we could do this, instead:
 
 ```java
-keyBy(ride -> GeoUtils.mapToGridCell(ride.startLon, ride.startLat))
+keyBy(ride -> GeoUtils.mapToGridCell(ride.startLon, ride.startLat));
 ```
 
 ### Aggregations on Keyed Streams
@@ -375,7 +375,7 @@ in an unbounded way, it's necessary to clear the state for keys that are no long
 done by calling `clear()` on the state object, as in:
 
 ```java
-keyHasBeenSeen.clear()
+keyHasBeenSeen.clear();
 ```
 
 You might want to do this, for example, after a period of inactivity for a given key. You'll see how

--- a/docs/content/docs/learn-flink/streaming_analytics.md
+++ b/docs/content/docs/learn-flink/streaming_analytics.md
@@ -178,7 +178,7 @@ In its basic form, you apply windowing to a keyed stream like this:
 stream.
     .keyBy(<key selector>)
     .window(<window assigner>)
-    .reduce|aggregate|process(<window function>)
+    .reduce|aggregate|process(<window function>);
 ```
 
 You can also use windowing with non-keyed streams, but keep in mind that in this case, the
@@ -187,7 +187,7 @@ processing will _not_ be done in parallel:
 ```java
 stream.
     .windowAll(<window assigner>)
-    .reduce|aggregate|process(<window function>)
+    .reduce|aggregate|process(<window function>);
 ```
 
 ### Window Assigners
@@ -398,7 +398,7 @@ stream
     .window(<window assigner>)
     .reduce(<reduce function>)
     .windowAll(<same window assigner>)
-    .reduce(<same reduce function>)
+    .reduce(<same reduce function>);
 ```
 
 You might expect Flink's runtime to be smart enough to do this parallel pre-aggregation for you (provided you are using a ReduceFunction or AggregateFunction), but it's not.


### PR DESCRIPTION
[hotfix][docs] Add missing semicolons and remove unnecessary semicolons for learn-flink documents.

## What is the purpose of the change

Fix several typos in Flink doc: learning-flink, by adding missing semicolons while removing unnecessary semicolons.

## Brief change log

Add missing semicolons and remove unnecessary semicolons in:
- docs/content/docs/learn-flink/datastream_api.md
- docs/content/docs/learn-flink/etl.md
- docs/content/docs/learn-flink/streaming_analytics.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
