### PR TITLE
[FLINK-21849][sql-client] Add default module test case for 'SHOW [FULL] MODULES'

### DIFF
--- a/flink-table/flink-sql-client/src/test/resources/sql/module.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/module.q
@@ -24,6 +24,25 @@ SET sql-client.execution.result-mode = tableau;
 # test load module
 # ==========================================================================
 
+# list default loaded and enabled module
+SHOW MODULES;
++-------------+
+| module name |
++-------------+
+|        core |
++-------------+
+1 row in set
+!ok
+
+SHOW FULL MODULES;
++-------------+------+
+| module name | used |
++-------------+------+
+|        core | true |
++-------------+------+
+1 row in set
+!ok
+
 # load core module twice
 LOAD MODULE core;
 [ERROR] Could not execute SQL statement. Load module failed! Reason:


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds a case in `CliClientITCase` to test `SHOW [FULL] MODULES` for the default core module.


## Brief change log

  - Add `SHOW MODULES` and `SHOW FULL MODULES` in `module.q`

## Verifying this change

This change is can be verified by running `CliClientITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
