### PR TITLE
[FLINK-19142][runtime] Fix slot hijacking after task failover

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/SlotProfile.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -37,10 +35,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * SlotContext} against the slot profile and, potentially, further requirements.
  */
 public class SlotProfile {
-
-    /** Singleton object for a slot profile without any requirements. */
-    private static final SlotProfile NO_REQUIREMENTS = noLocality(ResourceProfile.UNKNOWN);
-
     /** This specifies the desired resource profile for the task slot. */
     private final ResourceProfile taskResourceProfile;
 
@@ -97,38 +91,6 @@ public class SlotProfile {
      */
     public Set<AllocationID> getPreviousExecutionGraphAllocations() {
         return previousExecutionGraphAllocations;
-    }
-
-    /** Returns a slot profile that has no requirements. */
-    @VisibleForTesting
-    public static SlotProfile noRequirements() {
-        return NO_REQUIREMENTS;
-    }
-
-    /** Returns a slot profile for the given resource profile, without any locality requirements. */
-    @VisibleForTesting
-    public static SlotProfile noLocality(ResourceProfile resourceProfile) {
-        return preferredLocality(resourceProfile, Collections.emptyList());
-    }
-
-    /**
-     * Returns a slot profile for the given resource profile and the preferred locations.
-     *
-     * @param resourceProfile specifying the slot requirements
-     * @param preferredLocations specifying the preferred locations
-     * @return Slot profile with the given resource profile and preferred locations
-     */
-    @VisibleForTesting
-    public static SlotProfile preferredLocality(
-            final ResourceProfile resourceProfile,
-            final Collection<TaskManagerLocation> preferredLocations) {
-
-        return priorAllocation(
-                resourceProfile,
-                resourceProfile,
-                preferredLocations,
-                Collections.emptyList(),
-                Collections.emptySet());
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PreviousAllocationSlotSelectionStrategy.java
@@ -61,8 +61,7 @@ public class PreviousAllocationSlotSelectionStrategy implements SlotSelectionStr
         }
 
         // Second, select based on location preference, excluding blacklisted allocations
-        Set<AllocationID> blackListedAllocations =
-                slotProfile.getPreviousExecutionGraphAllocations();
+        Set<AllocationID> blackListedAllocations = slotProfile.getReservedAllocations();
         Collection<SlotInfoAndResources> availableAndAllowedSlots =
                 computeWithoutBlacklistedSlots(availableSlots, blackListedAllocations);
         return fallbackSlotSelectionStrategy.selectBestSlotForProfile(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -62,6 +62,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -102,6 +103,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
     private final ShuffleMaster<?> shuffleMaster;
 
     private final Time rpcTimeout;
+
+    private final Map<AllocationID, Long> reservedAllocationRefCounters;
+
+    private final Map<ExecutionVertexID, AllocationID> reservedAllocationByExecutionVertex;
 
     DefaultScheduler(
             final Logger log,
@@ -148,6 +153,9 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         this.executionVertexOperations = checkNotNull(executionVertexOperations);
         this.shuffleMaster = checkNotNull(shuffleMaster);
         this.rpcTimeout = checkNotNull(rpcTimeout);
+
+        this.reservedAllocationRefCounters = new HashMap<>();
+        this.reservedAllocationByExecutionVertex = new HashMap<>();
 
         final FailoverStrategy failoverStrategy =
                 failoverStrategyFactory.create(
@@ -203,6 +211,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
     protected void updateTaskExecutionStateInternal(
             final ExecutionVertexID executionVertexId,
             final TaskExecutionStateTransition taskExecutionState) {
+
+        if (taskExecutionState.getExecutionState() == ExecutionState.FINISHED) {
+            stopReserveAllocation(executionVertexId);
+        }
 
         schedulingStrategy.onExecutionStateChange(
                 executionVertexId, taskExecutionState.getExecutionState());
@@ -517,8 +529,31 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
             final ExecutionVertex executionVertex = getExecutionVertex(executionVertexId);
             executionVertex.tryAssignResource(logicalSlot);
+
+            startReserveAllocation(executionVertexId, logicalSlot.getAllocationId());
+
             return logicalSlot;
         };
+    }
+
+    private void startReserveAllocation(
+            ExecutionVertexID executionVertexId, AllocationID newAllocation) {
+
+        // stop the previous allocation reservation if there is one
+        stopReserveAllocation(executionVertexId);
+
+        reservedAllocationByExecutionVertex.put(executionVertexId, newAllocation);
+        reservedAllocationRefCounters.compute(
+                newAllocation, (ignored, oldCount) -> oldCount == null ? 1 : oldCount + 1);
+    }
+
+    private void stopReserveAllocation(ExecutionVertexID executionVertexId) {
+        final AllocationID priorAllocation =
+                reservedAllocationByExecutionVertex.remove(executionVertexId);
+        if (priorAllocation != null) {
+            reservedAllocationRefCounters.compute(
+                    priorAllocation, (ignored, oldCount) -> oldCount > 1 ? oldCount - 1 : null);
+        }
     }
 
     private Function<LogicalSlot, CompletableFuture<Void>> registerProducedPartitions(
@@ -668,6 +703,11 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         @Override
         public Optional<TaskManagerLocation> getStateLocation(ExecutionVertexID executionVertexId) {
             return stateLocationRetriever.getStateLocation(executionVertexId);
+        }
+
+        @Override
+        public Set<AllocationID> getAllocationsToReserve() {
+            return reservedAllocationRefCounters.keySet();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocationContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
@@ -67,4 +68,14 @@ interface ExecutionSlotAllocationContext extends InputsLocationsRetriever, State
      * @return all co-location groups in the job
      */
     Set<CoLocationGroup> getCoLocationGroups();
+
+    /**
+     * Returns all allocations to reserve. These allocations/slots were used to run certain vertices
+     * and reserving them can prevent other vertices to take these slots and thus help vertices to
+     * be deployed into their previous slots again after failover. It is needed if {@link
+     * CheckpointingOptions#LOCAL_RECOVERY} is enabled.
+     *
+     * @return all allocations to reserve
+     */
+    Set<AllocationID> getAllocationsToReserve();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocationContext.java
@@ -70,12 +70,12 @@ interface ExecutionSlotAllocationContext extends InputsLocationsRetriever, State
     Set<CoLocationGroup> getCoLocationGroups();
 
     /**
-     * Returns all allocations to reserve. These allocations/slots were used to run certain vertices
+     * Returns all reserved allocations. These allocations/slots were used to run certain vertices
      * and reserving them can prevent other vertices to take these slots and thus help vertices to
      * be deployed into their previous slots again after failover. It is needed if {@link
      * CheckpointingOptions#LOCAL_RECOVERY} is enabled.
      *
-     * @return all allocations to reserve
+     * @return all reserved allocations
      */
-    Set<AllocationID> getAllocationsToReserve();
+    Set<AllocationID> getReservedAllocations();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverFactory.java
@@ -28,10 +28,9 @@ import org.apache.flink.util.Preconditions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 /** Factory for {@link MergingSharedSlotProfileRetriever}. */
 class MergingSharedSlotProfileRetrieverFactory
@@ -40,21 +39,21 @@ class MergingSharedSlotProfileRetrieverFactory
 
     private final Function<ExecutionVertexID, AllocationID> priorAllocationIdRetriever;
 
+    private final Supplier<Set<AllocationID>> reservedAllocationIdsRetriever;
+
     MergingSharedSlotProfileRetrieverFactory(
             SyncPreferredLocationsRetriever preferredLocationsRetriever,
-            Function<ExecutionVertexID, AllocationID> priorAllocationIdRetriever) {
+            Function<ExecutionVertexID, AllocationID> priorAllocationIdRetriever,
+            Supplier<Set<AllocationID>> reservedAllocationIdsRetriever) {
         this.preferredLocationsRetriever = Preconditions.checkNotNull(preferredLocationsRetriever);
         this.priorAllocationIdRetriever = Preconditions.checkNotNull(priorAllocationIdRetriever);
+        this.reservedAllocationIdsRetriever =
+                Preconditions.checkNotNull(reservedAllocationIdsRetriever);
     }
 
     @Override
     public SharedSlotProfileRetriever createFromBulk(Set<ExecutionVertexID> bulk) {
-        Set<AllocationID> allPriorAllocationIds =
-                bulk.stream()
-                        .map(priorAllocationIdRetriever)
-                        .filter(Objects::nonNull)
-                        .collect(Collectors.toSet());
-        return new MergingSharedSlotProfileRetriever(allPriorAllocationIds, bulk);
+        return new MergingSharedSlotProfileRetriever(reservedAllocationIdsRetriever.get(), bulk);
     }
 
     /**
@@ -62,16 +61,15 @@ class MergingSharedSlotProfileRetrieverFactory
      * schedule.
      */
     private class MergingSharedSlotProfileRetriever implements SharedSlotProfileRetriever {
-        /** All previous {@link AllocationID}s of the bulk to schedule. */
-        private final Set<AllocationID> allBulkPriorAllocationIds;
+        /** All reserved {@link AllocationID}s of the job. */
+        private final Set<AllocationID> reservedAllocationIds;
 
         /** All {@link ExecutionVertexID}s of the bulk. */
         private final Set<ExecutionVertexID> producersToIgnore;
 
         private MergingSharedSlotProfileRetriever(
-                Set<AllocationID> allBulkPriorAllocationIds,
-                Set<ExecutionVertexID> producersToIgnore) {
-            this.allBulkPriorAllocationIds = Preconditions.checkNotNull(allBulkPriorAllocationIds);
+                Set<AllocationID> reservedAllocationIds, Set<ExecutionVertexID> producersToIgnore) {
+            this.reservedAllocationIds = Preconditions.checkNotNull(reservedAllocationIds);
             this.producersToIgnore = Preconditions.checkNotNull(producersToIgnore);
         }
 
@@ -86,8 +84,7 @@ class MergingSharedSlotProfileRetrieverFactory
          * <p>The preferred {@link AllocationID}s of the {@link SlotProfile} are all previous {@link
          * AllocationID}s of all executions sharing the slot.
          *
-         * <p>The {@link SlotProfile} also refers to all previous {@link AllocationID}s of all
-         * executions within the bulk.
+         * <p>The {@link SlotProfile} also refers to all reserved {@link AllocationID}s of the job.
          *
          * @param executionSlotSharingGroup executions sharing the slot.
          * @param physicalSlotResourceProfile {@link ResourceProfile} of the slot.
@@ -110,7 +107,7 @@ class MergingSharedSlotProfileRetrieverFactory
                     physicalSlotResourceProfile,
                     preferredLocations,
                     priorAllocations,
-                    allBulkPriorAllocationIds);
+                    reservedAllocationIds);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
@@ -72,7 +72,9 @@ class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAllocator
                 new DefaultSyncPreferredLocationsRetriever(context, context);
         SharedSlotProfileRetrieverFactory sharedSlotProfileRetrieverFactory =
                 new MergingSharedSlotProfileRetrieverFactory(
-                        preferredLocationsRetriever, context::getPriorAllocationId);
+                        preferredLocationsRetriever,
+                        context::getPriorAllocationId,
+                        context::getAllocationsToReserve);
         return new SlotSharingExecutionSlotAllocator(
                 slotProvider,
                 slotWillBeOccupiedIndefinitely,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorFactory.java
@@ -74,7 +74,7 @@ class SlotSharingExecutionSlotAllocatorFactory implements ExecutionSlotAllocator
                 new MergingSharedSlotProfileRetrieverFactory(
                         preferredLocationsRetriever,
                         context::getPriorAllocationId,
-                        context::getAllocationsToReserve);
+                        context::getReservedAllocations);
         return new SlotSharingExecutionSlotAllocator(
                 slotProvider,
                 slotWillBeOccupiedIndefinitely,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/LocationPreferenceSlotSelectionStrategyTest.java
@@ -88,7 +88,7 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
     @Test
     public void matchNoRequirements() {
 
-        SlotProfile slotProfile = SlotProfile.noRequirements();
+        SlotProfile slotProfile = SlotProfileTestingUtils.noRequirements();
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         Assert.assertTrue(match.isPresent());
@@ -101,7 +101,8 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
     public void returnsHostLocalMatchingIfExactTMLocationCannotBeFulfilled() {
 
         SlotProfile slotProfile =
-                SlotProfile.preferredLocality(resourceProfile, Collections.singletonList(tmlX));
+                SlotProfileTestingUtils.preferredLocality(
+                        resourceProfile, Collections.singletonList(tmlX));
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         Assert.assertTrue(match.isPresent());
@@ -129,7 +130,7 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
                 new TaskManagerLocation(
                         new ResourceID("non-local-tm"), nonHostLocalInetAddress, 42);
         SlotProfile slotProfile =
-                SlotProfile.preferredLocality(
+                SlotProfileTestingUtils.preferredLocality(
                         resourceProfile, Collections.singletonList(nonLocalTm));
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
@@ -143,19 +144,21 @@ public class LocationPreferenceSlotSelectionStrategyTest extends SlotSelectionSt
     public void matchPreferredLocation() {
 
         SlotProfile slotProfile =
-                SlotProfile.preferredLocality(
+                SlotProfileTestingUtils.preferredLocality(
                         biggerResourceProfile, Collections.singletonList(tml2));
         Optional<SlotSelectionStrategy.SlotInfoAndLocality> match = runMatching(slotProfile);
 
         Assert.assertEquals(slotInfo2, match.get().getSlotInfo());
 
-        slotProfile = SlotProfile.preferredLocality(resourceProfile, Arrays.asList(tmlX, tml4));
+        slotProfile =
+                SlotProfileTestingUtils.preferredLocality(
+                        resourceProfile, Arrays.asList(tmlX, tml4));
         match = runMatching(slotProfile);
 
         Assert.assertEquals(slotInfo4, match.get().getSlotInfo());
 
         slotProfile =
-                SlotProfile.preferredLocality(
+                SlotProfileTestingUtils.preferredLocality(
                         resourceProfile, Arrays.asList(tml3, tml1, tml3, tmlX));
         match = runMatching(slotProfile);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotProfileTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/SlotProfileTestingUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.clusterframework.types;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/** Testing utils for {@link SlotProfile}. */
+public class SlotProfileTestingUtils {
+
+    /** Returns a slot profile that has no requirements. */
+    @VisibleForTesting
+    public static SlotProfile noRequirements() {
+        return noLocality(ResourceProfile.UNKNOWN);
+    }
+
+    /** Returns a slot profile for the given resource profile, without any locality requirements. */
+    @VisibleForTesting
+    public static SlotProfile noLocality(ResourceProfile resourceProfile) {
+        return preferredLocality(resourceProfile, Collections.emptyList());
+    }
+
+    /**
+     * Returns a slot profile for the given resource profile and the preferred locations.
+     *
+     * @param resourceProfile specifying the slot requirements
+     * @param preferredLocations specifying the preferred locations
+     * @return Slot profile with the given resource profile and preferred locations
+     */
+    @VisibleForTesting
+    public static SlotProfile preferredLocality(
+            final ResourceProfile resourceProfile,
+            final Collection<TaskManagerLocation> preferredLocations) {
+
+        return SlotProfile.priorAllocation(
+                resourceProfile,
+                resourceProfile,
+                preferredLocations,
+                Collections.emptyList(),
+                Collections.emptySet());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImplWithSpreadOutStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderImplWithSpreadOutStrategyTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfileTestingUtils;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.TestLogger;
@@ -84,7 +84,7 @@ public class PhysicalSlotProviderImplWithSpreadOutStrategyTest extends TestLogge
         PhysicalSlotRequest request1 =
                 new PhysicalSlotRequest(
                         new SlotRequestId(),
-                        SlotProfile.preferredLocality(
+                        SlotProfileTestingUtils.preferredLocality(
                                 ResourceProfile.ANY,
                                 Collections.singleton(preferredTaskManagerLocation)),
                         false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotProviderResource.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfileTestingUtils;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
@@ -89,7 +89,9 @@ public class PhysicalSlotProviderResource extends ExternalResource {
 
     public PhysicalSlotRequest createSimpleRequest() {
         return new PhysicalSlotRequest(
-                new SlotRequestId(), SlotProfile.noLocality(ResourceProfile.UNKNOWN), false);
+                new SlotRequestId(),
+                SlotProfileTestingUtils.noLocality(ResourceProfile.UNKNOWN),
+                false);
     }
 
     public ComponentMainThreadExecutor getMainThreadExecutor() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponentsFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerComponentsFactoryTest.java
@@ -20,10 +20,14 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
+import org.apache.flink.runtime.jobmaster.slotpool.PreviousAllocationSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolUtils;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotSelectionStrategy;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
 import org.apache.flink.util.TestLogger;
 
@@ -75,6 +79,32 @@ public class DefaultSchedulerComponentsFactoryTest extends TestLogger {
                     containsMessage(
                             "Approximate local recovery can not be used together with PipelinedRegionScheduler for now"));
         }
+    }
+
+    @Test
+    public void testCreatePreviousAllocationSlotSelectionStrategyForLocalRecoveryStreamingJob() {
+        final Configuration configuration = new Configuration();
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+
+        final SlotSelectionStrategy slotSelectionStrategy =
+                DefaultSchedulerComponents.selectSlotSelectionStrategy(
+                        JobType.STREAMING, configuration);
+
+        assertThat(
+                slotSelectionStrategy, instanceOf(PreviousAllocationSlotSelectionStrategy.class));
+    }
+
+    @Test
+    public void testCreateLocationPreferenceSlotSelectionStrategyForLocalRecoveryBatchJob() {
+        final Configuration configuration = new Configuration();
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+
+        final SlotSelectionStrategy slotSelectionStrategy =
+                DefaultSchedulerComponents.selectSlotSelectionStrategy(
+                        JobType.BATCH, configuration);
+
+        assertThat(
+                slotSelectionStrategy, instanceOf(LocationPreferenceSlotSelectionStrategy.class));
     }
 
     private static DefaultSchedulerComponents createSchedulerComponents(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -51,7 +52,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests for {@link org.apache.flink.runtime.scheduler.MergingSharedSlotProfileRetrieverFactory}.
  */
-public class MergingSharedSlotProfileRetrieverTest {
+public class MergingSharedSlotProfileRetrieverTest extends TestLogger {
 
     private static final SyncPreferredLocationsRetriever EMPTY_PREFERRED_LOCATIONS_RETRIEVER =
             (executionVertexId, producersToIgnore) -> Collections.emptyList();
@@ -61,7 +62,8 @@ public class MergingSharedSlotProfileRetrieverTest {
         SharedSlotProfileRetriever sharedSlotProfileRetriever =
                 new MergingSharedSlotProfileRetrieverFactory(
                                 EMPTY_PREFERRED_LOCATIONS_RETRIEVER,
-                                executionVertexID -> new AllocationID())
+                                executionVertexID -> new AllocationID(),
+                                () -> Collections.emptySet())
                         .createFromBulk(Collections.emptySet());
 
         SlotProfile slotProfile =
@@ -106,6 +108,7 @@ public class MergingSharedSlotProfileRetrieverTest {
         locations.put(executions.get(0), Arrays.asList(allLocations.get(0), allLocations.get(1)));
         locations.put(executions.get(1), Arrays.asList(allLocations.get(1), allLocations.get(2)));
 
+        List<AllocationID> prevAllocationIds = Collections.nCopies(3, new AllocationID());
         SlotProfile slotProfile =
                 getSlotProfile(
                         (executionVertexId, producersToIgnore) -> {
@@ -114,7 +117,8 @@ public class MergingSharedSlotProfileRetrieverTest {
                         },
                         executions,
                         ResourceProfile.ZERO,
-                        Collections.nCopies(3, new AllocationID()),
+                        prevAllocationIds,
+                        prevAllocationIds,
                         2);
 
         assertThat(
@@ -135,7 +139,8 @@ public class MergingSharedSlotProfileRetrieverTest {
     }
 
     @Test
-    public void testAllocationIdsOfSlotProfile() throws ExecutionException, InterruptedException {
+    public void testPreferredAllocationsOfSlotProfile()
+            throws ExecutionException, InterruptedException {
         AllocationID prevAllocationID1 = new AllocationID();
         AllocationID prevAllocationID2 = new AllocationID();
         List<AllocationID> prevAllocationIDs =
@@ -146,9 +151,26 @@ public class MergingSharedSlotProfileRetrieverTest {
         assertThat(
                 slotProfile.getPreferredAllocations(),
                 containsInAnyOrder(prevAllocationID1, prevAllocationID2));
+    }
+
+    @Test
+    public void testReservedAllocationsOfSlotProfile()
+            throws ExecutionException, InterruptedException {
+        List<AllocationID> reservedAllocationIds =
+                Arrays.asList(new AllocationID(), new AllocationID(), new AllocationID());
+
+        SlotProfile slotProfile =
+                getSlotProfile(
+                        EMPTY_PREFERRED_LOCATIONS_RETRIEVER,
+                        Collections.emptyList(),
+                        ResourceProfile.ZERO,
+                        Collections.emptyList(),
+                        reservedAllocationIds,
+                        0);
+
         assertThat(
                 slotProfile.getReservedAllocations(),
-                containsInAnyOrder(prevAllocationIDs.toArray()));
+                containsInAnyOrder(reservedAllocationIds.toArray()));
     }
 
     private static SlotProfile getSlotProfile(
@@ -165,6 +187,7 @@ public class MergingSharedSlotProfileRetrieverTest {
                 executions,
                 resourceProfile,
                 prevAllocationIDs,
+                prevAllocationIDs,
                 executionSlotSharingGroupSize);
     }
 
@@ -173,6 +196,7 @@ public class MergingSharedSlotProfileRetrieverTest {
             List<ExecutionVertexID> executions,
             ResourceProfile resourceProfile,
             List<AllocationID> prevAllocationIDs,
+            Collection<AllocationID> reservedAllocationIds,
             int executionSlotSharingGroupSize)
             throws ExecutionException, InterruptedException {
         SharedSlotProfileRetriever sharedSlotProfileRetriever =
@@ -180,7 +204,8 @@ public class MergingSharedSlotProfileRetrieverTest {
                                 preferredLocationsRetriever,
                                 executionVertexID ->
                                         prevAllocationIDs.get(
-                                                executions.indexOf(executionVertexID)))
+                                                executions.indexOf(executionVertexID)),
+                                () -> new HashSet<>(reservedAllocationIds))
                         .createFromBulk(new HashSet<>(executions));
 
         ExecutionSlotSharingGroup executionSlotSharingGroup = new ExecutionSlotSharingGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/MergingSharedSlotProfileRetrieverTest.java
@@ -72,7 +72,7 @@ public class MergingSharedSlotProfileRetrieverTest {
         assertThat(slotProfile.getPhysicalSlotResourceProfile(), is(ResourceProfile.ZERO));
         assertThat(slotProfile.getPreferredLocations(), hasSize(0));
         assertThat(slotProfile.getPreferredAllocations(), hasSize(0));
-        assertThat(slotProfile.getPreviousExecutionGraphAllocations(), hasSize(0));
+        assertThat(slotProfile.getReservedAllocations(), hasSize(0));
     }
 
     @Test
@@ -147,7 +147,7 @@ public class MergingSharedSlotProfileRetrieverTest {
                 slotProfile.getPreferredAllocations(),
                 containsInAnyOrder(prevAllocationID1, prevAllocationID2));
         assertThat(
-                slotProfile.getPreviousExecutionGraphAllocations(),
+                slotProfile.getReservedAllocations(),
                 containsInAnyOrder(prevAllocationIDs.toArray()));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SlotSharingExecutionSlotAllocatorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfileTestingUtils;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.TestingPayload;
@@ -655,7 +656,7 @@ public class SlotSharingExecutionSlotAllocatorTest extends TestLogger {
             askedBulks.add(bulk);
             return (group, resourceProfile) -> {
                 askedGroups.add(group);
-                return SlotProfile.noLocality(resourceProfile);
+                return SlotProfileTestingUtils.noLocality(resourceProfile);
             };
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocatorFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestExecutionSlotAllocatorFactory.java
@@ -27,6 +27,8 @@ public class TestExecutionSlotAllocatorFactory implements ExecutionSlotAllocator
 
     private final TestExecutionSlotAllocator testExecutionSlotAllocator;
 
+    private ExecutionSlotAllocationContext latestExecutionSlotAllocationContext;
+
     public TestExecutionSlotAllocatorFactory() {
         this.testExecutionSlotAllocator = new TestExecutionSlotAllocator();
     }
@@ -41,10 +43,15 @@ public class TestExecutionSlotAllocatorFactory implements ExecutionSlotAllocator
 
     @Override
     public ExecutionSlotAllocator createInstance(final ExecutionSlotAllocationContext context) {
+        this.latestExecutionSlotAllocationContext = context;
         return testExecutionSlotAllocator;
     }
 
     public TestExecutionSlotAllocator getTestExecutionSlotAllocator() {
         return testExecutionSlotAllocator;
+    }
+
+    public ExecutionSlotAllocationContext getLatestExecutionSlotAllocationContext() {
+        return latestExecutionSlotAllocationContext;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/WaitingCancelableInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/WaitingCancelableInvokable.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils;
+
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+/** An {@link AbstractInvokable} which waits until it is canceled. */
+public class WaitingCancelableInvokable extends CancelableInvokable {
+
+    private final Object lock = new Object();
+    private boolean running = true;
+
+    public WaitingCancelableInvokable(Environment environment) {
+        super(environment);
+    }
+
+    @Override
+    public void doInvoke() throws Exception {
+        synchronized (lock) {
+            while (running) {
+                lock.wait();
+            }
+        }
+    }
+
+    @Override
+    public void cancel() {
+        synchronized (lock) {
+            running = false;
+            lock.notifyAll();
+        }
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingLocalRecoveryITCase.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.client.program.MiniClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.configuration.JobManagerOptions.EXECUTION_FAILOVER_STRATEGY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+
+/** IT case for testing Flink's scheduling regarding local recovery. */
+public class SchedulingLocalRecoveryITCase extends TestLogger {
+
+    private static final long TIMEOUT = 10_000L;
+
+    @Test
+    public void testLocalRecoveryFull() throws Exception {
+        testLocalRecoveryInternal("full");
+    }
+
+    @Test
+    public void testLocalRecoveryRegion() throws Exception {
+        testLocalRecoveryInternal("region");
+    }
+
+    private void testLocalRecoveryInternal(String failoverStrategyValue) throws Exception {
+        final Configuration configuration = new Configuration();
+        configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), failoverStrategyValue);
+
+        final int parallelism = 10;
+        final ArchivedExecutionGraph graph = executeSchedulingTest(configuration, parallelism);
+        assertNonLocalRecoveredTasksEquals(graph, 1);
+    }
+
+    private void assertNonLocalRecoveredTasksEquals(ArchivedExecutionGraph graph, int expected) {
+        int nonLocalRecoveredTasks = 0;
+        for (ArchivedExecutionVertex vertex : graph.getAllExecutionVertices()) {
+            int currentAttemptNumber = vertex.getCurrentExecutionAttempt().getAttemptNumber();
+            if (currentAttemptNumber == 0) {
+                // the task had never restarted and do not need to recover
+                continue;
+            }
+            AllocationID priorAllocation =
+                    vertex.getPriorExecutionAttempt(currentAttemptNumber - 1)
+                            .getAssignedAllocationID();
+            AllocationID currentAllocation =
+                    vertex.getCurrentExecutionAttempt().getAssignedAllocationID();
+
+            assertNotNull(priorAllocation);
+            assertNotNull(currentAllocation);
+            if (!currentAllocation.equals(priorAllocation)) {
+                nonLocalRecoveredTasks++;
+            }
+        }
+        assertThat(nonLocalRecoveredTasks, is(expected));
+    }
+
+    private ArchivedExecutionGraph executeSchedulingTest(
+            Configuration configuration, int parallelism) throws Exception {
+        configuration.setString(RestOptions.BIND_PORT, "0");
+
+        final long slotIdleTimeout = TIMEOUT;
+        configuration.setLong(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
+
+        configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("64mb"));
+        configuration.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.parse("16mb"));
+        configuration.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, MemorySize.parse("16mb"));
+
+        final MiniClusterConfiguration miniClusterConfiguration =
+                new MiniClusterConfiguration.Builder()
+                        .setConfiguration(configuration)
+                        .setNumTaskManagers(parallelism)
+                        .setNumSlotsPerTaskManager(1)
+                        .build();
+
+        try (MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration)) {
+            miniCluster.start();
+
+            MiniClusterClient miniClusterClient = new MiniClusterClient(configuration, miniCluster);
+
+            JobGraph jobGraph = createJobGraph(parallelism);
+
+            // wait for the submission to succeed
+            JobID jobId = miniClusterClient.submitJob(jobGraph).get();
+
+            // wait until all tasks running before triggering task failures
+            waitUntilAllVerticesRunning(jobId, miniCluster, TIMEOUT);
+
+            // kill one TM to trigger task failure and remove one existing slot
+            CompletableFuture<Void> terminationFuture = miniCluster.terminateTaskManager(0);
+            terminationFuture.get();
+
+            // restart a taskmanager as a replacement for the killed one
+            miniCluster.startTaskManager();
+
+            // wait until all tasks running again
+            waitUntilAllVerticesRunning(jobId, miniCluster, TIMEOUT);
+
+            ArchivedExecutionGraph graph =
+                    miniCluster.getArchivedExecutionGraph(jobGraph.getJobID()).get();
+
+            miniCluster.cancelJob(jobId).get();
+
+            return graph;
+        }
+    }
+
+    private void waitUntilAllVerticesRunning(
+            JobID jobId, MiniCluster miniCluster, long maxWaitMillis) throws Exception {
+        final Deadline deadline = Deadline.fromNow(Duration.ofMillis(maxWaitMillis));
+
+        boolean checkResult = false;
+        do {
+            AccessExecutionGraph graph = miniCluster.getArchivedExecutionGraph(jobId).get();
+
+            // we need the job status to be RUNNING first to ensure execution vertices are created
+            if (graph.getState() != JobStatus.RUNNING) {
+                continue;
+            }
+
+            checkResult = areAllVerticesRunning(graph);
+
+            if (!checkResult) {
+                Thread.sleep(2L);
+            }
+        } while (!checkResult && deadline.hasTimeLeft());
+
+        if (!checkResult) {
+            throw new TimeoutException("Not all vertices becomes RUNNING in time.");
+        }
+    }
+
+    private boolean areAllVerticesRunning(AccessExecutionGraph graph) {
+        for (AccessExecutionVertex vertex : graph.getAllExecutionVertices()) {
+            if (vertex.getExecutionState() != ExecutionState.RUNNING) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private JobGraph createJobGraph(int parallelism) throws IOException {
+        final JobVertex source = new JobVertex("v1");
+        source.setInvokableClass(PendingInvokable.class);
+        source.setParallelism(parallelism);
+
+        ExecutionConfig executionConfig = new ExecutionConfig();
+        executionConfig.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 10));
+
+        return JobGraphBuilder.newStreamingJobGraphBuilder()
+                .addJobVertices(Arrays.asList(source))
+                .setExecutionConfig(executionConfig)
+                .build();
+    }
+
+    /** Invokable which does not finish. */
+    public static final class PendingInvokable extends AbstractInvokable {
+        private boolean canceled = false;
+
+        public PendingInvokable(Environment environment) {
+            super(environment);
+        }
+
+        @Override
+        public void invoke() throws Exception {
+            while (!canceled) {
+                Thread.sleep(100);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            canceled = true;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

MergingSharedSlotProfileRetriever does not properly set the previousExecutionGraphAllocations of a SlotProfile. So that some restarted region may take the previous slots of other failed regions, and the state local recovery will be affected.

To fix the problem, we need SlotProfile.previousExecutionGraphAllocations to include previous allocationId of all the vertices which need to be restarted at that time.

In this PR, we will find all the vertices which are not DEPLOYING/RUNNING/FINISHED at that moment, which indicates they may still want their previous slots, and set their prior allocation IDs to MergingSharedSlotProfileRetriever.

## Verifying this change

  - *Added UT*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
