### PR TITLE
[FLINK-21831][state][changelog] Add missing delegation of KeyGroupedInternalPriorityQueue

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/statemigration/TestType.java
@@ -94,6 +94,11 @@ public class TestType
         return 31 * key.hashCode() + value;
     }
 
+    @Override
+    public String toString() {
+        return String.format("TestType(key='%s', value=%d)", key, value);
+    }
+
     /** A serializer that read / writes {@link TestType} in schema version 1. */
     public static class V1TestTypeSerializer extends TestTypeSerializerBase {
         private static final long serialVersionUID = 5053346160938769779L;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.util.CloseableIterator;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * A {@link KeyGroupedInternalPriorityQueue} that keeps state on the underlying delegated {@link
+ * KeyGroupedInternalPriorityQueue} as well as on the state change log.
+ */
+public class ChangelogKeyGroupedPriorityQueue<T> implements KeyGroupedInternalPriorityQueue<T> {
+    private final KeyGroupedInternalPriorityQueue<T> delegatedPriorityQueue;
+
+    public ChangelogKeyGroupedPriorityQueue(
+            KeyGroupedInternalPriorityQueue<T> delegatedPriorityQueue) {
+        this.delegatedPriorityQueue = delegatedPriorityQueue;
+    }
+
+    @Override
+    public Set<T> getSubsetForKeyGroup(int keyGroupId) {
+        return delegatedPriorityQueue.getSubsetForKeyGroup(keyGroupId);
+    }
+
+    @Nullable
+    @Override
+    public T poll() {
+        return delegatedPriorityQueue.poll();
+    }
+
+    @Nullable
+    @Override
+    public T peek() {
+        return delegatedPriorityQueue.peek();
+    }
+
+    @Override
+    public boolean add(T toAdd) {
+        return delegatedPriorityQueue.add(toAdd);
+    }
+
+    @Override
+    public boolean remove(T toRemove) {
+        return delegatedPriorityQueue.remove(toRemove);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegatedPriorityQueue.isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return delegatedPriorityQueue.size();
+    }
+
+    @Override
+    public void addAll(@Nullable Collection<? extends T> toAdd) {
+        delegatedPriorityQueue.addAll(toAdd);
+    }
+
+    @Override
+    public CloseableIterator<T> iterator() {
+        // TODO: Wrap with loggingIterator implemented in FLINK-21355
+        return delegatedPriorityQueue.iterator();
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -247,7 +247,8 @@ class ChangelogKeyedStateBackend<K>
             KeyGroupedInternalPriorityQueue<T> create(
                     @Nonnull String stateName,
                     @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
-        return keyedStateBackend.create(stateName, byteOrderedElementSerializer);
+        return new ChangelogKeyGroupedPriorityQueue<T>(
+                keyedStateBackend.create(stateName, byteOrderedElementSerializer));
     }
 
     @VisibleForTesting


### PR DESCRIPTION
KeyGroupedInternalPriorityQueue provides public methods that will be modifying the delegated state backend, so it has to be proxyed as well.

## Verifying this change

This change is partially cover by tests. Proper test coverage is not possible until we test reading from the changelog. Newly added `StateBackendTestBase#testKeyGroupedInternalPriorityQueue` ensures that at least the calls are properly delegated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
