### PR TITLE
[FLINK-21852][table] Introduce SupportsAnyNull to BinaryRowData

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
@@ -59,7 +59,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * <p>Variable-length part may fall into multiple MemorySegments.
  */
 @Internal
-public final class BinaryRowData extends BinarySection implements RowData, TypedSetters {
+public final class BinaryRowData extends BinarySection
+        implements RowData, TypedSetters, SupportsAnyNull {
 
     public static final boolean LITTLE_ENDIAN =
             (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);
@@ -388,6 +389,7 @@ public final class BinaryRowData extends BinarySection implements RowData, Typed
     }
 
     /** The bit is 1 when the field is null. Default is 0. */
+    @Override
     public boolean anyNull() {
         // Skip the header.
         if ((segments[0].getLong(0) & FIRST_BYTE_ZERO) != 0) {
@@ -401,6 +403,7 @@ public final class BinaryRowData extends BinarySection implements RowData, Typed
         return false;
     }
 
+    @Override
     public boolean anyNull(int[] fields) {
         for (int field : fields) {
             if (isNullAt(field)) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRowData.java
@@ -60,7 +60,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 @Internal
 public final class BinaryRowData extends BinarySection
-        implements RowData, TypedSetters, SupportsAnyNull {
+        implements RowData, TypedSetters, NullAwareGetters {
 
     public static final boolean LITTLE_ENDIAN =
             (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NullAwareGetters.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/NullAwareGetters.java
@@ -20,9 +20,9 @@ package org.apache.flink.table.data.binary;
 
 import org.apache.flink.annotation.Internal;
 
-/** Supports optimized any null check. */
+/** Provides null related getters. */
 @Internal
-public interface SupportsAnyNull {
+public interface NullAwareGetters {
 
     /** If no field is null, return false. Returns true if one of the columns is null. */
     boolean anyNull();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/SupportsAnyNull.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/SupportsAnyNull.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.binary;
+
+/** Supports optimized any null check. */
+public interface SupportsAnyNull {
+
+    boolean anyNull();
+
+    /**
+     * For the input fields, if no field is null, return false. Returns true if one of the columns
+     * is null.
+     */
+    boolean anyNull(int[] fields);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/SupportsAnyNull.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/SupportsAnyNull.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.table.data.binary;
 
+import org.apache.flink.annotation.Internal;
+
 /** Supports optimized any null check. */
+@Internal
 public interface SupportsAnyNull {
 
     /** If no field is null, return false. Returns true if one of the columns is null. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/SupportsAnyNull.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/SupportsAnyNull.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.data.binary;
 /** Supports optimized any null check. */
 public interface SupportsAnyNull {
 
+    /** If no field is null, return false. Returns true if one of the columns is null. */
     boolean anyNull();
 
     /**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/interval/IntervalJoinFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/interval/IntervalJoinFunction.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.SupportsAnyNull;
 import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
@@ -46,7 +46,7 @@ public class IntervalJoinFunction extends RichFlatJoinFunction<RowData, RowData,
 
     private transient JoinCondition joinCondition;
     private transient JoinedRowData reusedJoinRowData;
-    private transient BinaryRowData joinKey;
+    private transient SupportsAnyNull joinKey;
 
     public IntervalJoinFunction(
             GeneratedJoinCondition joinCondition,
@@ -88,6 +88,6 @@ public class IntervalJoinFunction extends RichFlatJoinFunction<RowData, RowData,
     }
 
     public void setJoinKey(RowData currentKey) {
-        this.joinKey = (BinaryRowData) currentKey;
+        this.joinKey = (SupportsAnyNull) currentKey;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/interval/IntervalJoinFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/interval/IntervalJoinFunction.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.SupportsAnyNull;
+import org.apache.flink.table.data.binary.NullAwareGetters;
 import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
@@ -46,7 +46,7 @@ public class IntervalJoinFunction extends RichFlatJoinFunction<RowData, RowData,
 
     private transient JoinCondition joinCondition;
     private transient JoinedRowData reusedJoinRowData;
-    private transient SupportsAnyNull joinKey;
+    private transient NullAwareGetters joinKey;
 
     public IntervalJoinFunction(
             GeneratedJoinCondition joinCondition,
@@ -88,6 +88,6 @@ public class IntervalJoinFunction extends RichFlatJoinFunction<RowData, RowData,
     }
 
     public void setJoinKey(RowData currentKey) {
-        this.joinKey = (SupportsAnyNull) currentKey;
+        this.joinKey = (NullAwareGetters) currentKey;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.SupportsAnyNull;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
 import org.apache.flink.table.runtime.operators.join.NullAwareJoinHelper;
@@ -132,7 +132,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
         public boolean apply(RowData left, RowData right) {
             if (!nullSafe) { // is not null safe, return false if any null exists
                 // key is always BinaryRowData
-                BinaryRowData joinKey = (BinaryRowData) getCurrentKey();
+                SupportsAnyNull joinKey = (SupportsAnyNull) getCurrentKey();
                 if (filterAllNulls ? joinKey.anyNull() : joinKey.anyNull(nullFilterKeys)) {
                     // find null present, return false directly
                     return false;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.binary.SupportsAnyNull;
+import org.apache.flink.table.data.binary.NullAwareGetters;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
 import org.apache.flink.table.runtime.operators.join.NullAwareJoinHelper;
@@ -132,7 +132,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
         public boolean apply(RowData left, RowData right) {
             if (!nullSafe) { // is not null safe, return false if any null exists
                 // key is always BinaryRowData
-                SupportsAnyNull joinKey = (SupportsAnyNull) getCurrentKey();
+                NullAwareGetters joinKey = (NullAwareGetters) getCurrentKey();
                 if (filterAllNulls ? joinKey.anyNull() : joinKey.anyNull(nullFilterKeys)) {
                     // find null present, return false directly
                     return false;


### PR DESCRIPTION

## What is the purpose of the change

Introduce SupportsAnyNull to BinaryRowData.
We should avoid force casting to implementation. It is better to rely on interface.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no