### PR TITLE
[FLINK-21805][table-planner-blink] Support json ser/de for StreamExecRank, StreamExecLimit and StreamExecSortLimit

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/PartitionSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/PartitionSpec.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -25,17 +29,22 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** {@link PartitionSpec} describes how data is partitioned in Rank. */
 public class PartitionSpec {
 
+    public static final String FIELD_NAME_FIELDS = "fields";
+
     /** PartitionSpec makes all data in one partition. */
     public static final PartitionSpec ALL_IN_ONE = new PartitionSpec(new int[0]);
 
     /** 0-based index of field used in partitioning. */
+    @JsonProperty(FIELD_NAME_FIELDS)
     private final int[] fields;
 
-    public PartitionSpec(int[] fields) {
+    @JsonCreator
+    public PartitionSpec(@JsonProperty(FIELD_NAME_FIELDS) int[] fields) {
         this.fields = checkNotNull(fields);
     }
 
     /** Gets field index of all fields in input. */
+    @JsonIgnore
     public int[] getFieldIndices() {
         return fields;
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/SortSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/SortSpec.java
@@ -22,6 +22,10 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -34,12 +38,16 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** {@link SortSpec} describes how the data will be sorted. */
 public class SortSpec {
 
+    public static final String FIELD_NAME_FIELDS = "fields";
+
     /** SortSpec does not require sort. */
     public static final SortSpec ANY = new SortSpec(new SortFieldSpec[0]);
 
+    @JsonProperty(FIELD_NAME_FIELDS)
     private final SortFieldSpec[] fieldSpecs;
 
-    public SortSpec(SortFieldSpec[] fieldSpecs) {
+    @JsonCreator
+    public SortSpec(@JsonProperty(FIELD_NAME_FIELDS) SortFieldSpec[] fieldSpecs) {
         this.fieldSpecs = checkNotNull(fieldSpecs);
     }
 
@@ -52,11 +60,13 @@ public class SortSpec {
     }
 
     /** Gets field index of all fields in input. */
+    @JsonIgnore
     public int[] getFieldIndices() {
         return Arrays.stream(fieldSpecs).mapToInt(SortFieldSpec::getFieldIndex).toArray();
     }
 
     /** Gets flags of all fields for whether to sort in ascending order or not. */
+    @JsonIgnore
     public boolean[] getAscendingOrders() {
         boolean[] orders = new boolean[fieldSpecs.length];
         IntStream.range(0, fieldSpecs.length)
@@ -65,6 +75,7 @@ public class SortSpec {
     }
 
     /** Gets flags of all fields for whether to put null at last or not. */
+    @JsonIgnore
     public boolean[] getNullsIsLast() {
         boolean[] nullIsLasts = new boolean[fieldSpecs.length];
         IntStream.range(0, fieldSpecs.length)
@@ -73,6 +84,7 @@ public class SortSpec {
     }
 
     /** Gets all {@link SortFieldSpec} in the SortSpec. */
+    @JsonIgnore
     public SortFieldSpec[] getFieldSpecs() {
         return fieldSpecs;
     }
@@ -83,6 +95,7 @@ public class SortSpec {
     }
 
     /** Gets num of field in the spec. */
+    @JsonIgnore
     public int getFieldSize() {
         return fieldSpecs.length;
     }
@@ -116,27 +129,41 @@ public class SortSpec {
 
     /** Sort info for a Field. */
     public static class SortFieldSpec {
+        public static final String FIELD_NAME_INDEX = "index";
+        public static final String FIELD_NAME_IS_ASCENDING = "isAscending";
+        public static final String FIELD_NAME_NULL_IS_LAST = "nullIsLast";
+
         /** 0-based index of field being sorted. */
+        @JsonProperty(FIELD_NAME_INDEX)
         private final int fieldIndex;
         /** in ascending order or not. */
+        @JsonProperty(FIELD_NAME_IS_ASCENDING)
         private final boolean isAscendingOrder;
         /** put null at last or not. */
+        @JsonProperty(FIELD_NAME_NULL_IS_LAST)
         private final boolean nullIsLast;
 
-        public SortFieldSpec(int fieldIndex, boolean isAscendingOrder, boolean nullIsLast) {
+        @JsonCreator
+        public SortFieldSpec(
+                @JsonProperty(FIELD_NAME_INDEX) int fieldIndex,
+                @JsonProperty(FIELD_NAME_IS_ASCENDING) boolean isAscendingOrder,
+                @JsonProperty(FIELD_NAME_NULL_IS_LAST) boolean nullIsLast) {
             this.fieldIndex = fieldIndex;
             this.isAscendingOrder = isAscendingOrder;
             this.nullIsLast = nullIsLast;
         }
 
+        @JsonIgnore
         public int getFieldIndex() {
             return fieldIndex;
         }
 
+        @JsonIgnore
         public boolean getIsAscendingOrder() {
             return isAscendingOrder;
         }
 
+        @JsonIgnore
         public boolean getNullIsLast() {
             return nullIsLast;
         }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
@@ -69,7 +69,7 @@ public class StreamExecLimit extends StreamExecRank {
             @JsonProperty(FIELD_NAME_RANK_STRATEGY) RankProcessStrategy rankStrategy,
             @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE) boolean generateUpdateBefore,
             @JsonProperty(FIELD_NAME_ID) int id,
-            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperty,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
@@ -81,7 +81,7 @@ public class StreamExecLimit extends StreamExecRank {
                 false,
                 generateUpdateBefore,
                 id,
-                inputProperty,
+                inputProperties,
                 outputType,
                 description);
         this.limitEnd = rankRange.getRankEnd();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLimit.java
@@ -43,8 +43,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecLimit extends StreamExecRank {
 
-    @JsonIgnore
-    private final long limitEnd;
+    @JsonIgnore private final long limitEnd;
 
     public StreamExecLimit(
             long limitStart,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -53,10 +53,16 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.IntStream;
 
 /** Stream {@link ExecNode} for Rank. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecRank extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
@@ -70,12 +76,33 @@ public class StreamExecRank extends ExecNodeBase<RowData>
                             "TopN operator has a cache which caches partial state contents to reduce"
                                     + " state access. Cache size is the number of records in each TopN task.");
 
+    public static final String FIELD_NAME_RANK_TYPE = "rankType";
+    public static final String FIELD_NAME_PARTITION_SPEC = "partitionSpec";
+    public static final String FIELD_NAME_SORT_SPEC = "sortSpec";
+    public static final String FIELD_NAME_RANK_RANG = "rankRange";
+    public static final String FIELD_NAME_RANK_STRATEGY = "rankStrategy";
+    public static final String FIELD_NAME_GENERATE_UPDATE_BEFORE = "generateUpdateBefore";
+    public static final String FIELD_NAME_OUTPUT_RANK_NUMBER = "outputRowNumber";
+
+    @JsonProperty(FIELD_NAME_RANK_TYPE)
     private final RankType rankType;
+
+    @JsonProperty(FIELD_NAME_PARTITION_SPEC)
     private final PartitionSpec partitionSpec;
+
+    @JsonProperty(FIELD_NAME_SORT_SPEC)
     private final SortSpec sortSpec;
+
+    @JsonProperty(FIELD_NAME_RANK_RANG)
     private final RankRange rankRange;
+
+    @JsonProperty(FIELD_NAME_RANK_STRATEGY)
     private final RankProcessStrategy rankStrategy;
+
+    @JsonProperty(FIELD_NAME_OUTPUT_RANK_NUMBER)
     private final boolean outputRankNumber;
+
+    @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE)
     private final boolean generateUpdateBefore;
 
     public StreamExecRank(
@@ -89,7 +116,34 @@ public class StreamExecRank extends ExecNodeBase<RowData>
             InputProperty inputProperty,
             RowType outputType,
             String description) {
-        super(Collections.singletonList(inputProperty), outputType, description);
+        this(
+                rankType,
+                partitionSpec,
+                sortSpec,
+                rankRange,
+                rankStrategy,
+                outputRankNumber,
+                generateUpdateBefore,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
+                outputType,
+                description);
+    }
+
+    @JsonCreator
+    public StreamExecRank(
+            @JsonProperty(FIELD_NAME_RANK_TYPE) RankType rankType,
+            @JsonProperty(FIELD_NAME_PARTITION_SPEC) PartitionSpec partitionSpec,
+            @JsonProperty(FIELD_NAME_SORT_SPEC) SortSpec sortSpec,
+            @JsonProperty(FIELD_NAME_RANK_RANG) RankRange rankRange,
+            @JsonProperty(FIELD_NAME_RANK_STRATEGY) RankProcessStrategy rankStrategy,
+            @JsonProperty(FIELD_NAME_OUTPUT_RANK_NUMBER) boolean outputRankNumber,
+            @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE) boolean generateUpdateBefore,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperty,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(id, inputProperty, outputType, description);
         this.rankType = rankType;
         this.rankRange = rankRange;
         this.rankStrategy = rankStrategy;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -140,10 +140,10 @@ public class StreamExecRank extends ExecNodeBase<RowData>
             @JsonProperty(FIELD_NAME_OUTPUT_RANK_NUMBER) boolean outputRankNumber,
             @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE) boolean generateUpdateBefore,
             @JsonProperty(FIELD_NAME_ID) int id,
-            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperty,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
-        super(id, inputProperty, outputType, description);
+        super(id, inputProperties, outputType, description);
         this.rankType = rankType;
         this.rankRange = rankRange;
         this.rankStrategy = rankStrategy;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSortLimit.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSortLimit.java
@@ -71,7 +71,7 @@ public class StreamExecSortLimit extends StreamExecRank {
             @JsonProperty(FIELD_NAME_RANK_STRATEGY) RankProcessStrategy rankStrategy,
             @JsonProperty(FIELD_NAME_GENERATE_UPDATE_BEFORE) boolean generateUpdateBefore,
             @JsonProperty(FIELD_NAME_ID) int id,
-            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperty,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
 
@@ -84,7 +84,7 @@ public class StreamExecSortLimit extends StreamExecRank {
                 false,
                 generateUpdateBefore,
                 id,
-                inputProperty,
+                inputProperties,
                 outputType,
                 description);
         this.limitEnd = rankRange.getRankEnd();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RankProcessStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RankProcessStrategy.java
@@ -47,10 +47,10 @@ import java.util.Set;
 /** Base class of Strategy to choose different rank process function. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = RankProcessStrategy.UndefinedStrategy.class),
-        @JsonSubTypes.Type(value = RankProcessStrategy.AppendFastStrategy.class),
-        @JsonSubTypes.Type(value = RankProcessStrategy.RetractStrategy.class),
-        @JsonSubTypes.Type(value = RankProcessStrategy.UpdateFastStrategy.class)
+    @JsonSubTypes.Type(value = RankProcessStrategy.UndefinedStrategy.class),
+    @JsonSubTypes.Type(value = RankProcessStrategy.AppendFastStrategy.class),
+    @JsonSubTypes.Type(value = RankProcessStrategy.RetractStrategy.class),
+    @JsonSubTypes.Type(value = RankProcessStrategy.UpdateFastStrategy.class)
 })
 public interface RankProcessStrategy {
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RankProcessStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/utils/RankProcessStrategy.java
@@ -29,6 +29,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSubTypes;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -45,24 +46,13 @@ import java.util.Set;
 
 /** Base class of Strategy to choose different rank process function. */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes(
-        value = {
-            @JsonSubTypes.Type(
-                    value = RankProcessStrategy.UndefinedStrategy.class,
-                    name = "Undefined"),
-            @JsonSubTypes.Type(
-                    value = RankProcessStrategy.AppendFastStrategy.class,
-                    name = "AppendFast"),
-            @JsonSubTypes.Type(value = RankProcessStrategy.RetractStrategy.class, name = "Retract"),
-            @JsonSubTypes.Type(
-                    value = RankProcessStrategy.UpdateFastStrategy.class,
-                    name = "UpdateFast"),
-        })
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = RankProcessStrategy.UndefinedStrategy.class),
+        @JsonSubTypes.Type(value = RankProcessStrategy.AppendFastStrategy.class),
+        @JsonSubTypes.Type(value = RankProcessStrategy.RetractStrategy.class),
+        @JsonSubTypes.Type(value = RankProcessStrategy.UpdateFastStrategy.class)
+})
 public interface RankProcessStrategy {
-
-    String FIELD_NAME_TYPE = "type";
-
-    String getType();
 
     UndefinedStrategy UNDEFINED_STRATEGY = new UndefinedStrategy();
 
@@ -75,6 +65,7 @@ public interface RankProcessStrategy {
      * FlinkChangelogModeInferenceProgram}.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonTypeName("Undefined")
     class UndefinedStrategy implements RankProcessStrategy {
         @JsonCreator
         public UndefinedStrategy() {}
@@ -83,16 +74,11 @@ public interface RankProcessStrategy {
         public String toString() {
             return "UndefinedStrategy";
         }
-
-        @Override
-        @JsonProperty(FIELD_NAME_TYPE)
-        public String getType() {
-            return "Undefined";
-        }
     }
 
     /** A strategy which only works when input only contains insertion changes. */
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonTypeName("AppendFast")
     class AppendFastStrategy implements RankProcessStrategy {
         @JsonCreator
         public AppendFastStrategy() {}
@@ -101,16 +87,11 @@ public interface RankProcessStrategy {
         public String toString() {
             return "AppendFastStrategy";
         }
-
-        @Override
-        @JsonProperty(FIELD_NAME_TYPE)
-        public String getType() {
-            return "AppendFast";
-        }
     }
 
     /** A strategy which works when input contains update or deletion changes. */
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonTypeName("Retract")
     class RetractStrategy implements RankProcessStrategy {
         @JsonCreator
         public RetractStrategy() {}
@@ -119,12 +100,6 @@ public interface RankProcessStrategy {
         public String toString() {
             return "RetractStrategy";
         }
-
-        @Override
-        @JsonProperty(FIELD_NAME_TYPE)
-        public String getType() {
-            return "Retract";
-        }
     }
 
     /**
@@ -132,6 +107,7 @@ public interface RankProcessStrategy {
      * have the given {@link #primaryKeys} and should be monotonic on the order by field.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonTypeName("UpdateFast")
     class UpdateFastStrategy implements RankProcessStrategy {
 
         public static final String FIELD_NAME_PRIMARY_KEYS = "primaryKeys";
@@ -152,12 +128,6 @@ public interface RankProcessStrategy {
         @Override
         public String toString() {
             return String.format("UpdateFastStrategy[%s]", StringUtils.join(primaryKeys, ','));
-        }
-
-        @Override
-        @JsonProperty(FIELD_NAME_TYPE)
-        public String getType() {
-            return "UpdateFast";
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -507,8 +507,10 @@ final class TestValuesRuntimeFunctions {
             assert row != null;
             localRawResult.add(kind.shortString() + "(" + row.toString() + ")");
             if (kind == RowKind.INSERT || kind == RowKind.UPDATE_AFTER) {
+                row.setKind(RowKind.INSERT);
                 localRetractResult.add(row.toString());
             } else {
+                row.setKind(RowKind.INSERT);
                 boolean contains = localRetractResult.remove(row.toString());
                 if (!contains) {
                     throw new RuntimeException(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/PartitionSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/PartitionSpecSerdeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.planner.plan.nodes.exec.spec.PartitionSpec;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test PartitionSpec json ser/de. */
+public class PartitionSpecSerdeTest {
+
+    @Test
+    public void testPartitionSpec() throws JsonProcessingException {
+        PartitionSpec spec = new PartitionSpec(new int[] {1, 2, 3});
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(spec, mapper.readValue(mapper.writeValueAsString(spec), PartitionSpec.class));
+    }
+
+    @Test
+    public void testAllInOne() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(
+                PartitionSpec.ALL_IN_ONE,
+                mapper.readValue(
+                        mapper.writeValueAsString(PartitionSpec.ALL_IN_ONE), PartitionSpec.class));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankProcessStrategySerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankProcessStrategySerdeTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/** Test RankType json ser/de. */
+/** Test RankProcessStrategy json ser/de. */
 public class RankProcessStrategySerdeTest {
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankProcessStrategySerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankProcessStrategySerdeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.planner.plan.utils.RankProcessStrategy;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test RankType json ser/de. */
+public class RankProcessStrategySerdeTest {
+
+    @Test
+    public void testRankRange() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        RankProcessStrategy[] strategies =
+                new RankProcessStrategy[] {
+                    RankProcessStrategy.UNDEFINED_STRATEGY,
+                    RankProcessStrategy.APPEND_FAST_STRATEGY,
+                    RankProcessStrategy.RETRACT_STRATEGY,
+                    new RankProcessStrategy.UpdateFastStrategy(new int[] {1, 2})
+                };
+        for (RankProcessStrategy strategy : strategies) {
+            RankProcessStrategy result =
+                    mapper.readValue(
+                            mapper.writeValueAsString(strategy), RankProcessStrategy.class);
+            assertEquals(strategy.toString(), result.toString());
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankRangeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankRangeSerdeTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/** Test RankType json ser/de. */
+/** Test RankRange json ser/de. */
 public class RankRangeSerdeTest {
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankRangeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankRangeSerdeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.runtime.operators.rank.ConstantRankRange;
+import org.apache.flink.table.runtime.operators.rank.ConstantRankRangeWithoutEnd;
+import org.apache.flink.table.runtime.operators.rank.RankRange;
+import org.apache.flink.table.runtime.operators.rank.VariableRankRange;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test RankType json ser/de. */
+public class RankRangeSerdeTest {
+
+    @Test
+    public void testRankRange() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        RankRange[] ranges =
+                new RankRange[] {
+                    new ConstantRankRange(1, 2),
+                    new VariableRankRange(3),
+                    new ConstantRankRangeWithoutEnd(4)
+                };
+        for (RankRange range : ranges) {
+            RankRange result = mapper.readValue(mapper.writeValueAsString(range), RankRange.class);
+            assertEquals(range.toString(), result.toString());
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankTypeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RankTypeSerdeTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.runtime.operators.rank.RankType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test RankType json ser/de. */
+public class RankTypeSerdeTest {
+
+    @Test
+    public void testRankType() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        for (RankType type : RankType.values()) {
+            RankType result = mapper.readValue(mapper.writeValueAsString(type), RankType.class);
+            assertEquals(type, result);
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SortSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SortSpecSerdeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.planner.plan.nodes.exec.spec.SortSpec;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test PartitionSpec json ser/de. */
+public class SortSpecSerdeTest {
+
+    @Test
+    public void testSortSpec() throws JsonProcessingException {
+        SortSpec sortSpec =
+                SortSpec.builder()
+                        .addField(1, true, true)
+                        .addField(2, true, false)
+                        .addField(3, false, true)
+                        .addField(4, false, false)
+                        .build();
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(
+                sortSpec, mapper.readValue(mapper.writeValueAsString(sortSpec), SortSpec.class));
+    }
+
+    @Test
+    public void testAny() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(
+                SortSpec.ANY,
+                mapper.readValue(mapper.writeValueAsString(SortSpec.ANY), SortSpec.class));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SortSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/SortSpecSerdeTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/** Test PartitionSpec json ser/de. */
+/** Test SortSpec json ser/de. */
 public class SortSpecSerdeTest {
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -59,7 +59,6 @@ public class JsonSerdeCoverageTest {
                     "StreamExecPythonOverAggregate",
                     "StreamExecCorrelate",
                     "StreamExecPythonCorrelate",
-                    "StreamExecRank",
                     "StreamExecPythonCalc",
                     "StreamExecLimit",
                     "StreamExecSortLimit",

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -61,7 +61,6 @@ public class JsonSerdeCoverageTest {
                     "StreamExecPythonCorrelate",
                     "StreamExecPythonCalc",
                     "StreamExecLimit",
-                    "StreamExecSortLimit",
                     "StreamExecTemporalSort",
                     "StreamExecSort",
                     "StreamExecExpand",

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -60,7 +60,6 @@ public class JsonSerdeCoverageTest {
                     "StreamExecCorrelate",
                     "StreamExecPythonCorrelate",
                     "StreamExecPythonCalc",
-                    "StreamExecLimit",
                     "StreamExecTemporalSort",
                     "StreamExecSort",
                     "StreamExecExpand",

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest.java
@@ -60,8 +60,7 @@ public class LimitJsonPlanTest extends TableTestBase {
                         + "  'sink-insert-only' = 'false',\n"
                         + "  'table-sink-class' = 'DEFAULT')";
         tEnv.executeSql(sinkTableDdl);
-        String sql =
-                "insert into MySink SELECT a, a from MyTable limit 10";
+        String sql = "insert into MySink SELECT a, a from MyTable limit 10";
         util.verifyJsonPlan(sql);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization for sort limit. */
+public class LimitJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+
+        String srcTableDdl =
+                "CREATE TABLE MyTable (\n"
+                        + "  a bigint,\n"
+                        + "  b int not null,\n"
+                        + "  c varchar,\n"
+                        + "  d timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        tEnv.executeSql(srcTableDdl);
+    }
+
+    @Test
+    public void testLimit() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b bigint\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'sink-insert-only' = 'false',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        String sql =
+                "insert into MySink SELECT a, a from MyTable limit 10";
+        util.verifyJsonPlan(sql);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/RankJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/RankJsonPlanTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization for rank. */
+public class RankJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+
+        String srcTableDdl =
+                "CREATE TABLE MyTable (\n"
+                        + "  a bigint,\n"
+                        + "  b int not null,\n"
+                        + "  c varchar,\n"
+                        + "  d timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        tEnv.executeSql(srcTableDdl);
+    }
+
+    @Test
+    public void testRank() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b bigint\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'sink-insert-only' = 'false',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        String sql =
+                "insert into MySink SELECT a, row_num\n"
+                        + "FROM (\n"
+                        + "  SELECT a, ROW_NUMBER() OVER (PARTITION BY b ORDER BY a) as row_num\n"
+                        + "  FROM MyTable)\n"
+                        + "WHERE row_num <= a";
+        util.verifyJsonPlan(sql);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization for sort limit. */
+public class SortLimitJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+
+        String srcTableDdl =
+                "CREATE TABLE MyTable (\n"
+                        + "  a bigint,\n"
+                        + "  b int not null,\n"
+                        + "  c varchar,\n"
+                        + "  d timestamp(3)\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        tEnv.executeSql(srcTableDdl);
+    }
+
+    @Test
+    public void testSortLimit() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b bigint\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'sink-insert-only' = 'false',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        String sql =
+                "insert into MySink SELECT a, a from MyTable order by b limit 10";
+        util.verifyJsonPlan(sql);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest.java
@@ -60,8 +60,7 @@ public class SortLimitJsonPlanTest extends TableTestBase {
                         + "  'sink-insert-only' = 'false',\n"
                         + "  'table-sink-class' = 'DEFAULT')";
         tEnv.executeSql(sinkTableDdl);
-        String sql =
-                "insert into MySink SELECT a, a from MyTable order by b limit 10";
+        String sql = "insert into MySink SELECT a, a from MyTable order by b limit 10";
         util.verifyJsonPlan(sql);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.planner.utils.StreamTableTestUtil;
 import org.apache.flink.table.planner.utils.TableTestBase;
 
@@ -118,11 +117,6 @@ public class TableSourceJsonPlanTest extends TableTestBase {
 
     @Test
     public void testLimitPushDown() {
-        exception.expect(TableException.class);
-        // currently, there is a StreamExecLimit in the plan, once StreamExecLimit does support
-        // json serialization/deserialization, the following exception checking should be removed.
-        exception.expectMessage(
-                "StreamExecLimit does not implement @JsonCreator annotation on constructor");
         util.verifyJsonPlan("insert into MySink select * from MyTable limit 3");
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-/** Test for sort limit JsonPlan ser/de. */
+/** Test for limit JsonPlan ser/de. */
 public class LimitJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testLimit() throws ExecutionException, InterruptedException, IOException {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
@@ -30,9 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-/**
- * Test for sort limit JsonPlan ser/de.
- */
+/** Test for sort limit JsonPlan ser/de. */
 public class LimitJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testLimit() throws ExecutionException, InterruptedException, IOException {
@@ -41,21 +39,12 @@ public class LimitJsonPlanITCase extends JsonPlanTestBase {
                 JavaScalaConversionUtil.toJava(TestData.data1()),
                 "a int",
                 "b varchar",
-                "c int"
-                );
-        createTestNonInsertOnlyValuesSinkTable(
-                "`result`",
-                "a int",
-                "b varchar",
-                "c bigint");
+                "c int");
+        createTestNonInsertOnlyValuesSinkTable("`result`", "a int", "b varchar", "c bigint");
         String sql = "insert into `result` select * from MyTable limit 3";
         executeSqlWithJsonPlanVerified(sql).await();
 
-        List<String> expected =
-                Arrays.asList(
-                        "+I[2, a, 6]",
-                        "+I[4, b, 8]",
-                        "+I[6, c, 10]");
+        List<String> expected = Arrays.asList("+I[2, a, 6]", "+I[4, b, 8]", "+I[6, c, 10]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LimitJsonPlanITCase.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.TestData;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test for sort limit JsonPlan ser/de.
+ */
+public class LimitJsonPlanITCase extends JsonPlanTestBase {
+    @Test
+    public void testLimit() throws ExecutionException, InterruptedException, IOException {
+        createTestValuesSourceTable(
+                "MyTable",
+                JavaScalaConversionUtil.toJava(TestData.data1()),
+                "a int",
+                "b varchar",
+                "c int"
+                );
+        createTestNonInsertOnlyValuesSinkTable(
+                "`result`",
+                "a int",
+                "b varchar",
+                "c bigint");
+        String sql = "insert into `result` select * from MyTable limit 3";
+        executeSqlWithJsonPlanVerified(sql).await();
+
+        List<String> expected =
+                Arrays.asList(
+                        "+I[2, a, 6]",
+                        "+I[4, b, 8]",
+                        "+I[6, c, 10]");
+        assertResult(expected, TestValuesTableFactory.getResults("result"));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
@@ -30,9 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-/**
- * Test for Rank JsonPlan ser/de.
- */
+/** Test for Rank JsonPlan ser/de. */
 public class RankJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testRank() throws ExecutionException, InterruptedException, IOException {
@@ -41,23 +39,15 @@ public class RankJsonPlanITCase extends JsonPlanTestBase {
                 JavaScalaConversionUtil.toJava(TestData.data1()),
                 "a int",
                 "b varchar",
-                "c int"
-                );
-        createTestNonInsertOnlyValuesSinkTable(
-                "`result`",
-                "a int",
-                "b varchar",
-                "c bigint");
-        String sql = "insert into `result` select * from "
-                + "(select a, b, row_number() over(partition by b order by c) as c from MyTable)"
-                + " where c = 1";
+                "c int");
+        createTestNonInsertOnlyValuesSinkTable("`result`", "a int", "b varchar", "c bigint");
+        String sql =
+                "insert into `result` select * from "
+                        + "(select a, b, row_number() over(partition by b order by c) as c from MyTable)"
+                        + " where c = 1";
         executeSqlWithJsonPlanVerified(sql).await();
 
-        List<String> expected =
-                Arrays.asList(
-                        "+I[1, a, 1]",
-                        "+I[3, b, 1]",
-                        "+I[5, c, 1]");
+        List<String> expected = Arrays.asList("+I[1, a, 1]", "+I[3, b, 1]", "+I[5, c, 1]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/RankJsonPlanITCase.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.TestData;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test for Rank JsonPlan ser/de.
+ */
+public class RankJsonPlanITCase extends JsonPlanTestBase {
+    @Test
+    public void testRank() throws ExecutionException, InterruptedException, IOException {
+        createTestValuesSourceTable(
+                "MyTable",
+                JavaScalaConversionUtil.toJava(TestData.data1()),
+                "a int",
+                "b varchar",
+                "c int"
+                );
+        createTestNonInsertOnlyValuesSinkTable(
+                "`result`",
+                "a int",
+                "b varchar",
+                "c bigint");
+        String sql = "insert into `result` select * from "
+                + "(select a, b, row_number() over(partition by b order by c) as c from MyTable)"
+                + " where c = 1";
+        executeSqlWithJsonPlanVerified(sql).await();
+
+        List<String> expected =
+                Arrays.asList(
+                        "+I[1, a, 1]",
+                        "+I[3, b, 1]",
+                        "+I[5, c, 1]");
+        assertResult(expected, TestValuesTableFactory.getResults("result"));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
@@ -30,9 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-/**
- * Test for sort limit JsonPlan ser/de.
- */
+/** Test for sort limit JsonPlan ser/de. */
 public class SortLimitJsonPlanITCase extends JsonPlanTestBase {
     @Test
     public void testSortLimit() throws ExecutionException, InterruptedException, IOException {
@@ -41,21 +39,12 @@ public class SortLimitJsonPlanITCase extends JsonPlanTestBase {
                 JavaScalaConversionUtil.toJava(TestData.data1()),
                 "a int",
                 "b varchar",
-                "c int"
-                );
-        createTestNonInsertOnlyValuesSinkTable(
-                "`result`",
-                "a int",
-                "b varchar",
-                "c bigint");
+                "c int");
+        createTestNonInsertOnlyValuesSinkTable("`result`", "a int", "b varchar", "c bigint");
         String sql = "insert into `result` select * from MyTable order by a limit 3";
         executeSqlWithJsonPlanVerified(sql).await();
 
-        List<String> expected =
-                Arrays.asList(
-                        "+I[1, a, 5]",
-                        "+I[2, a, 6]",
-                        "+I[3, b, 7]");
+        List<String> expected = Arrays.asList("+I[1, a, 5]", "+I[2, a, 6]", "+I[3, b, 7]");
         assertResult(expected, TestValuesTableFactory.getResults("result"));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/SortLimitJsonPlanITCase.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.TestData;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test for sort limit JsonPlan ser/de.
+ */
+public class SortLimitJsonPlanITCase extends JsonPlanTestBase {
+    @Test
+    public void testSortLimit() throws ExecutionException, InterruptedException, IOException {
+        createTestValuesSourceTable(
+                "MyTable",
+                JavaScalaConversionUtil.toJava(TestData.data1()),
+                "a int",
+                "b varchar",
+                "c int"
+                );
+        createTestNonInsertOnlyValuesSinkTable(
+                "`result`",
+                "a int",
+                "b varchar",
+                "c bigint");
+        String sql = "insert into `result` select * from MyTable order by a limit 3";
+        executeSqlWithJsonPlanVerified(sql).await();
+
+        List<String> expected =
+                Arrays.asList(
+                        "+I[1, a, 5]",
+                        "+I[2, a, 6]",
+                        "+I[3, b, 7]");
+        assertResult(expected, TestValuesTableFactory.getResults("result"));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest_jsonplan/testLimit.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest_jsonplan/testLimit.out
@@ -23,19 +23,31 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ] ],
-        "producedType" : "ROW<`a` BIGINT> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          } ]
+        }
       }, {
         "type" : "LimitPushDown",
         "limit" : 10
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT>",
+    "id" : 15,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], limit=[10]]], fields=[a])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 2,
+    "id" : 16,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "SINGLETON"
@@ -43,7 +55,13 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      } ]
+    },
     "description" : "Exchange(distribution=[single])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLimit",
@@ -56,7 +74,7 @@
       "type" : "AppendFast"
     },
     "generateUpdateBefore" : false,
-    "id" : 3,
+    "id" : 17,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -64,7 +82,13 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      } ]
+    },
     "description" : "Limit(offset=[0], fetch=[10])",
     "rankType" : "ROW_NUMBER",
     "partitionSpec" : {
@@ -92,7 +116,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 4,
+    "id" : 18,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -100,7 +124,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `a0` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "a0" : "BIGINT"
+      } ]
+    },
     "description" : "Calc(select=[a, a AS a0])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -121,7 +153,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 5,
+    "id" : 19,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -129,33 +161,41 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `a0` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "a0" : "BIGINT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, a0])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 15,
+    "target" : 16,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 16,
+    "target" : 17,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 17,
+    "target" : 18,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 18,
+    "target" : 19,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest_jsonplan/testLimit.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LimitJsonPlanTest_jsonplan/testLimit.out
@@ -1,0 +1,164 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT NOT NULL"
+      },
+      "sourceAbilitySpecs" : [ {
+        "type" : "ProjectPushDown",
+        "projectedFields" : [ [ 0 ] ],
+        "producedType" : "ROW<`a` BIGINT> NOT NULL"
+      }, {
+        "type" : "LimitPushDown",
+        "limit" : 10
+      } ]
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], limit=[10]]], fields=[a])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "SINGLETON"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT>",
+    "description" : "Exchange(distribution=[single])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLimit",
+    "rankRange" : {
+      "type" : "Constant",
+      "start" : 1,
+      "end" : 10
+    },
+    "rankStrategy" : {
+      "type" : "AppendFast"
+    },
+    "generateUpdateBefore" : false,
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT>",
+    "description" : "Limit(offset=[0], fetch=[10])",
+    "rankType" : "ROW_NUMBER",
+    "partitionSpec" : {
+      "fields" : [ ]
+    },
+    "sortSpec" : {
+      "fields" : [ ]
+    },
+    "outputRowNumber" : false
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    } ],
+    "condition" : null,
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `a0` BIGINT>",
+    "description" : "Calc(select=[a, a AS a0])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "sink-insert-only" : "false",
+        "table-sink-class" : "DEFAULT",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "BIGINT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `a0` BIGINT>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, a0])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/RankJsonPlanTest_jsonplan/testRank.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/RankJsonPlanTest_jsonplan/testRank.out
@@ -21,8 +21,25 @@
         "schema.1.data-type" : "INT NOT NULL"
       }
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "id" : 9,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      }, {
+        "d" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
     "inputProperties" : [ ]
   }, {
@@ -43,7 +60,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 2,
+    "id" : 10,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -51,11 +68,19 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[a, b])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 3,
+    "id" : 11,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",
@@ -64,7 +89,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[hash[b]])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecRank",
@@ -88,7 +121,7 @@
     },
     "outputRowNumber" : true,
     "generateUpdateBefore" : true,
-    "id" : 4,
+    "id" : 12,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -96,7 +129,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `w0$o0` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      }, {
+        "w0$o0" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -116,7 +159,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 5,
+    "id" : 13,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -124,7 +167,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `w0$o0` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "w0$o0" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Calc(select=[a, w0$o0])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -145,7 +196,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
-    "id" : 6,
+    "id" : 14,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -153,40 +204,48 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `w0$o0` BIGINT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "w0$o0" : "BIGINT NOT NULL"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, w0$o0])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 9,
+    "target" : 10,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 10,
+    "target" : 11,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 11,
+    "target" : 12,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 12,
+    "target" : 13,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 5,
-    "target" : 6,
+    "source" : 13,
+    "target" : 14,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/RankJsonPlanTest_jsonplan/testRank.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/RankJsonPlanTest_jsonplan/testRank.out
@@ -1,0 +1,195 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT NOT NULL"
+      }
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `c` VARCHAR(2147483647), `d` TIMESTAMP(3)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    } ],
+    "condition" : null,
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "Calc(select=[a, b])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "HASH",
+        "keys" : [ 1 ]
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "Exchange(distribution=[hash[b]])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecRank",
+    "rankType" : "ROW_NUMBER",
+    "partitionSpec" : {
+      "fields" : [ 1 ]
+    },
+    "sortSpec" : {
+      "fields" : [ {
+        "index" : 0,
+        "isAscending" : true,
+        "nullIsLast" : false
+      } ]
+    },
+    "rankRange" : {
+      "type" : "Variable",
+      "endIndex" : 0
+    },
+    "rankStrategy" : {
+      "type" : "AppendFast"
+    },
+    "outputRowNumber" : true,
+    "generateUpdateBefore" : true,
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL, `w0$o0` BIGINT NOT NULL>",
+    "description" : "Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankEnd=a], partitionBy=[b], orderBy=[a ASC], select=[a, b, w0$o0])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : false
+      }
+    } ],
+    "condition" : null,
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `w0$o0` BIGINT NOT NULL>",
+    "description" : "Calc(select=[a, w0$o0])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "sink-insert-only" : "false",
+        "table-sink-class" : "DEFAULT",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "BIGINT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
+    "id" : 6,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `w0$o0` BIGINT NOT NULL>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, w0$o0])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 5,
+    "target" : 6,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest_jsonplan/testSortLimit.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest_jsonplan/testSortLimit.out
@@ -1,0 +1,165 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "schema.3.name" : "d",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT NOT NULL"
+      },
+      "sourceAbilitySpecs" : [ {
+        "type" : "ProjectPushDown",
+        "projectedFields" : [ [ 0 ], [ 1 ] ],
+        "producedType" : "ROW<`a` BIGINT, `b` INT NOT NULL> NOT NULL"
+      } ]
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "SINGLETON"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "Exchange(distribution=[single])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSortLimit",
+    "sortSpec" : {
+      "fields" : [ {
+        "index" : 1,
+        "isAscending" : true,
+        "nullIsLast" : false
+      } ]
+    },
+    "rankRange" : {
+      "type" : "Constant",
+      "start" : 1,
+      "end" : 10
+    },
+    "rankStrategy" : {
+      "type" : "AppendFast"
+    },
+    "generateUpdateBefore" : true,
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "description" : "SortLimit(orderBy=[b ASC], offset=[0], fetch=[10], strategy=[AppendFastStrategy])",
+    "rankType" : "ROW_NUMBER",
+    "partitionSpec" : {
+      "fields" : [ ]
+    },
+    "outputRowNumber" : false
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    } ],
+    "condition" : null,
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `a1` BIGINT>",
+    "description" : "Calc(select=[a, a AS a1])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "sink-insert-only" : "false",
+        "table-sink-class" : "DEFAULT",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "BIGINT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `a1` BIGINT>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, a1])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest_jsonplan/testSortLimit.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/SortLimitJsonPlanTest_jsonplan/testSortLimit.out
@@ -23,16 +23,32 @@
       "sourceAbilitySpecs" : [ {
         "type" : "ProjectPushDown",
         "projectedFields" : [ [ 0 ], [ 1 ] ],
-        "producedType" : "ROW<`a` BIGINT, `b` INT NOT NULL> NOT NULL"
+        "producedType" : {
+          "type" : "ROW",
+          "nullable" : false,
+          "fields" : [ {
+            "a" : "BIGINT"
+          }, {
+            "b" : "INT NOT NULL"
+          } ]
+        }
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "id" : 24,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, b]]], fields=[a, b])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 2,
+    "id" : 25,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "SINGLETON"
@@ -40,7 +56,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "Exchange(distribution=[single])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSortLimit",
@@ -60,7 +84,7 @@
       "type" : "AppendFast"
     },
     "generateUpdateBefore" : true,
-    "id" : 3,
+    "id" : 26,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -68,7 +92,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT NOT NULL>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT NOT NULL"
+      } ]
+    },
     "description" : "SortLimit(orderBy=[b ASC], offset=[0], fetch=[10], strategy=[AppendFastStrategy])",
     "rankType" : "ROW_NUMBER",
     "partitionSpec" : {
@@ -93,7 +125,7 @@
       }
     } ],
     "condition" : null,
-    "id" : 4,
+    "id" : 27,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -101,7 +133,15 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `a1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "a1" : "BIGINT"
+      } ]
+    },
     "description" : "Calc(select=[a, a AS a1])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
@@ -122,7 +162,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
-    "id" : 5,
+    "id" : 28,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -130,33 +170,41 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `a1` BIGINT>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "a1" : "BIGINT"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, a1])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 24,
+    "target" : 25,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 25,
+    "target" : 26,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 26,
+    "target" : 27,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 4,
-    "target" : 5,
+    "source" : 27,
+    "target" : 28,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testLimitPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testLimitPushDown.out
@@ -1,0 +1,124 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT"
+      },
+      "sourceAbilitySpecs" : [ {
+        "type" : "LimitPushDown",
+        "limit" : 3
+      } ]
+    },
+    "id" : 1,
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, limit=[3]]], fields=[a, b, c])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "SINGLETON"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "Exchange(distribution=[single])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLimit",
+    "rankRange" : {
+      "type" : "Constant",
+      "start" : 1,
+      "end" : 3
+    },
+    "rankStrategy" : {
+      "type" : "AppendFast"
+    },
+    "generateUpdateBefore" : false,
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "Limit(offset=[0], fetch=[3])",
+    "rankType" : "ROW_NUMBER",
+    "partitionSpec" : {
+      "fields" : [ ]
+    },
+    "sortSpec" : {
+      "fields" : [ ]
+    },
+    "outputRowNumber" : false
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "INT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testLimitPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSourceJsonPlanTest_jsonplan/testLimitPushDown.out
@@ -23,13 +23,23 @@
         "limit" : 3
       } ]
     },
-    "id" : 1,
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "id" : 47,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable, limit=[3]]], fields=[a, b, c])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
-    "id" : 2,
+    "id" : 48,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "SINGLETON"
@@ -37,7 +47,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Exchange(distribution=[single])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLimit",
@@ -50,7 +70,7 @@
       "type" : "AppendFast"
     },
     "generateUpdateBefore" : false,
-    "id" : 3,
+    "id" : 49,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -58,7 +78,17 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Limit(offset=[0], fetch=[3])",
     "rankType" : "ROW_NUMBER",
     "partitionSpec" : {
@@ -88,7 +118,7 @@
       }
     },
     "inputChangelogMode" : [ "INSERT" ],
-    "id" : 4,
+    "id" : 50,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -96,26 +126,36 @@
       "damBehavior" : "PIPELINED",
       "priority" : 0
     } ],
-    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "INT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
   } ],
   "edges" : [ {
-    "source" : 1,
-    "target" : 2,
+    "source" : 47,
+    "target" : 48,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 2,
-    "target" : 3,
+    "source" : 48,
+    "target" : 49,
     "shuffle" : {
       "type" : "FORWARD"
     },
     "shuffleMode" : "PIPELINED"
   }, {
-    "source" : 3,
-    "target" : 4,
+    "source" : 49,
+    "target" : 50,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRange.java
@@ -18,24 +18,42 @@
 
 package org.apache.flink.table.runtime.operators.rank;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /** rankStart and rankEnd are inclusive, rankStart always start from one. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConstantRankRange implements RankRange {
 
+    public static final String FIELD_NAME_START = "start";
+    public static final String FIELD_NAME_END = "end";
+
     private static final long serialVersionUID = 9062345289888078376L;
+
+    @JsonProperty(FIELD_NAME_START)
     private long rankStart;
+
+    @JsonProperty(FIELD_NAME_END)
     private long rankEnd;
 
-    public ConstantRankRange(long rankStart, long rankEnd) {
+    @JsonCreator
+    public ConstantRankRange(
+            @JsonProperty(FIELD_NAME_START) long rankStart,
+            @JsonProperty(FIELD_NAME_END) long rankEnd) {
         this.rankStart = rankStart;
         this.rankEnd = rankEnd;
     }
 
+    @JsonIgnore
     public long getRankStart() {
         return rankStart;
     }
 
+    @JsonIgnore
     public long getRankEnd() {
         return rankEnd;
     }
@@ -43,6 +61,12 @@ public class ConstantRankRange implements RankRange {
     @Override
     public String toString(List<String> inputFieldNames) {
         return toString();
+    }
+
+    @Override
+    @JsonProperty(FIELD_NAME_TYPE)
+    public String getType() {
+        return "Constant";
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRange.java
@@ -22,11 +22,13 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.List;
 
 /** rankStart and rankEnd are inclusive, rankStart always start from one. */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("Constant")
 public class ConstantRankRange implements RankRange {
 
     public static final String FIELD_NAME_START = "start";
@@ -35,10 +37,10 @@ public class ConstantRankRange implements RankRange {
     private static final long serialVersionUID = 9062345289888078376L;
 
     @JsonProperty(FIELD_NAME_START)
-    private long rankStart;
+    private final long rankStart;
 
     @JsonProperty(FIELD_NAME_END)
-    private long rankEnd;
+    private final long rankEnd;
 
     @JsonCreator
     public ConstantRankRange(
@@ -61,12 +63,6 @@ public class ConstantRankRange implements RankRange {
     @Override
     public String toString(List<String> inputFieldNames) {
         return toString();
-    }
-
-    @Override
-    @JsonProperty(FIELD_NAME_TYPE)
-    public String getType() {
-        return "Constant";
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRangeWithoutEnd.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRangeWithoutEnd.java
@@ -18,22 +18,36 @@
 
 package org.apache.flink.table.runtime.operators.rank;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /** ConstantRankRangeWithoutEnd is a RankRange which not specify RankEnd. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ConstantRankRangeWithoutEnd implements RankRange {
 
     private static final long serialVersionUID = -1944057111062598696L;
 
+    @JsonProperty(ConstantRankRange.FIELD_NAME_START)
     private final long rankStart;
 
-    public ConstantRankRangeWithoutEnd(long rankStart) {
+    @JsonCreator
+    public ConstantRankRangeWithoutEnd(
+            @JsonProperty(ConstantRankRange.FIELD_NAME_START) long rankStart) {
         this.rankStart = rankStart;
     }
 
     @Override
     public String toString(List<String> inputFieldNames) {
         return toString();
+    }
+
+    @Override
+    @JsonProperty(FIELD_NAME_TYPE)
+    public String getType() {
+        return "ConstantWithoutEnd";
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRangeWithoutEnd.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/ConstantRankRangeWithoutEnd.java
@@ -21,11 +21,13 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.List;
 
 /** ConstantRankRangeWithoutEnd is a RankRange which not specify RankEnd. */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("ConstantWithoutEnd")
 public class ConstantRankRangeWithoutEnd implements RankRange {
 
     private static final long serialVersionUID = -1944057111062598696L;
@@ -42,12 +44,6 @@ public class ConstantRankRangeWithoutEnd implements RankRange {
     @Override
     public String toString(List<String> inputFieldNames) {
         return toString();
-    }
-
-    @Override
-    @JsonProperty(FIELD_NAME_TYPE)
-    public String getType() {
-        return "ConstantWithoutEnd";
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RankRange.java
@@ -29,19 +29,11 @@ import java.util.List;
  * VariableRankRange.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes(
-        value = {
-            @JsonSubTypes.Type(value = ConstantRankRange.class, name = "Constant"),
-            @JsonSubTypes.Type(
-                    value = ConstantRankRangeWithoutEnd.class,
-                    name = "ConstantWithoutEnd"),
-            @JsonSubTypes.Type(value = VariableRankRange.class, name = "Variable"),
-        })
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ConstantRankRange.class),
+        @JsonSubTypes.Type(value = ConstantRankRangeWithoutEnd.class),
+        @JsonSubTypes.Type(value = VariableRankRange.class)
+})
 public interface RankRange extends Serializable {
-
-    String FIELD_NAME_TYPE = "type";
-
     String toString(List<String> inputFieldNames);
-
-    String getType();
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RankRange.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.runtime.operators.rank;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSubTypes;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -25,7 +28,20 @@ import java.util.List;
  * RankRange for Rank, including following 3 types : ConstantRankRange, ConstantRankRangeWithoutEnd,
  * VariableRankRange.
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+        value = {
+            @JsonSubTypes.Type(value = ConstantRankRange.class, name = "Constant"),
+            @JsonSubTypes.Type(
+                    value = ConstantRankRangeWithoutEnd.class,
+                    name = "ConstantWithoutEnd"),
+            @JsonSubTypes.Type(value = VariableRankRange.class, name = "Variable"),
+        })
 public interface RankRange extends Serializable {
 
+    String FIELD_NAME_TYPE = "type";
+
     String toString(List<String> inputFieldNames);
+
+    String getType();
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RankRange.java
@@ -30,9 +30,9 @@ import java.util.List;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = ConstantRankRange.class),
-        @JsonSubTypes.Type(value = ConstantRankRangeWithoutEnd.class),
-        @JsonSubTypes.Type(value = VariableRankRange.class)
+    @JsonSubTypes.Type(value = ConstantRankRange.class),
+    @JsonSubTypes.Type(value = ConstantRankRangeWithoutEnd.class),
+    @JsonSubTypes.Type(value = VariableRankRange.class)
 })
 public interface RankRange extends Serializable {
     String toString(List<String> inputFieldNames);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/VariableRankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/VariableRankRange.java
@@ -18,18 +18,30 @@
 
 package org.apache.flink.table.runtime.operators.rank;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /** changing rank limit depends on input. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class VariableRankRange implements RankRange {
 
+    public static final String FIELD_NAME_END_INDEX = "endIndex";
+
     private static final long serialVersionUID = 5579785886506433955L;
+
+    @JsonProperty(FIELD_NAME_END_INDEX)
     private int rankEndIndex;
 
-    public VariableRankRange(int rankEndIndex) {
+    @JsonCreator
+    public VariableRankRange(@JsonProperty(FIELD_NAME_END_INDEX) int rankEndIndex) {
         this.rankEndIndex = rankEndIndex;
     }
 
+    @JsonIgnore
     public int getRankEndIndex() {
         return rankEndIndex;
     }
@@ -37,6 +49,12 @@ public class VariableRankRange implements RankRange {
     @Override
     public String toString(List<String> inputFieldNames) {
         return "rankEnd=" + inputFieldNames.get(rankEndIndex);
+    }
+
+    @Override
+    @JsonProperty(FIELD_NAME_TYPE)
+    public String getType() {
+        return "Variable";
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/VariableRankRange.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/VariableRankRange.java
@@ -22,11 +22,13 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.List;
 
 /** changing rank limit depends on input. */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("Variable")
 public class VariableRankRange implements RankRange {
 
     public static final String FIELD_NAME_END_INDEX = "endIndex";
@@ -34,7 +36,7 @@ public class VariableRankRange implements RankRange {
     private static final long serialVersionUID = 5579785886506433955L;
 
     @JsonProperty(FIELD_NAME_END_INDEX)
-    private int rankEndIndex;
+    private final int rankEndIndex;
 
     @JsonCreator
     public VariableRankRange(@JsonProperty(FIELD_NAME_END_INDEX) int rankEndIndex) {
@@ -49,12 +51,6 @@ public class VariableRankRange implements RankRange {
     @Override
     public String toString(List<String> inputFieldNames) {
         return "rankEnd=" + inputFieldNames.get(rankEndIndex);
-    }
-
-    @Override
-    @JsonProperty(FIELD_NAME_TYPE)
-    public String getType() {
-        return "Variable";
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change
Support json ser/de for StreamExecRank, StreamExecLimit and StreamExecSortLimit

## Brief change log
Support json ser/de for StreamExecRank, StreamExecLimit and StreamExecSortLimit

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added tests that validates json ser/de work in some components including PartitionSpecSerdeTest,RankProcessStrategySerdeTest, RankRangeSerdeTest and RankTypeSerdeTest*
  - *Added json plan test that validates StreamExecRank/StreamExecLimit/StreamExecSortLimit json serialization work well*
  - *Added it test that validates StreamExecRank/StreamExecLimit/StreamExecSortLimit json deserialization work well*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
