### PR TITLE
[FLINK-21818][table] Refactor SlicingWindowAggOperatorBuilder to accept serializer instead of LogicalType

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -55,6 +55,7 @@ import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -174,19 +175,17 @@ public class StreamExecWindowAggregate extends ExecNodeBase<RowData>
                         planner.getRelBuilder(),
                         inputRowType.getChildren());
 
-        final LogicalType[] keyTypes =
-                Arrays.stream(grouping)
-                        .mapToObj(inputRowType::getTypeAt)
-                        .toArray(LogicalType[]::new);
+        final RowDataKeySelector selector =
+                KeySelectorUtil.getRowDataSelector(grouping, InternalTypeInfo.of(inputRowType));
         final LogicalType[] accTypes = convertToLogicalTypes(aggInfoList.getAccTypes());
 
         final OneInputStreamOperator<RowData, RowData> windowOperator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(inputRowType)
-                        .keyTypes(keyTypes)
+                        .inputSerializer(new RowDataSerializer(inputRowType))
+                        .keySerializer(selector.getKeySerializer())
                         .assigner(sliceAssigner)
                         .countStarIndex(aggInfoList.getIndexOfCountStar())
-                        .aggregate(generatedAggsHandler, accTypes)
+                        .aggregate(generatedAggsHandler, new RowDataSerializer(accTypes))
                         .build();
 
         final OneInputTransformation<RowData, RowData> transform =
@@ -199,8 +198,6 @@ public class StreamExecWindowAggregate extends ExecNodeBase<RowData>
                         WINDOW_AGG_MEMORY_RATIO);
 
         // set KeyType and Selector for state
-        final RowDataKeySelector selector =
-                KeySelectorUtil.getRowDataSelector(grouping, InternalTypeInfo.of(inputRowType));
         transform.setStateKeySelector(selector);
         transform.setStateKeyType(selector.getProducedType());
         return transform;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -55,6 +55,7 @@ import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -182,7 +183,9 @@ public class StreamExecWindowAggregate extends ExecNodeBase<RowData>
         final OneInputStreamOperator<RowData, RowData> windowOperator =
                 SlicingWindowAggOperatorBuilder.builder()
                         .inputSerializer(new RowDataSerializer(inputRowType))
-                        .keySerializer(selector.getKeySerializer())
+                        .keySerializer(
+                                (PagedTypeSerializer<RowData>)
+                                        selector.getProducedType().toSerializer())
                         .assigner(sliceAssigner)
                         .countStarIndex(aggInfoList.getIndexOfCountStar())
                         .aggregate(generatedAggsHandler, new RowDataSerializer(accTypes))

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/keyselector/RowDataKeySelector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/keyselector/RowDataKeySelector.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.keyselector;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
 /** RowDataKeySelector takes an RowData and extracts the deterministic key for the RowData. */
@@ -28,4 +29,8 @@ public interface RowDataKeySelector
         extends KeySelector<RowData, RowData>, ResultTypeQueryable<RowData> {
 
     InternalTypeInfo<RowData> getProducedType();
+
+    default AbstractRowDataSerializer<RowData> getKeySerializer() {
+        return getProducedType().toAbstractRowSerializer();
+    }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/keyselector/RowDataKeySelector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/keyselector/RowDataKeySelector.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.keyselector;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
 /** RowDataKeySelector takes an RowData and extracts the deterministic key for the RowData. */
@@ -29,8 +28,4 @@ public interface RowDataKeySelector
         extends KeySelector<RowData, RowData>, ResultTypeQueryable<RowData> {
 
     InternalTypeInfo<RowData> getProducedType();
-
-    default AbstractRowDataSerializer<RowData> getKeySerializer() {
-        return getProducedType().toAbstractRowSerializer();
-    }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.aggregate.window;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.RecordsWindowBuffer;
@@ -33,6 +34,7 @@ import org.apache.flink.table.runtime.operators.window.slicing.SliceUnsharedAssi
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;
 import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 
 import java.util.function.Supplier;
 
@@ -59,8 +61,8 @@ public class SlicingWindowAggOperatorBuilder {
 
     private SliceAssigner assigner;
     private AbstractRowDataSerializer<RowData> inputSerializer;
-    private AbstractRowDataSerializer<RowData> keySerializer;
-    private AbstractRowDataSerializer<RowData> accSerializer;
+    private PagedTypeSerializer<RowData> keySerializer;
+    private TypeSerializer<RowData> accSerializer;
     private GeneratedNamespaceAggsHandleFunction<Long> generatedAggregateFunction;
     private int indexOfCountStart = -1;
 
@@ -71,7 +73,7 @@ public class SlicingWindowAggOperatorBuilder {
     }
 
     public SlicingWindowAggOperatorBuilder keySerializer(
-            AbstractRowDataSerializer<RowData> keySerializer) {
+            PagedTypeSerializer<RowData> keySerializer) {
         this.keySerializer = keySerializer;
         return this;
     }
@@ -83,7 +85,7 @@ public class SlicingWindowAggOperatorBuilder {
 
     public SlicingWindowAggOperatorBuilder aggregate(
             GeneratedNamespaceAggsHandleFunction<Long> generatedAggregateFunction,
-            AbstractRowDataSerializer<RowData> accSerializer) {
+            TypeSerializer<RowData> accSerializer) {
         this.generatedAggregateFunction = generatedAggregateFunction;
         this.accSerializer = accSerializer;
         return this;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
 import org.apache.flink.table.runtime.util.KeyValueIterator;
 import org.apache.flink.table.runtime.util.WindowKey;
@@ -49,7 +50,7 @@ public final class RecordsWindowBuffer implements WindowBuffer {
             MemoryManager memoryManager,
             long memorySize,
             WindowCombineFunction combineFunction,
-            AbstractRowDataSerializer<RowData> keySer,
+            PagedTypeSerializer<RowData> keySer,
             AbstractRowDataSerializer<RowData> inputSer) {
         this.combineFunction = combineFunction;
         this.recordsBuffer =
@@ -114,12 +115,11 @@ public final class RecordsWindowBuffer implements WindowBuffer {
 
         private static final long serialVersionUID = 1L;
 
-        private final AbstractRowDataSerializer<RowData> keySer;
+        private final PagedTypeSerializer<RowData> keySer;
         private final AbstractRowDataSerializer<RowData> inputSer;
 
         public Factory(
-                AbstractRowDataSerializer<RowData> keySer,
-                AbstractRowDataSerializer<RowData> inputSer) {
+                PagedTypeSerializer<RowData> keySer, AbstractRowDataSerializer<RowData> inputSer) {
             this.keySer = keySer;
             this.inputSer = inputSer;
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.runtime.operators.aggregate.window.buffers;
 
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
@@ -61,7 +60,7 @@ public final class RecordsWindowBuffer implements WindowBuffer {
     }
 
     @Override
-    public void addElement(BinaryRowData key, long sliceEnd, RowData element) throws Exception {
+    public void addElement(RowData key, long sliceEnd, RowData element) throws Exception {
         // track the lowest trigger time, if watermark exceeds the trigger time,
         // it means there are some elements in the buffer belong to a window going to be fired,
         // and we need to flush the buffer into state for firing.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/WindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/WindowBuffer.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.operators.aggregate.window.buffers;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
 
 import java.io.IOException;
@@ -46,7 +45,7 @@ public interface WindowBuffer {
      * @throws Exception Thrown, if the element cannot be added to the buffer, or if the flushing
      *     throws an exception.
      */
-    void addElement(BinaryRowData key, long window, RowData element) throws Exception;
+    void addElement(RowData key, long window, RowData element) throws Exception;
 
     /**
      * Advances the progress time, the progress time is watermark if working in event-time mode, or

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/CombineRecordsFunction.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.aggregate.window.combines;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
@@ -28,7 +29,6 @@ import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunc
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.window.state.StateKeyContext;
 import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
-import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
 
 import java.util.Iterator;
@@ -58,10 +58,10 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     private final boolean requiresCopy;
 
     /** Serializer to copy key if required. */
-    private AbstractRowDataSerializer<RowData> keySerializer;
+    private final TypeSerializer<RowData> keySerializer;
 
     /** Serializer to copy record if required. */
-    private final AbstractRowDataSerializer<RowData> recordSerializer;
+    private final TypeSerializer<RowData> recordSerializer;
 
     /** Whether the operator works in event-time mode, used to indicate registering which timer. */
     private final boolean isEventTime;
@@ -72,8 +72,8 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
             WindowValueState<Long> accState,
             NamespaceAggsHandleFunction<Long> aggregator,
             boolean requiresCopy,
-            AbstractRowDataSerializer<RowData> keySerializer,
-            AbstractRowDataSerializer<RowData> recordSerializer,
+            TypeSerializer<RowData> keySerializer,
+            TypeSerializer<RowData> recordSerializer,
             boolean isEventTime) {
         this.timerService = timerService;
         this.keyContext = keyContext;
@@ -148,13 +148,13 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
         private static final long serialVersionUID = 1L;
 
         private final GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler;
-        private final AbstractRowDataSerializer<RowData> keySerializer;
-        private final AbstractRowDataSerializer<RowData> recordSerializer;
+        private final TypeSerializer<RowData> keySerializer;
+        private final TypeSerializer<RowData> recordSerializer;
 
         public Factory(
                 GeneratedNamespaceAggsHandleFunction<Long> genAggsHandler,
-                AbstractRowDataSerializer<RowData> keySerializer,
-                AbstractRowDataSerializer<RowData> recordSerializer) {
+                TypeSerializer<RowData> keySerializer,
+                TypeSerializer<RowData> recordSerializer) {
             this.genAggsHandler = genAggsHandler;
             this.keySerializer = keySerializer;
             this.recordSerializer = recordSerializer;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.runtime.dataview.PerWindowStateDataViewStore;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
@@ -119,7 +118,7 @@ public abstract class AbstractWindowAggProcessor implements SlicingWindowProcess
     }
 
     @Override
-    public boolean processElement(BinaryRowData key, RowData element) throws Exception {
+    public boolean processElement(RowData key, RowData element) throws Exception {
         long sliceEnd = sliceAssigner.assignSliceEnd(element, clockService);
         if (!isEventTime) {
             // always register processing time for every element when processing time mode

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
@@ -35,7 +35,6 @@ import org.apache.flink.table.runtime.operators.window.slicing.ClockService;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;
 import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
-import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 
 /** A base implementation of {@link SlicingWindowProcessor} for window aggregate. */
 public abstract class AbstractWindowAggProcessor implements SlicingWindowProcessor<Long> {
@@ -45,7 +44,7 @@ public abstract class AbstractWindowAggProcessor implements SlicingWindowProcess
     protected final WindowBuffer.Factory windowBufferFactory;
     protected final WindowCombineFunction.Factory combineFactory;
     protected final SliceAssigner sliceAssigner;
-    protected final AbstractRowDataSerializer<RowData> accSerializer;
+    protected final TypeSerializer<RowData> accSerializer;
     protected final boolean isEventTime;
 
     // ----------------------------------------------------------------------------------------
@@ -72,7 +71,7 @@ public abstract class AbstractWindowAggProcessor implements SlicingWindowProcess
             WindowBuffer.Factory bufferFactory,
             WindowCombineFunction.Factory combinerFactory,
             SliceAssigner sliceAssigner,
-            AbstractRowDataSerializer<RowData> accSerializer) {
+            TypeSerializer<RowData> accSerializer) {
         this.genAggsHandler = genAggsHandler;
         this.windowBufferFactory = bufferFactory;
         this.combineFactory = combinerFactory;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.aggregate.window.processors;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
@@ -25,7 +26,6 @@ import org.apache.flink.table.runtime.operators.aggregate.window.combines.Window
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;
-import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 
 import javax.annotation.Nullable;
 
@@ -51,7 +51,7 @@ public final class SliceSharedWindowAggProcessor extends AbstractWindowAggProces
             WindowBuffer.Factory bufferFactory,
             WindowCombineFunction.Factory combinerFactory,
             SliceSharedAssigner sliceAssigner,
-            AbstractRowDataSerializer<RowData> accSerializer,
+            TypeSerializer<RowData> accSerializer,
             int indexOfCountStar) {
         super(genAggsHandler, bufferFactory, combinerFactory, sliceAssigner, accSerializer);
         this.sliceSharedAssigner = sliceAssigner;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.runtime.operators.aggregate.window.combines.Window
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;
-import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 
 import javax.annotation.Nullable;
 
@@ -51,9 +51,9 @@ public final class SliceSharedWindowAggProcessor extends AbstractWindowAggProces
             WindowBuffer.Factory bufferFactory,
             WindowCombineFunction.Factory combinerFactory,
             SliceSharedAssigner sliceAssigner,
-            LogicalType[] accumulatorTypes,
+            AbstractRowDataSerializer<RowData> accSerializer,
             int indexOfCountStar) {
-        super(genAggsHandler, bufferFactory, combinerFactory, sliceAssigner, accumulatorTypes);
+        super(genAggsHandler, bufferFactory, combinerFactory, sliceAssigner, accSerializer);
         this.sliceSharedAssigner = sliceAssigner;
         this.emptySupplier = new WindowIsEmptySupplier(indexOfCountStar, sliceAssigner);
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunc
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
 import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceUnsharedAssigner;
-import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 
 /**
  * An window aggregate processor implementation which works for {@link SliceUnsharedAssigner}, e.g.
@@ -37,8 +37,8 @@ public final class SliceUnsharedWindowAggProcessor extends AbstractWindowAggProc
             WindowBuffer.Factory windowBufferFactory,
             WindowCombineFunction.Factory combineFactory,
             SliceUnsharedAssigner sliceAssigner,
-            LogicalType[] accumulatorTypes) {
-        super(genAggsHandler, windowBufferFactory, combineFactory, sliceAssigner, accumulatorTypes);
+            AbstractRowDataSerializer<RowData> accSerializer) {
+        super(genAggsHandler, windowBufferFactory, combineFactory, sliceAssigner, accSerializer);
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.table.runtime.operators.aggregate.window.processors;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
 import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceUnsharedAssigner;
-import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 
 /**
  * An window aggregate processor implementation which works for {@link SliceUnsharedAssigner}, e.g.
@@ -37,7 +37,7 @@ public final class SliceUnsharedWindowAggProcessor extends AbstractWindowAggProc
             WindowBuffer.Factory windowBufferFactory,
             WindowCombineFunction.Factory combineFactory,
             SliceUnsharedAssigner sliceAssigner,
-            AbstractRowDataSerializer<RowData> accSerializer) {
+            TypeSerializer<RowData> accSerializer) {
         super(genAggsHandler, windowBufferFactory, combineFactory, sliceAssigner, accSerializer);
     }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowOperator.java
@@ -38,7 +38,6 @@ import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
 
@@ -196,7 +195,7 @@ public final class SlicingWindowOperator<K, W> extends TableStreamOperator<RowDa
     @Override
     public void processElement(StreamRecord<RowData> element) throws Exception {
         RowData inputRow = element.getValue();
-        BinaryRowData currentKey = (BinaryRowData) getCurrentKey();
+        RowData currentKey = (RowData) getCurrentKey();
         boolean isElementDropped = windowProcessor.processElement(currentKey, inputRow);
         if (isElementDropped) {
             // markEvent will increase numLateRecordsDropped

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SlicingWindowProcessor.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
 
 import java.io.Serializable;
 
@@ -43,7 +42,7 @@ public interface SlicingWindowProcessor<W> extends Serializable {
      * @param key the key associated with the element
      * @param element The element to process.
      */
-    boolean processElement(BinaryRowData key, RowData element) throws Exception;
+    boolean processElement(RowData key, RowData element) throws Exception;
 
     /**
      * Advances the progress time, the progress time is watermark if working in event-time mode, or

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
@@ -120,10 +120,6 @@ public final class InternalTypeInfo<T> extends TypeInformation<T> implements Dat
         return (RowDataSerializer) typeSerializer;
     }
 
-    public AbstractRowDataSerializer<RowData> toAbstractRowSerializer() {
-        return (AbstractRowDataSerializer<RowData>) typeSerializer;
-    }
-
     /**
      * @deprecated {@link TypeInformation} should just be a thin wrapper of a serializer. This
      *     method only exists for legacy code. It is recommended to use the {@link RowType} instead

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
@@ -120,6 +120,10 @@ public final class InternalTypeInfo<T> extends TypeInformation<T> implements Dat
         return (RowDataSerializer) typeSerializer;
     }
 
+    public AbstractRowDataSerializer<RowData> toAbstractRowSerializer() {
+        return (AbstractRowDataSerializer<RowData>) typeSerializer;
+    }
+
     /**
      * @deprecated {@link TypeInformation} should just be a thin wrapper of a serializer. This
      *     method only exists for legacy code. It is recommended to use the {@link RowType} instead

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/WindowKey.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/WindowKey.java
@@ -18,27 +18,26 @@
 
 package org.apache.flink.table.runtime.util;
 
-import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.RowData;
 
 import java.util.Objects;
 
 /**
  * The {@link WindowKey} structure represents a combination of key and window. This is mainly used
- * in the mini-batch window operators where the key is a {@link BinaryRowData} and window is
- * identified by window end timestamp.
+ * in the mini-batch window operators and window is identified by window end timestamp.
  */
 public final class WindowKey {
 
     private long window;
-    private BinaryRowData key;
+    private RowData key;
 
-    public WindowKey(long window, BinaryRowData key) {
+    public WindowKey(long window, RowData key) {
         this.window = window;
         this.key = key;
     }
 
     /** Replace the currently stored key and window by the given new key and new window. */
-    public WindowKey replace(long window, BinaryRowData key) {
+    public WindowKey replace(long window, RowData key) {
         this.window = window;
         this.key = key;
         return this;
@@ -48,7 +47,7 @@ public final class WindowKey {
         return window;
     }
 
-    public BinaryRowData getKey() {
+    public RowData getKey() {
         return key;
     }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesHashMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesHashMap.java
@@ -93,13 +93,22 @@ public abstract class AbstractBytesHashMap<K> extends BytesMap<K, BinaryRowData>
             long memorySize,
             PagedTypeSerializer<K> keySerializer,
             LogicalType[] valueTypes) {
+        this(owner, memoryManager, memorySize, keySerializer, valueTypes.length);
+    }
+
+    public AbstractBytesHashMap(
+            final Object owner,
+            MemoryManager memoryManager,
+            long memorySize,
+            PagedTypeSerializer<K> keySerializer,
+            int valueArity) {
         super(owner, memoryManager, memorySize, keySerializer);
 
         this.recordArea = new RecordArea();
 
         this.keySerializer = keySerializer;
-        this.valueSerializer = new BinaryRowDataSerializer(valueTypes.length);
-        if (valueTypes.length == 0) {
+        this.valueSerializer = new BinaryRowDataSerializer(valueArity);
+        if (valueArity == 0) {
             this.hashSetMode = true;
             this.reusedValue = new BinaryRowData(0);
             this.reusedValue.pointTo(MemorySegmentFactory.wrap(new byte[8]), 0, 8);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/AbstractBytesMultiMap.java
@@ -99,12 +99,21 @@ public abstract class AbstractBytesMultiMap<K> extends BytesMap<K, Iterator<RowD
             long memorySize,
             PagedTypeSerializer<K> keySerializer,
             LogicalType[] valueTypes) {
+        this(owner, memoryManager, memorySize, keySerializer, valueTypes.length);
+    }
+
+    public AbstractBytesMultiMap(
+            final Object owner,
+            MemoryManager memoryManager,
+            long memorySize,
+            PagedTypeSerializer<K> keySerializer,
+            int valueArity) {
         super(owner, memoryManager, memorySize, keySerializer);
-        checkArgument(valueTypes.length > 0);
+        checkArgument(valueArity > 0);
 
         this.recordArea = new RecordArea();
         this.keySerializer = keySerializer;
-        this.valueSerializer = new BinaryRowDataSerializer(valueTypes.length);
+        this.valueSerializer = new BinaryRowDataSerializer(valueArity);
         this.reusedValue = ((RecordArea) this.recordArea).valueIterator(-1);
         this.reusedRecord = valueSerializer.createInstance();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesHashMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesHashMap.java
@@ -19,9 +19,10 @@
 package org.apache.flink.table.runtime.util.collections.binary;
 
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
-import org.apache.flink.table.types.logical.LogicalType;
 
 /**
  * A binary map in the structure like {@code Map<WindowKey, BinaryRowData>}.
@@ -34,13 +35,8 @@ public final class WindowBytesHashMap extends AbstractBytesHashMap<WindowKey> {
             final Object owner,
             MemoryManager memoryManager,
             long memorySize,
-            LogicalType[] keyTypes,
-            LogicalType[] valueTypes) {
-        super(
-                owner,
-                memoryManager,
-                memorySize,
-                new WindowKeySerializer(keyTypes.length),
-                valueTypes);
+            PagedTypeSerializer<RowData> keySer,
+            int valueArity) {
+        super(owner, memoryManager, memorySize, new WindowKeySerializer(keySer), valueArity);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMap.java
@@ -19,9 +19,10 @@
 package org.apache.flink.table.runtime.util.collections.binary;
 
 import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
-import org.apache.flink.table.types.logical.LogicalType;
 
 /**
  * A binary map in the structure like {@code Map<WindowKey, List<BinaryRowData>>}.
@@ -34,13 +35,8 @@ public final class WindowBytesMultiMap extends AbstractBytesMultiMap<WindowKey> 
             Object owner,
             MemoryManager memoryManager,
             long memorySize,
-            LogicalType[] keyTypes,
-            LogicalType[] valueTypes) {
-        super(
-                owner,
-                memoryManager,
-                memorySize,
-                new WindowKeySerializer(keyTypes.length),
-                valueTypes);
+            PagedTypeSerializer<RowData> keySer,
+            int valueArity) {
+        super(owner, memoryManager, memorySize, new WindowKeySerializer(keySer), valueArity);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
+import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
 import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
@@ -65,11 +66,10 @@ public class SlicingWindowAggOperatorTest {
                             new RowType.RowField("f1", new IntType()),
                             new RowType.RowField("f2", new BigIntType())));
 
-    private static final LogicalType[] KEY_TYPES =
-            new LogicalType[] {new VarCharType(Integer.MAX_VALUE)};
+    private static final RowDataSerializer INPUT_ROW_SER = new RowDataSerializer(INPUT_ROW_TYPE);
 
-    private static final LogicalType[] ACC_TYPES =
-            new LogicalType[] {new BigIntType(), new BigIntType()};
+    private static final AbstractRowDataSerializer<RowData> ACC_SER =
+            new RowDataSerializer(new BigIntType(), new BigIntType());
 
     private static final LogicalType[] OUTPUT_TYPES =
             new LogicalType[] {
@@ -83,6 +83,9 @@ public class SlicingWindowAggOperatorTest {
     private static final BinaryRowDataKeySelector KEY_SELECTOR =
             new BinaryRowDataKeySelector(
                     new int[] {0}, INPUT_ROW_TYPE.getChildren().toArray(new LogicalType[0]));
+
+    private static final AbstractRowDataSerializer<RowData> KEY_SER =
+            KEY_SELECTOR.getProducedType().toAbstractRowSerializer();
 
     private static final TypeSerializer<RowData> OUT_SERIALIZER =
             new RowDataSerializer(OUTPUT_TYPES);
@@ -99,10 +102,10 @@ public class SlicingWindowAggOperatorTest {
         final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
         SlicingWindowOperator<RowData, ?> operator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(INPUT_ROW_TYPE)
-                        .keyTypes(KEY_TYPES)
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
                         .assigner(assigner)
-                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                         .countStarIndex(1)
                         .build();
 
@@ -206,10 +209,10 @@ public class SlicingWindowAggOperatorTest {
         final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
         SlicingWindowOperator<RowData, ?> operator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(INPUT_ROW_TYPE)
-                        .keyTypes(KEY_TYPES)
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
                         .assigner(assigner)
-                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                         .countStarIndex(1)
                         .build();
 
@@ -278,10 +281,10 @@ public class SlicingWindowAggOperatorTest {
         final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
         SlicingWindowOperator<RowData, ?> operator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(INPUT_ROW_TYPE)
-                        .keyTypes(KEY_TYPES)
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
                         .assigner(assigner)
-                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -384,10 +387,10 @@ public class SlicingWindowAggOperatorTest {
         final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
         SlicingWindowOperator<RowData, ?> operator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(INPUT_ROW_TYPE)
-                        .keyTypes(KEY_TYPES)
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
                         .assigner(assigner)
-                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -456,10 +459,10 @@ public class SlicingWindowAggOperatorTest {
         final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
         SlicingWindowOperator<RowData, ?> operator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(INPUT_ROW_TYPE)
-                        .keyTypes(KEY_TYPES)
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
                         .assigner(assigner)
-                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -556,10 +559,10 @@ public class SlicingWindowAggOperatorTest {
         final SumAndCountAggsFunction aggsFunction = new SumAndCountAggsFunction(assigner);
         SlicingWindowOperator<RowData, ?> operator =
                 SlicingWindowAggOperatorBuilder.builder()
-                        .inputType(INPUT_ROW_TYPE)
-                        .keyTypes(KEY_TYPES)
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
                         .assigner(assigner)
-                        .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                        .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -613,10 +616,10 @@ public class SlicingWindowAggOperatorTest {
         try {
             // hopping window without specifying count star index
             SlicingWindowAggOperatorBuilder.builder()
-                    .inputType(INPUT_ROW_TYPE)
-                    .keyTypes(KEY_TYPES)
+                    .inputSerializer(INPUT_ROW_SER)
+                    .keySerializer(KEY_SER)
                     .assigner(assigner)
-                    .aggregate(wrapGenerated(aggsFunction), ACC_TYPES)
+                    .aggregate(wrapGenerated(aggsFunction), ACC_SER)
                     .build();
             fail("should fail");
         } catch (Exception e) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
-import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.util.BinaryRowDataKeySelector;
 import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
@@ -68,7 +68,7 @@ public class SlicingWindowAggOperatorTest {
 
     private static final RowDataSerializer INPUT_ROW_SER = new RowDataSerializer(INPUT_ROW_TYPE);
 
-    private static final AbstractRowDataSerializer<RowData> ACC_SER =
+    private static final RowDataSerializer ACC_SER =
             new RowDataSerializer(new BigIntType(), new BigIntType());
 
     private static final LogicalType[] OUTPUT_TYPES =
@@ -84,8 +84,8 @@ public class SlicingWindowAggOperatorTest {
             new BinaryRowDataKeySelector(
                     new int[] {0}, INPUT_ROW_TYPE.getChildren().toArray(new LogicalType[0]));
 
-    private static final AbstractRowDataSerializer<RowData> KEY_SER =
-            KEY_SELECTOR.getProducedType().toAbstractRowSerializer();
+    private static final PagedTypeSerializer<RowData> KEY_SER =
+            (PagedTypeSerializer<RowData>) KEY_SELECTOR.getProducedType().toSerializer();
 
     private static final TypeSerializer<RowData> OUT_SERIALIZER =
             new RowDataSerializer(OUTPUT_TYPES);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/WindowKeySerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/WindowKeySerializerTest.java
@@ -30,7 +30,7 @@ public class WindowKeySerializerTest extends SerializerTestBase<WindowKey> {
 
     @Override
     protected TypeSerializer<WindowKey> createSerializer() {
-        return new WindowKeySerializer(2);
+        return new WindowKeySerializer((AbstractRowDataSerializer) new BinaryRowDataSerializer(2));
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesHashMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesHashMapTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.runtime.util.collections.binary;
 
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -30,7 +32,9 @@ import java.util.Random;
 public class WindowBytesHashMapTest extends BytesHashMapTestBase<WindowKey> {
 
     public WindowBytesHashMapTest() {
-        super(new WindowKeySerializer(KEY_TYPES.length));
+        super(
+                new WindowKeySerializer(
+                        (PagedTypeSerializer) new BinaryRowDataSerializer(KEY_TYPES.length)));
     }
 
     @Override
@@ -39,7 +43,12 @@ public class WindowBytesHashMapTest extends BytesHashMapTestBase<WindowKey> {
             int memorySize,
             LogicalType[] keyTypes,
             LogicalType[] valueTypes) {
-        return new WindowBytesHashMap(this, memoryManager, memorySize, keyTypes, valueTypes);
+        return new WindowBytesHashMap(
+                this,
+                memoryManager,
+                memorySize,
+                (PagedTypeSerializer) new BinaryRowDataSerializer(keyTypes.length),
+                valueTypes.length);
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMapTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/collections/binary/WindowBytesMultiMapTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.table.runtime.util.collections.binary;
 
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;
 import org.apache.flink.table.runtime.util.WindowKey;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -30,7 +32,9 @@ import java.util.Random;
 public class WindowBytesMultiMapTest extends BytesMultiMapTestBase<WindowKey> {
 
     public WindowBytesMultiMapTest() {
-        super(new WindowKeySerializer(KEY_TYPES.length));
+        super(
+                new WindowKeySerializer(
+                        (PagedTypeSerializer) new BinaryRowDataSerializer(KEY_TYPES.length)));
     }
 
     @Override
@@ -39,7 +43,12 @@ public class WindowBytesMultiMapTest extends BytesMultiMapTestBase<WindowKey> {
             int memorySize,
             LogicalType[] keyTypes,
             LogicalType[] valueTypes) {
-        return new WindowBytesMultiMap(this, memoryManager, memorySize, keyTypes, valueTypes);
+        return new WindowBytesMultiMap(
+                this,
+                memoryManager,
+                memorySize,
+                (PagedTypeSerializer) new BinaryRowDataSerializer(keyTypes.length),
+                valueTypes.length);
     }
 
     @Override


### PR DESCRIPTION

## What is the purpose of the change

Refactor SlicingWindowAggOperatorBuilder to accept serializer instead of LogicalType
Now SlicingWindowAggOperatorBuilder accept LogicalTypes, it is better to avoid LogicalTypes in runtime operators and functions.

## Brief change log

Refactor SlicingWindowAggOperatorBuilder.

## Verifying this change

This change is a trivial reworkwithout any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no