### PR TITLE
[FLINK-19607][table-runtime-blink] Implement streaming window TopN operator

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.logical.WindowAttachedWindowingStrategy;
+import org.apache.flink.table.planner.plan.logical.WindowingStrategy;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.PartitionSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.SortSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.rank.ConstantRankRange;
+import org.apache.flink.table.runtime.operators.rank.RankRange;
+import org.apache.flink.table.runtime.operators.rank.RankType;
+import org.apache.flink.table.runtime.operators.rank.window.WindowRankOperatorBuilder;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Stream {@link ExecNode} for WindowRank. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StreamExecWindowRank extends ExecNodeBase<RowData>
+        implements StreamExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    private static final long WINDOW_RANK_MEMORY_RATIO = 100;
+
+    public static final String FIELD_NAME_RANK_TYPE = "rankType";
+    public static final String FIELD_NAME_PARTITION_SPEC = "partitionSpec";
+    public static final String FIELD_NAME_SORT_SPEC = "sortSpec";
+    public static final String FIELD_NAME_RANK_RANG = "rankRange";
+    public static final String FIELD_NAME_OUTPUT_RANK_NUMBER = "outputRowNumber";
+    public static final String FIELD_NAME_WINDOWING = "windowing";
+
+    @JsonProperty(FIELD_NAME_RANK_TYPE)
+    private final RankType rankType;
+
+    @JsonProperty(FIELD_NAME_PARTITION_SPEC)
+    private final PartitionSpec partitionSpec;
+
+    @JsonProperty(FIELD_NAME_SORT_SPEC)
+    private final SortSpec sortSpec;
+
+    @JsonProperty(FIELD_NAME_RANK_RANG)
+    private final RankRange rankRange;
+
+    @JsonProperty(FIELD_NAME_OUTPUT_RANK_NUMBER)
+    private final boolean outputRankNumber;
+
+    @JsonProperty(FIELD_NAME_WINDOWING)
+    private final WindowingStrategy windowing;
+
+    public StreamExecWindowRank(
+            RankType rankType,
+            PartitionSpec partitionSpec,
+            SortSpec sortSpec,
+            RankRange rankRange,
+            boolean outputRankNumber,
+            WindowingStrategy windowing,
+            InputProperty inputProperty,
+            RowType outputType,
+            String description) {
+        super(Collections.singletonList(inputProperty), outputType, description);
+        this.rankType = rankType;
+        this.rankRange = rankRange;
+        this.sortSpec = sortSpec;
+        this.partitionSpec = partitionSpec;
+        this.outputRankNumber = outputRankNumber;
+        this.windowing = windowing;
+    }
+
+    @JsonCreator
+    public StreamExecWindowRank(
+            @JsonProperty(FIELD_NAME_RANK_TYPE) RankType rankType,
+            @JsonProperty(FIELD_NAME_PARTITION_SPEC) PartitionSpec partitionSpec,
+            @JsonProperty(FIELD_NAME_SORT_SPEC) SortSpec sortSpec,
+            @JsonProperty(FIELD_NAME_RANK_RANG) RankRange rankRange,
+            @JsonProperty(FIELD_NAME_OUTPUT_RANK_NUMBER) boolean outputRankNumber,
+            @JsonProperty(FIELD_NAME_WINDOWING) WindowingStrategy windowing,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(id, inputProperties, outputType, description);
+        checkArgument(inputProperties.size() == 1);
+        this.rankType = checkNotNull(rankType);
+        this.partitionSpec = checkNotNull(partitionSpec);
+        this.sortSpec = checkNotNull(sortSpec);
+        this.rankRange = checkNotNull(rankRange);
+        this.outputRankNumber = outputRankNumber;
+        this.windowing = checkNotNull(windowing);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Transformation<RowData> translateToPlanInternal(PlannerBase planner) {
+        // validate rank type
+        switch (rankType) {
+            case ROW_NUMBER:
+                break;
+            case RANK:
+                throw new TableException("RANK() on window rank is not supported currently.");
+            case DENSE_RANK:
+                throw new TableException("DENSE_RANK() on window rank is not supported currently.");
+            default:
+                throw new TableException(
+                        String.format(
+                                "Rank function %s on window rank is not supported currently.",
+                                rankType));
+        }
+
+        // validate rank range
+        ConstantRankRange constantRankRange;
+        if (rankRange instanceof ConstantRankRange) {
+            constantRankRange = (ConstantRankRange) rankRange;
+        } else {
+            throw new TableException(
+                    String.format(
+                            "Rank strategy %s on window rank is not supported currently.",
+                            rankRange));
+        }
+
+        // validate window strategy
+        if (!windowing.isRowtime()) {
+            throw new TableException("PROC-TIME on window rank is not supported currently.");
+        }
+        int windowEndIndex;
+        if (windowing instanceof WindowAttachedWindowingStrategy) {
+            windowEndIndex = ((WindowAttachedWindowingStrategy) windowing).getWindowEnd();
+        } else {
+            throw new UnsupportedOperationException(
+                    windowing.getClass().getName() + " is not supported yet.");
+        }
+
+        ExecEdge inputEdge = getInputEdges().get(0);
+        Transformation<RowData> inputTransform =
+                (Transformation<RowData>) inputEdge.translateToPlan(planner);
+
+        RowType inputType = (RowType) inputEdge.getOutputType();
+        InternalTypeInfo<RowData> inputRowTypeInfo = InternalTypeInfo.of(inputType);
+        int[] sortFields = sortSpec.getFieldIndices();
+        RowDataKeySelector sortKeySelector =
+                KeySelectorUtil.getRowDataSelector(sortFields, inputRowTypeInfo);
+
+        SortSpec.SortSpecBuilder builder = SortSpec.builder();
+        IntStream.range(0, sortFields.length)
+                .forEach(
+                        idx ->
+                                builder.addField(
+                                        idx,
+                                        sortSpec.getFieldSpec(idx).getIsAscendingOrder(),
+                                        sortSpec.getFieldSpec(idx).getNullIsLast()));
+        SortSpec sortSpecInSortKey = builder.build();
+        TableConfig tableConfig = planner.getTableConfig();
+        GeneratedRecordComparator sortKeyComparator =
+                ComparatorCodeGenerator.gen(
+                        tableConfig,
+                        "StreamExecSortComparator",
+                        RowType.of(sortSpec.getFieldTypes(inputType)),
+                        sortSpecInSortKey);
+        RowDataKeySelector selector =
+                KeySelectorUtil.getRowDataSelector(
+                        partitionSpec.getFieldIndices(), inputRowTypeInfo);
+
+        OneInputStreamOperator<RowData, RowData> operator =
+                WindowRankOperatorBuilder.builder()
+                        .inputSerializer(new RowDataSerializer(inputType))
+                        .keySerializer(
+                                (PagedTypeSerializer<RowData>)
+                                        selector.getProducedType().toSerializer())
+                        .sortKeySelector(sortKeySelector)
+                        .sortKeyComparator(sortKeyComparator)
+                        .outputRankNumber(outputRankNumber)
+                        .rankStart(constantRankRange.getRankStart())
+                        .rankEnd(constantRankRange.getRankEnd())
+                        .windowEndIndex(windowEndIndex)
+                        .build();
+
+        OneInputTransformation<RowData, RowData> transform =
+                ExecNodeUtil.createOneInputTransformation(
+                        inputTransform,
+                        getDescription(),
+                        SimpleOperatorFactory.of(operator),
+                        InternalTypeInfo.of(getOutputType()),
+                        inputTransform.getParallelism(),
+                        WINDOW_RANK_MEMORY_RATIO);
+
+        // set KeyType and Selector for state
+        transform.setStateKeySelector(selector);
+        transform.setStateKeyType(selector.getProducedType());
+        return transform;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowRank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowRank.scala
@@ -17,9 +17,12 @@
  */
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.logical.WindowingStrategy
 import org.apache.flink.table.planner.plan.nodes.calcite.Rank
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
+import org.apache.flink.table.planner.plan.nodes.exec.spec.PartitionSpec
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWindowRank
 import org.apache.flink.table.planner.plan.utils._
 import org.apache.flink.table.runtime.operators.rank._
 
@@ -89,6 +92,17 @@ class StreamPhysicalWindowRank(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
-    ???
+    val fieldCollations = orderKey.getFieldCollations
+    new StreamExecWindowRank(
+      rankType,
+      new PartitionSpec(partitionKey.toArray),
+      SortUtil.getSortSpec(fieldCollations),
+      rankRange,
+      outputRankNumber,
+      windowing,
+      InputProperty.DEFAULT,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription
+    )
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowRankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowRankTest.scala
@@ -204,7 +204,7 @@ class WindowRankTest extends TableTestBase {
       """.stripMargin
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("PROC-TIME on window rank is not supported currently.")
+    thrown.expectMessage("Processing time Window TopN is not supported yet.")
     util.verifyExplain(sql)
   }
 
@@ -265,7 +265,7 @@ class WindowRankTest extends TableTestBase {
       """.stripMargin
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("PROC-TIME on window rank is not supported currently.")
+    thrown.expectMessage("Processing time Window TopN is not supported yet.")
     util.verifyExplain(sql)
   }
 
@@ -330,7 +330,7 @@ class WindowRankTest extends TableTestBase {
       """.stripMargin
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("PROC-TIME on window rank is not supported currently.")
+    thrown.expectMessage("Processing time Window TopN is not supported yet.")
     util.verifyExplain(sql)
   }
 
@@ -435,7 +435,8 @@ class WindowRankTest extends TableTestBase {
       """.stripMargin
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("RANK() on window rank is not supported currently.")
+    thrown.expectMessage(
+      "RANK() function is not supported on Window TopN currently, only ROW_NUMBER() is supported.")
     util.verifyExplain(sql)
   }
 
@@ -466,7 +467,9 @@ class WindowRankTest extends TableTestBase {
       """.stripMargin
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("DENSE_RANK() on window rank is not supported currently.")
+    thrown.expectMessage(
+      "DENSE_RANK() function is not supported on Window TopN currently, " +
+        "only ROW_NUMBER() is supported.")
     util.verifyExplain(sql)
   }
 
@@ -498,7 +501,7 @@ class WindowRankTest extends TableTestBase {
       """.stripMargin
 
     thrown.expect(classOf[TableException])
-    thrown.expectMessage("Rank strategy rankEnd=$7 on window rank is not supported currently.")
+    thrown.expectMessage("Rank strategy rankEnd=max_b is not supported on window rank currently.")
     util.verifyExplain(sql)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowRankITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowRankITCase.scala
@@ -1,0 +1,465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.CheckpointingMode
+import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.ConcatDistinctAggFunction
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.runtime.utils.{FailingCollectionSource, StreamingWithStateTestBase, TestData, TestingAppendSink}
+import org.apache.flink.types.Row
+
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.{Before, Test}
+
+@RunWith(classOf[Parameterized])
+class WindowRankITCase(mode: StateBackendMode)
+  extends StreamingWithStateTestBase(mode) {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    // enable checkpoint, we are using failing source to force have a complete checkpoint
+    // and cover restore path
+    env.enableCheckpointing(100, CheckpointingMode.EXACTLY_ONCE)
+    env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0))
+    FailingCollectionSource.reset()
+
+    val dataId = TestValuesTableFactory.registerData(TestData.windowData)
+    tEnv.executeSql(
+      s"""
+        |CREATE TABLE T1 (
+        | `ts` STRING,
+        | `int` INT,
+        | `double` DOUBLE,
+        | `float` FLOAT,
+        | `bigdec` DECIMAL(10, 2),
+        | `string` STRING,
+        | `name` STRING,
+        | `rowtime` AS TO_TIMESTAMP(`ts`),
+        | WATERMARK for `rowtime` AS `rowtime` - INTERVAL '1' SECOND
+        |) WITH (
+        | 'connector' = 'values',
+        | 'data-id' = '$dataId',
+        | 'failing-source' = 'true'
+        |)
+        |""".stripMargin)
+    tEnv.createFunction("concat_distinct_agg", classOf[ConcatDistinctAggFunction])
+  }
+
+  @Test
+  def testEventTimeTumbleWindow(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |    FROM TABLE(
+        |      TUMBLE(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+        |  GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-10T00:00,2020-10-10T00:00:05,4,11.10,5.0,1.0,2,Hi|Comment#1,1",
+      "a,2020-10-10T00:00:05,2020-10-10T00:00:10,1,3.33,null,3.0,1,Comment#2,2",
+      "b,2020-10-10T00:00:05,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi,1",
+      "b,2020-10-10T00:00:15,2020-10-10T00:00:20,1,4.44,4.0,4.0,1,Hi,1",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3,2",
+      "null,2020-10-10T00:00:30,2020-10-10T00:00:35,1,7.77,7.0,7.0,0,null,1")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeTumbleWindowWithRankOffset(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |    FROM TABLE(
+        |      TUMBLE(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+        |  GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum > 1 AND rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-10T00:00:05,2020-10-10T00:00:10,1,3.33,null,3.0,1,Comment#2,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3,2")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeTumbleWindowWithoutRankNumber(): Unit = {
+    val sql =
+      """
+        |SELECT `name`, window_start, window_end, cnt, sum_b, max_d, min_f, uv, distinct_str
+        |FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |    FROM TABLE(
+        |      TUMBLE(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+        |  GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum > 1 AND rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-10T00:00:05,2020-10-10T00:00:10,1,3.33,null,3.0,1,Comment#2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeHopWindow(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |  FROM TABLE(
+        |    HOP(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND, INTERVAL '10' SECOND))
+        |    GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-09T23:59:55,2020-10-10T00:00:05,4,11.10,5.0,1.0,2,Hi|Comment#1,1",
+      "a,2020-10-10T00:00,2020-10-10T00:00:10,5,14.43,5.0,1.0,3,Comment#2|Hi|Comment#1,1",
+      "a,2020-10-10T00:00:05,2020-10-10T00:00:15,1,3.33,null,3.0,1,Comment#2,2",
+      "b,2020-10-10T00:00,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi,2",
+      "b,2020-10-10T00:00:05,2020-10-10T00:00:15,2,6.66,6.0,3.0,2,Hello|Hi,1",
+      "b,2020-10-10T00:00:10,2020-10-10T00:00:20,1,4.44,4.0,4.0,1,Hi,1",
+      "b,2020-10-10T00:00:15,2020-10-10T00:00:25,1,4.44,4.0,4.0,1,Hi,1",
+      "b,2020-10-10T00:00:25,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:40,1,3.33,3.0,3.0,1,Comment#3,2",
+      "null,2020-10-10T00:00:25,2020-10-10T00:00:35,1,7.77,7.0,7.0,0,null,1",
+      "null,2020-10-10T00:00:30,2020-10-10T00:00:40,1,7.77,7.0,7.0,0,null,1")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeHopWindowWithRankOffset(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |  FROM TABLE(
+        |    HOP(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND, INTERVAL '10' SECOND))
+        |    GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum > 1 AND rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-10T00:00:05,2020-10-10T00:00:15,1,3.33,null,3.0,1,Comment#2,2",
+      "b,2020-10-10T00:00,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi,2",
+      "b,2020-10-10T00:00:25,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:40,1,3.33,3.0,3.0,1,Comment#3,2")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeHopWindowWithoutRankNumber(): Unit = {
+    val sql =
+      """
+        |SELECT `name`, window_start, window_end, cnt, sum_b, max_d, min_f, uv, distinct_str
+        |FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |  FROM TABLE(
+        |    HOP(TABLE T1, DESCRIPTOR(rowtime), INTERVAL '5' SECOND, INTERVAL '10' SECOND))
+        |    GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum > 1 AND rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-10T00:00:05,2020-10-10T00:00:15,1,3.33,null,3.0,1,Comment#2",
+      "b,2020-10-10T00:00,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi",
+      "b,2020-10-10T00:00:25,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:40,1,3.33,3.0,3.0,1,Comment#3")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeCumulateWindow(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |    FROM TABLE(
+        |      CUMULATE(
+        |        TABLE T1,
+        |        DESCRIPTOR(rowtime),
+        |        INTERVAL '5' SECOND,
+        |        INTERVAL '15' SECOND))
+        |    GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "a,2020-10-10T00:00,2020-10-10T00:00:05,4,11.10,5.0,1.0,2,Hi|Comment#1,1",
+      "a,2020-10-10T00:00,2020-10-10T00:00:10,5,14.43,5.0,1.0,3,Hi|Comment#1|Comment#2,1",
+      "a,2020-10-10T00:00,2020-10-10T00:00:15,5,14.43,5.0,1.0,3,Hi|Comment#1|Comment#2,1",
+      "b,2020-10-10T00:00,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi,2",
+      "b,2020-10-10T00:00,2020-10-10T00:00:15,2,6.66,6.0,3.0,2,Hello|Hi,2",
+      "b,2020-10-10T00:00:15,2020-10-10T00:00:20,1,4.44,4.0,4.0,1,Hi,1",
+      "b,2020-10-10T00:00:15,2020-10-10T00:00:25,1,4.44,4.0,4.0,1,Hi,1",
+      "b,2020-10-10T00:00:15,2020-10-10T00:00:30,1,4.44,4.0,4.0,1,Hi,1",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:40,1,3.33,3.0,3.0,1,Comment#3,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:45,1,3.33,3.0,3.0,1,Comment#3,2",
+      "null,2020-10-10T00:00:30,2020-10-10T00:00:35,1,7.77,7.0,7.0,0,null,1",
+      "null,2020-10-10T00:00:30,2020-10-10T00:00:40,1,7.77,7.0,7.0,0,null,1",
+      "null,2020-10-10T00:00:30,2020-10-10T00:00:45,1,7.77,7.0,7.0,0,null,1")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeCumulateWindowWithRankOffset(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |    FROM TABLE(
+        |      CUMULATE(
+        |        TABLE T1,
+        |        DESCRIPTOR(rowtime),
+        |        INTERVAL '5' SECOND,
+        |        INTERVAL '15' SECOND))
+        |    GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum > 1 AND rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "b,2020-10-10T00:00,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi,2",
+      "b,2020-10-10T00:00,2020-10-10T00:00:15,2,6.66,6.0,3.0,2,Hello|Hi,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:40,1,3.33,3.0,3.0,1,Comment#3,2",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:45,1,3.33,3.0,3.0,1,Comment#3,2")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+
+  @Test
+  def testEventTimeCumulateWindowWithoutRankNumber(): Unit = {
+    val sql =
+      """
+        |SELECT `name`, window_start, window_end, cnt, sum_b, max_d, min_f, uv, distinct_str
+        |FROM
+        |(
+        |  SELECT *,
+        |    ROW_NUMBER() OVER(
+        |      PARTITION BY window_start, window_end ORDER BY sum_b DESC) as rownum
+        |  FROM (
+        |    SELECT
+        |      `name`,
+        |      window_start,
+        |      window_end,
+        |      COUNT(*) as cnt,
+        |      SUM(`bigdec`) as sum_b,
+        |      MAX(`double`) as max_d,
+        |      MIN(`float`) as min_f,
+        |      COUNT(DISTINCT `string`) as uv,
+        |      concat_distinct_agg(`string`) as distinct_str
+        |    FROM TABLE(
+        |      CUMULATE(
+        |        TABLE T1,
+        |        DESCRIPTOR(rowtime),
+        |        INTERVAL '5' SECOND,
+        |        INTERVAL '15' SECOND))
+        |    GROUP BY `name`, window_start, window_end
+        |  )
+        |)
+        |WHERE rownum > 1 AND rownum <= 2
+      """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
+    env.execute()
+
+    val expected = Seq(
+      "b,2020-10-10T00:00,2020-10-10T00:00:10,2,6.66,6.0,3.0,2,Hello|Hi",
+      "b,2020-10-10T00:00,2020-10-10T00:00:15,2,6.66,6.0,3.0,2,Hello|Hi",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:35,1,3.33,3.0,3.0,1,Comment#3",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:40,1,3.33,3.0,3.0,1,Comment#3",
+      "b,2020-10-10T00:00:30,2020-10-10T00:00:45,1,3.33,3.0,3.0,1,Comment#3")
+    assertEquals(expected.sorted.mkString("\n"), sink.getAppendResults.sorted.mkString("\n"))
+  }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.RecordsWindowBuffer;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.CombineRecordsFunction;
+import org.apache.flink.table.runtime.operators.aggregate.window.combines.AggRecordsCombiner;
 import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
 import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceUnsharedWindowAggProcessor;
 import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
@@ -112,7 +112,7 @@ public class SlicingWindowAggOperatorBuilder {
         final WindowBuffer.Factory bufferFactory =
                 new RecordsWindowBuffer.Factory(keySerializer, inputSerializer);
         final WindowCombineFunction.Factory combinerFactory =
-                new CombineRecordsFunction.Factory(
+                new AggRecordsCombiner.Factory(
                         generatedAggregateFunction, keySerializer, inputSerializer);
         final SlicingWindowProcessor<Long> windowProcessor;
         if (assigner instanceof SliceSharedAssigner) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorBuilder.java
@@ -24,9 +24,9 @@ import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunc
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.RecordsWindowBuffer;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
 import org.apache.flink.table.runtime.operators.aggregate.window.combines.CombineRecordsFunction;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceSharedWindowAggProcessor;
 import org.apache.flink.table.runtime.operators.aggregate.window.processors.SliceUnsharedWindowAggProcessor;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners.HoppingSliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/RecordsWindowBuffer.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.operators.aggregate.window.buffers;
 
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
 import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
 import org.apache.flink.table.runtime.typeutils.WindowKeySerializer;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/WindowBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/buffers/WindowBuffer.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.aggregate.window.buffers;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/AggRecordsCombiner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/combines/AggRecordsCombiner.java
@@ -42,7 +42,7 @@ import static org.apache.flink.table.runtime.util.StateConfigUtil.isStateImmutab
  * An implementation of {@link WindowCombineFunction} that accumulates input records into the window
  * accumulator state.
  */
-public final class CombineRecordsFunction implements WindowCombineFunction {
+public final class AggRecordsCombiner implements WindowCombineFunction {
 
     /** The service to register event-time or processing-time timers. */
     private final InternalTimerService<Long> timerService;
@@ -68,7 +68,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     /** Whether the operator works in event-time mode, used to indicate registering which timer. */
     private final boolean isEventTime;
 
-    public CombineRecordsFunction(
+    public AggRecordsCombiner(
             InternalTimerService<Long> timerService,
             StateKeyContext keyContext,
             WindowValueState<Long> accState,
@@ -144,7 +144,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     // Factory
     // ----------------------------------------------------------------------------------------
 
-    /** Factory to create {@link CombineRecordsFunction}. */
+    /** Factory to create {@link AggRecordsCombiner}. */
     public static final class Factory implements WindowCombineFunction.Factory {
 
         private static final long serialVersionUID = 1L;
@@ -177,7 +177,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
                             stateBackend, LongSerializer.INSTANCE, runtimeContext));
             boolean requiresCopy = !isStateImmutableInStateBackend(stateBackend);
             WindowValueState<Long> windowValueState = (WindowValueState<Long>) windowState;
-            return new CombineRecordsFunction(
+            return new AggRecordsCombiner(
                     timerService,
                     stateBackend::setCurrentKey,
                     windowValueState,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.runtime.dataview.PerWindowStateDataViewStore;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.generated.NamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.ClockService;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceSharedWindowAggProcessor.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigner;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceAssigners;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceSharedAssigner;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/SliceUnsharedWindowAggProcessor.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedNamespaceAggsHandleFunction;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
-import org.apache.flink.table.runtime.operators.aggregate.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SliceUnsharedAssigner;
 
 /**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AbstractTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AbstractTopNFunction.java
@@ -40,9 +40,7 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.function.Function;
 
 /** Base class for TopN Function. */
@@ -226,20 +224,7 @@ public abstract class AbstractTopNFunction
      * @return true if the record should be put into the buffer.
      */
     protected boolean checkSortKeyInBufferRange(RowData sortKey, TopNBuffer buffer) {
-        Comparator<RowData> comparator = buffer.getSortKeyComparator();
-        Map.Entry<RowData, Collection<RowData>> worstEntry = buffer.lastEntry();
-        if (worstEntry == null) {
-            // return true if the buffer is empty.
-            return true;
-        } else {
-            RowData worstKey = worstEntry.getKey();
-            int compare = comparator.compare(sortKey, worstKey);
-            if (compare < 0) {
-                return true;
-            } else {
-                return buffer.getCurrentTopNum() < getDefaultTopNSize();
-            }
-        }
+        return buffer.checkSortKeyInBufferRange(sortKey, getDefaultTopNSize());
     }
 
     protected void registerMetric(long heapSize) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank.window;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.RecordsWindowBuffer;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
+import org.apache.flink.table.runtime.operators.rank.window.combines.CombineRecordsFunction;
+import org.apache.flink.table.runtime.operators.rank.window.processors.WindowRankProcessor;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;
+import org.apache.flink.table.runtime.typeutils.AbstractRowDataSerializer;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link WindowRankOperatorBuilder} is used to build a {@link SlicingWindowOperator} for window
+ * rank.
+ *
+ * <pre>
+ * SlicingWindowRankOperatorBuilder.builder()
+ *   .inputSerializer(inputSerializer)
+ *   .keySerializer(keySerializer)
+ *   .sortKeySelector(sortKeySelector)
+ *   .sortKeyComparator(genSortKeyComparator)
+ *   .outputRankNumber(true)
+ *   .rankStart(0)
+ *   .rankEnd(100)
+ *   .windowEndIndex(windowEndIndex)
+ *   .build();
+ * </pre>
+ */
+public class WindowRankOperatorBuilder {
+
+    public static WindowRankOperatorBuilder builder() {
+        return new WindowRankOperatorBuilder();
+    }
+
+    private AbstractRowDataSerializer<RowData> inputSerializer;
+    private PagedTypeSerializer<RowData> keySerializer;
+    private RowDataKeySelector sortKeySelector;
+    private GeneratedRecordComparator generatedSortKeyComparator;
+    private boolean outputRankNumber;
+    private long rankStart = -1;
+    private long rankEnd = -1;
+    private int windowEndIndex = -1;
+
+    public WindowRankOperatorBuilder inputSerializer(
+            AbstractRowDataSerializer<RowData> inputSerializer) {
+        this.inputSerializer = inputSerializer;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder keySerializer(PagedTypeSerializer<RowData> keySerializer) {
+        this.keySerializer = keySerializer;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder sortKeySelector(RowDataKeySelector sortKeySelector) {
+        this.sortKeySelector = sortKeySelector;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder sortKeyComparator(
+            GeneratedRecordComparator genSortKeyComparator) {
+        this.generatedSortKeyComparator = genSortKeyComparator;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder outputRankNumber(boolean outputRankNumber) {
+        this.outputRankNumber = outputRankNumber;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder rankStart(long rankStart) {
+        this.rankStart = rankStart;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder rankEnd(long rankEnd) {
+        this.rankEnd = rankEnd;
+        return this;
+    }
+
+    public WindowRankOperatorBuilder windowEndIndex(int windowEndIndex) {
+        this.windowEndIndex = windowEndIndex;
+        return this;
+    }
+
+    public SlicingWindowOperator<RowData, ?> build() {
+        checkNotNull(inputSerializer);
+        checkNotNull(keySerializer);
+        checkNotNull(sortKeySelector);
+        checkNotNull(generatedSortKeyComparator);
+        checkArgument(
+                rankStart > 0,
+                String.format("Illegal rank start %s, it should be positive!", rankStart));
+        checkArgument(
+                rankEnd > 1,
+                String.format("Illegal rank end %s, it should be bigger than 1!", rankEnd));
+        checkArgument(
+                rankEnd >= rankStart,
+                String.format(
+                        "Illegal rank start %s and rank end %s, rank start should not be bigger than or equal to rank end!",
+                        rankStart, rankEnd));
+        checkArgument(
+                windowEndIndex >= 0,
+                String.format(
+                        "Illegal window end index %s, it should not be negative!", windowEndIndex));
+        final WindowBuffer.Factory bufferFactory =
+                new RecordsWindowBuffer.Factory(keySerializer, inputSerializer);
+        final WindowCombineFunction.Factory combinerFactory =
+                new CombineRecordsFunction.Factory(
+                        generatedSortKeyComparator,
+                        sortKeySelector,
+                        keySerializer,
+                        inputSerializer,
+                        rankEnd);
+        final SlicingWindowProcessor<Long> windowProcessor =
+                new WindowRankProcessor(
+                        inputSerializer,
+                        generatedSortKeyComparator,
+                        sortKeySelector.getProducedType().toSerializer(),
+                        bufferFactory,
+                        combinerFactory,
+                        rankStart,
+                        rankEnd,
+                        outputRankNumber,
+                        windowEndIndex);
+        return new SlicingWindowOperator<>(windowProcessor);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.RecordsWindowBuffer;
 import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
-import org.apache.flink.table.runtime.operators.rank.window.combines.CombineRecordsFunction;
+import org.apache.flink.table.runtime.operators.rank.window.combines.TopNRecordsCombiner;
 import org.apache.flink.table.runtime.operators.rank.window.processors.WindowRankProcessor;
 import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
 import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
@@ -131,7 +131,7 @@ public class WindowRankOperatorBuilder {
         final WindowBuffer.Factory bufferFactory =
                 new RecordsWindowBuffer.Factory(keySerializer, inputSerializer);
         final WindowCombineFunction.Factory combinerFactory =
-                new CombineRecordsFunction.Factory(
+                new TopNRecordsCombiner.Factory(
                         generatedSortKeyComparator,
                         sortKeySelector,
                         keySerializer,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/combines/TopNRecordsCombiner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/combines/TopNRecordsCombiner.java
@@ -47,7 +47,7 @@ import static org.apache.flink.table.runtime.util.StateConfigUtil.isStateImmutab
  * An implementation of {@link WindowCombineFunction} that save topN records of incremental input
  * records into the window state.
  */
-public final class CombineRecordsFunction implements WindowCombineFunction {
+public final class TopNRecordsCombiner implements WindowCombineFunction {
 
     /** The service to register event-time or processing-time timers. */
     private final InternalTimerService<Long> timerService;
@@ -79,7 +79,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     /** Whether the operator works in event-time mode, used to indicate registering which timer. */
     private final boolean isEventTime;
 
-    public CombineRecordsFunction(
+    public TopNRecordsCombiner(
             InternalTimerService<Long> timerService,
             StateKeyContext keyContext,
             WindowMapState<Long, List<RowData>> dataState,
@@ -157,7 +157,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
     // Factory
     // ----------------------------------------------------------------------------------------
 
-    /** Factory to create {@link CombineRecordsFunction}. */
+    /** Factory to create {@link TopNRecordsCombiner}. */
     public static final class Factory implements WindowCombineFunction.Factory {
 
         private static final long serialVersionUID = 1L;
@@ -195,7 +195,7 @@ public final class CombineRecordsFunction implements WindowCombineFunction {
             boolean requiresCopyKey = !isStateImmutableInStateBackend(stateBackend);
             WindowMapState<Long, List<RowData>> windowMapState =
                     (WindowMapState<Long, List<RowData>>) windowState;
-            return new CombineRecordsFunction(
+            return new TopNRecordsCombiner(
                     timerService,
                     stateBackend::setCurrentKey,
                     windowMapState,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/processors/WindowRankProcessor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/processors/WindowRankProcessor.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank.window.processors;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.JoinedRowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.operators.aggregate.window.buffers.WindowBuffer;
+import org.apache.flink.table.runtime.operators.rank.TopNBuffer;
+import org.apache.flink.table.runtime.operators.window.combines.WindowCombineFunction;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowProcessor;
+import org.apache.flink.table.runtime.operators.window.state.WindowMapState;
+import org.apache.flink.types.RowKind;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/** An window rank processor. */
+public final class WindowRankProcessor implements SlicingWindowProcessor<Long> {
+    private static final long serialVersionUID = 1L;
+
+    private final GeneratedRecordComparator generatedSortKeyComparator;
+
+    /** The util to compare two sortKey equals to each other. */
+    private Comparator<RowData> sortKeyComparator;
+
+    private final TypeSerializer<RowData> sortKeySerializer;
+
+    private final WindowBuffer.Factory bufferFactory;
+    private final WindowCombineFunction.Factory combineFactory;
+    private final TypeSerializer<RowData> inputSerializer;
+    private final long rankStart;
+    private final long rankEnd;
+    private final boolean outputRankNumber;
+    private final int windowEndIndex;
+
+    // ----------------------------------------------------------------------------------------
+
+    private transient long currentProgress;
+
+    private transient Context<Long> ctx;
+
+    private transient WindowBuffer windowBuffer;
+
+    /** state schema: [key, window_end, sort key, records]. */
+    private transient WindowMapState<Long, List<RowData>> windowState;
+
+    private transient JoinedRowData reuseOutput;
+    private transient GenericRowData reuseRankRow;
+
+    public WindowRankProcessor(
+            TypeSerializer<RowData> inputSerializer,
+            GeneratedRecordComparator genSortKeyComparator,
+            TypeSerializer<RowData> sortKeySerializer,
+            WindowBuffer.Factory bufferFactory,
+            WindowCombineFunction.Factory combineFactory,
+            long rankStart,
+            long rankEnd,
+            boolean outputRankNumber,
+            int windowEndIndex) {
+        this.inputSerializer = inputSerializer;
+        this.generatedSortKeyComparator = genSortKeyComparator;
+        this.sortKeySerializer = sortKeySerializer;
+        this.bufferFactory = bufferFactory;
+        this.combineFactory = combineFactory;
+        this.rankStart = rankStart;
+        this.rankEnd = rankEnd;
+        this.outputRankNumber = outputRankNumber;
+        this.windowEndIndex = windowEndIndex;
+    }
+
+    @Override
+    public void open(Context<Long> context) throws Exception {
+        this.ctx = context;
+
+        // compile comparator
+        sortKeyComparator =
+                generatedSortKeyComparator.newInstance(
+                        ctx.getRuntimeContext().getUserCodeClassLoader());
+
+        final LongSerializer namespaceSerializer = LongSerializer.INSTANCE;
+        ListSerializer<RowData> listSerializer = new ListSerializer<>(inputSerializer);
+        MapStateDescriptor<RowData, List<RowData>> mapStateDescriptor =
+                new MapStateDescriptor<>("window_rank", sortKeySerializer, listSerializer);
+        MapState<RowData, List<RowData>> state =
+                ctx.getKeyedStateBackend()
+                        .getOrCreateKeyedState(namespaceSerializer, mapStateDescriptor);
+        this.windowState =
+                new WindowMapState<>(
+                        (InternalMapState<RowData, Long, RowData, List<RowData>>) state);
+        final WindowCombineFunction combineFunction =
+                combineFactory.create(
+                        ctx.getRuntimeContext(),
+                        ctx.getTimerService(),
+                        ctx.getKeyedStateBackend(),
+                        windowState,
+                        true);
+        this.windowBuffer =
+                bufferFactory.create(
+                        ctx.getOperatorOwner(),
+                        ctx.getMemoryManager(),
+                        ctx.getMemorySize(),
+                        combineFunction);
+
+        this.reuseOutput = new JoinedRowData();
+        this.reuseRankRow = new GenericRowData(1);
+        this.currentProgress = Long.MIN_VALUE;
+    }
+
+    @Override
+    public boolean processElement(RowData key, RowData element) throws Exception {
+        long sliceEnd = element.getLong(windowEndIndex);
+        if (sliceEnd - 1 <= currentProgress) {
+            // element is late and should be dropped
+            return true;
+        }
+        windowBuffer.addElement(key, sliceEnd, element);
+        return false;
+    }
+
+    @Override
+    public void advanceProgress(long progress) throws Exception {
+        if (progress > currentProgress) {
+            currentProgress = progress;
+            windowBuffer.advanceProgress(currentProgress);
+        }
+    }
+
+    @Override
+    public void prepareCheckpoint() throws Exception {
+        windowBuffer.flush();
+    }
+
+    @Override
+    public void clearWindow(Long windowEnd) throws Exception {
+        windowState.clear(windowEnd);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (windowBuffer != null) {
+            windowBuffer.close();
+        }
+    }
+
+    @Override
+    public TypeSerializer<Long> createWindowSerializer() {
+        return LongSerializer.INSTANCE;
+    }
+
+    @Override
+    public void fireWindow(Long windowEnd) throws Exception {
+        TopNBuffer buffer = new TopNBuffer(sortKeyComparator, ArrayList::new);
+        // step 1: load state data into TopNBuffer
+        Iterator<Map.Entry<RowData, List<RowData>>> stateIterator = windowState.iterator(windowEnd);
+        while (stateIterator.hasNext()) {
+            Map.Entry<RowData, List<RowData>> entry = stateIterator.next();
+            RowData sortKey = entry.getKey();
+            if (buffer.checkSortKeyInBufferRange(sortKey, rankEnd)) {
+                buffer.putAll(sortKey, entry.getValue());
+            }
+        }
+
+        // step 2: send [rankStart, rankEnd] result
+        Iterator<Map.Entry<RowData, Collection<RowData>>> bufferItr = buffer.entrySet().iterator();
+        long currentRank = 1L;
+        while (bufferItr.hasNext() && currentRank <= rankEnd) {
+            Map.Entry<RowData, Collection<RowData>> entry = bufferItr.next();
+            Collection<RowData> records = entry.getValue();
+            Iterator<RowData> recordsIter = records.iterator();
+            while (recordsIter.hasNext() && currentRank <= rankEnd) {
+                RowData rowData = recordsIter.next();
+                if (currentRank >= rankStart && currentRank <= rankEnd) {
+                    ctx.output(createOutputRow(rowData, currentRank));
+                }
+                currentRank += 1;
+            }
+        }
+    }
+
+    private RowData createOutputRow(RowData inputRow, long rank) {
+        if (outputRankNumber) {
+            reuseRankRow.setField(0, rank);
+            reuseOutput.replace(inputRow, reuseRankRow);
+            reuseOutput.setRowKind(RowKind.INSERT);
+            return reuseOutput;
+        } else {
+            return inputRow;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/combines/WindowCombineFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/combines/WindowCombineFunction.java
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.operators.aggregate.window.combines;
+package org.apache.flink.table.runtime.operators.window.combines;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.operators.window.state.WindowValueState;
+import org.apache.flink.table.runtime.operators.window.state.WindowState;
 import org.apache.flink.table.runtime.util.WindowKey;
 
 import java.io.Serializable;
@@ -65,7 +65,7 @@ public interface WindowCombineFunction {
                 RuntimeContext runtimeContext,
                 InternalTimerService<Long> timerService,
                 KeyedStateBackend<RowData> stateBackend,
-                WindowValueState<Long> windowState,
+                WindowState<Long> windowState,
                 boolean isEventTime)
                 throws Exception;
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowMapState.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowMapState.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.window.state;
+
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.table.data.RowData;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/** A wrapper of {@link MapState} which is easier to update based on window namespace. */
+public final class WindowMapState<W, UV> implements WindowState<W> {
+
+    private final InternalMapState<RowData, W, RowData, UV> windowState;
+
+    public WindowMapState(InternalMapState<RowData, W, RowData, UV> windowState) {
+        this.windowState = windowState;
+    }
+
+    public void clear(W window) {
+        windowState.setCurrentNamespace(window);
+        windowState.clear();
+    }
+
+    /**
+     * Returns the current value associated with the given key.
+     *
+     * @param key The key of the mapping
+     * @return The value of the mapping with the given key
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public UV get(W window, RowData key) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.get(key);
+    }
+
+    /**
+     * Associates a new value with the given key.
+     *
+     * @param key The key of the mapping
+     * @param value The new value of the mapping
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public void put(W window, RowData key, UV value) throws Exception {
+        windowState.setCurrentNamespace(window);
+        windowState.put(key, value);
+    }
+
+    /**
+     * Copies all of the mappings from the given map into the state.
+     *
+     * @param map The mappings to be stored in this state
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public void putAll(W window, Map<RowData, UV> map) throws Exception {
+        windowState.setCurrentNamespace(window);
+        windowState.putAll(map);
+    }
+
+    /**
+     * Deletes the mapping of the given key.
+     *
+     * @param key The key of the mapping
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public void remove(W window, RowData key) throws Exception {
+        windowState.setCurrentNamespace(window);
+        windowState.remove(key);
+    }
+
+    /**
+     * Returns whether there exists the given mapping.
+     *
+     * @param key The key of the mapping
+     * @return True if there exists a mapping whose key equals to the given key
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public boolean contains(W window, RowData key) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.contains(key);
+    }
+
+    /**
+     * Returns all the mappings in the state.
+     *
+     * @return An iterable view of all the key-value pairs in the state.
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public Iterable<Map.Entry<RowData, UV>> entries(W window) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.entries();
+    }
+
+    /**
+     * Returns all the keys in the state.
+     *
+     * @return An iterable view of all the keys in the state.
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public Iterable<RowData> keys(W window) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.keys();
+    }
+
+    /**
+     * Returns all the values in the state.
+     *
+     * @return An iterable view of all the values in the state.
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public Iterable<UV> values(W window) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.values();
+    }
+
+    /**
+     * Iterates over all the mappings in the state.
+     *
+     * @return An iterator over all the mappings in the state
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public Iterator<Map.Entry<RowData, UV>> iterator(W window) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.iterator();
+    }
+
+    /**
+     * Returns true if this state contains no key-value mappings, otherwise false.
+     *
+     * @return True if this state contains no key-value mappings, otherwise false.
+     * @throws Exception Thrown if the system cannot access the state.
+     */
+    public boolean isEmpty(W window) throws Exception {
+        windowState.setCurrentNamespace(window);
+        return windowState.isEmpty();
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank.window;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.sort.IntRecordComparator;
+import org.apache.flink.table.runtime.operators.window.slicing.SlicingWindowOperator;
+import org.apache.flink.table.runtime.typeutils.PagedTypeSerializer;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for window rank operators created by {@link WindowRankOperatorBuilder}. */
+public class WindowRankOperatorTest {
+
+    private static final RowType INPUT_ROW_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new RowType.RowField("f0", new VarCharType(Integer.MAX_VALUE)),
+                            new RowType.RowField("f1", new IntType()),
+                            new RowType.RowField("f2", new BigIntType())));
+
+    private static final RowDataSerializer INPUT_ROW_SER = new RowDataSerializer(INPUT_ROW_TYPE);
+
+    private static final RowDataKeySelector KEY_SELECTOR =
+            HandwrittenSelectorUtil.getRowDataSelector(
+                    new int[] {0}, INPUT_ROW_TYPE.getChildren().toArray(new LogicalType[0]));
+
+    private static final PagedTypeSerializer<RowData> KEY_SER =
+            (PagedTypeSerializer<RowData>) KEY_SELECTOR.getProducedType().toSerializer();
+
+    private static final GeneratedRecordComparator GENERATED_SORT_KEY_COMPARATOR =
+            new GeneratedRecordComparator("", "", new Object[0]) {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public RecordComparator newInstance(ClassLoader classLoader) {
+                    return IntRecordComparator.INSTANCE;
+                }
+            };
+
+    private static final int SORT_KEY_IDX = 1;
+
+    private static final RowDataKeySelector SORT_KEY_SELECTOR =
+            HandwrittenSelectorUtil.getRowDataSelector(
+                    new int[] {SORT_KEY_IDX},
+                    INPUT_ROW_TYPE.getChildren().toArray(new LogicalType[0]));
+
+    private static final int WINDOW_END_INDEX = 2;
+
+    private static final LogicalType[] OUTPUT_TYPES =
+            new LogicalType[] {
+                new VarCharType(Integer.MAX_VALUE),
+                new IntType(),
+                new BigIntType(),
+                new BigIntType()
+            };
+
+    private static final TypeSerializer<RowData> OUT_SERIALIZER =
+            new RowDataSerializer(OUTPUT_TYPES);
+
+    private static final RowDataHarnessAssertor ASSERTER =
+            new RowDataHarnessAssertor(
+                    OUTPUT_TYPES,
+                    new GenericRowRecordSortComparator(0, new VarCharType(VarCharType.MAX_LENGTH)));
+
+    private static final LogicalType[] OUTPUT_TYPES_WITHOUT_RANK_NUMBER =
+            new LogicalType[] {new VarCharType(Integer.MAX_VALUE), new IntType(), new BigIntType()};
+
+    private static final TypeSerializer<RowData> OUT_SERIALIZER_WITHOUT_RANK_NUMBER =
+            new RowDataSerializer(OUTPUT_TYPES_WITHOUT_RANK_NUMBER);
+
+    private static final RowDataHarnessAssertor ASSERTER_WITHOUT_RANK_NUMBER =
+            new RowDataHarnessAssertor(
+                    OUTPUT_TYPES_WITHOUT_RANK_NUMBER,
+                    new GenericRowRecordSortComparator(0, new VarCharType(VarCharType.MAX_LENGTH)));
+
+    @Test
+    public void testTop2Windows() throws Exception {
+        SlicingWindowOperator<RowData, ?> operator =
+                WindowRankOperatorBuilder.builder()
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
+                        .sortKeyComparator(GENERATED_SORT_KEY_COMPARATOR)
+                        .sortKeySelector(SORT_KEY_SELECTOR)
+                        .outputRankNumber(true)
+                        .rankStart(1)
+                        .rankEnd(2)
+                        .windowEndIndex(WINDOW_END_INDEX)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // add elements out-of-order
+        testHarness.processElement(insertRecord("key2", 1, 999L));
+        testHarness.processElement(insertRecord("key2", 4, 999L));
+        testHarness.processElement(insertRecord("key2", 5, 999L));
+        testHarness.processElement(insertRecord("key2", 3, 999L));
+        testHarness.processElement(insertRecord("key2", 2, 1999L));
+        testHarness.processElement(insertRecord("key2", 7, 3999L));
+        testHarness.processElement(insertRecord("key2", 8, 3999L));
+        testHarness.processElement(insertRecord("key2", 1, 3999L));
+
+        testHarness.processElement(insertRecord("key1", 2, 999L));
+        testHarness.processElement(insertRecord("key1", 1, 999L));
+        testHarness.processElement(insertRecord("key1", 3, 999L));
+        testHarness.processElement(insertRecord("key1", 3, 999L));
+        testHarness.processElement(insertRecord("key1", 4, 1999L));
+        testHarness.processElement(insertRecord("key1", 6, 1999L));
+        testHarness.processElement(insertRecord("key1", 7, 1999L));
+
+        testHarness.processWatermark(new Watermark(999));
+        expectedOutput.add(insertRecord("key1", 1, 999L, 1L));
+        expectedOutput.add(insertRecord("key1", 2, 999L, 2L));
+        expectedOutput.add(insertRecord("key2", 1, 999L, 1L));
+        expectedOutput.add(insertRecord("key2", 3, 999L, 2L));
+        expectedOutput.add(new Watermark(999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(1999));
+        expectedOutput.add(insertRecord("key1", 4, 1999L, 1L));
+        expectedOutput.add(insertRecord("key1", 6, 1999L, 2L));
+        expectedOutput.add(insertRecord("key2", 2, 1999L, 1L));
+        expectedOutput.add(new Watermark(1999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        testHarness = createTestHarness(operator);
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        testHarness.processWatermark(new Watermark(3999));
+        expectedOutput.add(insertRecord("key2", 1, 3999L, 1L));
+        expectedOutput.add(insertRecord("key2", 7, 3999L, 2L));
+        expectedOutput.add(new Watermark(3999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // late element, should be dropped
+        testHarness.processElement(insertRecord("key2", 1, 3500L));
+
+        testHarness.processWatermark(new Watermark(4999));
+        expectedOutput.add(new Watermark(4999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        assertEquals(1, operator.getNumLateRecordsDropped().getCount());
+
+        testHarness.close();
+    }
+
+    @Test
+    public void testTop2WindowsWithOffset() throws Exception {
+        SlicingWindowOperator<RowData, ?> operator =
+                WindowRankOperatorBuilder.builder()
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
+                        .sortKeyComparator(GENERATED_SORT_KEY_COMPARATOR)
+                        .sortKeySelector(SORT_KEY_SELECTOR)
+                        .outputRankNumber(true)
+                        .rankStart(2)
+                        .rankEnd(2)
+                        .windowEndIndex(WINDOW_END_INDEX)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // add elements out-of-order
+        testHarness.processElement(insertRecord("key2", 1, 999L));
+        testHarness.processElement(insertRecord("key2", 4, 999L));
+        testHarness.processElement(insertRecord("key2", 5, 999L));
+        testHarness.processElement(insertRecord("key2", 3, 999L));
+        testHarness.processElement(insertRecord("key2", 2, 1999L));
+        testHarness.processElement(insertRecord("key2", 7, 3999L));
+        testHarness.processElement(insertRecord("key2", 8, 3999L));
+        testHarness.processElement(insertRecord("key2", 1, 3999L));
+
+        testHarness.processElement(insertRecord("key1", 2, 999L));
+        testHarness.processElement(insertRecord("key1", 1, 999L));
+        testHarness.processElement(insertRecord("key1", 3, 999L));
+        testHarness.processElement(insertRecord("key1", 3, 999L));
+        testHarness.processElement(insertRecord("key1", 4, 1999L));
+        testHarness.processElement(insertRecord("key1", 6, 1999L));
+        testHarness.processElement(insertRecord("key1", 7, 1999L));
+
+        testHarness.processWatermark(new Watermark(999));
+        expectedOutput.add(insertRecord("key1", 2, 999L, 2L));
+        expectedOutput.add(insertRecord("key2", 3, 999L, 2L));
+        expectedOutput.add(new Watermark(999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(1999));
+        expectedOutput.add(insertRecord("key1", 6, 1999L, 2L));
+        expectedOutput.add(new Watermark(1999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        testHarness = createTestHarness(operator);
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        testHarness.processWatermark(new Watermark(3999));
+        expectedOutput.add(insertRecord("key2", 7, 3999L, 2L));
+        expectedOutput.add(new Watermark(3999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
+    @Test
+    public void testTop2WindowsWithoutRankNumber() throws Exception {
+        SlicingWindowOperator<RowData, ?> operator =
+                WindowRankOperatorBuilder.builder()
+                        .inputSerializer(INPUT_ROW_SER)
+                        .keySerializer(KEY_SER)
+                        .sortKeyComparator(GENERATED_SORT_KEY_COMPARATOR)
+                        .sortKeySelector(SORT_KEY_SELECTOR)
+                        .outputRankNumber(false)
+                        .rankStart(1)
+                        .rankEnd(2)
+                        .windowEndIndex(WINDOW_END_INDEX)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER_WITHOUT_RANK_NUMBER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        // add elements out-of-order
+        testHarness.processElement(insertRecord("key2", 1, 999L));
+        testHarness.processElement(insertRecord("key2", 4, 999L));
+        testHarness.processElement(insertRecord("key2", 5, 999L));
+        testHarness.processElement(insertRecord("key2", 3, 999L));
+        testHarness.processElement(insertRecord("key2", 2, 1999L));
+        testHarness.processElement(insertRecord("key2", 7, 3999L));
+        testHarness.processElement(insertRecord("key2", 8, 3999L));
+        testHarness.processElement(insertRecord("key2", 1, 3999L));
+
+        testHarness.processElement(insertRecord("key1", 2, 999L));
+        testHarness.processElement(insertRecord("key1", 1, 999L));
+        testHarness.processElement(insertRecord("key1", 3, 999L));
+        testHarness.processElement(insertRecord("key1", 3, 999L));
+        testHarness.processElement(insertRecord("key1", 4, 1999L));
+        testHarness.processElement(insertRecord("key1", 6, 1999L));
+        testHarness.processElement(insertRecord("key1", 7, 1999L));
+
+        testHarness.processWatermark(new Watermark(999));
+        expectedOutput.add(insertRecord("key1", 1, 999L));
+        expectedOutput.add(insertRecord("key1", 2, 999L));
+        expectedOutput.add(insertRecord("key2", 1, 999L));
+        expectedOutput.add(insertRecord("key2", 3, 999L));
+        expectedOutput.add(new Watermark(999));
+        ASSERTER_WITHOUT_RANK_NUMBER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(1999));
+        expectedOutput.add(insertRecord("key1", 4, 1999L));
+        expectedOutput.add(insertRecord("key1", 6, 1999L));
+        expectedOutput.add(insertRecord("key2", 2, 1999L));
+        expectedOutput.add(new Watermark(1999));
+        ASSERTER_WITHOUT_RANK_NUMBER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        testHarness = createTestHarness(operator);
+        testHarness.setup(OUT_SERIALIZER_WITHOUT_RANK_NUMBER);
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        testHarness.processWatermark(new Watermark(3999));
+        expectedOutput.add(insertRecord("key2", 1, 3999L));
+        expectedOutput.add(insertRecord("key2", 7, 3999L));
+        expectedOutput.add(new Watermark(3999));
+        ASSERTER_WITHOUT_RANK_NUMBER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+    }
+
+    private static OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
+            SlicingWindowOperator<RowData, ?> operator) throws Exception {
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                operator, KEY_SELECTOR, KEY_SELECTOR.getProducedType());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to implement streaming window topN operator.

## Brief change log

  - Introduce `CombineRecordsFunction` in rank/window/combines package to get TopN data of incremental inputs
  - move `WindowCombineFunction` from aggregate/window/combines/  to window/combines in order to be inherited by new introduced `CombineRecordsFunction`
  - Introduce `WindowRankProcessor` which inherits `SlicingWindowProcessor` to processes elements for WindowRank.
  - Introduce `WindowRankOperatorBuilder` to build 'WindowRankOperator' which is exactly a `SlicingWindowOperator` based on `WindowRankProcessor`
  - Introduce `WindowMapState` which is a wrapper of `MapState` to make it easier to update based on window namespace
  - Introduce `StreamExecWindowRank` which is a stream `ExecNode` for WindowRank

## Verifying this change

  - Add more plan test for invalid query in existed `WindowRankTest`
  - Add ITCase(`WindowRankITCase`) to test WindowRank
  - Add harness test (`WindowRankOperatorTest`) to test WindowRankOperator

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
