### PR TITLE
[FLINK-21788][network] Throw PartitionNotFoundException if the partition file has been lost for blocking shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -30,6 +30,7 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -212,6 +213,10 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
         synchronized (lock) {
             checkState(!isReleased, "data partition already released");
             checkState(isFinished, "writing of blocking partition not yet finished");
+
+            if (!Files.isReadable(data.getFilePath())) {
+                throw new PartitionNotFoundException(parent.getPartitionId());
+            }
 
             final ResultSubpartitionView reader;
             if (useDirectFileTransfer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFile.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -92,6 +93,10 @@ public class PartitionedFile {
 
     public int getNumRegions() {
         return numRegions;
+    }
+
+    public boolean isReadable() {
+        return Files.isReadable(dataFilePath) && Files.isReadable(indexFilePath);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -405,6 +405,10 @@ public class SortMergeResultPartition extends ResultPartition {
             checkState(!isReleased(), "Partition released.");
             checkState(isFinished(), "Trying to read unfinished blocking partition.");
 
+            if (!resultFile.isReadable()) {
+                throw new PartitionNotFoundException(getPartitionId());
+            }
+
             return readScheduler.crateSubpartitionReader(
                     availabilityListener, subpartitionIndex, resultFile);
         }


### PR DESCRIPTION
## What is the purpose of the change

Currently, if the partition file has been lost for blocking shuffle, FileNotFoundException will be thrown and the partition data is not regenerated. This patch makes it throw PartitionNotFoundException instead.


## Brief change log

  - Throw PartitionNotFoundException if the partition file has been lost for blocking shuffle.

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
