### PR TITLE
[FLINK-21790][network] Shuffle data directories to make directory selection of different TaskManagers fairer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -36,6 +36,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 
 /** Configuration object for the network stack. */
@@ -251,6 +252,9 @@ public class NettyShuffleEnvironmentConfiguration {
                 configuration.getBoolean(NettyShuffleEnvironmentOptions.NETWORK_DETAILED_METRICS);
 
         String[] tempDirs = ConfigurationUtils.parseTempDirectories(configuration);
+        // shuffle the data directories to make it fairer for directory selection between different
+        // TaskManagers, which is good for load balance especially when there are multiple disks
+        Collections.shuffle(Arrays.asList(tempDirs));
 
         Duration requestSegmentsTimeout =
                 Duration.ofMillis(


### PR DESCRIPTION
## What is the purpose of the change

Currently, different TaskManagers select shuffle data directory in the same order and if there are multiple disks, some disks may stores more data than others which is bad for performance. This patch shuffles the data directories to make it fairer for selection between different TaskManagers, which is good for load balance especially when there are multiple disks.

## Brief change log

  - Shuffle data directories to make directory selection of different TaskManagers fairer.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
