### PR TITLE
[FLINK-20130][core] Add ZStandard to FileInputFormat

### DIFF
--- a/docs/content.zh/docs/dev/dataset/overview.md
+++ b/docs/content.zh/docs/dev/dataset/overview.md
@@ -1008,6 +1008,7 @@ The following table lists the currently supported compression methods.
 | GZip | .gz, .gzip | no |
 | Bzip2 | .bz2 | no |
 | XZ | .xz | no |
+| ZStandart | .zst | no |
 
 ## Data Sinks
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -79,6 +79,13 @@ under the License.
 			<artifactId>commons-compress</artifactId>
 			<!-- managed version -->
 		</dependency>
+		<dependency>
+			<groupId>com.github.luben</groupId>
+			<artifactId>zstd-jni</artifactId>
+			<version>1.4.9-1</version>
+			<scope>test</scope>
+		</dependency>
+
 
 		<!-- Ratelimiting dependencies -->
 		<dependency>

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.io.compression.DeflateInflaterInputStreamFact
 import org.apache.flink.api.common.io.compression.GzipInflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.InflaterInputStreamFactory;
 import org.apache.flink.api.common.io.compression.XZInputStreamFactory;
+import org.apache.flink.api.common.io.compression.ZStandardInputStreamFactory;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -120,6 +121,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
             GzipInflaterInputStreamFactory.getInstance(),
             Bzip2InputStreamFactory.getInstance(),
             XZInputStreamFactory.getInstance(),
+            ZStandardInputStreamFactory.getInstance()
         };
         for (InflaterInputStreamFactory<?> inputStreamFactory : defaultFactories) {
             for (String fileExtension : inputStreamFactory.getCommonFileExtensions()) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/compression/ZStandardInputStreamFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/compression/ZStandardInputStreamFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.io.compression;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Factory for ZStandard decompressors. */
+@Internal
+public class ZStandardInputStreamFactory
+        implements InflaterInputStreamFactory<ZstdCompressorInputStream> {
+
+    private static final ZStandardInputStreamFactory INSTANCE = new ZStandardInputStreamFactory();
+
+    public static ZStandardInputStreamFactory getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public ZstdCompressorInputStream create(InputStream in) throws IOException {
+        return new ZstdCompressorInputStream(in);
+    }
+
+    @Override
+    public Collection<String> getCommonFileExtensions() {
+        return Collections.singleton("zst");
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/GenericCsvInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/GenericCsvInputFormatTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.types.LongValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
 
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -169,6 +170,46 @@ public class GenericCsvInputFormatTest {
         try {
             final String fileContent = "111|222|333|444|555\n666|777|888|999|000|";
             final FileInputSplit split = createTempGzipFile(fileContent);
+
+            final Configuration parameters = new Configuration();
+
+            format.setFieldDelimiter("|");
+            format.setFieldTypesGeneric(
+                    IntValue.class, IntValue.class, IntValue.class, IntValue.class, IntValue.class);
+
+            format.configure(parameters);
+            format.open(split);
+
+            Value[] values = createIntValues(5);
+
+            values = format.nextRecord(values);
+            assertNotNull(values);
+            assertEquals(111, ((IntValue) values[0]).getValue());
+            assertEquals(222, ((IntValue) values[1]).getValue());
+            assertEquals(333, ((IntValue) values[2]).getValue());
+            assertEquals(444, ((IntValue) values[3]).getValue());
+            assertEquals(555, ((IntValue) values[4]).getValue());
+
+            values = format.nextRecord(values);
+            assertNotNull(values);
+            assertEquals(666, ((IntValue) values[0]).getValue());
+            assertEquals(777, ((IntValue) values[1]).getValue());
+            assertEquals(888, ((IntValue) values[2]).getValue());
+            assertEquals(999, ((IntValue) values[3]).getValue());
+            assertEquals(000, ((IntValue) values[4]).getValue());
+
+            assertNull(format.nextRecord(values));
+            assertTrue(format.reachedEnd());
+        } catch (Exception ex) {
+            fail("Test failed due to a " + ex.getClass().getSimpleName() + ": " + ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testReadNoPosAllZStandard() throws IOException {
+        try {
+            final String fileContent = "111|222|333|444|555\n666|777|888|999|000|";
+            final FileInputSplit split = createTempZStandardFile(fileContent);
 
             final Configuration parameters = new Configuration();
 
@@ -790,6 +831,24 @@ public class GenericCsvInputFormatTest {
 
         DataOutputStream dos =
                 new DataOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile)));
+        dos.writeBytes(content);
+        dos.close();
+
+        return new FileInputSplit(
+                0,
+                new Path(tempFile.toURI().toString()),
+                0,
+                tempFile.length(),
+                new String[] {"localhost"});
+    }
+
+    private FileInputSplit createTempZStandardFile(String content) throws IOException {
+        File tempFile = File.createTempFile("test_contents", "tmp.zst");
+        tempFile.deleteOnExit();
+
+        DataOutputStream dos =
+                new DataOutputStream(
+                        new ZstdCompressorOutputStream(new FileOutputStream(tempFile)));
         dos.writeBytes(content);
         dos.close();
 


### PR DESCRIPTION
## What is the purpose of the change

Allow FileInputFormat to read files compressed in ZStandard format

## Brief change log

Added ZStandard as stream input

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: ( don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( yes )
