### PR TITLE
[FLINK-21801][table-common] Deprecate TableSchema and related classes

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableColumn.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableColumn.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
@@ -32,7 +34,10 @@ import java.util.Optional;
  *
  * <p>A table column is fully resolved with a name and {@link DataType}. It describes either a
  * {@link PhysicalColumn}, {@link ComputedColumn}, or {@link MetadataColumn}.
+ *
+ * @deprecated See {@link ResolvedSchema} and {@link Column}.
  */
+@Deprecated
 @PublicEvolving
 public abstract class TableColumn {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -59,7 +59,15 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isCom
 import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
-/** A table schema that represents a table's structure with field names and data types. */
+/**
+ * A table schema that represents a table's structure with field names and data types.
+ *
+ * @deprecated This class has been deprecated as part of FLIP-164. It has been replaced by two more
+ *     dedicated classes {@link Schema} and {@link ResolvedSchema}. Use {@link Schema} for
+ *     declaration in APIs. {@link ResolvedSchema} is offered by the framework after resolution and
+ *     validation.
+ */
+@Deprecated
 @PublicEvolving
 public class TableSchema {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.api;
 
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.types.DataType;
 
 import java.util.Objects;
@@ -32,7 +33,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   <li>the string representation of watermark generation expression.
  *   <li>the data type of the computation result of watermark generation expression.
  * </ol>
+ *
+ * @deprecated See {@link ResolvedSchema} and {@link org.apache.flink.table.catalog.WatermarkSpec}.
  */
+@Deprecated
 public class WatermarkSpec {
 
     private final String rowtimeAttribute;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/constraints/Constraint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/constraints/Constraint.java
@@ -19,11 +19,15 @@
 package org.apache.flink.table.api.constraints;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.ResolvedSchema;
 
 /**
  * Integrity constraints, generally referred to simply as constraints, define the valid states of
  * SQL-data by constraining the values in the base tables.
+ *
+ * @deprecated See {@link ResolvedSchema} and {@link org.apache.flink.table.catalog.Constraint}.
  */
+@Deprecated
 @PublicEvolving
 public interface Constraint {
     String getName();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/constraints/UniqueConstraint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/constraints/UniqueConstraint.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.constraints;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.ResolvedSchema;
 
 import java.util.List;
 import java.util.Objects;
@@ -29,7 +30,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A unique key constraint. It can be declared also as a PRIMARY KEY.
  *
  * @see ConstraintType
+ * @deprecated See {@link ResolvedSchema} and {@link
+ *     org.apache.flink.table.catalog.UniqueConstraint}.
  */
+@Deprecated
 @PublicEvolving
 public final class UniqueConstraint extends AbstractConstraint {
     private final List<String> columns;


### PR DESCRIPTION
## What is the purpose of the change

Deprecates the old `TableSchema` class.


## Brief change log

Deprecates the old `TableSchema` class and subclasses.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
