### PR TITLE
[FLINK-21875][hotfix] Fix compilation error in IntelliJ for GSR test

### DIFF
--- a/flink-end-to-end-tests/flink-glue-schema-registry-test/src/main/java/org/apache/flink/glue/schema/registry/test/GSRKinesisPubsubClient.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-test/src/main/java/org/apache/flink/glue/schema/registry/test/GSRKinesisPubsubClient.java
@@ -17,24 +17,8 @@
 
 package org.apache.flink.glue.schema.registry.test;
 
-import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.GetRecordsResult;
-import org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.Record;
-import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
-import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
-import org.apache.flink.streaming.connectors.kinesis.proxy.GetShardListResult;
-import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxy;
-import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.kinesis.AmazonKinesis;
-import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
-import com.amazonaws.services.kinesis.model.PutRecordRequest;
-import com.amazonaws.services.kinesis.model.PutRecordResult;
-import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.schemaregistry.common.AWSDeserializerInput;
 import com.amazonaws.services.schemaregistry.common.AWSSerializerInput;
 import com.amazonaws.services.schemaregistry.deserializers.AWSDeserializer;
@@ -42,13 +26,9 @@ import com.amazonaws.services.schemaregistry.serializers.avro.AWSAvroSerializer;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
 import org.apache.avro.generic.GenericRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 import java.nio.ByteBuffer;
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,44 +40,13 @@ import java.util.UUID;
  * Connectors and Glue Schema Registry classes.
  */
 public class GSRKinesisPubsubClient {
-    private static final Logger LOG = LoggerFactory.getLogger(GSRKinesisPubsubClient.class);
-
-    private final AmazonKinesis kinesisClient;
-    private final Properties properties;
+    private final KinesisPubsubClient client;
 
     public GSRKinesisPubsubClient(Properties properties) {
-        this.kinesisClient = createClientWithCredentials(properties);
-        this.properties = properties;
-    }
-
-    public void createStream(String stream, int shards, Properties props) throws Exception {
-        try {
-            kinesisClient.describeStream(stream);
-            kinesisClient.deleteStream(stream);
-        } catch (ResourceNotFoundException rnfe) {
-            // Exception can be ignored
-        }
-
-        kinesisClient.createStream(stream, shards);
-        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(5));
-        while (deadline.hasTimeLeft()) {
-            try {
-                Thread.sleep(250);
-                if (kinesisClient.describeStream(stream).getStreamDescription().getShards().size()
-                        != shards) {
-                    continue;
-                }
-                break;
-            } catch (ResourceNotFoundException rnfe) {
-                // Exception can be ignored
-            }
-        }
+        this.client = new KinesisPubsubClient(properties);
     }
 
     public void sendMessage(String schema, String streamName, GenericRecord msg) {
-        PutRecordRequest putRecordRequest = new PutRecordRequest();
-        putRecordRequest.setStreamName(streamName);
-        putRecordRequest.setPartitionKey("fakePartitionKey");
         UUID schemaVersionId =
                 createSerializer()
                         .registerSchema(
@@ -107,42 +56,24 @@ public class GSRKinesisPubsubClient {
                                         .transportName(streamName)
                                         .build());
 
-        byte[] serializedData = createSerializer().serialize(msg, schemaVersionId);
-        putRecordRequest.withData(ByteBuffer.wrap(serializedData));
-        PutRecordResult putRecordResult = kinesisClient.putRecord(putRecordRequest);
-
-        LOG.info("added record: {}", putRecordResult.getSequenceNumber());
+        client.sendMessage(streamName, createSerializer().serialize(msg, schemaVersionId));
     }
 
     public List<Object> readAllMessages(String streamName) throws Exception {
-        KinesisProxyInterface kinesisProxy = KinesisProxy.create(properties);
-        Map<String, String> streamNamesWithLastSeenShardIds = new HashMap<>();
-        streamNamesWithLastSeenShardIds.put(streamName, null);
-
-        GetShardListResult shardListResult =
-                kinesisProxy.getShardList(streamNamesWithLastSeenShardIds);
         AWSDeserializer awsDeserializer = createDeserializer();
-        int maxRecordsToFetch = 10;
 
-        List<Object> messages = new ArrayList<>();
-        // retrieve records from all shards
-        for (StreamShardHandle ssh : shardListResult.getRetrievedShardListOfStream(streamName)) {
-            String shardIterator = kinesisProxy.getShardIterator(ssh, "TRIM_HORIZON", null);
-            GetRecordsResult getRecordsResult =
-                    kinesisProxy.getRecords(shardIterator, maxRecordsToFetch);
-            List<org.apache.flink.kinesis.shaded.com.amazonaws.services.kinesis.model.Record>
-                    aggregatedRecords = getRecordsResult.getRecords();
-            for (Record record : aggregatedRecords) {
-                Object obj =
+        return client.readAllMessages(
+                streamName,
+                bytes ->
                         awsDeserializer.deserialize(
                                 AWSDeserializerInput.builder()
-                                        .buffer(ByteBuffer.wrap(record.getData().array()))
+                                        .buffer(ByteBuffer.wrap(bytes))
                                         .transportName(streamName)
-                                        .build());
-                messages.add(obj);
-            }
-        }
-        return messages;
+                                        .build()));
+    }
+
+    public void createStream(String stream, int shards, Properties props) throws Exception {
+        client.createTopic(stream, shards, props);
     }
 
     private Map<String, Object> getSerDeConfigs() {
@@ -167,18 +98,6 @@ public class GSRKinesisPubsubClient {
         return AWSDeserializer.builder()
                 .configs(getSerDeConfigs())
                 .credentialProvider(DefaultCredentialsProvider.builder().build())
-                .build();
-    }
-
-    private static AmazonKinesis createClientWithCredentials(Properties props)
-            throws AmazonClientException {
-        AWSCredentialsProvider credentialsProvider = new EnvironmentVariableCredentialsProvider();
-        return AmazonKinesisClientBuilder.standard()
-                .withCredentials(credentialsProvider)
-                .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration(
-                                props.getProperty(ConsumerConfigConstants.AWS_ENDPOINT),
-                                "ca-central-1"))
                 .build();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix error where GSR end to end test does not compile in IntelliJ.

## Brief change log

Removed reference to AWS SDK classes that are shaded by Kinesis client by:
- Made `KinesisPubsubClient` more generic
- Delegate GSR Kinesis functionality to the `KinesisPubsubClient`


## Verifying this change

- Run Kinesis e2e tests
- Run GSR e2e tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
