### PR TITLE
[FLINK-21789][network] Make FileChannelManagerImpl#getNextPathNum select data directories fairly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/FileChannelManagerImpl.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -50,7 +51,7 @@ public class FileChannelManagerImpl implements FileChannelManager {
     private final Random random;
 
     /** The number of the next path to use. */
-    private volatile int nextPath;
+    private final AtomicLong nextPath = new AtomicLong(0);
 
     /** Prefix of the temporary directories to create. */
     private final String prefix;
@@ -69,7 +70,6 @@ public class FileChannelManagerImpl implements FileChannelManager {
         checkArgument(tempDirs.length > 0, "The temporary directories must not be empty.");
 
         this.random = new Random();
-        this.nextPath = 0;
         this.prefix = prefix;
 
         shutdownHook =
@@ -106,7 +106,7 @@ public class FileChannelManagerImpl implements FileChannelManager {
     public ID createChannel() {
         checkState(!isShutdown.get(), "File channel manager has shutdown.");
 
-        int num = getNextPathNum();
+        int num = (int) (nextPath.getAndIncrement() % paths.length);
         return new ID(paths[num], num, random);
     }
 
@@ -157,12 +157,5 @@ public class FileChannelManagerImpl implements FileChannelManager {
                 throw new IOException(errorMessage, e);
             }
         };
-    }
-
-    private int getNextPathNum() {
-        int next = nextPath;
-        int newNext = next + 1;
-        nextPath = newNext >= paths.length ? 0 : newNext;
-        return next;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.disk;
 
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.testutils.TestJvmProcess;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.ShutdownHookUtil;
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -53,6 +55,42 @@ public class FileChannelManagerImplTest extends TestLogger {
     private static final Duration TEST_TIMEOUT = Duration.ofSeconds(10);
 
     @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testFairness() throws Exception {
+        String directory1 = temporaryFolder.newFolder().getAbsoluteFile().getAbsolutePath();
+        String directory2 = temporaryFolder.newFolder().getAbsoluteFile().getAbsolutePath();
+        FileChannelManager fileChannelManager =
+                new FileChannelManagerImpl(new String[] {directory1, directory2}, "test");
+
+        int numChannelIDs = 1000000;
+        AtomicInteger counter1 = new AtomicInteger();
+        AtomicInteger counter2 = new AtomicInteger();
+
+        int numThreads = 10;
+        Thread[] threads = new Thread[numThreads];
+        for (int i = 0; i < numThreads; ++i) {
+            threads[i] =
+                    new Thread(
+                            () -> {
+                                for (int j = 0; j < numChannelIDs; ++j) {
+                                    FileIOChannel.ID channelID = fileChannelManager.createChannel();
+                                    if (channelID.getPath().startsWith(directory1)) {
+                                        counter1.incrementAndGet();
+                                    } else {
+                                        counter2.incrementAndGet();
+                                    }
+                                }
+                            });
+            threads[i].start();
+        }
+
+        for (int i = 0; i < numThreads; ++i) {
+            threads[i].join();
+        }
+
+        assertEquals(counter1.get(), counter2.get());
+    }
 
     @Test
     public void testDirectoriesCleanupOnKillWithoutCallerHook() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

FileChannelManagerImpl#getNextPathNum is not atomic which may cause unfairness of data directory selection. This patch makes the selection of data directories fair which is good for load balance and performance especially when there are multiple disks.


## Brief change log

  - Make FileChannelManagerImpl#getNextPathNum select data directories fairly.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
