### PR TITLE
[FLINK-20977][sql-client] Fix USE DATABASE & USE CATALOG fails with quoted identifiers containing characters to be escaped

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -592,7 +592,7 @@ public class CliClient implements AutoCloseable {
 
     private void callUseCatalog(SqlCommandCall cmdCall) {
         try {
-            executor.executeSql(sessionId, "USE CATALOG " + cmdCall.operands[0]);
+            executor.executeSql(sessionId, "USE CATALOG `" + cmdCall.operands[0] + "`");
         } catch (SqlExecutionException e) {
             printExecutionException(e);
             return;
@@ -602,7 +602,7 @@ public class CliClient implements AutoCloseable {
 
     private void callUseDatabase(SqlCommandCall cmdCall) {
         try {
-            executor.executeSql(sessionId, "USE " + cmdCall.operands[0]);
+            executor.executeSql(sessionId, "USE `" + cmdCall.operands[0] + "`");
         } catch (SqlExecutionException e) {
             printExecutionException(e);
             return;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -197,7 +197,7 @@ public class CliClientTest extends TestLogger {
                 new TestingExecutorBuilder()
                         .setExecuteSqlConsumer(
                                 (ignored1, sql) -> {
-                                    if (sql.toLowerCase().equals("use catalog cat")) {
+                                    if (sql.toLowerCase().equals("use catalog `cat`")) {
                                         return TestTableResult.TABLE_RESULT_OK;
                                     } else if (sql.toLowerCase().equals("show current catalog")) {
                                         SHOW_ROW.setField(0, "cat");
@@ -218,7 +218,7 @@ public class CliClientTest extends TestLogger {
 
         String output = testExecuteSql(executor, "use catalog cat;");
         assertThat(executor.getNumExecuteSqlCalls(), is(1));
-        assertFalse(output.contains("unexpected catalog name"));
+        assertFalse(output.contains("unexpected sql statement"));
 
         output = testExecuteSql(executor, "show current catalog;");
         assertThat(executor.getNumExecuteSqlCalls(), is(2));
@@ -231,7 +231,7 @@ public class CliClientTest extends TestLogger {
                 new TestingExecutorBuilder()
                         .setExecuteSqlConsumer(
                                 (ignored1, sql) -> {
-                                    if (sql.toLowerCase().equals("use db")) {
+                                    if (sql.toLowerCase().equals("use `db`")) {
                                         return TestTableResult.TABLE_RESULT_OK;
                                     } else if (sql.toLowerCase().equals("show current database")) {
                                         SHOW_ROW.setField(0, "db");


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix USE DATABASE & USE CATALOG fails with quoted identifiers containing characters to be escaped in SQL Client.

## Brief change log

- Escape identifiers when convert command to SQL statement


## Verifying this change

This change is already covered by existing tests, such as `CliClientTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

