### PR TITLE
[FLINK-21532][Table SQL/API]Make CatalogTableImpl#toProperties and Ca…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
@@ -76,7 +76,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
 
     @Override
     public Map<String, String> toProperties() {
-        DescriptorProperties descriptor = new DescriptorProperties();
+        DescriptorProperties descriptor = new DescriptorProperties(false);
 
         descriptor.putTableSchema(SCHEMA, getSchema());
         descriptor.putPartitionKeys(getPartitionKeys());
@@ -96,7 +96,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
 
     /** Construct a {@link CatalogTableImpl} from complete properties that contains table schema. */
     public static CatalogTableImpl fromProperties(Map<String, String> properties) {
-        DescriptorProperties descriptorProperties = new DescriptorProperties();
+        DescriptorProperties descriptorProperties = new DescriptorProperties(false);
         descriptorProperties.putProperties(properties);
         TableSchema tableSchema = descriptorProperties.getTableSchema(SCHEMA);
         List<String> partitionKeys = descriptorProperties.getPartitionKeys();
@@ -111,7 +111,7 @@ public class CatalogTableImpl extends AbstractCatalogTable {
     public static Map<String, String> removeRedundant(
             Map<String, String> properties, TableSchema schema, List<String> partitionKeys) {
         Map<String, String> ret = new HashMap<>(properties);
-        DescriptorProperties descriptorProperties = new DescriptorProperties();
+        DescriptorProperties descriptorProperties = new DescriptorProperties(false);
         descriptorProperties.putTableSchema(SCHEMA, schema);
         descriptorProperties.putPartitionKeys(partitionKeys);
         descriptorProperties.asMap().keySet().forEach(ret::remove);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTableImpTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTableImpTest.java
@@ -42,16 +42,31 @@ public class CatalogTableImpTest {
         Map<String, String> prop = createProperties();
         CatalogTable table = new CatalogTableImpl(schema, createPartitionKeys(), prop, TEST);
 
-        DescriptorProperties descriptorProperties = new DescriptorProperties();
+        DescriptorProperties descriptorProperties = new DescriptorProperties(false);
         descriptorProperties.putProperties(table.toProperties());
 
         assertEquals(schema, descriptorProperties.getTableSchema(Schema.SCHEMA));
+    }
+
+    @Test
+    public void testFromProperties() {
+        TableSchema schema = createTableSchema();
+        Map<String, String> prop = createProperties();
+        CatalogTable table = new CatalogTableImpl(schema, createPartitionKeys(), prop, TEST);
+
+        CatalogTableImpl tableFromProperties =
+                CatalogTableImpl.fromProperties(table.toProperties());
+
+        assertEquals(tableFromProperties.getOptions(), table.getOptions());
+        assertEquals(tableFromProperties.getPartitionKeys(), table.getPartitionKeys());
+        assertEquals(tableFromProperties.getSchema(), table.getSchema());
     }
 
     private static Map<String, String> createProperties() {
         return new HashMap<String, String>() {
             {
                 put("k", "v");
+                put("K1", "V1"); // for test case-sensitive
             }
         };
     }
@@ -61,6 +76,7 @@ public class CatalogTableImpTest {
                 .field("first", DataTypes.STRING())
                 .field("second", DataTypes.INT())
                 .field("third", DataTypes.DOUBLE())
+                .field("Fourth", DataTypes.BOOLEAN()) // for test case-sensitive
                 .build();
     }
 


### PR DESCRIPTION
…talogTableImpl#fromProperties case sensitive


## What is the purpose of the change

*make these two functions mentioned above case-senstive, fix the misleading problem introduced in JIRA *


## Brief change log

  - *disable key normalizing in these two functions*
 


## Verifying this change



This change is a trivial rework.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
