### PR TITLE
[FLINK-21745][tests] Sets the parallelism in tests to comply to the AdaptiveScheduler requirements

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PerJobMiniClusterFactoryTest.java
@@ -187,6 +187,7 @@ public class PerJobMiniClusterFactoryTest extends TestLogger {
     private static JobGraph getCancellableJobGraph() {
         JobVertex jobVertex = new JobVertex("jobVertex");
         jobVertex.setInvokableClass(MyCancellableInvokable.class);
+        jobVertex.setParallelism(1);
         return JobGraphTestUtils.streamingJobGraph(jobVertex);
     }
 

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -88,6 +88,7 @@ public class JMXJobManagerMetricTest extends TestLogger {
         try {
             JobVertex sourceJobVertex = new JobVertex("Source");
             sourceJobVertex.setInvokableClass(BlockingInvokable.class);
+            sourceJobVertex.setParallelism(1);
 
             final JobCheckpointingSettings jobCheckpointingSettings =
                     new JobCheckpointingSettings(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -1026,6 +1026,9 @@ public class DispatcherTest extends TestLogger {
     private Tuple2<JobGraph, BlockingJobVertex> getBlockingJobGraphAndVertex() {
         final BlockingJobVertex blockingJobVertex = new BlockingJobVertex("testVertex");
         blockingJobVertex.setInvokableClass(NoOpInvokable.class);
+        // AdaptiveScheduler expects the parallelism to be set for each vertex
+        blockingJobVertex.setParallelism(1);
+
         return Tuple2.of(
                 JobGraphBuilder.newStreamingJobGraphBuilder()
                         .setJobId(jobId)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobGraphTestUtils.java
@@ -32,6 +32,7 @@ public class JobGraphTestUtils {
     public static JobGraph singleNoOpJobGraph() {
         JobVertex jobVertex = new JobVertex("jobVertex");
         jobVertex.setInvokableClass(NoOpInvokable.class);
+        jobVertex.setParallelism(1);
 
         return JobGraphBuilder.newStreamingJobGraphBuilder().addJobVertex(jobVertex).build();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1783,6 +1783,7 @@ public class JobMasterTest extends TestLogger {
             SavepointRestoreSettings savepointRestoreSettings) {
         final JobVertex source = new JobVertex("source");
         source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(1);
 
         return TestUtils.createJobGraphFromJobVerticesWithCheckpointing(
                 savepointRestoreSettings, source);

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -95,6 +95,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 
         final JobVertex vertex = new JobVertex("testVertex");
         vertex.setInvokableClass(NoOpBlockingInvokable.class);
+        vertex.setParallelism(1);
 
         final JobCheckpointingSettings jobCheckpointingSettings =
                 new JobCheckpointingSettings(

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -82,6 +82,7 @@ public class JobRetrievalITCase extends TestLogger {
     public void testJobRetrieval() throws Exception {
         final JobVertex imalock = new JobVertex("imalock");
         imalock.setInvokableClass(SemaphoreInvokable.class);
+        imalock.setParallelism(1);
 
         final JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(imalock);
         final JobID jobId = jobGraph.getJobID();

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
@@ -80,6 +80,7 @@ public class JobSubmissionFailsITCase extends TestLogger {
     public void testExceptionInInitializeOnMaster() throws Exception {
         final JobVertex failingJobVertex = new FailingJobVertex("Failing job vertex");
         failingJobVertex.setInvokableClass(NoOpInvokable.class);
+        failingJobVertex.setParallelism(1);
 
         final JobGraph failingJobGraph = JobGraphTestUtils.streamingJobGraph(failingJobVertex);
         runJobSubmissionTest(


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-21135](https://issues.apache.org/jira/browse/FLINK-21135) removed the code for setting the parallelism of each `JobVertex` to `1` if not properly set, yet. This caused `IllegalStateExceptions` in different tests having `flink.tests.enable-adaptive-scheduler` enabled where the parallelism was not set.

## Brief change log

- introduces a `Precondition` in `AdaptiveScheduler` checking the parallelism of each `JobVertex`
- sets the parallelism for vertices in failing tests if the test failure was caused by the newly introduced `IllegalStateException`

## Verifying this change

- I ran affected tests and fixed the related test failures

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
