### PR TITLE
[FLINK-21728] Do not release segments in MemoryManager#release(Collection<MemorySegment>) if they have been released

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/ThrowOnDoubleMemoryFreeing.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/ThrowOnDoubleMemoryFreeing.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils;
+
+import org.apache.flink.core.memory.HybridMemorySegment;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.ExternalResource;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A rule that can be used to enable throwing exception on multiple freeing of {@link
+ * HybridMemorySegment}.
+ */
+public class ThrowOnDoubleMemoryFreeing implements ExternalResource {
+
+    private Map<String, String> systemEnv = new HashMap<>();
+
+    @Override
+    public void before() throws Exception {
+        systemEnv = System.getenv();
+        CommonTestUtils.setEnv(
+                Collections.singletonMap(MemorySegment.CHECK_MULTIPLE_FREE_PROPERTY, ""), false);
+    }
+
+    @Override
+    public void afterTestSuccess() {
+        if (systemEnv != null) {
+            CommonTestUtils.setEnv(systemEnv, true);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The PR fixes releasing memory segments via `MemoryManager#release(Collection<MemorySegment>)`. Prior to the change the method did not check if the segments have been removed before, but it was freeing all segments nevertheless.

## Brief change log

  - Free segment only if it still exists in the `MemoryManager` allocated pages.
  - Throw exception if a `HybridMemorySegment` is freed twice.

## Verifying this change

Added tests in `MemoryManagerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
