### PR TITLE
[hotfix][table] Use type from RowDataKeySelector in StreamExecTemporalJoin

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
@@ -45,14 +45,12 @@ import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.runtime.operators.join.temporal.TemporalProcessTimeJoinOperator;
 import org.apache.flink.table.runtime.operators.join.temporal.TemporalRowTimeJoinOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
 import java.util.Optional;
-import java.util.stream.IntStream;
 
 /**
  * {@link StreamExecNode} for temporal table join (FOR SYSTEM_TIME AS OF) and temporal TableFunction
@@ -141,11 +139,7 @@ public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
         RowDataKeySelector leftKeySelector = getLeftKeySelector(leftInputType);
         RowDataKeySelector rightKeySelector = getRightKeySelector(rightInputType);
         ret.setStateKeySelectors(leftKeySelector, rightKeySelector);
-        LogicalType[] keyTypes =
-                IntStream.of(joinSpec.getLeftKeys())
-                        .mapToObj(leftInputType::getTypeAt)
-                        .toArray(LogicalType[]::new);
-        ret.setStateKeyType(InternalTypeInfo.ofFields(keyTypes));
+        ret.setStateKeyType(leftKeySelector.getProducedType());
         return ret;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Use type from RowDataKeySelector in StreamExecTemporalJoin

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no