### PR TITLE
[FLINK-21945][streaming] Omit pointwise connections from checkpointing in unaligned checkpoints.

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -48,7 +48,7 @@ public final class SnapshotUtils {
             throws Exception {
 
         CheckpointOptions options =
-                new CheckpointOptions(
+                CheckpointOptions.forConfig(
                         CheckpointType.SAVEPOINT,
                         AbstractFsCheckpointStorageAccess.encodePathAsReference(savepointPath),
                         isExactlyOnceMode,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
@@ -66,6 +66,12 @@ public class CheckpointBarrier extends RuntimeEvent {
         return checkpointOptions;
     }
 
+    public CheckpointBarrier withOptions(CheckpointOptions checkpointOptions) {
+        return this.checkpointOptions == checkpointOptions
+                ? this
+                : new CheckpointBarrier(id, timestamp, checkpointOptions);
+    }
+
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -235,8 +235,7 @@ public class EventSerializer {
             buf.putInt(locationBytes.length);
             buf.put(locationBytes);
         }
-        buf.put((byte) (checkpointOptions.isExactlyOnceMode() ? 1 : 0));
-        buf.put((byte) (checkpointOptions.isUnalignedCheckpoint() ? 1 : 0));
+        buf.put((byte) checkpointOptions.getAlignment().ordinal());
         buf.putLong(checkpointOptions.getAlignmentTimeout());
 
         buf.flip();
@@ -272,19 +271,15 @@ public class EventSerializer {
             buffer.get(bytes);
             locationRef = new CheckpointStorageLocationReference(bytes);
         }
-        final boolean isExactlyOnceMode = buffer.get() == 1;
-        final boolean isUnalignedCheckpoint = buffer.get() == 1;
+        final CheckpointOptions.AlignmentType alignmentType =
+                CheckpointOptions.AlignmentType.values()[buffer.get()];
         final long alignmentTimeout = buffer.getLong();
 
         return new CheckpointBarrier(
                 id,
                 timestamp,
                 new CheckpointOptions(
-                        checkpointType,
-                        locationRef,
-                        isExactlyOnceMode,
-                        isUnalignedCheckpoint,
-                        alignmentTimeout));
+                        checkpointType, locationRef, alignmentType, alignmentTimeout));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
@@ -183,6 +183,17 @@ public enum SubtaskStateMapper {
             }
             return subtasks.toArray();
         }
+    },
+
+    UNSUPPORTED {
+        @Override
+        public int[] getOldSubtasks(
+                int newSubtaskIndex, int oldNumberOfSubtasks, int newNumberOfSubtasks) {
+            throw new UnsupportedOperationException(
+                    "Cannot rescale the given pointwise partitioner.\n"
+                            + "Did you change the partitioner to forward or rescale?\n"
+                            + "It may also help to add an explicit shuffle().");
+        }
     };
 
     private static final int[] EMPTY = new int[0];

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions.AlignmentType;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 
 import org.junit.Test;
@@ -31,6 +32,7 @@ import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link CheckpointOptions} class. */
@@ -66,7 +68,10 @@ public class CheckpointOptionsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testSavepointNeedsAlignment() {
         new CheckpointOptions(
-                SAVEPOINT, CheckpointStorageLocationReference.getDefault(), true, true, 0);
+                SAVEPOINT,
+                CheckpointStorageLocationReference.getDefault(),
+                AlignmentType.UNALIGNED,
+                0);
     }
 
     @Test
@@ -74,16 +79,18 @@ public class CheckpointOptionsTest {
         CheckpointStorageLocationReference location =
                 CheckpointStorageLocationReference.getDefault();
         assertFalse(
-                new CheckpointOptions(CHECKPOINT, location, true, true, Long.MAX_VALUE)
+                new CheckpointOptions(CHECKPOINT, location, AlignmentType.UNALIGNED, Long.MAX_VALUE)
                         .needsAlignment());
         assertTrue(
-                new CheckpointOptions(CHECKPOINT, location, true, false, Long.MAX_VALUE)
+                new CheckpointOptions(CHECKPOINT, location, AlignmentType.ALIGNED, Long.MAX_VALUE)
+                        .needsAlignment());
+        assertTrue(
+                new CheckpointOptions(
+                                CHECKPOINT, location, AlignmentType.FORCED_ALIGNED, Long.MAX_VALUE)
                         .needsAlignment());
         assertFalse(
-                new CheckpointOptions(CHECKPOINT, location, false, true, Long.MAX_VALUE)
-                        .needsAlignment());
-        assertFalse(
-                new CheckpointOptions(CHECKPOINT, location, false, false, Long.MAX_VALUE)
+                new CheckpointOptions(
+                                CHECKPOINT, location, AlignmentType.AT_LEAST_ONCE, Long.MAX_VALUE)
                         .needsAlignment());
     }
 
@@ -94,6 +101,46 @@ public class CheckpointOptionsTest {
         assertTimeoutable(CheckpointOptions.alignedWithTimeout(location, 10), false, true, 10);
         assertTimeoutable(
                 CheckpointOptions.unaligned(location), true, false, NO_ALIGNMENT_TIME_OUT);
+        assertTimeoutable(
+                CheckpointOptions.alignedWithTimeout(location, 10).withUnalignedUnsupported(),
+                false,
+                false,
+                10);
+        assertTimeoutable(
+                CheckpointOptions.unaligned(location).withUnalignedUnsupported(),
+                false,
+                false,
+                NO_ALIGNMENT_TIME_OUT);
+    }
+
+    @Test
+    public void testForceAlignmentIsReversable() {
+        CheckpointStorageLocationReference location =
+                CheckpointStorageLocationReference.getDefault();
+        assertReversable(CheckpointOptions.alignedWithTimeout(location, 10), true);
+        assertReversable(CheckpointOptions.unaligned(location), true);
+
+        assertReversable(CheckpointOptions.alignedNoTimeout(CHECKPOINT, location), false);
+        assertReversable(CheckpointOptions.alignedNoTimeout(SAVEPOINT, location), false);
+        assertReversable(CheckpointOptions.notExactlyOnce(CHECKPOINT, location), false);
+        assertReversable(CheckpointOptions.notExactlyOnce(SAVEPOINT, location), false);
+    }
+
+    private void assertReversable(CheckpointOptions options, boolean forceHasEffect) {
+        assertEquals(
+                "all non-forced options support unaligned mode",
+                options,
+                options.withUnalignedSupported());
+        CheckpointOptions unalignedUnsupported = options.withUnalignedUnsupported();
+        if (forceHasEffect) {
+            assertNotEquals("expected changes in the options", options, unalignedUnsupported);
+        } else {
+            assertEquals("not expected changes to the options", options, unalignedUnsupported);
+        }
+        assertEquals(
+                "expected fully reversable options",
+                options,
+                unalignedUnsupported.withUnalignedSupported());
     }
 
     private void assertTimeoutable(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -62,6 +62,8 @@ public class StreamEdge implements Serializable {
 
     private long bufferTimeout;
 
+    private boolean supportsUnalignedCheckpoints = true;
+
     public StreamEdge(
             StreamNode sourceVertex,
             StreamNode targetVertex,
@@ -154,6 +156,14 @@ public class StreamEdge implements Serializable {
 
     public long getBufferTimeout() {
         return bufferTimeout;
+    }
+
+    public void setSupportsUnalignedCheckpoints(boolean supportsUnalignedCheckpoints) {
+        this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
+    }
+
+    public boolean supportsUnalignedCheckpoints() {
+        return supportsUnalignedCheckpoints;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -301,6 +301,14 @@ public class StreamGraphGenerator {
             transform(transformation);
         }
 
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            if (node.getInEdges().stream().anyMatch(edge -> edge.getPartitioner().isPointwise())) {
+                for (StreamEdge edge : node.getInEdges()) {
+                    edge.setSupportsUnalignedCheckpoints(false);
+                }
+            }
+        }
+
         final StreamGraph builtStreamGraph = streamGraph;
 
         alreadyTransformed.clear();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -65,7 +65,6 @@ import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
-import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationHead;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationTail;
@@ -799,7 +798,7 @@ public class StreamingJobGraphGenerator {
         checkAndResetBufferTimeout(resultPartitionType, edge);
 
         JobEdge jobEdge;
-        if (isPointwisePartitioner(partitioner)) {
+        if (partitioner.isPointwise()) {
             jobEdge =
                     downStreamVertex.connectNewDataSetAsInput(
                             headVertex, DistributionPattern.POINTWISE, resultPartitionType);
@@ -838,11 +837,6 @@ public class StreamingJobGraphGenerator {
         }
     }
 
-    private static boolean isPointwisePartitioner(StreamPartitioner<?> partitioner) {
-        return partitioner instanceof ForwardPartitioner
-                || partitioner instanceof RescalePartitioner;
-    }
-
     private ResultPartitionType determineResultPartitionType(StreamPartitioner<?> partitioner) {
         switch (streamGraph.getGlobalDataExchangeMode()) {
             case ALL_EDGES_BLOCKING:
@@ -854,7 +848,7 @@ public class StreamingJobGraphGenerator {
                     return ResultPartitionType.BLOCKING;
                 }
             case POINTWISE_EDGES_PIPELINED:
-                if (isPointwisePartitioner(partitioner)) {
+                if (partitioner.isPointwise()) {
                     return ResultPartitionType.PIPELINED_BOUNDED;
                 } else {
                     return ResultPartitionType.BLOCKING;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.api.operators.Output;
@@ -49,6 +50,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
 
     private final StreamStatusProvider streamStatusProvider;
 
+    private final boolean supportsUnalignedCheckpoints;
+
     private final OutputTag outputTag;
 
     private final WatermarkGauge watermarkGauge = new WatermarkGauge();
@@ -58,7 +61,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
             RecordWriter<SerializationDelegate<StreamRecord<OUT>>> recordWriter,
             TypeSerializer<OUT> outSerializer,
             OutputTag outputTag,
-            StreamStatusProvider streamStatusProvider) {
+            StreamStatusProvider streamStatusProvider,
+            boolean supportsUnalignedCheckpoints) {
 
         checkNotNull(recordWriter);
         this.outputTag = outputTag;
@@ -75,6 +79,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
         }
 
         this.streamStatusProvider = checkNotNull(streamStatusProvider);
+
+        this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
     }
 
     @Override
@@ -140,6 +146,13 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
     }
 
     public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {
+        if (isPriorityEvent
+                && event instanceof CheckpointBarrier
+                && !supportsUnalignedCheckpoints) {
+            final CheckpointBarrier barrier = (CheckpointBarrier) event;
+            event = barrier.withOptions(barrier.getCheckpointOptions().withUnalignedUnsupported());
+            isPriorityEvent = false;
+        }
         recordWriter.broadcastEvent(event, isPriorityEvent);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
@@ -62,6 +62,11 @@ public class BroadcastPartitioner<T> extends StreamPartitioner<T> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "BROADCAST";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
@@ -77,6 +77,11 @@ public class CustomPartitionerWrapper<K, T> extends StreamPartitioner<T> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "CUSTOM";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitioner.java
@@ -52,6 +52,11 @@ public class ForwardPartitioner<T> extends StreamPartitioner<T> {
 
     @Override
     public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
-        return SubtaskStateMapper.ROUND_ROBIN;
+        return SubtaskStateMapper.UNSUPPORTED;
+    }
+
+    @Override
+    public SubtaskStateMapper getUpstreamSubtaskStateMapper() {
+        return SubtaskStateMapper.UNSUPPORTED;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitioner.java
@@ -41,6 +41,11 @@ public class ForwardPartitioner<T> extends StreamPartitioner<T> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "FORWARD";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitioner.java
@@ -47,6 +47,11 @@ public class GlobalPartitioner<T> extends StreamPartitioner<T> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "GLOBAL";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitioner.java
@@ -75,6 +75,11 @@ public class KeyGroupStreamPartitioner<T, K> extends StreamPartitioner<T>
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "HASH";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -58,6 +58,11 @@ public class RebalancePartitioner<T> extends StreamPartitioner<T> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "REBALANCE";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
@@ -70,4 +70,9 @@ public class RescalePartitioner<T> extends StreamPartitioner<T> {
     public String toString() {
         return "RESCALE";
     }
+
+    @Override
+    public boolean isPointwise() {
+        return true;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
@@ -59,7 +59,12 @@ public class RescalePartitioner<T> extends StreamPartitioner<T> {
 
     @Override
     public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
-        return SubtaskStateMapper.ROUND_ROBIN;
+        return SubtaskStateMapper.UNSUPPORTED;
+    }
+
+    @Override
+    public SubtaskStateMapper getUpstreamSubtaskStateMapper() {
+        return SubtaskStateMapper.UNSUPPORTED;
     }
 
     public StreamPartitioner<T> copy() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitioner.java
@@ -51,6 +51,11 @@ public class ShufflePartitioner<T> extends StreamPartitioner<T> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "SHUFFLE";
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
@@ -76,4 +76,6 @@ public abstract class StreamPartitioner<T>
      * in-flight data.
      */
     public abstract SubtaskStateMapper getDownstreamSubtaskStateMapper();
+
+    public abstract boolean isPointwise();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -715,7 +715,12 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                             taskEnvironment.getUserCodeClassLoader().asClassLoader());
         }
 
-        return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag, this);
+        return new RecordWriterOutput<>(
+                recordWriter,
+                outSerializer,
+                sideOutputTag,
+                this,
+                edge.supportsUnalignedCheckpoints());
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -276,6 +276,13 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             return;
         }
 
+        // if checkpoint has been previously unaligned, but was forced to be aligned (pointwise
+        // connection), revert it here so that it can jump over output data
+        if (options.getAlignment() == CheckpointOptions.AlignmentType.FORCED_ALIGNED) {
+            options = options.withUnalignedSupported();
+            initCheckpoint(metadata.getCheckpointId(), options);
+        }
+
         // Step (1): Prepare the checkpoint, allow operators to do some pre-barrier work.
         //           The pre-barrier work should be nothing or minimal in the common case.
         operatorChain.prepareSnapshotPreBarrier(metadata.getCheckpointId());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
@@ -27,12 +28,14 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
 import org.apache.flink.streaming.api.datastream.ConnectedStreams;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
@@ -57,6 +60,7 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.NoOpIntMap;
+import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Description;
@@ -74,6 +78,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -288,6 +293,61 @@ public class StreamGraphGeneratorTest extends TestLogger {
         assertEquals(1, streamGraph.getStreamEdges(source2.getId()).size());
         assertEquals(1, streamGraph.getStreamEdges(source3.getId()).size());
         assertEquals(0, streamGraph.getStreamEdges(transform.getId()).size());
+    }
+
+    @Test
+    public void testUnalignedCheckpointDisabledOnPointwise() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(42);
+
+        DataStream<Long> source1 = env.fromSequence(1L, 10L);
+        DataStream<Long> map1 = source1.forward().map(l -> l);
+        DataStream<Long> source2 = env.fromSequence(2L, 11L);
+        DataStream<Long> map2 = source2.shuffle().map(l -> l);
+
+        final MapStateDescriptor<Long, Long> descriptor =
+                new MapStateDescriptor<>(
+                        "broadcast", BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO);
+        final BroadcastStream<Long> broadcast = map1.broadcast(descriptor);
+        final SingleOutputStreamOperator<Long> joined =
+                map2.connect(broadcast)
+                        .process(
+                                new BroadcastProcessFunction<Long, Long, Long>() {
+                                    @Override
+                                    public void processElement(
+                                            Long value, ReadOnlyContext ctx, Collector<Long> out) {}
+
+                                    @Override
+                                    public void processBroadcastElement(
+                                            Long value, Context ctx, Collector<Long> out) {}
+                                });
+
+        DataStream<Long> map3 = joined.shuffle().map(l -> l);
+        DataStream<Long> map4 = map3.rescale().map(l -> l).setParallelism(1337);
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        assertEquals(7, streamGraph.getStreamNodes().size());
+
+        // forward
+        assertFalse(supportsUnalignedCheckpoints(streamGraph, source1, map1));
+        // shuffle
+        assertTrue(supportsUnalignedCheckpoints(streamGraph, source2, map2));
+        // broadcast, but other channel is forwarded
+        assertFalse(supportsUnalignedCheckpoints(streamGraph, map1, joined));
+        // forward
+        assertFalse(supportsUnalignedCheckpoints(streamGraph, map2, joined));
+        // shuffle
+        assertTrue(supportsUnalignedCheckpoints(streamGraph, joined, map3));
+        // rescale
+        assertFalse(supportsUnalignedCheckpoints(streamGraph, map3, map4));
+    }
+
+    private boolean supportsUnalignedCheckpoints(
+            StreamGraph streamGraph, DataStream<Long> op1, DataStream<Long> op2) {
+        return streamGraph
+                .getStreamEdges(op1.getId(), op2.getId())
+                .get(0)
+                .supportsUnalignedCheckpoints();
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -31,11 +31,13 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriterImpl;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.writer.NonRecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -174,6 +176,50 @@ public class SubtaskCheckpointCoordinatorTest {
                 () -> true);
 
         assertEquals(false, broadcastedPriorityEvent.get());
+    }
+
+    @Test
+    public void testForceAlignedCheckpointResultingInPriorityEvents() throws Exception {
+        MockEnvironment mockEnvironment = MockEnvironment.builder().build();
+
+        SubtaskCheckpointCoordinator coordinator =
+                new MockSubtaskCheckpointCoordinatorBuilder()
+                        .setUnalignedCheckpointEnabled(true)
+                        .setEnvironment(mockEnvironment)
+                        .build();
+
+        AtomicReference<Boolean> broadcastedPriorityEvent = new AtomicReference<>(null);
+        final OperatorChain<?, ?> operatorChain =
+                new OperatorChain(
+                        new MockStreamTaskBuilder(mockEnvironment).build(),
+                        new NonRecordWriter<>()) {
+                    @Override
+                    public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent)
+                            throws IOException {
+                        super.broadcastEvent(event, isPriorityEvent);
+                        broadcastedPriorityEvent.set(isPriorityEvent);
+                        // test if we can write output data
+                        coordinator
+                                .getChannelStateWriter()
+                                .addOutputData(
+                                        0,
+                                        new ResultSubpartitionInfo(0, 0),
+                                        0,
+                                        BufferBuilderTestUtils.buildSomeBuffer(1337));
+                    }
+                };
+
+        CheckpointOptions forcedAlignedOptions =
+                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault())
+                        .withUnalignedUnsupported();
+        coordinator.checkpointState(
+                new CheckpointMetaData(42, 0),
+                forcedAlignedOptions,
+                new CheckpointMetricsBuilder(),
+                operatorChain,
+                () -> true);
+
+        assertEquals(true, broadcastedPriorityEvent.get());
     }
 
     @Test

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/partitioner/BinaryHashPartitioner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/partitioner/BinaryHashPartitioner.java
@@ -72,6 +72,11 @@ public class BinaryHashPartitioner extends StreamPartitioner<RowData> {
     }
 
     @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "HASH" + Arrays.toString(hashFieldNames);
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.util.Collector;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,9 +47,13 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.stream.Stream;
 
 import static org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks;
 import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterables.getOnlyElement;
+import static org.apache.flink.test.checkpointing.UnalignedCheckpointTestBase.ChannelType.LOCAL;
+import static org.apache.flink.test.checkpointing.UnalignedCheckpointTestBase.ChannelType.MIXED;
+import static org.apache.flink.test.checkpointing.UnalignedCheckpointTestBase.ChannelType.REMOTE;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -99,87 +104,158 @@ import static org.hamcrest.Matchers.equalTo;
 @RunWith(Parameterized.class)
 @Category(FailsWithAdaptiveScheduler.class) // FLINK-21689
 public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
+    enum Topology implements DagCreator {
+        PIPELINE {
+            @Override
+            public void create(
+                    StreamExecutionEnvironment env,
+                    int minCheckpoints,
+                    boolean slotSharing,
+                    int expectedRestarts) {
+                final int parallelism = env.getParallelism();
+                final SingleOutputStreamOperator<Long> stream =
+                        env.fromSource(
+                                        new LongSource(
+                                                minCheckpoints,
+                                                parallelism,
+                                                expectedRestarts,
+                                                env.getCheckpointInterval()),
+                                        noWatermarks(),
+                                        "source")
+                                .slotSharingGroup(slotSharing ? "default" : "source")
+                                .disableChaining()
+                                .map(i -> checkHeader(i))
+                                .name("forward")
+                                .uid("forward")
+                                .slotSharingGroup(slotSharing ? "default" : "forward")
+                                .keyBy(i -> withoutHeader(i) % parallelism * parallelism)
+                                .process(new KeyedIdentityFunction())
+                                .name("keyed")
+                                .uid("keyed");
+                addFailingPipeline(minCheckpoints, slotSharing, stream);
+            }
+        },
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-            new Object[] {
-                "non-parallel pipeline with local channels", createPipelineSettings(1, 1, true)
-            },
-            new Object[] {
-                "non-parallel pipeline with remote channels", createPipelineSettings(1, 1, false)
-            },
-            new Object[] {
-                "parallel pipeline with local channels, p = 5", createPipelineSettings(5, 5, true)
-            },
-            new Object[] {
-                "parallel pipeline with remote channels, p = 5", createPipelineSettings(5, 1, false)
-            },
-            new Object[] {
-                "parallel pipeline with mixed channels, p = 5", createPipelineSettings(5, 3, true)
-            },
-            new Object[] {
-                "parallel pipeline with mixed channels, p = 20",
-                createPipelineSettings(20, 10, true)
-            },
-            new Object[] {
-                "parallel pipeline with mixed channels, p = 20, timeout=1",
-                createPipelineSettings(20, 10, true, 1)
-            },
-            new Object[] {"Parallel cogroup, p = 5", createCogroupSettings(5)},
-            new Object[] {"Parallel cogroup, p = 10", createCogroupSettings(10)},
-            new Object[] {"Parallel union, p = 5", createUnionSettings(5)},
-            new Object[] {"Parallel union, p = 10", createUnionSettings(10)},
+        MULTI_INPUT {
+            @Override
+            public void create(
+                    StreamExecutionEnvironment env,
+                    int minCheckpoints,
+                    boolean slotSharing,
+                    int expectedRestarts) {
+                final int parallelism = env.getParallelism();
+                DataStream<Long> combinedSource = null;
+                for (int inputIndex = 0; inputIndex < NUM_SOURCES; inputIndex++) {
+                    final SingleOutputStreamOperator<Long> source =
+                            env.fromSource(
+                                            new LongSource(
+                                                    minCheckpoints,
+                                                    parallelism,
+                                                    expectedRestarts,
+                                                    env.getCheckpointInterval()),
+                                            noWatermarks(),
+                                            "source" + inputIndex)
+                                    .slotSharingGroup(
+                                            slotSharing ? "default" : ("source" + inputIndex))
+                                    .disableChaining();
+                    combinedSource =
+                            combinedSource == null
+                                    ? source
+                                    : combinedSource
+                                            .connect(source)
+                                            .flatMap(new MinEmittingFunction())
+                                            .name("min" + inputIndex)
+                                            .uid("min" + inputIndex)
+                                            .slotSharingGroup(
+                                                    slotSharing ? "default" : ("min" + inputIndex));
+                }
+
+                addFailingPipeline(minCheckpoints, slotSharing, combinedSource);
+            }
+        },
+
+        UNION {
+            @Override
+            public void create(
+                    StreamExecutionEnvironment env,
+                    int minCheckpoints,
+                    boolean slotSharing,
+                    int expectedRestarts) {
+                final int parallelism = env.getParallelism();
+                DataStream<Long> combinedSource = null;
+                for (int inputIndex = 0; inputIndex < NUM_SOURCES; inputIndex++) {
+                    final SingleOutputStreamOperator<Long> source =
+                            env.fromSource(
+                                            new LongSource(
+                                                    minCheckpoints,
+                                                    parallelism,
+                                                    expectedRestarts,
+                                                    env.getCheckpointInterval()),
+                                            noWatermarks(),
+                                            "source" + inputIndex)
+                                    .slotSharingGroup(
+                                            slotSharing ? "default" : ("source" + inputIndex))
+                                    .disableChaining();
+                    combinedSource = combinedSource == null ? source : combinedSource.union(source);
+                }
+
+                final SingleOutputStreamOperator<Long> deduplicated =
+                        combinedSource
+                                .partitionCustom(
+                                        (key, numPartitions) ->
+                                                (int) (withoutHeader(key) % numPartitions),
+                                        l -> l)
+                                .flatMap(new CountingMapFunction(NUM_SOURCES));
+                addFailingPipeline(minCheckpoints, slotSharing, deduplicated);
+            }
         };
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
     }
 
-    private static UnalignedSettings createPipelineSettings(
-            int parallelism, int slotsPerTaskManager, boolean slotSharing) {
-        return createPipelineSettings(parallelism, slotsPerTaskManager, slotSharing, 0);
+    @Parameterized.Parameters(name = "{0} with {2} channels, p = {1}, timeout = {3}")
+    public static Object[][] parameters() {
+        Object[] defaults = {Topology.PIPELINE, 1, MIXED, 0};
+
+        Object[][] runs = {
+            new Object[] {Topology.PIPELINE, 1, LOCAL},
+            new Object[] {Topology.PIPELINE, 1, REMOTE},
+            new Object[] {Topology.PIPELINE, 5, LOCAL},
+            new Object[] {Topology.PIPELINE, 5, REMOTE},
+            new Object[] {Topology.PIPELINE, 20},
+            new Object[] {Topology.PIPELINE, 20, MIXED, 1},
+            new Object[] {Topology.MULTI_INPUT, 5},
+            new Object[] {Topology.MULTI_INPUT, 10},
+            new Object[] {Topology.UNION, 5},
+            new Object[] {Topology.UNION, 10},
+        };
+        return Stream.of(runs)
+                .map(params -> addDefaults(params, defaults))
+                .toArray(Object[][]::new);
     }
 
-    private static UnalignedSettings createPipelineSettings(
-            int parallelism, int slotsPerTaskManager, boolean slotSharing, int timeout) {
-        int numShuffles = 4;
-        return new UnalignedSettings(UnalignedCheckpointITCase::createPipeline)
-                .setParallelism(parallelism)
-                .setSlotSharing(slotSharing)
-                .setNumSlots(slotSharing ? parallelism : parallelism * numShuffles)
-                .setSlotsPerTaskManager(slotsPerTaskManager)
-                .setExpectedFailures(5)
-                .setFailuresAfterSourceFinishes(1)
-                .setAlignmentTimeout(timeout);
-    }
-
-    private static UnalignedSettings createCogroupSettings(int parallelism) {
-        int numShuffles = 10;
-        return new UnalignedSettings(UnalignedCheckpointITCase::createMultipleInputTopology)
-                .setParallelism(parallelism)
-                .setSlotSharing(true)
-                .setNumSlots(parallelism * numShuffles)
-                .setSlotsPerTaskManager(parallelism)
-                .setExpectedFailures(5)
-                .setFailuresAfterSourceFinishes(1);
-    }
-
-    private static UnalignedSettings createUnionSettings(int parallelism) {
-        int numShuffles = 6;
-        return new UnalignedSettings(UnalignedCheckpointITCase::createUnionTopology)
-                .setParallelism(parallelism)
-                .setSlotSharing(true)
-                .setNumSlots(parallelism * numShuffles)
-                .setSlotsPerTaskManager(parallelism)
-                .setExpectedFailures(5)
-                .setFailuresAfterSourceFinishes(1);
+    private static Object[] addDefaults(Object[] params, Object[] defaults) {
+        return ArrayUtils.addAll(
+                params, ArrayUtils.subarray(defaults, params.length, defaults.length));
     }
 
     private final UnalignedSettings settings;
 
-    public UnalignedCheckpointITCase(String desc, UnalignedSettings settings) {
-        this.settings = settings;
+    public UnalignedCheckpointITCase(
+            Topology topology, int parallelism, ChannelType channelType, int timeout) {
+        settings =
+                new UnalignedSettings(topology)
+                        .setParallelism(parallelism)
+                        .setChannelTypes(channelType)
+                        .setExpectedFailures(5)
+                        .setFailuresAfterSourceFinishes(1)
+                        .setAlignmentTimeout(timeout);
     }
 
-    @Test(timeout = 60_000)
+    @Test
     public void execute() throws Exception {
         execute(settings);
     }
@@ -196,99 +272,6 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                 "NUM_FAILURES",
                 result.<Integer>getAccumulatorResult(NUM_FAILURES),
                 equalTo(settings.expectedFailures));
-    }
-
-    private static void createPipeline(
-            StreamExecutionEnvironment env,
-            int minCheckpoints,
-            boolean slotSharing,
-            int expectedRestarts) {
-        final int parallelism = env.getParallelism();
-        final SingleOutputStreamOperator<Long> stream =
-                env.fromSource(
-                                new LongSource(
-                                        minCheckpoints,
-                                        parallelism,
-                                        expectedRestarts,
-                                        env.getCheckpointInterval()),
-                                noWatermarks(),
-                                "source")
-                        .slotSharingGroup(slotSharing ? "default" : "source")
-                        .disableChaining()
-                        .map(i -> checkHeader(i))
-                        .name("forward")
-                        .uid("forward")
-                        .slotSharingGroup(slotSharing ? "default" : "forward")
-                        .keyBy(i -> withoutHeader(i) % parallelism * parallelism)
-                        .process(new KeyedIdentityFunction())
-                        .name("keyed")
-                        .uid("keyed");
-        addFailingPipeline(minCheckpoints, slotSharing, stream);
-    }
-
-    private static void createMultipleInputTopology(
-            StreamExecutionEnvironment env,
-            int minCheckpoints,
-            boolean slotSharing,
-            int expectedRestarts) {
-        final int parallelism = env.getParallelism();
-        DataStream<Long> combinedSource = null;
-        for (int inputIndex = 0; inputIndex < NUM_SOURCES; inputIndex++) {
-            final SingleOutputStreamOperator<Long> source =
-                    env.fromSource(
-                                    new LongSource(
-                                            minCheckpoints,
-                                            parallelism,
-                                            expectedRestarts,
-                                            env.getCheckpointInterval()),
-                                    noWatermarks(),
-                                    "source" + inputIndex)
-                            .slotSharingGroup(slotSharing ? "default" : ("source" + inputIndex))
-                            .disableChaining();
-            combinedSource =
-                    combinedSource == null
-                            ? source
-                            : combinedSource
-                                    .connect(source)
-                                    .flatMap(new MinEmittingFunction())
-                                    .name("min" + inputIndex)
-                                    .uid("min" + inputIndex)
-                                    .slotSharingGroup(
-                                            slotSharing ? "default" : ("min" + inputIndex));
-        }
-
-        addFailingPipeline(minCheckpoints, slotSharing, combinedSource);
-    }
-
-    private static void createUnionTopology(
-            StreamExecutionEnvironment env,
-            int minCheckpoints,
-            boolean slotSharing,
-            int expectedRestarts) {
-        final int parallelism = env.getParallelism();
-        DataStream<Long> combinedSource = null;
-        for (int inputIndex = 0; inputIndex < NUM_SOURCES; inputIndex++) {
-            final SingleOutputStreamOperator<Long> source =
-                    env.fromSource(
-                                    new LongSource(
-                                            minCheckpoints,
-                                            parallelism,
-                                            expectedRestarts,
-                                            env.getCheckpointInterval()),
-                                    noWatermarks(),
-                                    "source" + inputIndex)
-                            .slotSharingGroup(slotSharing ? "default" : ("source" + inputIndex))
-                            .disableChaining();
-            combinedSource = combinedSource == null ? source : combinedSource.union(source);
-        }
-
-        final SingleOutputStreamOperator<Long> deduplicated =
-                combinedSource
-                        .partitionCustom(
-                                (key, numPartitions) -> (int) (withoutHeader(key) % numPartitions),
-                                l -> l)
-                        .flatMap(new CountingMapFunction(NUM_SOURCES));
-        addFailingPipeline(minCheckpoints, slotSharing, deduplicated);
     }
 
     private static DataStreamSink<Long> addFailingPipeline(
@@ -311,7 +294,7 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                                 state -> state.runNumber == 4))
                 .name("failing-map")
                 .uid("failing-map")
-                .slotSharingGroup(slotSharing ? "default" : "map")
+                .slotSharingGroup(slotSharing ? "default" : "failing-map")
                 .partitionCustom(new ChunkDistributingPartitioner(), l -> l)
                 .addSink(
                         new StrictOrderVerifyingSink(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

With #13845, unaligned checkpoints are rescalable. However, for pointwise connection we are losing certain implicit guarantees as outlined in FLINK-21936. Unless, we provide forward the keyed context to downstream operations, there is no easy way to rescale pointwise connections. Thus, this PR removes pointwise connections from unaligned checkpoint and thus allows the rescaling for arbitrary jobs at the cost of checkpoint barriers not being able to overtake pointwise buffers.

## Brief change log

- Adding forced aligned checkpoints. These unaligned checkpoints or aligned checkpoints with timeout are turned into pure aligned checkpoints on pointwise connections. They are restored downstream.
- Adding `StreamEdge#supportsUnalignedCheckpoint` to all incoming edges iff a `StreamNode` has at least one pointwise connection.
- Use that flag to force a checkpoint to be aligned on `RecordOutputWriter`.
- Restore forced checkpoint barriers inside `SubtaskCheckpointCoordinatorImpl`.
- Adding pointwise connections to `UnalignedCheckpointRescaleITCase`
- Some refactoring to `UnalignedCheckpoint(Rescale)ITCase` to avoid manual specification of slots.

## Verifying this change

Added pointwise connections to `UnalignedCheckpointRescaleITCase` and a new broadcast topology.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
