### PR TITLE
[hotfix] Put the delegating log to ChangelogStateBackend constructor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -386,10 +386,6 @@ public class StateBackendLoader {
     private static StateBackend loadChangelogStateBackend(
             StateBackend backend, ClassLoader classLoader) throws DynamicCodeLoadingException {
 
-        LOG.info(
-                "Delegate State Backend is used, and the root State Backend is {}",
-                backend.getClass().getSimpleName());
-
         // ChangelogStateBackend resides in a separate module, load it using reflection
         try {
             Constructor<? extends DelegatingStateBackend> constructor =

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -38,6 +38,9 @@ import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
@@ -50,6 +53,8 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
 
     private static final long serialVersionUID = 1000L;
 
+    private static final Logger LOG = LoggerFactory.getLogger(ChangelogStateBackend.class);
+
     private final StateBackend delegatedStateBackend;
 
     public ChangelogStateBackend(StateBackend stateBackend) {
@@ -58,6 +63,10 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
         Preconditions.checkArgument(
                 !(stateBackend instanceof DelegatingStateBackend),
                 "Recursive Delegation is not supported.");
+
+        LOG.info(
+                "ChangelogStateBackend is used, delegating {}.",
+                delegatedStateBackend.getClass().getSimpleName());
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Now that we support constructing `ChangelogStateBackend` from API,  `loadChangelogStateBackend` is no longer the only place for delegating a statebackend.

Move the log to ChangelogStateBackend constructor instead.