### PR TITLE
[FLINK-21874][coordination] Ignore outdated slot allocation confirmations

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -555,10 +555,10 @@ public class DeclarativeSlotManager implements SlotManager {
         CompletableFuture<Void> slotAllocationResponseProcessingFuture =
                 requestFuture.handleAsync(
                         (Acknowledge acknowledge, Throwable throwable) -> {
-                            final AllocationID pendingSlotAllocation =
+                            final AllocationID currentAllocationForSlot =
                                     pendingSlotAllocations.get(slotId);
-                            if (pendingSlotAllocation == null
-                                    || !pendingSlotAllocation.equals(allocationId)) {
+                            if (currentAllocationForSlot == null
+                                    || !currentAllocationForSlot.equals(allocationId)) {
                                 LOG.debug(
                                         "Ignoring slot allocation update from task executor {} for slot {} and job {}, because the allocation was already completed or cancelled.",
                                         instanceId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -49,7 +49,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -77,7 +76,7 @@ public class DeclarativeSlotManager implements SlotManager {
     private final SlotManagerMetricGroup slotManagerMetricGroup;
 
     private final Map<JobID, String> jobMasterTargetAddresses = new HashMap<>();
-    private final Set<SlotID> pendingSlotAllocations;
+    private final Map<SlotID, AllocationID> pendingSlotAllocations;
 
     private boolean sendNotEnoughResourceNotifications = true;
 
@@ -105,7 +104,7 @@ public class DeclarativeSlotManager implements SlotManager {
         this.slotManagerMetricGroup = Preconditions.checkNotNull(slotManagerMetricGroup);
         this.resourceTracker = Preconditions.checkNotNull(resourceTracker);
 
-        pendingSlotAllocations = new HashSet<>(16);
+        pendingSlotAllocations = new HashMap<>(16);
 
         this.slotTracker = Preconditions.checkNotNull(slotTracker);
         slotTracker.registerSlotStatusUpdateListener(createSlotStatusUpdateListener());
@@ -536,16 +535,18 @@ public class DeclarativeSlotManager implements SlotManager {
                 taskManagerSlot.getTaskManagerConnection();
         final TaskExecutorGateway gateway = taskExecutorConnection.getTaskExecutorGateway();
 
+        final AllocationID allocationId = new AllocationID();
+
         slotTracker.notifyAllocationStart(slotId, jobId);
         taskExecutorManager.markUsed(instanceId);
-        pendingSlotAllocations.add(slotId);
+        pendingSlotAllocations.put(slotId, allocationId);
 
         // RPC call to the task manager
         CompletableFuture<Acknowledge> requestFuture =
                 gateway.requestSlot(
                         slotId,
                         jobId,
-                        new AllocationID(),
+                        allocationId,
                         resourceProfile,
                         targetAddress,
                         resourceManagerId,
@@ -554,7 +555,10 @@ public class DeclarativeSlotManager implements SlotManager {
         CompletableFuture<Void> slotAllocationResponseProcessingFuture =
                 requestFuture.handleAsync(
                         (Acknowledge acknowledge, Throwable throwable) -> {
-                            if (!pendingSlotAllocations.contains(slotId)) {
+                            final AllocationID pendingSlotAllocation =
+                                    pendingSlotAllocations.get(slotId);
+                            if (pendingSlotAllocation == null
+                                    || !pendingSlotAllocation.equals(allocationId)) {
                                 LOG.debug(
                                         "Ignoring slot allocation update from task executor {} for slot {} and job {}, because the allocation was already completed or cancelled.",
                                         instanceId,


### PR DESCRIPTION
The `DeclarativeSlotManager` accounts for the possibility of slot allocation confirmations coming in after the slot has already been freed or fully allocated (e.g., through a SlotReport) by checking whether there is still a pending request for that slot.
However, this only works properly if the slot was allocated.

If the slot was freed in the mean time then it could've already been re-assigned to another job, which result in an IllegalStateException once the confirmation arrives because a transition from Pending -> Allocation is not allowed if the JobIDs are not matching.
It can also happen that the slot is reassigned to the same job, which can result in a premature confirmation of the allocation.


To remedy this we now additionally record the AllocationID for pending allocations (although any random value or allocation counter would work). The allocation confirmation will only be processed if the AllocationIDs are still matching.