### PR TITLE
[FLINK-21794][metrics] Support retrieving slot details via rest api

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -3018,6 +3018,22 @@
             }
           }
         },
+        "allocatedSlots" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:SlotInfo",
+            "properties" : {
+              "jobId" : {
+                "type" : "any"
+              },
+              "resource" : {
+                "type" : "object",
+                "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo"
+              }
+            }
+          }
+        },
         "metrics" : {
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerMetricsInfo",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -671,7 +671,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     }
 
     @Override
-    public CompletableFuture<TaskManagerInfo> requestTaskManagerInfo(
+    public CompletableFuture<TaskManagerInfoWithSlots> requestTaskManagerDetailsInfo(
             ResourceID resourceId, Time timeout) {
 
         final WorkerRegistration<WorkerType> taskExecutor = taskExecutors.get(resourceId);
@@ -680,21 +680,23 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             return FutureUtils.completedExceptionally(new UnknownTaskExecutorException(resourceId));
         } else {
             final InstanceID instanceId = taskExecutor.getInstanceID();
-            final TaskManagerInfo taskManagerInfo =
-                    new TaskManagerInfo(
-                            resourceId,
-                            taskExecutor.getTaskExecutorGateway().getAddress(),
-                            taskExecutor.getDataPort(),
-                            taskExecutor.getJmxPort(),
-                            taskManagerHeartbeatManager.getLastHeartbeatFrom(resourceId),
-                            slotManager.getNumberRegisteredSlotsOf(instanceId),
-                            slotManager.getNumberFreeSlotsOf(instanceId),
-                            slotManager.getRegisteredResourceOf(instanceId),
-                            slotManager.getFreeResourceOf(instanceId),
-                            taskExecutor.getHardwareDescription(),
-                            taskExecutor.getMemoryConfiguration());
+            final TaskManagerInfoWithSlots taskManagerInfoWithSlots =
+                    new TaskManagerInfoWithSlots(
+                            new TaskManagerInfo(
+                                    resourceId,
+                                    taskExecutor.getTaskExecutorGateway().getAddress(),
+                                    taskExecutor.getDataPort(),
+                                    taskExecutor.getJmxPort(),
+                                    taskManagerHeartbeatManager.getLastHeartbeatFrom(resourceId),
+                                    slotManager.getNumberRegisteredSlotsOf(instanceId),
+                                    slotManager.getNumberFreeSlotsOf(instanceId),
+                                    slotManager.getRegisteredResourceOf(instanceId),
+                                    slotManager.getFreeResourceOf(instanceId),
+                                    taskExecutor.getHardwareDescription(),
+                                    taskExecutor.getMemoryConfiguration()),
+                            slotManager.getAllocatedSlotsOf(instanceId));
 
-            return CompletableFuture.completedFuture(taskManagerInfo);
+            return CompletableFuture.completedFuture(taskManagerInfoWithSlots);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -192,13 +192,13 @@ public interface ResourceManagerGateway
     CompletableFuture<Collection<TaskManagerInfo>> requestTaskManagerInfo(@RpcTimeout Time timeout);
 
     /**
-     * Requests information about the given {@link TaskExecutor}.
+     * Requests detail information about the given {@link TaskExecutor}.
      *
      * @param taskManagerId identifying the TaskExecutor for which to return information
      * @param timeout of the request
-     * @return Future TaskManager information
+     * @return Future TaskManager information and its allocated slots
      */
-    CompletableFuture<TaskManagerInfo> requestTaskManagerInfo(
+    CompletableFuture<TaskManagerInfoWithSlots> requestTaskManagerDetailsInfo(
             ResourceID taskManagerId, @RpcTimeout Time timeout);
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskManagerInfoWithSlots.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/TaskManagerInfoWithSlots.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/** Contains the base information about a {@link TaskExecutor} and its allocated slots. */
+public class TaskManagerInfoWithSlots {
+
+    private final TaskManagerInfo taskManagerInfo;
+    private final Collection<SlotInfo> allocatedSlots;
+
+    public TaskManagerInfoWithSlots(
+            TaskManagerInfo taskManagerInfo, Collection<SlotInfo> allocatedSlots) {
+        this.taskManagerInfo = Preconditions.checkNotNull(taskManagerInfo);
+        this.allocatedSlots = Preconditions.checkNotNull(allocatedSlots);
+    }
+
+    public final Collection<SlotInfo> getAllocatedSlots() {
+        return Collections.unmodifiableCollection(allocatedSlots);
+    }
+
+    public TaskManagerInfo getTaskManagerInfo() {
+        return taskManagerInfo;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
@@ -716,6 +717,12 @@ public class DeclarativeSlotManager implements SlotManager {
     @Override
     public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
         return taskExecutorManager.getTotalFreeResourcesOf(instanceID);
+    }
+
+    @Override
+    public Collection<SlotInfo> getAllocatedSlotsOf(InstanceID instanceID) {
+        // This information is currently not supported for this slot manager.
+        return Collections.emptyList();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
@@ -634,6 +635,15 @@ public class FineGrainedSlotManager implements SlotManager {
     @Override
     public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
         return taskManagerTracker.getRegisteredResourceOf(instanceID);
+    }
+
+    @Override
+    public Collection<SlotInfo> getAllocatedSlotsOf(InstanceID instanceID) {
+        return taskManagerTracker.getRegisteredTaskManager(instanceID)
+                .map(TaskManagerInfo::getAllocatedSlots).map(Map::values)
+                .orElse(Collections.emptyList()).stream()
+                .map(slot -> new SlotInfo(slot.getJobId(), slot.getResourceProfile()))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -27,9 +27,11 @@ import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -69,6 +71,8 @@ public interface SlotManager extends AutoCloseable {
     ResourceProfile getFreeResource();
 
     ResourceProfile getFreeResourceOf(InstanceID instanceID);
+
+    Collection<SlotInfo> getAllocatedSlotsOf(InstanceID instanceID);
 
     int getNumberPendingSlotRequests();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
@@ -53,6 +54,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -262,6 +264,12 @@ public class SlotManagerImpl implements SlotManager {
                                         .getDefaultSlotResourceProfile()
                                         .multiply(taskManagerRegistration.getNumberFreeSlots()))
                 .orElse(ResourceProfile.ZERO);
+    }
+
+    @Override
+    public Collection<SlotInfo> getAllocatedSlotsOf(InstanceID instanceID) {
+        // This information is currently not supported for this slot manager.
+        return Collections.emptyList();
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/SlotInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/SlotInfo.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.rest.messages.ResourceProfileInfo;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.json.JobIDDeserializer;
+import org.apache.flink.runtime.rest.messages.json.JobIDSerializer;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Class containing information for a slot of {@link
+ * org.apache.flink.runtime.resourcemanager.slotmanager.TaskManagerSlot}.
+ */
+public class SlotInfo implements ResponseBody, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final String FIELD_NAME_RESOURCE = "resource";
+
+    public static final String FIELD_NAME_JOB_ID = "jobId";
+
+    @JsonProperty(FIELD_NAME_RESOURCE)
+    private final ResourceProfileInfo resource;
+
+    @JsonProperty(FIELD_NAME_JOB_ID)
+    @JsonSerialize(using = JobIDSerializer.class)
+    private final JobID jobId;
+
+    @JsonCreator
+    public SlotInfo(
+            @JsonDeserialize(using = JobIDDeserializer.class) @JsonProperty(FIELD_NAME_JOB_ID)
+                    JobID jobId,
+            @JsonProperty(FIELD_NAME_RESOURCE) ResourceProfileInfo resource) {
+        this.jobId = Preconditions.checkNotNull(jobId);
+        this.resource = Preconditions.checkNotNull(resource);
+    }
+
+    public SlotInfo(JobID jobId, ResourceProfile resource) {
+        this(jobId, ResourceProfileInfo.fromResrouceProfile(resource));
+    }
+
+    @JsonIgnore
+    public JobID getJobId() {
+        return jobId;
+    }
+
+    @JsonIgnore
+    public ResourceProfileInfo getResource() {
+        return resource;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SlotInfo that = (SlotInfo) o;
+        return Objects.equals(jobId, that.jobId) && Objects.equals(resource, that.resource);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jobId, resource);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
@@ -38,6 +39,7 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 
     public static final String FIELD_NAME_METRICS = "metrics";
 
+    @JsonProperty(FIELD_NAME_METRICS)
     private final TaskManagerMetricsInfo taskManagerMetrics;
 
     @JsonCreator
@@ -89,7 +91,7 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
                 taskManagerMetrics);
     }
 
-    @JsonProperty(FIELD_NAME_METRICS)
+    @JsonIgnore
     @VisibleForTesting
     public final TaskManagerMetricsInfo getTaskManagerMetricsInfo() {
         return this.taskManagerMetrics;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest.messages.taskmanager;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.resourcemanager.TaskManagerInfoWithSlots;
 import org.apache.flink.runtime.rest.messages.ResourceProfileInfo;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDDeserializer;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
@@ -32,6 +33,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import java.util.Collection;
 import java.util.Objects;
 
 /** Message containing base information about a {@link TaskExecutor} and more detailed metrics. */
@@ -39,8 +41,13 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 
     public static final String FIELD_NAME_METRICS = "metrics";
 
+    public static final String FIELD_NAME_ALLOCATED_SLOTS = "allocatedSlots";
+
     @JsonProperty(FIELD_NAME_METRICS)
     private final TaskManagerMetricsInfo taskManagerMetrics;
+
+    @JsonProperty(FIELD_NAME_ALLOCATED_SLOTS)
+    private final Collection<SlotInfo> allocatedSlots;
 
     @JsonCreator
     public TaskManagerDetailsInfo(
@@ -57,6 +64,7 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
             @JsonProperty(FIELD_NAME_AVAILABLE_RESOURCE) ResourceProfileInfo freeResource,
             @JsonProperty(FIELD_NAME_HARDWARE) HardwareDescription hardwareDescription,
             @JsonProperty(FIELD_NAME_MEMORY) TaskExecutorMemoryConfiguration memoryConfiguration,
+            @JsonProperty(FIELD_NAME_ALLOCATED_SLOTS) Collection<SlotInfo> allocatedSlots,
             @JsonProperty(FIELD_NAME_METRICS) TaskManagerMetricsInfo taskManagerMetrics) {
         super(
                 resourceId,
@@ -72,22 +80,25 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
                 memoryConfiguration);
 
         this.taskManagerMetrics = Preconditions.checkNotNull(taskManagerMetrics);
+        this.allocatedSlots = Preconditions.checkNotNull(allocatedSlots);
     }
 
     public TaskManagerDetailsInfo(
-            TaskManagerInfo taskManagerInfo, TaskManagerMetricsInfo taskManagerMetrics) {
+            TaskManagerInfoWithSlots taskManagerInfoWithSlots,
+            TaskManagerMetricsInfo taskManagerMetrics) {
         this(
-                taskManagerInfo.getResourceId(),
-                taskManagerInfo.getAddress(),
-                taskManagerInfo.getDataPort(),
-                taskManagerInfo.getJmxPort(),
-                taskManagerInfo.getLastHeartbeat(),
-                taskManagerInfo.getNumberSlots(),
-                taskManagerInfo.getNumberAvailableSlots(),
-                taskManagerInfo.getTotalResource(),
-                taskManagerInfo.getFreeResource(),
-                taskManagerInfo.getHardwareDescription(),
-                taskManagerInfo.getMemoryConfiguration(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getResourceId(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getAddress(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getDataPort(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getJmxPort(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getLastHeartbeat(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getNumberSlots(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getNumberAvailableSlots(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getTotalResource(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getFreeResource(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getHardwareDescription(),
+                taskManagerInfoWithSlots.getTaskManagerInfo().getMemoryConfiguration(),
+                taskManagerInfoWithSlots.getAllocatedSlots(),
                 taskManagerMetrics);
     }
 
@@ -95,6 +106,11 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
     @VisibleForTesting
     public final TaskManagerMetricsInfo getTaskManagerMetricsInfo() {
         return this.taskManagerMetrics;
+    }
+
+    @JsonIgnore
+    public Collection<SlotInfo> getAllocatedSlots() {
+        return allocatedSlots;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -152,46 +153,57 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
                 memoryConfiguration);
     }
 
+    @JsonIgnore
     public ResourceID getResourceId() {
         return resourceId;
     }
 
+    @JsonIgnore
     public String getAddress() {
         return address;
     }
 
+    @JsonIgnore
     public int getDataPort() {
         return dataPort;
     }
 
+    @JsonIgnore
     public int getJmxPort() {
         return jmxPort;
     }
 
+    @JsonIgnore
     public long getLastHeartbeat() {
         return lastHeartbeat;
     }
 
+    @JsonIgnore
     public int getNumberSlots() {
         return numberSlots;
     }
 
+    @JsonIgnore
     public int getNumberAvailableSlots() {
         return numberAvailableSlots;
     }
 
+    @JsonIgnore
     public ResourceProfileInfo getTotalResource() {
         return totalResource;
     }
 
+    @JsonIgnore
     public ResourceProfileInfo getFreeResource() {
         return freeResource;
     }
 
+    @JsonIgnore
     public HardwareDescription getHardwareDescription() {
         return hardwareDescription;
     }
 
+    @JsonIgnore
     public TaskExecutorMemoryConfiguration getMemoryConfiguration() {
         return memoryConfiguration;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -151,11 +152,12 @@ public class ResourceManagerTest extends TestLogger {
         registerTaskExecutor(
                 resourceManagerGateway, taskManagerId, taskExecutorGateway.getAddress());
 
-        CompletableFuture<TaskManagerInfo> taskManagerInfoFuture =
-                resourceManagerGateway.requestTaskManagerInfo(
+        CompletableFuture<TaskManagerInfoWithSlots> taskManagerInfoFuture =
+                resourceManagerGateway.requestTaskManagerDetailsInfo(
                         taskManagerId, TestingUtils.TIMEOUT());
 
-        TaskManagerInfo taskManagerInfo = taskManagerInfoFuture.get();
+        TaskManagerInfoWithSlots taskManagerInfoWithSlots = taskManagerInfoFuture.get();
+        TaskManagerInfo taskManagerInfo = taskManagerInfoWithSlots.getTaskManagerInfo();
 
         assertEquals(taskManagerId, taskManagerInfo.getResourceId());
         assertEquals(hardwareDescription, taskManagerInfo.getHardwareDescription());
@@ -164,6 +166,7 @@ public class ResourceManagerTest extends TestLogger {
         assertEquals(jmxPort, taskManagerInfo.getJmxPort());
         assertEquals(0, taskManagerInfo.getNumberSlots());
         assertEquals(0, taskManagerInfo.getNumberAvailableSlots());
+        assertThat(taskManagerInfoWithSlots.getAllocatedSlots(), is(empty()));
     }
 
     private void registerTaskExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -26,9 +26,12 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
+import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -90,6 +93,11 @@ public class TestingSlotManager implements SlotManager {
     @Override
     public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
         return ResourceProfile.ZERO;
+    }
+
+    @Override
+    public Collection<SlotInfo> getAllocatedSlotsOf(InstanceID instanceID) {
+        return Collections.emptyList();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
+import org.apache.flink.runtime.resourcemanager.TaskManagerInfoWithSlots;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
 import org.apache.flink.runtime.rest.messages.LogInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
@@ -111,8 +112,8 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     private volatile Function<ResourceID, CompletableFuture<Collection<LogInfo>>>
             requestTaskManagerLogListFunction;
 
-    private volatile Function<ResourceID, CompletableFuture<TaskManagerInfo>>
-            requestTaskManagerInfoFunction;
+    private volatile Function<ResourceID, CompletableFuture<TaskManagerInfoWithSlots>>
+            requestTaskManagerDetailsInfoFunction;
 
     private volatile Function<ResourceID, CompletableFuture<ThreadDumpInfo>>
             requestThreadDumpFunction;
@@ -202,10 +203,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
         this.requestTaskManagerLogListFunction = requestTaskManagerLogListFunction;
     }
 
-    public void setRequestTaskManagerInfoFunction(
-            Function<ResourceID, CompletableFuture<TaskManagerInfo>>
-                    requestTaskManagerInfoFunction) {
-        this.requestTaskManagerInfoFunction = requestTaskManagerInfoFunction;
+    public void setRequestTaskManagerDetailsInfoFunction(
+            Function<ResourceID, CompletableFuture<TaskManagerInfoWithSlots>>
+                    requestTaskManagerDetailsInfoFunction) {
+        this.requestTaskManagerDetailsInfoFunction = requestTaskManagerDetailsInfoFunction;
     }
 
     public void setDisconnectTaskExecutorConsumer(
@@ -395,10 +396,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     }
 
     @Override
-    public CompletableFuture<TaskManagerInfo> requestTaskManagerInfo(
+    public CompletableFuture<TaskManagerInfoWithSlots> requestTaskManagerDetailsInfo(
             ResourceID resourceId, Time timeout) {
-        final Function<ResourceID, CompletableFuture<TaskManagerInfo>> function =
-                requestTaskManagerInfoFunction;
+        final Function<ResourceID, CompletableFuture<TaskManagerInfoWithSlots>> function =
+                requestTaskManagerDetailsInfoFunction;
 
         if (function != null) {
             return function.apply(resourceId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandlerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.resourcemanager.TaskManagerInfoWithSlots;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.HandlerRequestException;
@@ -87,8 +88,11 @@ public class TaskManagerDetailsHandlerTest extends TestLogger {
             throws RestHandlerException, ExecutionException, InterruptedException,
                     JsonProcessingException, HandlerRequestException {
         initializeMetricStore(metricFetcher.getMetricStore());
-        resourceManagerGateway.setRequestTaskManagerInfoFunction(
-                taskManagerId -> CompletableFuture.completedFuture(createEmptyTaskManagerInfo()));
+        resourceManagerGateway.setRequestTaskManagerDetailsInfoFunction(
+                taskManagerId ->
+                        CompletableFuture.completedFuture(
+                                new TaskManagerInfoWithSlots(
+                                        createEmptyTaskManagerInfo(), Collections.emptyList())));
 
         HandlerRequest<EmptyRequestBody, TaskManagerMessageParameters> request = createRequest();
         TaskManagerDetailsInfo taskManagerDetailsInfo =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfoTest.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.runtime.rest.messages.taskmanager;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.resourcemanager.TaskManagerInfoWithSlots;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -38,10 +42,13 @@ public class TaskManagerDetailsInfoTest
 
     @Override
     protected TaskManagerDetailsInfo getTestResponseInstance() throws Exception {
-        final TaskManagerInfo taskManagerInfo = TaskManagerInfoTest.createRandomTaskManagerInfo();
+        final TaskManagerInfoWithSlots taskManagerInfoWithSlots =
+                new TaskManagerInfoWithSlots(
+                        TaskManagerInfoTest.createRandomTaskManagerInfo(),
+                        Collections.singletonList(new SlotInfo(new JobID(), ResourceProfile.ANY)));
         final TaskManagerMetricsInfo taskManagerMetricsInfo = createRandomTaskManagerMetricsInfo();
 
-        return new TaskManagerDetailsInfo(taskManagerInfo, taskManagerMetricsInfo);
+        return new TaskManagerDetailsInfo(taskManagerInfoWithSlots, taskManagerMetricsInfo);
     }
 
     static TaskManagerMetricsInfo createRandomTaskManagerMetricsInfo() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
