### PR TITLE
[FLINK-21816][table-planner-blink] Suport json ser/de for StreamExecMatch

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonDeserializer.java
@@ -46,6 +46,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
@@ -60,6 +61,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_ALPHA;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_LOWER;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_TYPE;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.FIELD_NAME_BOUND_UPPER;
@@ -86,6 +88,7 @@ import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSe
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_FIELD_ACCESS;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_INPUT_REF;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_LITERAL;
+import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_PATTERN_INPUT_REF;
 import static org.apache.flink.table.planner.plan.nodes.exec.serde.RexNodeJsonSerializer.SQL_KIND_REX_CALL;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -118,6 +121,8 @@ public class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
                 return deserializeCorrelVariable(jsonNode, ctx);
             case SQL_KIND_REX_CALL:
                 return deserializeCall(jsonNode, ctx);
+            case SQL_KIND_PATTERN_INPUT_REF:
+                return deserializePatternInputRef(jsonNode, ctx);
             default:
                 throw new TableException("Cannot convert to RexNode: " + jsonNode.toPrettyString());
         }
@@ -130,6 +135,18 @@ public class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
         RelDataType fieldType =
                 ctx.getObjectMapper().readValue(typeNode.toPrettyString(), RelDataType.class);
         return ctx.getSerdeContext().getRexBuilder().makeInputRef(fieldType, inputIndex);
+    }
+
+    private RexNode deserializePatternInputRef(JsonNode jsonNode, FlinkDeserializationContext ctx)
+            throws JsonProcessingException {
+        int inputIndex = jsonNode.get(FIELD_NAME_INPUT_INDEX).intValue();
+        String alpha = jsonNode.get(FIELD_NAME_ALPHA).asText();
+        JsonNode typeNode = jsonNode.get(FIELD_NAME_TYPE);
+        RelDataType fieldType =
+                ctx.getObjectMapper().readValue(typeNode.toPrettyString(), RelDataType.class);
+        return ctx.getSerdeContext()
+                .getRexBuilder()
+                .makePatternFieldRef(alpha, fieldType, inputIndex);
     }
 
     private RexNode deserializeLiteral(JsonNode jsonNode, FlinkDeserializationContext ctx)
@@ -321,6 +338,21 @@ public class RexNodeJsonDeserializer extends StdDeserializer<RexNode> {
         SqlSyntax sqlSyntax = SqlSyntax.valueOf(jsonNode.get(FIELD_NAME_SYNTAX).asText());
         List<SqlOperator> operators = new ArrayList<>();
         ctx.getOperatorTable()
+                .lookupOperatorOverloads(
+                        new SqlIdentifier(name, new SqlParserPos(0, 0)),
+                        null, // category
+                        sqlSyntax,
+                        operators,
+                        SqlNameMatchers.liberal());
+        for (SqlOperator operator : operators) {
+            // in case different operator has the same kind, check with both name and kind.
+            if (operator.kind == sqlKind) {
+                return operator;
+            }
+        }
+
+        // try to find operator from std operator table.
+        SqlStdOperatorTable.instance()
                 .lookupOperatorOverloads(
                         new SqlIdentifier(name, new SqlParserPos(0, 0)),
                         null, // category

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeJsonSerializer.java
@@ -37,6 +37,7 @@ import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexPatternFieldRef;
 import org.apache.calcite.runtime.FlatLists;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -59,6 +60,8 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
     public static final String FIELD_NAME_NAME = "name";
     // RexInputRef fields
     public static final String FIELD_NAME_INPUT_INDEX = "inputIndex";
+    // RexPatternFieldRef fields
+    public static final String FIELD_NAME_ALPHA = "alpha";
     // RexLiteral fields
     public static final String FIELD_NAME_CLASS = "class";
     // RexFieldAccess fields
@@ -84,6 +87,7 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
     public static final String FIELD_NAME_CONTAINS_NULL = "containsNull";
 
     // supported SqlKinds
+    public static final String SQL_KIND_PATTERN_INPUT_REF = "PATTERN_INPUT_REF";
     public static final String SQL_KIND_INPUT_REF = "INPUT_REF";
     public static final String SQL_KIND_LITERAL = "LITERAL";
     public static final String SQL_KIND_FIELD_ACCESS = "FIELD_ACCESS";
@@ -113,6 +117,9 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
             case CORREL_VARIABLE:
                 serialize((RexCorrelVariable) rexNode, jsonGenerator);
                 break;
+            case PATTERN_INPUT_REF:
+                serialize((RexPatternFieldRef) rexNode, jsonGenerator);
+                break;
             default:
                 if (rexNode instanceof RexCall) {
                     serialize((RexCall) rexNode, jsonGenerator);
@@ -120,6 +127,15 @@ public class RexNodeJsonSerializer extends StdSerializer<RexNode> {
                     throw new TableException("Unknown RexNode: " + rexNode);
                 }
         }
+    }
+
+    private void serialize(RexPatternFieldRef inputRef, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(FIELD_NAME_KIND, SQL_KIND_PATTERN_INPUT_REF);
+        gen.writeStringField(FIELD_NAME_ALPHA, inputRef.getAlpha());
+        gen.writeNumberField(FIELD_NAME_INPUT_INDEX, inputRef.getIndex());
+        gen.writeObjectField(FIELD_NAME_TYPE, inputRef.getType());
+        gen.writeEndObject();
     }
 
     private void serialize(RexInputRef inputRef, JsonGenerator gen) throws IOException {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/MatchSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/MatchSpec.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -30,36 +35,57 @@ import java.util.SortedSet;
  * {@link MatchSpec} describes the MATCH_RECOGNIZE info, see {@link
  * org.apache.calcite.rel.core.Match}.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MatchSpec {
+    public static final String FIELD_NAME_PATTERN = "pattern";
+    public static final String FIELD_NAME_PATTERN_DEF = "patternDefinitions";
+    public static final String FIELD_NAME_MEASURES = "measures";
+    public static final String FIELD_NAME_AFTER = "after";
+    public static final String FIELD_NAME_SUBSETS = "subsets";
+    public static final String FIELD_NAME_ALL_ROWS = "allRows";
+    public static final String FIELD_NAME_PARTITION = "partition";
+    public static final String FIELD_NAME_ORDER = "order";
+    public static final String FIELD_NAME_INTERVAL = "interval";
+
     /** Regular expression that defines pattern variables. */
+    @JsonProperty(FIELD_NAME_PATTERN)
     private final RexNode pattern;
     /** Pattern definitions. */
+    @JsonProperty(FIELD_NAME_PATTERN_DEF)
     private final Map<String, RexNode> patternDefinitions;
     /** Measure definitions. */
+    @JsonProperty(FIELD_NAME_MEASURES)
     private final Map<String, RexNode> measures;
     /** After match definitions. */
+    @JsonProperty(FIELD_NAME_AFTER)
     private final RexNode after;
     /** Subsets of pattern variables. */
+    @JsonProperty(FIELD_NAME_SUBSETS)
     private final Map<String, SortedSet<String>> subsets;
     /** Whether all rows per match (false means one row per match). */
+    @JsonProperty(FIELD_NAME_ALL_ROWS)
     private final boolean allRows;
     /** Partition by columns. */
+    @JsonProperty(FIELD_NAME_PARTITION)
     private final PartitionSpec partition;
     /** Order by columns. */
+    @JsonProperty(FIELD_NAME_ORDER)
     private final SortSpec orderKeys;
     /** Interval definition, null if WITHIN clause is not defined. */
+    @JsonProperty(FIELD_NAME_INTERVAL)
     private final @Nullable RexNode interval;
 
+    @JsonCreator
     public MatchSpec(
-            RexNode pattern,
-            Map<String, RexNode> patternDefinitions,
-            Map<String, RexNode> measures,
-            RexNode after,
-            Map<String, SortedSet<String>> subsets,
-            boolean allRows,
-            PartitionSpec partition,
-            SortSpec orderKeys,
-            @Nullable RexNode interval) {
+            @JsonProperty(FIELD_NAME_PATTERN) RexNode pattern,
+            @JsonProperty(FIELD_NAME_PATTERN_DEF) Map<String, RexNode> patternDefinitions,
+            @JsonProperty(FIELD_NAME_MEASURES) Map<String, RexNode> measures,
+            @JsonProperty(FIELD_NAME_AFTER) RexNode after,
+            @JsonProperty(FIELD_NAME_SUBSETS) Map<String, SortedSet<String>> subsets,
+            @JsonProperty(FIELD_NAME_ALL_ROWS) boolean allRows,
+            @JsonProperty(FIELD_NAME_PARTITION) PartitionSpec partition,
+            @JsonProperty(FIELD_NAME_ORDER) SortSpec orderKeys,
+            @JsonProperty(FIELD_NAME_INTERVAL) @Nullable RexNode interval) {
         this.pattern = pattern;
         this.patternDefinitions = patternDefinitions;
         this.measures = measures;
@@ -71,38 +97,47 @@ public class MatchSpec {
         this.interval = interval;
     }
 
+    @JsonIgnore
     public RexNode getPattern() {
         return pattern;
     }
 
+    @JsonIgnore
     public Map<String, RexNode> getPatternDefinitions() {
         return patternDefinitions;
     }
 
+    @JsonIgnore
     public Map<String, RexNode> getMeasures() {
         return measures;
     }
 
+    @JsonIgnore
     public RexNode getAfter() {
         return after;
     }
 
+    @JsonIgnore
     public Map<String, SortedSet<String>> getSubsets() {
         return subsets;
     }
 
+    @JsonIgnore
     public boolean isAllRows() {
         return allRows;
     }
 
+    @JsonIgnore
     public PartitionSpec getPartition() {
         return partition;
     }
 
+    @JsonIgnore
     public SortSpec getOrderKeys() {
         return orderKeys;
     }
 
+    @JsonIgnore
     public Optional<RexNode> getInterval() {
         return Optional.ofNullable(interval);
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
@@ -63,6 +63,10 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.util.MathUtils;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -79,9 +83,13 @@ import java.util.List;
 import java.util.Optional;
 
 /** Stream {@link ExecNode} which matches along with MATCH_RECOGNIZE. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecMatch extends ExecNodeBase<RowData>
         implements StreamExecNode<RowData>, MultipleTransformationTranslator<RowData> {
 
+    public static final String FIELD_NAME_MATCH_SPEC = "matchSpec";
+
+    @JsonProperty(FIELD_NAME_MATCH_SPEC)
     private final MatchSpec matchSpec;
 
     public StreamExecMatch(
@@ -89,7 +97,22 @@ public class StreamExecMatch extends ExecNodeBase<RowData>
             InputProperty inputProperty,
             RowType outputType,
             String description) {
-        super(Collections.singletonList(inputProperty), outputType, description);
+        this(
+                matchSpec,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
+                outputType,
+                description);
+    }
+
+    @JsonCreator
+    public StreamExecMatch(
+            @JsonProperty(FIELD_NAME_MATCH_SPEC) MatchSpec matchSpec,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(id, inputProperties, outputType, description);
         this.matchSpec = matchSpec;
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
@@ -348,7 +348,11 @@ public class RexNodeSerdeTest {
                                                 BuiltInFunctionDefinitions.TYPE_OF.getName()),
                                         BuiltInFunctionDefinitions.TYPE_OF),
                                 rexBuilder.makeInputRef(
-                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 0)));
+                                        FACTORY.createSqlType(SqlTypeName.INTEGER), 0)),
+                        rexBuilder.makePatternFieldRef(
+                                "test",
+                                FACTORY.createSqlType(SqlTypeName.INTEGER),
+                                0));
         return rexNodes.stream().map(n -> new Object[] {n, flinkContext}).toArray(Object[][]::new);
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/RexNodeSerdeTest.java
@@ -350,9 +350,7 @@ public class RexNodeSerdeTest {
                                 rexBuilder.makeInputRef(
                                         FACTORY.createSqlType(SqlTypeName.INTEGER), 0)),
                         rexBuilder.makePatternFieldRef(
-                                "test",
-                                FACTORY.createSqlType(SqlTypeName.INTEGER),
-                                0));
+                                "test", FACTORY.createSqlType(SqlTypeName.INTEGER), 0));
         return rexNodes.stream().map(n -> new Object[] {n, flinkContext}).toArray(Object[][]::new);
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -63,7 +63,6 @@ public class JsonSerdeCoverageTest {
                     "StreamExecSort",
                     "StreamExecExpand",
                     "StreamExecMultipleInput",
-                    "StreamExecMatch",
                     "StreamExecValues");
 
     @SuppressWarnings({"rawtypes"})

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization for match recognize. */
+public class MatchRecognizeJsonPlanTest extends TableTestBase {
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+    }
+
+    @Test
+    public void testMatch() {
+        String srcTableDdl =
+                "CREATE TABLE MyTable (\n"
+                        + "  id bigint,\n"
+                        + "  name varchar,\n"
+                        + "  proctime as PROCTIME()\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        tEnv.executeSql(srcTableDdl);
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a bigint,\n"
+                        + "  b bigint,\n"
+                        + "  c bigint\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'sink-insert-only' = 'false',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+
+        String sql =
+                "insert into MySink"
+                        + " SELECT T.aid, T.bid, T.cid\n"
+                        + "     FROM MyTable MATCH_RECOGNIZE (\n"
+                        + "             ORDER BY proctime\n"
+                        + "             MEASURES\n"
+                        + "             `A\"`.id AS aid,\n"
+                        + "             \u006C.id AS bid,\n"
+                        + "             C.id AS cid\n"
+                        + "             PATTERN (`A\"` \u006C C)\n"
+                        + "             DEFINE\n"
+                        + "                 `A\"` AS name = 'a',\n"
+                        + "                 \u006C AS name = 'b',\n"
+                        + "                 C AS name = 'c'\n"
+                        + "     ) AS T";
+        util.verifyJsonPlan(sql);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
@@ -24,15 +24,13 @@ import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 /** Test json deserialization for match recognize. */
 public class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
     @Test
-    public void testSimpleMatch() throws ExecutionException, InterruptedException, IOException {
+    public void testSimpleMatch() throws Exception {
         List<Row> data =
                 Arrays.asList(
                         Row.of(1L, "a"),
@@ -71,7 +69,7 @@ public class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
     }
 
     @Test
-    public void testComplexMatch() throws ExecutionException, InterruptedException, IOException {
+    public void testComplexMatch() throws Exception {
         List<Row> data =
                 Arrays.asList(
                         Row.of("ACME", 1L, 19, 1),

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/MatchRecognizeJsonPlanITCase.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/** Test json deserialization for match recognize. */
+public class MatchRecognizeJsonPlanITCase extends JsonPlanTestBase {
+    @Test
+    public void testSimpleMatch() throws ExecutionException, InterruptedException, IOException {
+        List<Row> data =
+                Arrays.asList(
+                        Row.of(1L, "a"),
+                        Row.of(2L, "z"),
+                        Row.of(3L, "b"),
+                        Row.of(4L, "c"),
+                        Row.of(5L, "d"),
+                        Row.of(6L, "a"),
+                        Row.of(7L, "b"),
+                        Row.of(8L, "c"),
+                        Row.of(9L, "h"));
+
+        createTestValuesSourceTable(
+                "MyTable", data, "id bigint", "name varchar", "proctime as PROCTIME()");
+        createTestValuesSinkTable("MySink", "a bigint", "b bigint", "c bigint");
+
+        String sql =
+                "insert into MySink"
+                        + " SELECT T.aid, T.bid, T.cid\n"
+                        + "     FROM MyTable MATCH_RECOGNIZE (\n"
+                        + "             ORDER BY proctime\n"
+                        + "             MEASURES\n"
+                        + "             `A\"`.id AS aid,\n"
+                        + "             \u006C.id AS bid,\n"
+                        + "             C.id AS cid\n"
+                        + "             PATTERN (`A\"` \u006C C)\n"
+                        + "             DEFINE\n"
+                        + "                 `A\"` AS name = 'a',\n"
+                        + "                 \u006C AS name = 'b',\n"
+                        + "                 C AS name = 'c'\n"
+                        + "     ) AS T";
+        executeSqlWithJsonPlanVerified(sql).await();
+
+        List<String> expected = Arrays.asList("+I[6, 7, 8]");
+        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+    }
+
+    @Test
+    public void testComplexMatch() throws ExecutionException, InterruptedException, IOException {
+        List<Row> data =
+                Arrays.asList(
+                        Row.of("ACME", 1L, 19, 1),
+                        Row.of("ACME", 2L, 17, 2),
+                        Row.of("ACME", 3L, 13, 3),
+                        Row.of("ACME", 4L, 20, 4));
+        createTestValuesSourceTable(
+                "MyTable",
+                data,
+                "symbol string",
+                "tstamp bigint",
+                "price int",
+                "tax int",
+                "proctime as PROCTIME()");
+        createTestValuesSinkTable("MySink", "a bigint", "b bigint", "c bigint");
+
+        String sql =
+                "insert into MySink SELECT * FROM MyTable MATCH_RECOGNIZE (\n"
+                        + "  ORDER BY proctime\n"
+                        + "  MEASURES\n"
+                        + "    FIRST(DOWN.price) as first,\n"
+                        + "    LAST(DOWN.price) as last,\n"
+                        + "    FIRST(DOWN.price, 5) as nullPrice\n"
+                        + "  ONE ROW PER MATCH\n"
+                        + "  AFTER MATCH SKIP PAST LAST ROW\n"
+                        + "  PATTERN (DOWN{2,} UP)\n"
+                        + "  DEFINE\n"
+                        + "    DOWN AS price < LAST(DOWN.price, 1) OR LAST(DOWN.price, 1) IS NULL,\n"
+                        + "    UP AS price > LAST(DOWN.price)\n"
+                        + ") AS T";
+        executeSqlWithJsonPlanVerified(sql).await();
+
+        List<String> expected = Arrays.asList("+I[19, 13, null]");
+        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/MatchRecognizeJsonPlanTest_jsonplan/testMatch.out
@@ -1,0 +1,501 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.2.expr" : "PROCTIME()",
+        "schema.2.data-type" : "TIMESTAMP(3) NOT NULL",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "proctime",
+        "schema.1.name" : "name",
+        "bounded" : "false",
+        "schema.0.name" : "id",
+        "schema.1.data-type" : "VARCHAR(2147483647)"
+      }
+    },
+    "id" : 1,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "id" : "BIGINT"
+      }, {
+        "name" : "VARCHAR(2147483647)"
+      } ]
+    },
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[id, name])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ ],
+      "type" : {
+        "timestampKind" : "PROCTIME",
+        "nullable" : false
+      }
+    } ],
+    "condition" : null,
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "id" : "BIGINT"
+      }, {
+        "name" : "VARCHAR(2147483647)"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[id, name, PROCTIME() AS proctime])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecExchange",
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "SINGLETON"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "id" : "BIGINT"
+      }, {
+        "name" : "VARCHAR(2147483647)"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      } ]
+    },
+    "description" : "Exchange(distribution=[single])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecMatch",
+    "matchSpec" : {
+      "pattern" : {
+        "kind" : "REX_CALL",
+        "operator" : {
+          "name" : "",
+          "kind" : "PATTERN_CONCAT",
+          "syntax" : "BINARY"
+        },
+        "operands" : [ {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "",
+            "kind" : "PATTERN_CONCAT",
+            "syntax" : "BINARY"
+          },
+          "operands" : [ {
+            "kind" : "LITERAL",
+            "value" : "A\"",
+            "type" : {
+              "typeName" : "CHAR",
+              "nullable" : false,
+              "precision" : 2
+            }
+          }, {
+            "kind" : "LITERAL",
+            "value" : "l",
+            "type" : {
+              "typeName" : "CHAR",
+              "nullable" : false,
+              "precision" : 1
+            }
+          } ],
+          "type" : {
+            "typeName" : "NULL",
+            "nullable" : true
+          }
+        }, {
+          "kind" : "LITERAL",
+          "value" : "C",
+          "type" : {
+            "typeName" : "CHAR",
+            "nullable" : false,
+            "precision" : 1
+          }
+        } ],
+        "type" : {
+          "typeName" : "NULL",
+          "nullable" : true
+        }
+      },
+      "patternDefinitions" : {
+        "A\"" : {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "=",
+            "kind" : "EQUALS",
+            "syntax" : "BINARY"
+          },
+          "operands" : [ {
+            "kind" : "REX_CALL",
+            "operator" : {
+              "name" : "LAST",
+              "kind" : "LAST",
+              "syntax" : "FUNCTION"
+            },
+            "operands" : [ {
+              "kind" : "PATTERN_INPUT_REF",
+              "alpha" : "*",
+              "inputIndex" : 1,
+              "type" : {
+                "typeName" : "VARCHAR",
+                "nullable" : true,
+                "precision" : 2147483647
+              }
+            }, {
+              "kind" : "LITERAL",
+              "value" : "0",
+              "type" : {
+                "typeName" : "INTEGER",
+                "nullable" : false
+              }
+            } ],
+            "type" : {
+              "typeName" : "VARCHAR",
+              "nullable" : true,
+              "precision" : 2147483647
+            }
+          }, {
+            "kind" : "LITERAL",
+            "value" : "a",
+            "type" : {
+              "typeName" : "VARCHAR",
+              "nullable" : false,
+              "precision" : 2147483647
+            }
+          } ],
+          "type" : {
+            "typeName" : "BOOLEAN",
+            "nullable" : true
+          }
+        },
+        "l" : {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "=",
+            "kind" : "EQUALS",
+            "syntax" : "BINARY"
+          },
+          "operands" : [ {
+            "kind" : "REX_CALL",
+            "operator" : {
+              "name" : "LAST",
+              "kind" : "LAST",
+              "syntax" : "FUNCTION"
+            },
+            "operands" : [ {
+              "kind" : "PATTERN_INPUT_REF",
+              "alpha" : "*",
+              "inputIndex" : 1,
+              "type" : {
+                "typeName" : "VARCHAR",
+                "nullable" : true,
+                "precision" : 2147483647
+              }
+            }, {
+              "kind" : "LITERAL",
+              "value" : "0",
+              "type" : {
+                "typeName" : "INTEGER",
+                "nullable" : false
+              }
+            } ],
+            "type" : {
+              "typeName" : "VARCHAR",
+              "nullable" : true,
+              "precision" : 2147483647
+            }
+          }, {
+            "kind" : "LITERAL",
+            "value" : "b",
+            "type" : {
+              "typeName" : "VARCHAR",
+              "nullable" : false,
+              "precision" : 2147483647
+            }
+          } ],
+          "type" : {
+            "typeName" : "BOOLEAN",
+            "nullable" : true
+          }
+        },
+        "C" : {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "=",
+            "kind" : "EQUALS",
+            "syntax" : "BINARY"
+          },
+          "operands" : [ {
+            "kind" : "REX_CALL",
+            "operator" : {
+              "name" : "LAST",
+              "kind" : "LAST",
+              "syntax" : "FUNCTION"
+            },
+            "operands" : [ {
+              "kind" : "PATTERN_INPUT_REF",
+              "alpha" : "*",
+              "inputIndex" : 1,
+              "type" : {
+                "typeName" : "VARCHAR",
+                "nullable" : true,
+                "precision" : 2147483647
+              }
+            }, {
+              "kind" : "LITERAL",
+              "value" : "0",
+              "type" : {
+                "typeName" : "INTEGER",
+                "nullable" : false
+              }
+            } ],
+            "type" : {
+              "typeName" : "VARCHAR",
+              "nullable" : true,
+              "precision" : 2147483647
+            }
+          }, {
+            "kind" : "LITERAL",
+            "value" : "c",
+            "type" : {
+              "typeName" : "VARCHAR",
+              "nullable" : false,
+              "precision" : 2147483647
+            }
+          } ],
+          "type" : {
+            "typeName" : "BOOLEAN",
+            "nullable" : true
+          }
+        }
+      },
+      "measures" : {
+        "aid" : {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "FINAL",
+            "kind" : "FINAL",
+            "syntax" : "PREFIX"
+          },
+          "operands" : [ {
+            "kind" : "PATTERN_INPUT_REF",
+            "alpha" : "A\"",
+            "inputIndex" : 0,
+            "type" : {
+              "typeName" : "BIGINT",
+              "nullable" : true
+            }
+          } ],
+          "type" : {
+            "typeName" : "BIGINT",
+            "nullable" : true
+          }
+        },
+        "bid" : {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "FINAL",
+            "kind" : "FINAL",
+            "syntax" : "PREFIX"
+          },
+          "operands" : [ {
+            "kind" : "PATTERN_INPUT_REF",
+            "alpha" : "l",
+            "inputIndex" : 0,
+            "type" : {
+              "typeName" : "BIGINT",
+              "nullable" : true
+            }
+          } ],
+          "type" : {
+            "typeName" : "BIGINT",
+            "nullable" : true
+          }
+        },
+        "cid" : {
+          "kind" : "REX_CALL",
+          "operator" : {
+            "name" : "FINAL",
+            "kind" : "FINAL",
+            "syntax" : "PREFIX"
+          },
+          "operands" : [ {
+            "kind" : "PATTERN_INPUT_REF",
+            "alpha" : "C",
+            "inputIndex" : 0,
+            "type" : {
+              "typeName" : "BIGINT",
+              "nullable" : true
+            }
+          } ],
+          "type" : {
+            "typeName" : "BIGINT",
+            "nullable" : true
+          }
+        }
+      },
+      "after" : {
+        "kind" : "LITERAL",
+        "value" : "SKIP_TO_NEXT_ROW",
+        "class" : "org.apache.calcite.sql.SqlMatchRecognize$AfterOption",
+        "type" : {
+          "typeName" : "SYMBOL",
+          "nullable" : false
+        }
+      },
+      "subsets" : { },
+      "allRows" : false,
+      "partition" : {
+        "fields" : [ ]
+      },
+      "order" : {
+        "fields" : [ {
+          "index" : 2,
+          "isAscending" : true,
+          "nullIsLast" : false
+        } ]
+      },
+      "interval" : null
+    },
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "aid" : "BIGINT"
+      }, {
+        "bid" : "BIGINT"
+      }, {
+        "cid" : "BIGINT"
+      } ]
+    },
+    "description" : "Match(orderBy=[proctime ASC], measures=[FINAL(A\".id) AS aid, FINAL(l.id) AS bid, FINAL(C.id) AS cid], rowsPerMatch=[ONE ROW PER MATCH], after=[SKIP TO NEXT ROW], pattern=[((_UTF-16LE'A\"', _UTF-16LE'l'), _UTF-16LE'C')], define=[{A\"==(LAST(*.$1, 0), _UTF-16LE'a'), l==(LAST(*.$1, 0), _UTF-16LE'b'), C==(LAST(*.$1, 0), _UTF-16LE'c')}])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "sink-insert-only" : "false",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "BIGINT",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "BIGINT"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "aid" : "BIGINT"
+      }, {
+        "bid" : "BIGINT"
+      }, {
+        "cid" : "BIGINT"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[aid, bid, cid])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}


### PR DESCRIPTION

## What is the purpose of the change
Suport json ser/de for StreamExecMatch


## Brief change log
1. Support json ser/de for pattern RexCall
2. Suport json ser/de for StreamExecMatch


## Verifying this change


This change added tests and can be verified as follows:
1. MatchRecognizeJsonPlanTest and MatchRecognizeJsonPlanITCase are added to verify the ser/de

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
