### PR TITLE
[FLINK-21801][table-api] Update use new schema in Table and TableResult

### DIFF
--- a/flink-python/pyflink/table/tests/test_table_completeness.py
+++ b/flink-python/pyflink/table/tests/test_table_completeness.py
@@ -41,7 +41,8 @@ class TableAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTestCase):
         # complete type system, which does not exist currently. It will be implemented after
         # FLINK-12408 is merged. So we exclude this method for the time being.
         return {'map', 'flatMap', 'flatAggregate',  'aggregate', 'leftOuterJoinLateral',
-                'createTemporalTableFunction', 'joinLateral', 'getQueryOperation', 'limit'}
+                'createTemporalTableFunction', 'joinLateral', 'getQueryOperation', 'limit',
+                'getResolvedSchema'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
@@ -277,7 +277,9 @@ public class CliChangelogResultView
         schemaHeader.append("op");
         schemaHeader.style(AttributedStyle.DEFAULT);
 
-        Arrays.stream(resultDescriptor.getResultSchema().getFieldNames())
+        resultDescriptor
+                .getResultSchema()
+                .getColumnNames()
                 .forEach(
                         s -> {
                             schemaHeader.append(' ');

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -517,7 +517,7 @@ public class CliClient implements AutoCloseable {
             return;
         }
         PrintUtils.printAsTableauForm(
-                result.getTableSchema(),
+                result.getResolvedSchema(),
                 result.collect(),
                 terminal.writer(),
                 Integer.MAX_VALUE,

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.client.cli;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.types.DataType;
 
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStringBuilder;
@@ -145,9 +146,12 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
         final CliRowView view =
                 new CliRowView(
                         client,
-                        resultDescriptor.getResultSchema().getFieldNames(),
+                        resultDescriptor.getResultSchema().getColumnNames().toArray(new String[0]),
                         CliUtils.typesToString(
-                                resultDescriptor.getResultSchema().getFieldDataTypes()),
+                                resultDescriptor
+                                        .getResultSchema()
+                                        .getColumnDataTypes()
+                                        .toArray(new DataType[0])),
                         getRow(results.get(selectedRow)));
         view.open(); // enter view
     }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
@@ -264,7 +264,9 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
     protected List<AttributedString> computeMainHeaderLines() {
         final AttributedStringBuilder schemaHeader = new AttributedStringBuilder();
 
-        Arrays.stream(resultDescriptor.getResultSchema().getFieldNames())
+        resultDescriptor
+                .getResultSchema()
+                .getColumnNames()
                 .forEach(
                         s -> {
                             schemaHeader.append(' ');

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableauResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableauResultView.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
-import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
@@ -117,14 +117,14 @@ public class CliTableauResultView implements AutoCloseable {
     }
 
     private void printResults(AtomicInteger receivedRowCount, boolean isStreamingMode) {
-        List<TableColumn> columns = resultDescriptor.getResultSchema().getTableColumns();
+        List<Column> columns = resultDescriptor.getResultSchema().getColumns();
         final String[] fieldNames;
         final int[] colWidths;
         if (isStreamingMode) {
             fieldNames =
                     Stream.concat(
                                     Stream.of(PrintUtils.ROW_KIND_COLUMN),
-                                    columns.stream().map(TableColumn::getName))
+                                    columns.stream().map(Column::getName))
                             .toArray(String[]::new);
             colWidths =
                     PrintUtils.columnWidthsByType(
@@ -133,7 +133,7 @@ public class CliTableauResultView implements AutoCloseable {
                             PrintUtils.NULL_COLUMN,
                             PrintUtils.ROW_KIND_COLUMN);
         } else {
-            fieldNames = columns.stream().map(TableColumn::getName).toArray(String[]::new);
+            fieldNames = columns.stream().map(Column::getName).toArray(String[]::new);
             colWidths =
                     PrintUtils.columnWidthsByType(
                             columns, DEFAULT_COLUMN_WIDTH, PrintUtils.NULL_COLUMN, null);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ResultDescriptor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ResultDescriptor.java
@@ -18,14 +18,14 @@
 
 package org.apache.flink.table.client.gateway;
 
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 
 /** Describes a result to be expected from a table program. */
 public class ResultDescriptor {
 
     private final String resultId;
 
-    private final TableSchema resultSchema;
+    private final ResolvedSchema resultSchema;
 
     private final boolean isMaterialized;
 
@@ -35,7 +35,7 @@ public class ResultDescriptor {
 
     public ResultDescriptor(
             String resultId,
-            TableSchema resultSchema,
+            ResolvedSchema resultSchema,
             boolean isMaterialized,
             boolean isTableauMode,
             boolean isStreamingMode) {
@@ -50,7 +50,7 @@ public class ResultDescriptor {
         return resultId;
     }
 
-    public TableSchema getResultSchema() {
+    public ResolvedSchema getResultSchema() {
         return resultSchema;
     }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -40,9 +40,6 @@ import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
-import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.types.Row;
 
 import org.slf4j.Logger;
@@ -300,24 +297,9 @@ public class LocalExecutor implements Executor {
         resultStore.storeResult(jobId, result);
         return new ResultDescriptor(
                 jobId,
-                removeTimeAttributes(tableResult.getTableSchema()),
+                tableResult.getResolvedSchema(),
                 result.isMaterialized(),
                 config.get(EXECUTION_RESULT_MODE).equals(ResultMode.TABLEAU),
                 config.get(RUNTIME_MODE).equals(RuntimeExecutionMode.STREAMING));
-    }
-
-    // --------------------------------------------------------------------------------------------
-
-    private static TableSchema removeTimeAttributes(TableSchema schema) {
-        final TableSchema.Builder builder = TableSchema.builder();
-        for (int i = 0; i < schema.getFieldCount(); i++) {
-            final DataType dataType = schema.getFieldDataTypes()[i];
-            final DataType convertedType =
-                    DataTypeUtils.replaceLogicalType(
-                            dataType,
-                            LogicalTypeUtils.removeTimeAttributes(dataType.getLogicalType()));
-            builder.field(schema.getFieldNames()[i], convertedType);
-        }
-        return builder.build();
     }
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -24,7 +24,8 @@ import org.apache.flink.streaming.environment.TestingJobClient;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.cli.utils.SqlParserHelper;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.cli.utils.TestTableResult;
@@ -150,9 +151,9 @@ public class CliClientTest extends TestLogger {
                                         SHOW_ROW.setField(0, "v1");
                                         return new TestTableResult(
                                                 ResultKind.SUCCESS_WITH_CONTENT,
-                                                TableSchema.builder()
-                                                        .field("view", DataTypes.STRING())
-                                                        .build(),
+                                                ResolvedSchema.of(
+                                                        Column.physical(
+                                                                "view", DataTypes.STRING())),
                                                 CloseableIterator.ofElement(SHOW_ROW, ele -> {}));
                                     } else {
                                         throw new SqlExecutionException(
@@ -297,7 +298,7 @@ public class CliClientTest extends TestLogger {
                 return new TestTableResult(
                         new TestingJobClient(),
                         ResultKind.SUCCESS_WITH_CONTENT,
-                        TableSchema.builder().field("result", DataTypes.BIGINT()).build(),
+                        ResolvedSchema.of(Column.physical("result", DataTypes.BIGINT())),
                         CloseableIterator.adapterForIterator(
                                 Collections.singletonList(Row.of(-1L)).iterator()));
             }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -17,9 +17,10 @@
 
 package org.apache.flink.table.client.cli;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.Types;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
@@ -86,7 +87,7 @@ public class CliResultViewTest {
         final ResultDescriptor descriptor =
                 new ResultDescriptor(
                         "result-id",
-                        TableSchema.builder().field("Null Field", Types.STRING()).build(),
+                        ResolvedSchema.of(Column.physical("Null Field", DataTypes.STRING())),
                         false,
                         false,
                         true);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -21,7 +21,8 @@ package org.apache.flink.table.client.cli;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
@@ -53,7 +54,7 @@ public class CliTableauResultViewTest {
 
     private ByteArrayOutputStream terminalOutput;
     private Terminal terminal;
-    private TableSchema schema;
+    private ResolvedSchema schema;
     private List<Row> data;
     private List<Row> streamingData;
 
@@ -63,14 +64,13 @@ public class CliTableauResultViewTest {
         terminal = TerminalUtils.createDummyTerminal(terminalOutput);
 
         schema =
-                TableSchema.builder()
-                        .field("boolean", DataTypes.BOOLEAN())
-                        .field("int", DataTypes.INT())
-                        .field("bigint", DataTypes.BIGINT())
-                        .field("varchar", DataTypes.STRING())
-                        .field("decimal(10, 5)", DataTypes.DECIMAL(10, 5))
-                        .field("timestamp", DataTypes.TIMESTAMP(6))
-                        .build();
+                ResolvedSchema.of(
+                        Column.physical("boolean", DataTypes.BOOLEAN()),
+                        Column.physical("int", DataTypes.INT()),
+                        Column.physical("bigint", DataTypes.BIGINT()),
+                        Column.physical("varchar", DataTypes.STRING()),
+                        Column.physical("decimal(10, 5)", DataTypes.DECIMAL(10, 5)),
+                        Column.physical("timestamp", DataTypes.TIMESTAMP(6)));
 
         data = new ArrayList<>();
         data.add(

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/TestTableResult.java
@@ -22,47 +22,46 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
 import java.util.Collections;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /** {@link TableResult} for testing. */
 public class TestTableResult implements TableResult {
     private final JobClient jobClient;
-    private final TableSchema tableSchema;
+    private final ResolvedSchema resolvedSchema;
     private final ResultKind resultKind;
     private final CloseableIterator<Row> data;
 
     public static final TestTableResult TABLE_RESULT_OK =
             new TestTableResult(
                     ResultKind.SUCCESS,
-                    TableSchema.builder().field("result", DataTypes.STRING()).build(),
+                    ResolvedSchema.of(Column.physical("result", DataTypes.STRING())),
                     CloseableIterator.adapterForIterator(
                             Collections.singletonList(Row.of("OK")).iterator()));
 
-    public TestTableResult(ResultKind resultKind, TableSchema tableSchema) {
-        this(resultKind, tableSchema, CloseableIterator.empty());
+    public TestTableResult(ResultKind resultKind, ResolvedSchema resolvedSchema) {
+        this(resultKind, resolvedSchema, CloseableIterator.empty());
     }
 
     public TestTableResult(
-            ResultKind resultKind, TableSchema tableSchema, CloseableIterator<Row> data) {
-        this(null, resultKind, tableSchema, data);
+            ResultKind resultKind, ResolvedSchema resolvedSchema, CloseableIterator<Row> data) {
+        this(null, resultKind, resolvedSchema, data);
     }
 
     public TestTableResult(
             JobClient jobClient,
             ResultKind resultKind,
-            TableSchema tableSchema,
+            ResolvedSchema resolvedSchema,
             CloseableIterator<Row> data) {
         this.jobClient = jobClient;
         this.resultKind = resultKind;
-        this.tableSchema = tableSchema;
+        this.resolvedSchema = resolvedSchema;
         this.data = data;
     }
 
@@ -72,15 +71,14 @@ public class TestTableResult implements TableResult {
     }
 
     @Override
-    public void await() throws InterruptedException, ExecutionException {}
+    public void await() {}
 
     @Override
-    public void await(long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {}
+    public void await(long timeout, TimeUnit unit) {}
 
     @Override
-    public TableSchema getTableSchema() {
-        return tableSchema;
+    public ResolvedSchema getResolvedSchema() {
+        return resolvedSchema;
     }
 
     @Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/context/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/context/ExecutionContextTest.java
@@ -28,12 +28,12 @@ import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.config.entries.CatalogEntry;
@@ -311,20 +311,19 @@ public class ExecutionContextTest {
                 new String[] {"sourcetemporaltable", "viewtemporaltable"},
                 tableEnv.listUserDefinedFunctions());
 
-        assertArrayEquals(
-                new String[] {
-                    "integerField",
-                    "stringField",
-                    "rowtimeField",
-                    "integerField0",
-                    "stringField0",
-                    "rowtimeField0"
-                },
-                tableEnv.from("TemporalTableUsage").getSchema().getFieldNames());
+        assertEquals(
+                Arrays.asList(
+                        "integerField",
+                        "stringField",
+                        "rowtimeField",
+                        "integerField0",
+                        "stringField0",
+                        "rowtimeField0"),
+                tableEnv.from("TemporalTableUsage").getResolvedSchema().getColumnNames());
 
         // Please delete this test after removing registerTableSourceInternal in SQL-CLI.
-        TableSchema tableSchema = tableEnv.from("EnrichmentSource").getSchema();
-        LogicalType timestampType = tableSchema.getFieldDataTypes()[2].getLogicalType();
+        ResolvedSchema schema = tableEnv.from("EnrichmentSource").getResolvedSchema();
+        LogicalType timestampType = schema.getColumnDataTypes().get(2).getLogicalType();
         assertTrue(timestampType instanceof TimestampType);
         assertEquals(TimestampKind.ROWTIME, ((TimestampType) timestampType).getKind());
     }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogPropertiesUtil;
@@ -95,21 +94,17 @@ public class DependencyTest {
         try {
             final TableResult tableResult = executor.executeSql(sessionId, "DESCRIBE TableNumber1");
             assertEquals(
-                    tableResult.getTableSchema(),
-                    TableSchema.builder()
-                            .fields(
-                                    new String[] {
-                                        "name", "type", "null", "key", "extras", "watermark"
-                                    },
-                                    new DataType[] {
-                                        DataTypes.STRING(),
-                                        DataTypes.STRING(),
-                                        DataTypes.BOOLEAN(),
-                                        DataTypes.STRING(),
-                                        DataTypes.STRING(),
-                                        DataTypes.STRING()
-                                    })
-                            .build());
+                    tableResult.getResolvedSchema(),
+                    ResolvedSchema.physical(
+                            new String[] {"name", "type", "null", "key", "extras", "watermark"},
+                            new DataType[] {
+                                DataTypes.STRING(),
+                                DataTypes.STRING(),
+                                DataTypes.BOOLEAN(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING()
+                            }));
             List<Row> schemaData =
                     Arrays.asList(
                             Row.of("IntegerField1", "INT", true, null, null, null),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectResultTest.java
@@ -20,7 +20,8 @@ package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.cli.utils.TestTableResult;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
@@ -47,7 +48,7 @@ public class ChangelogCollectResultTest {
                 new ChangelogCollectResult(
                         new TestTableResult(
                                 ResultKind.SUCCESS_WITH_CONTENT,
-                                TableSchema.builder().field("id", DataTypes.INT()).build(),
+                                ResolvedSchema.of(Column.physical("id", DataTypes.INT())),
                                 data));
 
         int count = 0;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResultTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.client.gateway.local.result;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.cli.utils.TestTableResult;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.types.DataType;
@@ -39,16 +39,14 @@ public class MaterializedCollectBatchResultTest {
 
     @Test
     public void testSnapshot() throws Exception {
-        TableSchema tableSchema =
-                TableSchema.builder()
-                        .fields(
-                                new String[] {"f0", "f1"},
-                                new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()})
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.physical(
+                        new String[] {"f0", "f1"},
+                        new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()});
 
         try (TestMaterializedCollectBatchResult result =
                 new TestMaterializedCollectBatchResult(
-                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, tableSchema),
+                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, schema),
                         Integer.MAX_VALUE)) {
 
             result.isRetrieving = true;
@@ -79,16 +77,14 @@ public class MaterializedCollectBatchResultTest {
 
     @Test
     public void testLimitedSnapshot() throws Exception {
-        TableSchema tableSchema =
-                TableSchema.builder()
-                        .fields(
-                                new String[] {"f0", "f1"},
-                                new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()})
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.physical(
+                        new String[] {"f0", "f1"},
+                        new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()});
 
         try (TestMaterializedCollectBatchResult result =
                 new TestMaterializedCollectBatchResult(
-                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, tableSchema),
+                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, schema),
                         2, // limit the materialized table to 2 rows
                         3)) { // with 3 rows overcommitment
             result.isRetrieving = true;

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.client.gateway.local.result;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.client.cli.utils.TestTableResult;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.types.DataType;
@@ -40,16 +40,14 @@ public class MaterializedCollectStreamResultTest {
 
     @Test
     public void testSnapshot() throws Exception {
-        TableSchema tableSchema =
-                TableSchema.builder()
-                        .fields(
-                                new String[] {"f0", "f1"},
-                                new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()})
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.physical(
+                        new String[] {"f0", "f1"},
+                        new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()});
 
         try (TestMaterializedCollectStreamResult result =
                 new TestMaterializedCollectStreamResult(
-                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, tableSchema),
+                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, schema),
                         Integer.MAX_VALUE)) {
             result.isRetrieving = true;
 
@@ -86,18 +84,16 @@ public class MaterializedCollectStreamResultTest {
 
     @Test
     public void testLimitedSnapshot() throws Exception {
-        TableSchema tableSchema =
-                TableSchema.builder()
-                        .fields(
-                                new String[] {"f0", "f1"},
-                                new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()})
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.physical(
+                        new String[] {"f0", "f1"},
+                        new DataType[] {DataTypes.STRING(), DataTypes.BIGINT()});
 
         // limit the materialized table to 2 rows
         // with 3 rows overcommitment
         try (TestMaterializedCollectStreamResult result =
                 new TestMaterializedCollectStreamResult(
-                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, tableSchema), 2, 3)) {
+                        new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, schema), 2, 3)) {
 
             result.isRetrieving = true;
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.TemporalTableFunction;
@@ -69,10 +70,23 @@ import org.apache.flink.table.sinks.TableSink;
 @PublicEvolving
 public interface Table {
 
-    /** Returns the schema of this table. */
-    TableSchema getSchema();
+    /**
+     * Returns the schema of this table.
+     *
+     * @deprecated This method has been deprecated as part of FLIP-164. {@link TableSchema} has been
+     *     replaced by two more dedicated classes {@link Schema} and {@link ResolvedSchema}. Use
+     *     {@link Schema} for declaration in APIs. {@link ResolvedSchema} is offered by the
+     *     framework after resolution and validation.
+     */
+    @Deprecated
+    default TableSchema getSchema() {
+        return TableSchema.fromResolvedSchema(getResolvedSchema());
+    }
 
-    /** Prints the schema of this table to the console in a tree format. */
+    /** Returns the resolved schema of this table. */
+    ResolvedSchema getResolvedSchema();
+
+    /** Prints the schema of this table to the console in a summary format. */
     void printSchema();
 
     /** Returns underlying logical representation of this table. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableResult.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
@@ -69,7 +70,7 @@ public interface TableResult {
             throws InterruptedException, ExecutionException, TimeoutException;
 
     /**
-     * Get the schema of result.
+     * Returns the schema of the result.
      *
      * <p>The schema of DDL, USE, EXPLAIN:
      *
@@ -107,7 +108,7 @@ public interface TableResult {
      * | type             | STRING      | field type expressed as a String                                            |
      * | null             | BOOLEAN     | field nullability: true if a field is nullable, else false                  |
      * | key              | BOOLEAN     | key constraint: 'PRI' for primary keys, 'UNQ' for unique keys, else null    |
-     * | computed column  | STRING      | computed column: string expression if a field is computed column, else null |
+     * | extras           | STRING      | extras such as computed or metadata column information, else null           |
      * | watermark        | STRING      | watermark: string expression if a field is watermark, else null             |
      * +------------------+-------------+-----------------------------------------------------------------------------+
      * </pre>
@@ -124,7 +125,20 @@ public interface TableResult {
      *
      * <p>The schema of SELECT is the selected field names and types.
      */
-    TableSchema getTableSchema();
+    ResolvedSchema getResolvedSchema();
+
+    /**
+     * Returns the schema of the result.
+     *
+     * @deprecated This method has been deprecated as part of FLIP-164. {@link TableSchema} has been
+     *     replaced by two more dedicated classes {@link Schema} and {@link ResolvedSchema}. Use
+     *     {@link Schema} for declaration in APIs. {@link ResolvedSchema} is offered by the
+     *     framework after resolution and validation.
+     */
+    @Deprecated
+    default TableSchema getTableSchema() {
+        return TableSchema.fromResolvedSchema(getResolvedSchema());
+    }
 
     /**
      * Return the {@link ResultKind} which represents the result type.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -31,11 +31,11 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.WindowGroupedTable;
 import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionParser;
@@ -102,13 +102,13 @@ public class TableImpl implements Table {
     }
 
     @Override
-    public TableSchema getSchema() {
-        return TableSchema.fromResolvedSchema(operationTree.getResolvedSchema());
+    public ResolvedSchema getResolvedSchema() {
+        return operationTree.getResolvedSchema();
     }
 
     @Override
     public void printSchema() {
-        System.out.println(getSchema());
+        System.out.println(getResolvedSchema());
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
@@ -202,14 +202,14 @@ public class SchemaResolutionTest {
                 SCHEMA.toString(),
                 equalTo(
                         "(\n"
-                                + "  `id` INT NOT NULL, \n"
-                                + "  `counter` INT NOT NULL, \n"
-                                + "  `payload` [ROW<name STRING, age INT, flag BOOLEAN>], \n"
-                                + "  `topic` METADATA VIRTUAL, \n"
-                                + "  `ts` AS [orig_ts - INTERVAL '60' MINUTE], \n"
-                                + "  `orig_ts` METADATA FROM 'timestamp', \n"
-                                + "  `proctime` AS [PROCTIME()], \n"
-                                + "  WATERMARK FOR `ts` AS [ts - INTERVAL '5' SECOND], \n"
+                                + "  `id` INT NOT NULL,\n"
+                                + "  `counter` INT NOT NULL,\n"
+                                + "  `payload` [ROW<name STRING, age INT, flag BOOLEAN>],\n"
+                                + "  `topic` METADATA VIRTUAL,\n"
+                                + "  `ts` AS [orig_ts - INTERVAL '60' MINUTE],\n"
+                                + "  `orig_ts` METADATA FROM 'timestamp',\n"
+                                + "  `proctime` AS [PROCTIME()],\n"
+                                + "  WATERMARK FOR `ts` AS [ts - INTERVAL '5' SECOND],\n"
                                 + "  CONSTRAINT `primary_constraint` PRIMARY KEY (`id`) NOT ENFORCED\n"
                                 + ")"));
     }
@@ -221,14 +221,14 @@ public class SchemaResolutionTest {
                 resolvedSchema.toString(),
                 equalTo(
                         "(\n"
-                                + "  `id` INT NOT NULL, \n"
-                                + "  `counter` INT NOT NULL, \n"
-                                + "  `payload` ROW<`name` STRING, `age` INT, `flag` BOOLEAN>, \n"
-                                + "  `topic` STRING METADATA VIRTUAL, \n"
-                                + "  `ts` TIMESTAMP(3) *ROWTIME* AS orig_ts - INTERVAL '60' MINUTE, \n"
-                                + "  `orig_ts` TIMESTAMP(3) METADATA FROM 'timestamp', \n"
-                                + "  `proctime` TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME(), \n"
-                                + "  WATERMARK FOR `ts`: TIMESTAMP(3) AS ts - INTERVAL '5' SECOND, \n"
+                                + "  `id` INT NOT NULL,\n"
+                                + "  `counter` INT NOT NULL,\n"
+                                + "  `payload` ROW<`name` STRING, `age` INT, `flag` BOOLEAN>,\n"
+                                + "  `topic` STRING METADATA VIRTUAL,\n"
+                                + "  `ts` TIMESTAMP(3) *ROWTIME* AS orig_ts - INTERVAL '60' MINUTE,\n"
+                                + "  `orig_ts` TIMESTAMP(3) METADATA FROM 'timestamp',\n"
+                                + "  `proctime` TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME(),\n"
+                                + "  WATERMARK FOR `ts`: TIMESTAMP(3) AS ts - INTERVAL '5' SECOND,\n"
                                 + "  CONSTRAINT `primary_constraint` PRIMARY KEY (`id`) NOT ENFORCED\n"
                                 + ")"));
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
@@ -117,7 +117,7 @@ public final class Schema {
         return components.stream()
                 .map(Objects::toString)
                 .map(s -> "  " + s)
-                .collect(Collectors.joining(", \n", "(\n", "\n)"));
+                .collect(Collectors.joining(",\n", "(\n", "\n)"));
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
@@ -234,7 +234,7 @@ public final class ResolvedSchema {
         return components.stream()
                 .map(Objects::toString)
                 .map(s -> "  " + s)
-                .collect(Collectors.joining(", \n", "(\n", "\n)"));
+                .collect(Collectors.joining(",\n", "(\n", "\n)"));
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -19,8 +19,8 @@
 package org.apache.flink.table.utils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.IntType;
@@ -74,9 +74,9 @@ public class PrintUtils {
      * </pre>
      */
     public static void printAsTableauForm(
-            TableSchema tableSchema, Iterator<Row> it, PrintWriter printWriter) {
+            ResolvedSchema resolvedSchema, Iterator<Row> it, PrintWriter printWriter) {
         printAsTableauForm(
-                tableSchema, it, printWriter, MAX_COLUMN_WIDTH, NULL_COLUMN, false, false);
+                resolvedSchema, it, printWriter, MAX_COLUMN_WIDTH, NULL_COLUMN, false, false);
     }
 
     /**
@@ -99,7 +99,7 @@ public class PrintUtils {
      * 4 rows in set
      * </pre>
      *
-     * @param tableSchema The schema of the data to print
+     * @param resolvedSchema The schema of the data to print
      * @param it The iterator for the data to print
      * @param printWriter The writer to write to
      * @param maxColumnWidth The max width of a column
@@ -109,7 +109,7 @@ public class PrintUtils {
      * @param printRowKind A flag to indicate whether print row kind info
      */
     public static void printAsTableauForm(
-            TableSchema tableSchema,
+            ResolvedSchema resolvedSchema,
             Iterator<Row> it,
             PrintWriter printWriter,
             int maxColumnWidth,
@@ -121,8 +121,8 @@ public class PrintUtils {
             printWriter.flush();
             return;
         }
-        final List<TableColumn> columns = tableSchema.getTableColumns();
-        String[] columnNames = columns.stream().map(TableColumn::getName).toArray(String[]::new);
+        final List<Column> columns = resolvedSchema.getColumns();
+        String[] columnNames = columns.stream().map(Column::getName).toArray(String[]::new);
         if (printRowKind) {
             columnNames =
                     Stream.concat(Stream.of(ROW_KIND_COLUMN), Arrays.stream(columnNames))
@@ -230,7 +230,7 @@ public class PrintUtils {
      * stored in java heap memory, we can't determine column widths based on column values.
      */
     public static int[] columnWidthsByType(
-            List<TableColumn> columns,
+            List<Column> columns,
             int maxColumnWidth,
             String nullColumn,
             @Nullable String rowKindColumn) {
@@ -239,7 +239,7 @@ public class PrintUtils {
 
         // determine proper column width based on types
         for (int i = 0; i < columns.size(); ++i) {
-            LogicalType type = columns.get(i).getType().getLogicalType();
+            LogicalType type = columns.get(i).getDataType().getLogicalType();
             int len;
             switch (type.getTypeRoot()) {
                 case TINYINT:

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/PrintUtilsTest.java
@@ -19,7 +19,8 @@
 package org.apache.flink.table.utils;
 
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 
@@ -236,15 +237,14 @@ public class PrintUtilsTest {
                 outContent.toString());
     }
 
-    private TableSchema getSchema() {
-        return TableSchema.builder()
-                .field("boolean", DataTypes.BOOLEAN())
-                .field("int", DataTypes.INT())
-                .field("bigint", DataTypes.BIGINT())
-                .field("varchar", DataTypes.STRING())
-                .field("decimal(10, 5)", DataTypes.DECIMAL(10, 5))
-                .field("timestamp", DataTypes.TIMESTAMP(6))
-                .build();
+    private ResolvedSchema getSchema() {
+        return ResolvedSchema.of(
+                Column.physical("boolean", DataTypes.BOOLEAN()),
+                Column.physical("int", DataTypes.INT()),
+                Column.physical("bigint", DataTypes.BIGINT()),
+                Column.physical("varchar", DataTypes.STRING()),
+                Column.physical("decimal(10, 5)", DataTypes.DECIMAL(10, 5)),
+                Column.physical("timestamp", DataTypes.TIMESTAMP(6)));
     }
 
     private List<Row> getData() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -173,7 +173,7 @@ public abstract class BuiltInFunctionTestBase {
         assertEquals(
                 "Logical type doesn't match.",
                 expectedDataType.getLogicalType(),
-                result.getTableSchema().getFieldDataTypes()[0].getLogicalType());
+                result.getResolvedSchema().getColumnDataTypes().get(0).getLogicalType());
 
         assertEquals("Result doesn't match.", testItem.result, row.getField(0));
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/ConstructedAccessFunctionsITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/ConstructedAccessFunctionsITCase.java
@@ -24,8 +24,9 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -160,12 +161,12 @@ public class ConstructedAccessFunctionsITCase {
                                     + "(SELECT * FROM (VALUES(1))), "
                                     + "LATERAL TABLE(RowTableFunction()) AS t(a, b)");
             assertThat(
-                    result.getTableSchema(),
+                    result.getResolvedSchema(),
                     equalTo(
-                            TableSchema.builder()
-                                    .field("b", DataTypes.ARRAY(DataTypes.STRING()).notNull())
-                                    .field("a", DataTypes.STRING())
-                                    .build()));
+                            ResolvedSchema.of(
+                                    Column.physical(
+                                            "b", DataTypes.ARRAY(DataTypes.STRING()).notNull()),
+                                    Column.physical("a", DataTypes.STRING()))));
             try (CloseableIterator<Row> it = result.collect()) {
                 assertThat(it.next(), equalTo(Row.of(new String[] {"A", "B"}, "A")));
                 assertFalse(it.hasNext());
@@ -229,12 +230,11 @@ public class ConstructedAccessFunctionsITCase {
                             .execute();
 
             assertThat(
-                    result.getTableSchema(),
+                    result.getResolvedSchema(),
                     equalTo(
-                            TableSchema.builder()
-                                    .field("f0$nested0", BIGINT().nullable())
-                                    .field("f0$nested1", STRING().nullable())
-                                    .build()));
+                            ResolvedSchema.of(
+                                    Column.physical("f0$nested0", BIGINT().nullable()),
+                                    Column.physical("f0$nested1", STRING().nullable()))));
 
             try (CloseableIterator<Row> it = result.collect()) {
                 assertThat(it.next(), equalTo(Row.of(1L, "ABC")));

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/PrintConnectorITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/PrintConnectorITCase.java
@@ -87,7 +87,7 @@ public class PrintConnectorITCase extends StreamingTestBase {
                                 + "'print-identifier' = 'test_print',"
                                 + "'sink.parallelism' = '2',"
                                 + "'standard-error'='false')");
-        DataType type = tEnv().from("print_t").getSchema().toRowDataType();
+        DataType type = tEnv().from("print_t").getResolvedSchema().toPhysicalRowDataType();
         Row row = Row.of(1, 1.1);
         tEnv().fromValues(type, Collections.singleton(row)).executeInsert("print_t").await();
 
@@ -119,7 +119,7 @@ public class PrintConnectorITCase extends StreamingTestBase {
                                         + "'print-identifier' = '%s',"
                                         + "'standard-error'='%b')",
                                 "test_print", standardError));
-        DataType type = tEnv().from("print_t").getSchema().toRowDataType();
+        DataType type = tEnv().from("print_t").getResolvedSchema().toPhysicalRowDataType();
         Map<Integer, Integer> mapData = new HashMap<>();
         mapData.put(1, 1);
         mapData.put(2, 2);

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -574,11 +574,10 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("id", DataTypes.INT())
-        .field("full name", DataTypes.STRING())
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("id", DataTypes.INT()),
+        Column.physical("full name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.of(Integer.valueOf(2), "Bob Taylor"),
       Row.of(Integer.valueOf(4), "Peter Smith"),
@@ -599,8 +598,8 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("c", DataTypes.BIGINT().notNull()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("c", DataTypes.BIGINT().notNull())),
+      tableResult.getResolvedSchema)
     val expected = if (isStreaming) {
       util.Arrays.asList(
         Row.ofKind(RowKind.INSERT, JLong.valueOf(1)),
@@ -639,11 +638,10 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("name", DataTypes.STRING())
-        .field("pt", DataTypes.TIMESTAMP(3))
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("name", DataTypes.STRING()),
+        Column.physical("pt", DataTypes.TIMESTAMP(3))),
+      tableResult.getResolvedSchema)
     val it = tableResult.collect()
     assertTrue(it.hasNext)
     val row = it.next()
@@ -789,7 +787,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
       util.Arrays.asList(fieldNames: _*),
-      util.Arrays.asList(tableResult.getTableSchema.getFieldNames: _*))
+      tableResult.getResolvedSchema.getColumnNames)
     // return the result until the job is finished
     val it = tableResult.collect()
     assertTrue(it.hasNext)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -27,7 +27,7 @@ import org.apache.flink.core.testutils.FlinkMatchers.containsMessage
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment, _}
-import org.apache.flink.table.catalog.{GenericInMemoryCatalog, ObjectPath}
+import org.apache.flink.table.catalog.{Column, GenericInMemoryCatalog, ObjectPath, ResolvedSchema}
 import org.apache.flink.table.module.ModuleEntry
 import org.apache.flink.table.planner.runtime.stream.sql.FunctionITCase.TestUDF
 import org.apache.flink.table.planner.runtime.stream.table.FunctionITCase.SimpleScalarFunction
@@ -35,11 +35,13 @@ import org.apache.flink.table.planner.utils.TableTestUtil.replaceStageId
 import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSourceSinks}
 import org.apache.flink.table.types.DataType
 import org.apache.flink.types.Row
+
 import org.junit.Assert._
 import org.junit.rules.ExpectedException
 import org.junit.{Rule, Test}
 
 import _root_.java.util
+
 import _root_.scala.collection.JavaConverters._
 
 class TableEnvironmentTest {
@@ -447,8 +449,8 @@ class TableEnvironmentTest {
     val tableResult = tableEnv.executeSql("SHOW CATALOGS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("catalog name", DataTypes.STRING()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("catalog name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("default_catalog"), Row.of("my_catalog")).iterator(),
       tableResult.collect())
@@ -461,8 +463,8 @@ class TableEnvironmentTest {
     val tableResult2 = tableEnv.executeSql("SHOW DATABASES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
     assertEquals(
-      TableSchema.builder().field("database name", DataTypes.STRING()).build(),
-      tableResult2.getTableSchema)
+      ResolvedSchema.of(Column.physical("database name", DataTypes.STRING())),
+      tableResult2.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("default_database"), Row.of("db1")).iterator(),
       tableResult2.collect())
@@ -487,8 +489,8 @@ class TableEnvironmentTest {
     val tableResult2 = tableEnv.executeSql("SHOW TABLES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
     assertEquals(
-      TableSchema.builder().field("table name", DataTypes.STRING()).build(),
-      tableResult2.getTableSchema)
+      ResolvedSchema.of(Column.physical("table name", DataTypes.STRING())),
+      tableResult2.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("tbl1")).iterator(),
       tableResult2.collect())
@@ -499,8 +501,8 @@ class TableEnvironmentTest {
     val tableResult = tableEnv.executeSql("SHOW FUNCTIONS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("function name", DataTypes.STRING()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("function name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     checkData(
       tableEnv.listFunctions().map(Row.of(_)).toList.asJava.iterator(),
       tableResult.collect())
@@ -511,8 +513,8 @@ class TableEnvironmentTest {
     val tableResult2 = tableEnv.executeSql("SHOW USER FUNCTIONS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
     assertEquals(
-      TableSchema.builder().field("function name", DataTypes.STRING()).build(),
-      tableResult2.getTableSchema)
+      ResolvedSchema.of(Column.physical("function name", DataTypes.STRING())),
+      tableResult2.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("f1")).iterator(),
       tableResult2.collect())
@@ -1071,8 +1073,8 @@ class TableEnvironmentTest {
     val tableResult3 = tableEnv.executeSql("SHOW VIEWS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult3.getResultKind)
     assertEquals(
-      TableSchema.builder().field("view name", DataTypes.STRING()).build(),
-      tableResult3.getTableSchema)
+      ResolvedSchema.of(Column.physical("view name", DataTypes.STRING())),
+      tableResult3.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("view1")).iterator(),
       tableResult3.collect())
@@ -1394,15 +1396,15 @@ class TableEnvironmentTest {
   private def validateShowModules(expectedEntries: (String, java.lang.Boolean)*): Unit = {
     val showModules = tableEnv.executeSql("SHOW MODULES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, showModules.getResultKind)
-    assertEquals(TableSchema.builder().field("module name", DataTypes.STRING()).build(),
-      showModules.getTableSchema)
+    assertEquals(ResolvedSchema.of(Column.physical("module name", DataTypes.STRING())),
+      showModules.getResolvedSchema)
 
     val showFullModules = tableEnv.executeSql("SHOW FULL MODULES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, showFullModules.getResultKind)
-    assertEquals(TableSchema.builder().fields(
+    assertEquals(ResolvedSchema.physical(
       Array[String]("module name", "used"),
-      Array[DataType](DataTypes.STRING(), DataTypes.BOOLEAN())).build(),
-      showFullModules.getTableSchema)
+      Array[DataType](DataTypes.STRING(), DataTypes.BOOLEAN())),
+      showFullModules.getResolvedSchema)
 
     // show modules only list used modules
     checkData(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobStatus
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.table.planner.utils.TestTableSourceSinks
 import org.apache.flink.types.{Row, RowKind}
 import org.apache.flink.util.{CollectionUtil, TestLogger}
@@ -82,11 +83,10 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("id", DataTypes.INT())
-        .field("full name", DataTypes.STRING())
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("id", DataTypes.INT()),
+        Column.physical("full name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.of(Integer.valueOf(2), "Bob Taylor"),
       Row.of(Integer.valueOf(4), "Peter Smith"),
@@ -138,8 +138,8 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("c", DataTypes.BIGINT().notNull()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("c", DataTypes.BIGINT().notNull())),
+      tableResult.getResolvedSchema)
     val expected = if (isStreaming) {
       util.Arrays.asList(
         Row.ofKind(RowKind.INSERT, JLong.valueOf(1)),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableTest.scala
@@ -18,10 +18,12 @@
 
 package org.apache.flink.table.planner.catalog
 
-import org.apache.flink.table.api.{DataTypes, EnvironmentSettings, TableEnvironment, TableSchema}
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
-import org.junit.Test
+import org.apache.flink.table.api.{DataTypes, EnvironmentSettings, TableEnvironment}
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
+
 import org.junit.Assert.assertEquals
+import org.junit.Test
 
 /**
   * Unit tests around catalog table and DDL.
@@ -43,24 +45,26 @@ class CatalogTableTest {
         |  f5 TIMESTAMP(2) NOT NULL,
         |  f6 TIME,
         |  f7 DATE,
-        |  f8 VARCHAR(10) NOT NULL
+        |  f8 VARCHAR(10) NOT NULL,
+        |  c AS f3 || f8
         |) WITH (
         |  'connector' = 'COLLECTION'
         |)
       """.stripMargin
     )
 
-    val actual = tEnv.sqlQuery("SELECT * FROM t1").getSchema
-    val expected = TableSchema.builder()
-      .field("f1", DataTypes.INT())
-      .field("f2", DataTypes.BIGINT().notNull())
-      .field("f3", DataTypes.STRING())
-      .field("f4", DataTypes.DECIMAL(10, 4))
-      .field("f5", DataTypes.TIMESTAMP(2).notNull())
-      .field("f6", DataTypes.TIME())
-      .field("f7", DataTypes.DATE())
-      .field("f8", DataTypes.VARCHAR(10).notNull())
-      .build()
+    val actual = tEnv.sqlQuery("SELECT * FROM t1").getResolvedSchema
+    val expected = ResolvedSchema.of(
+      Column.physical("f1", DataTypes.INT()),
+      Column.physical("f2", DataTypes.BIGINT().notNull()),
+      Column.physical("f3", DataTypes.STRING()),
+      Column.physical("f4", DataTypes.DECIMAL(10, 4)),
+      Column.physical("f5", DataTypes.TIMESTAMP(2).notNull()),
+      Column.physical("f6", DataTypes.TIME()),
+      Column.physical("f7", DataTypes.DATE()),
+      Column.physical("f8", DataTypes.VARCHAR(10).notNull()),
+      Column.physical("c", DataTypes.STRING()) // physical because SQL is a black box for now
+    )
 
     assertEquals(expected, actual)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/SetOperatorsITCase.scala
@@ -68,10 +68,11 @@ class SetOperatorsITCase extends BatchTestBase {
 
     val unionTable = table1.unionAll(table2)
 
+    val schema = unionTable.getResolvedSchema.getColumnDataTypes
     assertThat(
-      unionTable.getSchema.getFieldDataTypes()(0),
+      schema.get(0),
       equalTo(DataTypes.DECIMAL(13, 3).notNull()))
-    assertThat(unionTable.getSchema.getFieldDataTypes()(1), equalTo(DataTypes.VARCHAR(3).notNull()))
+    assertThat(schema.get(1), equalTo(DataTypes.VARCHAR(3).notNull()))
 
     val results = executeQuery(unionTable)
     val expected = "12.000,\n" + "1234.123,ABC\n"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.TableEnvironmentITCase.getPersonCsvTableSource
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment}
 import org.apache.flink.table.api.internal.{TableEnvironmentImpl, TableEnvironmentInternal}
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.table.runtime.utils.StreamITCase
 import org.apache.flink.table.sinks.CsvTableSink
 import org.apache.flink.table.sources.CsvTableSource
@@ -454,11 +455,10 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("id", DataTypes.INT())
-        .field("full name", DataTypes.STRING())
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("id", DataTypes.INT()),
+        Column.physical("full name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.of(Integer.valueOf(2), "Bob Taylor"),
       Row.of(Integer.valueOf(4), "Peter Smith"),
@@ -479,8 +479,9 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("c", DataTypes.BIGINT().notNull()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("c", DataTypes.BIGINT().notNull())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.ofKind(RowKind.INSERT, JLong.valueOf(1)),
       Row.ofKind(RowKind.DELETE, JLong.valueOf(1)),
@@ -514,11 +515,11 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("name", DataTypes.STRING())
-        .field("pt", Types.SQL_TIMESTAMP())
-        .build(),
-      tableResult.getTableSchema)
+      s"""(
+         |  `name` STRING,
+         |  `pt` TIMESTAMP(3) *PROCTIME*
+         |)""".stripMargin,
+      tableResult.getResolvedSchema.toString)
     val it = tableResult.collect()
     assertTrue(it.hasNext)
     val row = it.next()
@@ -575,7 +576,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
       util.Arrays.asList(fieldNames: _*),
-      util.Arrays.asList(tableResult.getTableSchema.getFieldNames: _*))
+      tableResult.getResolvedSchema.getColumnNames)
     // return the result until the job is finished
     val it = tableResult.collect()
     assertTrue(it.hasNext)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api.TableEnvironmentITCase.getPersonCsvTableSource
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment
 import org.apache.flink.table.api.internal.{TableEnvironmentImpl, TableEnvironmentInternal}
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.types.{Row, RowKind}
 import org.apache.flink.util.CollectionUtil
 
@@ -79,11 +80,10 @@ class TableITCase(tableEnvName: String) {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("id", DataTypes.INT())
-        .field("full name", DataTypes.STRING())
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("id", DataTypes.INT()),
+        Column.physical("full name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.of(Integer.valueOf(2), "Bob Taylor"),
       Row.of(Integer.valueOf(4), "Peter Smith"),
@@ -104,8 +104,8 @@ class TableITCase(tableEnvName: String) {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("c", DataTypes.BIGINT().notNull()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("c", DataTypes.BIGINT().notNull())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.ofKind(RowKind.INSERT, JLong.valueOf(1)),
       Row.ofKind(RowKind.DELETE, JLong.valueOf(1)),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.config.TableConfigOptions
-import org.apache.flink.table.catalog.{GenericInMemoryCatalog, ObjectPath}
+import org.apache.flink.table.catalog.{Column, GenericInMemoryCatalog, ObjectPath, ResolvedSchema}
 import org.apache.flink.table.runtime.stream.sql.FunctionITCase.{SimpleScalarFunction, TestUDF}
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil.{readFromResource, replaceStageId, _}
@@ -223,8 +223,8 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val tableResult = testUtil.tableEnv.executeSql("SHOW CATALOGS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("catalog name", DataTypes.STRING()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("catalog name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("default_catalog"), Row.of("my_catalog")).iterator(),
       tableResult.collect())
@@ -239,8 +239,8 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val tableResult2 = testUtil.tableEnv.executeSql("SHOW DATABASES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
     assertEquals(
-      TableSchema.builder().field("database name", DataTypes.STRING()).build(),
-      tableResult2.getTableSchema)
+      ResolvedSchema.of(Column.physical("database name", DataTypes.STRING())),
+      tableResult2.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("default_database"), Row.of("db1")).iterator(),
       tableResult2.collect())
@@ -266,8 +266,8 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val tableResult2 = testUtil.tableEnv.executeSql("SHOW TABLES")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
     assertEquals(
-      TableSchema.builder().field("table name", DataTypes.STRING()).build(),
-      tableResult2.getTableSchema)
+      ResolvedSchema.of(Column.physical("table name", DataTypes.STRING())),
+      tableResult2.getResolvedSchema)
     checkData(
       util.Arrays.asList(Row.of("tbl1")).iterator(),
       tableResult2.collect())
@@ -279,8 +279,8 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val tableResult = util.tableEnv.executeSql("SHOW FUNCTIONS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder().field("function name", DataTypes.STRING()).build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(Column.physical("function name", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     checkData(
       util.tableEnv.listFunctions().map(Row.of(_)).toList.asJava.iterator(),
       tableResult.collect())
@@ -343,8 +343,8 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val tableResult4 = util.tableEnv.executeSql("SHOW VIEWS")
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult4.getResultKind)
     assertEquals(
-      TableSchema.builder().field("view name", DataTypes.STRING()).build(),
-      tableResult4.getTableSchema)
+      ResolvedSchema.of(Column.physical("view name", DataTypes.STRING())),
+      tableResult4.getResolvedSchema)
     checkData(
       util.tableEnv.listViews().map(Row.of(_)).toList.asJava.iterator(),
       tableResult4.collect())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
@@ -27,6 +27,7 @@ import org.apache.flink.core.fs.FileSystem.WriteMode
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.internal.TableEnvironmentInternal
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.sinks.CsvTableSink
@@ -535,11 +536,10 @@ class TableEnvironmentITCase(
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("a", DataTypes.INT())
-        .field("c", DataTypes.STRING())
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("a", DataTypes.INT()),
+        Column.physical("c", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.of(Integer.valueOf(2), "Hello"),
       Row.of(Integer.valueOf(3), "Hello world"))
@@ -573,7 +573,7 @@ class TableEnvironmentITCase(
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
       util.Arrays.asList(fieldNames: _*),
-      util.Arrays.asList(tableResult.getTableSchema.getFieldNames: _*))
+      tableResult.getResolvedSchema.getColumnNames)
     // return the result until the job is finished
     val it = tableResult.collect()
     assertTrue(it.hasNext)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableITCase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
 import org.apache.flink.types.Row
 import org.apache.flink.util.CollectionUtil
 
@@ -44,11 +45,10 @@ class TableITCase {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     assertEquals(
-      TableSchema.builder()
-        .field("a", DataTypes.INT())
-        .field("c", DataTypes.STRING())
-        .build(),
-      tableResult.getTableSchema)
+      ResolvedSchema.of(
+        Column.physical("a", DataTypes.INT()),
+        Column.physical("c", DataTypes.STRING())),
+      tableResult.getResolvedSchema)
     val expected = util.Arrays.asList(
       Row.of(Integer.valueOf(2), "Hello"),
       Row.of(Integer.valueOf(3), "Hello world"))


### PR DESCRIPTION
## What is the purpose of the change

Updates the mentioned interfaces with `ResolvedSchema`.

## Brief change log

- Replaces `Table(Result).getSchema` with `Table(Result).getResolvedSchema`
- Deprecates the old one

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
