### PR TITLE
[FLINK-21713][table-api/table-planner] Correct function CURRENT_TIMESTAMP/CURRENT_TIME/CURRENT_DATE/NOW/LOCALTIME/LOCALTIMESTAMP

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -415,18 +415,23 @@ temporal:
       NUMERIC.milli
       NUMERIC.millis
     description: Creates an interval of NUMERIC milliseconds.
-  - sql: CURRENT_DATE
-    table: currentDate()
-    description: Returns the current SQL date in the UTC time zone.
-  - sql: CURRENT_TIME
-    table: currentTime()
-    description: Returns the current SQL time in the UTC time zone.
   - sql: LOCALTIME
     table: localTime()
-    description: Returns the current SQL timestamp in the UTC time zone.
+    description: Returns the current SQL time in the local time zone. It is evaluated for each record in streaming mode. But in batch mode, it is evaluated once as the query starts and uses the same result for every row.
   - sql: LOCALTIMESTAMP
     table: localTimestamp()
-    description: Returns the current SQL timestamp in local time zone.
+    description: Returns the current SQL timestamp in local time zone, the return type is TIMESTAMP WITHOUT ITME ZONE. It is evaluated for each record in streaming mode. But in batch mode, it is evaluated once as the query starts and uses the same result for every row.
+  - sql: CURRENT_TIME
+    table: currentTime()
+    description: Returns the current SQL time in the local time zone, this is a synonym of LOCAL_TIME.
+  - sql: CURRENT_DATE
+    table: currentDate()
+    description: Returns the current SQL date in the local time zone. It is evaluated for each record in streaming mode. But in batch mode, it is evaluated once as the query starts and uses the same result for every row.
+  - sql: CURRENT_TIMESTAMP
+    table: currentTimestamp()
+    description: Returns the current SQL timestamp in the local time zone, the return type is TIMESTAMP WITH LOCAL TIME ZONE. It is evaluated for each record in streaming mode. But in batch mode, it is evaluated once as the query starts and uses the same result for every row.
+  - sql: NOW()
+    description: Returns the current SQL timestamp in the local time zone, this is a synonym of CURRENT_TIMESTAMP.
   - sql: EXTRACT(timeinteravlunit FROM temporal)
     table: TEMPORAL.extract(TIMEINTERVALUNIT)
     description: Returns a long value extracted from the timeintervalunit part of temporal. E.g., EXTRACT(DAY FROM DATE '2006-06-05') returns 5.
@@ -478,8 +483,6 @@ temporal:
     description: "Converts a epoch seconds or epoch milliseconds to a TIMESTAMP_LTZ, the valid precision is 0 or 3, the 0 is default value which means TO_TIMESTAMP_LTZ(epochSeconds, 0), the 3 represents TO_TIMESTAMP_LTZ(epochMilliseconds, 3)."
   - sql: TO_TIMESTAMP(string1[, string2])
     description: "Converts date time string string1 with format string2 (by default: 'yyyy-MM-dd HH:mm:ss') under the session time zone (specified by TableConfig) to a timestamp."
-  - sql: NOW()
-    description: Returns the current SQL timestamp in the UTC time zone. This function is not deterministic which means the value would be recalculated for each record.
 
 conditional:
   - sql: |
@@ -542,7 +545,7 @@ collection:
     description: Returns the element at position INT in array. The index starts from 1.
   - sql: ELEMENT(array)
     table: ARRAY.element()
-    table: Returns the sole element of array (whose cardinality should be one); returns NULL if array is empty. Throws an exception if array has more than one element.
+    description: Returns the sole element of array (whose cardinality should be one); returns NULL if array is empty. Throws an exception if array has more than one element.
   - sql: CARDINALITY(map)
     table: MAP.cardinality()
     description: Returns the number of entries in map.

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -183,21 +183,22 @@ CURRENT_RANGE = Expression("CURRENT_RANGE")  # type: Expression
 
 def current_date() -> Expression:
     """
-    Returns the current SQL date in UTC time zone.
+    Returns the current SQL date in local time zone.
     """
     return _leaf_op("currentDate")
 
 
 def current_time() -> Expression:
     """
-    Returns the current SQL time in UTC time zone.
+    Returns the current SQL time in local time zone.
     """
     return _leaf_op("currentTime")
 
 
 def current_timestamp() -> Expression:
     """
-    Returns the current SQL timestamp in UTC time zone.
+    Returns the current SQL timestamp in local time zone,
+    the underlying function return type is TIMESTAMP_LTZ.
     """
     return _leaf_op("currentTimestamp")
 
@@ -211,7 +212,8 @@ def local_time() -> Expression:
 
 def local_timestamp() -> Expression:
     """
-    Returns the current SQL timestamp in local time zone.
+    Returns the current SQL timestamp in local time zone,
+    the underlying function return type is TIMESTAMP.
     """
     return _leaf_op("localTimestamp")
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -186,27 +186,42 @@ public final class Expressions {
     public static final ApiExpression CURRENT_RANGE =
             apiCall(BuiltInFunctionDefinitions.CURRENT_RANGE);
 
-    /** Returns the current SQL date in UTC time zone. */
+    /**
+     * Returns the current SQL date in local time zone, the return type of this expression is {@link
+     * DataTypes#DATE()}.
+     */
     public static ApiExpression currentDate() {
         return apiCall(BuiltInFunctionDefinitions.CURRENT_DATE);
     }
 
-    /** Returns the current SQL time in UTC time zone. */
+    /**
+     * Returns the current SQL time in local time zone, the return type of this expression is {@link
+     * DataTypes#TIME()}.
+     */
     public static ApiExpression currentTime() {
         return apiCall(BuiltInFunctionDefinitions.CURRENT_TIME);
     }
 
-    /** Returns the current SQL timestamp in UTC time zone. */
+    /**
+     * Returns the current SQL timestamp in local time zone, the return type of this expression is
+     * {@link DataTypes#TIMESTAMP_WITH_LOCAL_TIME_ZONE()}.
+     */
     public static ApiExpression currentTimestamp() {
         return apiCall(BuiltInFunctionDefinitions.CURRENT_TIMESTAMP);
     }
 
-    /** Returns the current SQL time in local time zone. */
+    /**
+     * Returns the current SQL time in local time zone, the return type of this expression is {@link
+     * DataTypes#TIME()}, this is a synonym for {@link Expressions#currentTime()}.
+     */
     public static ApiExpression localTime() {
         return apiCall(BuiltInFunctionDefinitions.LOCAL_TIME);
     }
 
-    /** Returns the current SQL timestamp in local time zone. */
+    /**
+     * Returns the current SQL timestamp in local time zone, the return type of this expression is
+     * {@link DataTypes#TIMESTAMP()}.
+     */
     public static ApiExpression localTimestamp() {
         return apiCall(BuiltInFunctionDefinitions.LOCAL_TIMESTAMP);
     }

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -421,49 +421,55 @@ trait ImplicitExpressionConversions {
   }
 
   /**
-    * Returns the current SQL date in UTC time zone.
+    * Returns the current SQL date in local time zone,
+    * the return type of this expression is [[DataTypes.DATE]].
     */
   def currentDate(): Expression = {
     Expressions.currentDate()
   }
 
   /**
-    * Returns the current SQL time in UTC time zone.
+    * Returns the current SQL time in local time zone,
+    * the return type of this expression is [[DataTypes.TIME]].
     */
   def currentTime(): Expression = {
     Expressions.currentTime()
   }
 
   /**
-    * Returns the current SQL timestamp in UTC time zone.
+    * Returns the current SQL timestamp in local time zone,
+    * the return type of this expression is [[DataTypes.TIMESTAMP_LTZ()]].
     */
   def currentTimestamp(): Expression = {
     Expressions.currentTimestamp()
   }
 
   /**
-    * Returns the current SQL time in local time zone.
+    * Returns the current SQL time in local time zone,
+    * the return type of this expression is [[DataTypes.TIME]],
+    * this is a synonym for [[ImplicitExpressionConversions.currentTime()]].
     */
   def localTime(): Expression = {
     Expressions.localTime()
   }
 
   /**
-    * Returns the current SQL timestamp in local time zone.
+    * Returns the current SQL timestamp in local time zone,
+    * the return type of this expression is [[DataTypes.TIMESTAMP]].
     */
   def localTimestamp(): Expression = {
     Expressions.localTimestamp()
   }
 
   /**
-   * Converts a numeric type epoch seconds to {@link DataTypes#TIMESTAMP_LTZ()}.
+   * Converts a numeric type epoch seconds to [[DataTypes#TIMESTAMP_LTZ]].
    */
   def toTimestampLtz(numericEpochTime: Expression): Expression = {
     Expressions.toTimestampLtz(numericEpochTime, lit(0))
   }
 
   /**
-   * Converts a numeric type epoch time to {@link DataTypes#TIMESTAMP_LTZ()}.
+   * Converts a numeric type epoch time to [[DataTypes#TIMESTAMP_LTZ]].
    *
    * <p>The supported precision is 0 or 3:
    *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LocalZonedTimestampType.java
@@ -80,7 +80,8 @@ public final class LocalZonedTimestampType extends LogicalType {
                     Integer.class.getName(),
                     int.class.getName(),
                     Long.class.getName(),
-                    long.class.getName());
+                    long.class.getName(),
+                    TimestampData.class.getName());
 
     private static final Class<?> DEFAULT_CONVERSION = java.time.Instant.class;
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -556,24 +556,15 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     SqlFunctionCategory.STRING);
 
     public static final SqlFunction NOW =
-            new SqlFunction(
-                    "NOW",
-                    SqlKind.OTHER_FUNCTION,
-                    ReturnTypes.explicit(SqlTypeName.TIMESTAMP, 0),
-                    null,
-                    OperandTypes.NILADIC,
-                    SqlFunctionCategory.TIMEDATE) {
-
+            new SqlCurrentTimestampFunction("NOW") {
                 @Override
-                public boolean isDeterministic() {
-                    return false;
-                }
-
-                @Override
-                public SqlMonotonicity getMonotonicity(SqlOperatorBinding call) {
-                    return SqlMonotonicity.INCREASING;
+                public SqlSyntax getSyntax() {
+                    return SqlSyntax.FUNCTION;
                 }
             };
+
+    public static final SqlFunction CURRENT_TIMESTAMP =
+            new SqlCurrentTimestampFunction("CURRENT_TIMESTAMP");
 
     public static final SqlFunction UNIX_TIMESTAMP =
             new SqlFunction(
@@ -1101,7 +1092,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlFunction LOCALTIME = SqlStdOperatorTable.LOCALTIME;
     public static final SqlFunction LOCALTIMESTAMP = SqlStdOperatorTable.LOCALTIMESTAMP;
     public static final SqlFunction CURRENT_TIME = SqlStdOperatorTable.CURRENT_TIME;
-    public static final SqlFunction CURRENT_TIMESTAMP = SqlStdOperatorTable.CURRENT_TIMESTAMP;
     public static final SqlFunction CURRENT_DATE = SqlStdOperatorTable.CURRENT_DATE;
     public static final SqlFunction CAST = SqlStdOperatorTable.CAST;
     public static final SqlOperator SCALAR_QUERY = SqlStdOperatorTable.SCALAR_QUERY;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/SqlCurrentTimestampFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/SqlCurrentTimestampFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.calcite.sql.fun.SqlAbstractTimeFunction;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Function that returns current timestamp, the function return type is {@link
+ * SqlTypeName#TIMESTAMP_WITH_LOCAL_TIME_ZONE}.
+ */
+public class SqlCurrentTimestampFunction extends SqlAbstractTimeFunction {
+
+    public SqlCurrentTimestampFunction(String name) {
+        // access protected constructor
+        super(name, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return false;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/InternalConfigOptions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/InternalConfigOptions.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * This class holds internal configuration constants used by Flink's table module.
+ *
+ * <p>This is only used for the Blink planner.
+ *
+ * <p>NOTE: All option keys in this class must start with "__" and end up with "__", and all options
+ * shouldn't expose to users, all options should erase after plan finished.
+ */
+@Internal
+public final class InternalConfigOptions {
+
+    public static final ConfigOption<Long> TABLE_QUERY_START_EPOCH_TIME =
+            key("__table.query-start.epoch-time__")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The config used to save the epoch time at query start, this config will be"
+                                    + " used by some temporal functions like CURRENT_TIMESTAMP in batch job to make sure"
+                                    + " these temporal functions has query-start semantics.");
+
+    public static final ConfigOption<Long> TABLE_QUERY_START_LOCAL_TIME =
+            key("__table.query-start.local-time__")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The config used to save the local timestamp at query start, the timestamp value is stored"
+                                    + " as UTC+0 milliseconds since epoch for simplification, this config will be used by"
+                                    + " some temporal functions like LOCAL_TIMESTAMP in batch job to make sure these"
+                                    + " temporal functions has query-start semantics.");
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -26,6 +26,8 @@ import org.apache.flink.table.data.conversion.{DataStructureConverter, DataStruc
 import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GenerateUtils.generateRecordStatement
+import org.apache.flink.table.planner.utils.InternalConfigOptions
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils
 import org.apache.flink.table.runtime.operators.TableStreamOperator
 import org.apache.flink.table.runtime.typeutils.{ExternalSerializer, InternalSerializers}
 import org.apache.flink.table.runtime.util.collections._
@@ -34,9 +36,8 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.util.InstantiationUtil
 
-import org.apache.calcite.avatica.util.DateTimeUtils
-
 import java.util.TimeZone
+import java.util.function.{Supplier => JSupplier}
 
 import scala.collection.mutable
 
@@ -441,9 +442,12 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   }
 
   /**
-    * Adds a reusable timestamp to the beginning of the SAM of the generated class.
-    */
-  def addReusableTimestamp(): String = {
+   * Adds a reusable record-level timestamp to the beginning of the SAM of the generated class.
+   *
+   * <p> The timestamp value is evaluated for per record, this
+   * function is generally used in stream job.
+   */
+  def addReusableRecordLevelCurrentTimestamp(): String = {
     val fieldTerm = s"timestamp"
 
     reusableMemberStatements.add(s"private $TIMESTAMP_DATA $fieldTerm;")
@@ -458,37 +462,44 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   }
 
   /**
-    * Adds a reusable time to the beginning of the SAM of the generated [[Function]].
-    */
-  def addReusableTime(): String = {
-    val fieldTerm = s"time"
+   * Adds a reusable query-level timestamp to the beginning of the SAM of the generated class.
+   *
+   * <p> The timestamp value is evaluated once at query-start, this
+   * function is generally used in batch job.
+   */
+  def addReusableQueryLevelCurrentTimestamp(): String = {
+    val fieldTerm = s"queryStartTimestamp"
 
-    val timestamp = addReusableTimestamp()
+    val queryStartEpoch = tableConfig.getConfiguration
+      .getOptional(InternalConfigOptions.TABLE_QUERY_START_EPOCH_TIME)
+      .orElseThrow(
+        new JSupplier[Throwable] {
+          override def get() = new CodeGenException(
+            "Try to obtain epoch time of query-start fail." +
+              " This is a bug, please file an issue.")
+        }
+      )
 
-    // declaration
-    reusableMemberStatements.add(s"private int $fieldTerm;")
-
-    // assignment
-    // adopted from org.apache.calcite.runtime.SqlFunctions.currentTime()
-    val field =
+    reusableMemberStatements.add(
       s"""
-         |$fieldTerm = (int) ($timestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY});
-         |if (time < 0) {
-         |  time += ${DateTimeUtils.MILLIS_PER_DAY};
-         |}
-         |""".stripMargin
-    reusablePerRecordStatements.add(field)
+          |private static final $TIMESTAMP_DATA $fieldTerm =
+          |$TIMESTAMP_DATA.fromEpochMillis(${queryStartEpoch}L);
+          |""".stripMargin)
     fieldTerm
   }
 
   /**
-    * Adds a reusable local date time to the beginning of the SAM of the generated class.
-    */
-  def addReusableLocalDateTime(): String = {
-    val fieldTerm = s"localtimestamp"
+   * Adds a reusable record-level local date time to the beginning of the
+   * SAM of the generated class.
+   *
+   * <p> The timestamp value is evaluated for per record, this
+   * function is generally used in stream job.
+   */
+  def addReusableRecordLevelLocalDateTime(): String = {
+    val fieldTerm = s"localTimestamp"
 
     val sessionTimeZone = addReusableSessionTimeZone()
-    val timestamp = addReusableTimestamp()
+    val timestamp = addReusableRecordLevelCurrentTimestamp()
 
     // declaration
     reusableMemberStatements.add(s"private $TIMESTAMP_DATA $fieldTerm;")
@@ -505,48 +516,105 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   }
 
   /**
-    * Adds a reusable local time to the beginning of the SAM of the generated class.
-    */
-  def addReusableLocalTime(): String = {
-    val fieldTerm = s"localtime"
+   * Adds a reusable query-level local date time to the beginning of
+   * the SAM of the generated class.
+   *
+   * <p> The timestamp value is evaluated once at query-start, this
+   * function is generally used in batch job.
+   */
+  def addReusableQueryLevelLocalDateTime(): String = {
+    val fieldTerm = s"queryStartLocaltimestamp"
 
-    val localtimestamp = addReusableLocalDateTime()
+    val queryStartLocalTimestamp = tableConfig.getConfiguration
+      .getOptional(InternalConfigOptions.TABLE_QUERY_START_LOCAL_TIME)
+      .orElseThrow(
+        new JSupplier[Throwable] {
+          override def get() = new CodeGenException(
+            "Try to obtain local time of query-start fail." +
+              " This is a bug, please file an issue.")
+        }
+      )
+
+    reusableMemberStatements.add(
+      s"""
+         |private static final $TIMESTAMP_DATA $fieldTerm =
+         |$TIMESTAMP_DATA.fromEpochMillis(${queryStartLocalTimestamp}L);
+         |""".stripMargin)
+    fieldTerm
+  }
+
+  /**
+   * Adds a reusable record-level local time to the beginning of the SAM of the generated class.
+   */
+  def addReusableRecordLevelLocalTime(): String = {
+    val fieldTerm = s"localTime"
+
+    val localtimestamp = addReusableRecordLevelLocalDateTime()
 
     // declaration
     reusableMemberStatements.add(s"private int $fieldTerm;")
+    val utilsName = classOf[SqlDateTimeUtils].getCanonicalName
 
     // assignment
-    // adopted from org.apache.calcite.runtime.SqlFunctions.localTime()
     val field =
     s"""
-       |$fieldTerm = (int) ($localtimestamp.getMillisecond() % ${DateTimeUtils.MILLIS_PER_DAY});
+       |$fieldTerm = $utilsName.getTimeInMills($localtimestamp.getMillisecond());
        |""".stripMargin
     reusablePerRecordStatements.add(field)
     fieldTerm
   }
 
   /**
-    * Adds a reusable date to the beginning of the SAM of the generated class.
+   * Adds a reusable query-level local time to the beginning of
+   * the SAM of the generated class.
+   */
+  def addReusableQueryLevelLocalTime(): String = {
+    val fieldTerm = s"queryStartLocaltime"
+
+    val queryStartLocalTimestamp = addReusableQueryLevelLocalDateTime()
+    val utilsName = classOf[SqlDateTimeUtils].getCanonicalName
+    // declaration
+    reusableMemberStatements.add(
+      s"""
+          |private static final int $fieldTerm =
+          | $utilsName.getTimeInMills($queryStartLocalTimestamp.getMillisecond());
+          | """.stripMargin)
+    fieldTerm
+  }
+
+  /**
+    * Adds a reusable record-level date to the beginning of the SAM of the generated class.
     */
-  def addReusableDate(): String = {
+  def addReusableRecordLevelCurrentDate(): String = {
     val fieldTerm = s"date"
 
-    val timestamp = addReusableTimestamp()
-    val time = addReusableTime()
+    val timestamp = addReusableRecordLevelLocalDateTime()
+    val utilsName = classOf[SqlDateTimeUtils].getCanonicalName
 
     // declaration
     reusableMemberStatements.add(s"private int $fieldTerm;")
 
     // assignment
-    // adopted from org.apache.calcite.runtime.SqlFunctions.currentDate()
-    val field =
-      s"""
-         |$fieldTerm = (int) ($timestamp.getMillisecond() / ${DateTimeUtils.MILLIS_PER_DAY});
-         |if ($time < 0) {
-         |  $fieldTerm -= 1;
-         |}
-         |""".stripMargin
+    val field = s"$fieldTerm = $utilsName.getDateInDays($timestamp.getMillisecond());"
+
     reusablePerRecordStatements.add(field)
+    fieldTerm
+  }
+
+  /**
+   * Adds a reusable query-level date to the beginning of the SAM of the generated class.
+   */
+  def addReusableQueryLevelCurrentDate(): String = {
+    val fieldTerm = s"queryStartDate"
+    val utilsName = classOf[SqlDateTimeUtils].getCanonicalName
+
+    val timestamp = addReusableQueryLevelLocalDateTime()
+    reusableMemberStatements.add(
+    s"""
+       |private static final int $fieldTerm =
+       | $fieldTerm = $utilsName.getDateInDays($timestamp.getMillisecond());
+       |""".stripMargin)
+
     fieldTerm
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -836,6 +836,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
         StringCallGen.generateCallExpression(ctx, call.getOperator, operands, resultType)
           .getOrElse {
             FunctionGenerator
+              .getInstance(ctx.tableConfig)
               .getCallGenerator(
                 sqlOperator,
                 operands.map(expr => expr.resultType),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -504,7 +504,8 @@ object GenerateUtils {
 
   def generateCurrentTimestamp(
       ctx: CodeGeneratorContext): GeneratedExpression = {
-    new CurrentTimePointCallGen(false).generate(ctx, Seq(), new TimestampType(3))
+    //TODO return TIMESTAMP for PROCTIME(), will return TIMESTAMP_LTZ once FLINK-21617 finished
+    new CurrentTimePointCallGen(true, true).generate(ctx, Seq(), new TimestampType(3))
   }
 
   def generateRowtimeAccess(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -117,6 +117,7 @@ class BatchPlanner(
     val execGraph = translateToExecNodeGraph(optimizedRelNodes)
 
     val transformations = translateToPlan(execGraph)
+    cleanupInternalConfigurations()
 
     val execEnv = getExecEnv
     ExecutorUtils.setBatchProperties(execEnv)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -107,6 +107,7 @@ class StreamPlanner(
     val execGraph = translateToExecNodeGraph(optimizedRelNodes)
 
     val transformations = translateToPlan(execGraph)
+    cleanupInternalConfigurations()
     val streamGraph = ExecutorUtils.generateStreamGraph(getExecEnv, transformations)
 
     val sb = new StringBuilder
@@ -157,6 +158,8 @@ class StreamPlanner(
     validateAndOverrideConfiguration()
     val execGraph = ExecNodeGraph.createExecNodeGraph(jsonPlan, createSerdeContext)
     val transformations = translateToPlan(execGraph)
+    cleanupInternalConfigurations()
+
     val streamGraph = ExecutorUtils.generateStreamGraph(getExecEnv, transformations)
 
     val sb = new StringBuilder

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
@@ -20,15 +20,20 @@ package org.apache.flink.table.planner.expressions
 
 import java.sql.Time
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDateTime, ZoneId}
-
+import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.util.TimeZone
+import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.configuration.ExecutionOptions
 import org.apache.flink.table.api._
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.planner.expressions.utils.ExpressionTestBase
+import org.apache.flink.table.planner.utils.InternalConfigOptions
 import org.apache.flink.types.Row
-
+import org.junit.Assert.assertEquals
 import org.junit.Test
+
+import scala.collection.mutable
 
 /**
   * Tests that check all non-deterministic functions can be executed.
@@ -36,87 +41,112 @@ import org.junit.Test
 class NonDeterministicTests extends ExpressionTestBase {
 
   @Test
-  def testCurrentDate(): Unit = {
-    testAllApis(
-      currentDate().isGreater("1970-01-01".toDate),
-      "currentDate() > '1970-01-01'.toDate",
-      "CURRENT_DATE > DATE '1970-01-01'",
-      "true")
+  def testTemporalFunctionsInStreamMode(): Unit = {
+    val temporalFunctions = getCodeGenFunctions(List(
+      "CURRENT_DATE",
+      "CURRENT_TIME",
+      "CURRENT_TIMESTAMP",
+      "NOW()",
+      "LOCALTIME",
+      "LOCALTIMESTAMP"))
+    val round1 = evaluateFunctionResult(temporalFunctions)
+    Thread.sleep(1 * 1000L)
+    val round2: List[String] = evaluateFunctionResult(temporalFunctions)
+
+    assertEquals(round1.size, round2.size)
+    round1.zip(round2).zipWithIndex.foreach {
+      case ((result1: String, result2: String), index: Int) => {
+        // CURRENT_DATE may be same between two records
+        if (index == 0) {
+          assert(result1 <= result2)
+        } else {
+          assert(result1 < result2)
+        }
+      }
+    }
   }
 
   @Test
-  def testCurrentTime(): Unit = {
-    testAllApis(
-      currentTime().isGreaterOrEqual("00:00:00".toTime),
-      "currentTime() >= '00:00:00'.toTime",
-      "CURRENT_TIME >= TIME '00:00:00'",
-      "true")
+  def testTemporalFunctionsInBatchMode(): Unit = {
+    val zoneId = ZoneId.of("Asia/Shanghai")
+    config.setLocalTimeZone(zoneId)
+    config.getConfiguration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH)
+
+    config.getConfiguration.setLong(InternalConfigOptions.TABLE_QUERY_START_EPOCH_TIME, 1000L)
+    config.getConfiguration.setLong(InternalConfigOptions.TABLE_QUERY_START_LOCAL_TIME,
+      1000L + TimeZone.getTimeZone(zoneId).getOffset(1000L))
+
+    val temporalFunctions = getCodeGenFunctions(List(
+      "CURRENT_DATE",
+      "CURRENT_TIME",
+      "CURRENT_TIMESTAMP",
+      "NOW()",
+      "LOCALTIME",
+      "LOCALTIMESTAMP"))
+
+    val expected = mutable.MutableList[String](
+      "1970-01-01",
+      "08:00:01",
+      "1970-01-01 08:00:01",
+      "1970-01-01 08:00:01",
+      "08:00:01",
+      "1970-01-01 08:00:01")
+
+    val result = evaluateFunctionResult(temporalFunctions)
+    assertEquals(expected.toList.sorted, result.sorted)
+
   }
 
   @Test
-  def testCurrentTimestamp(): Unit = {
-    testAllApis(
-      currentTimestamp().isGreater("1970-01-01 00:00:00".toTimestamp),
-      "currentTimestamp() > '1970-01-01 00:00:00'.toTimestamp",
-      "CURRENT_TIMESTAMP > TIMESTAMP '1970-01-01 00:00:00'",
-      "true")
+  def testTemporalFunctionsInUTC(): Unit = {
+    testTemporalTimestamp(ZoneId.of("UTC"))
   }
 
   @Test
-  def testNow(): Unit = {
-    testSqlApi(
-      "NOW() > TIMESTAMP '1970-01-01 00:00:00'",
-      "true")
+  def testTemporalFunctionsInShanghai(): Unit = {
+    testTemporalTimestamp(ZoneId.of("Asia/Shanghai"))
   }
 
-  @Test
-  def testLocalTimestampInUTC(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("UTC"))
-    val localDateTime = LocalDateTime.now(ZoneId.of("UTC"))
+  private def testTemporalTimestamp(zoneId: ZoneId) :Unit = {
+    config.setLocalTimeZone(zoneId)
+    val localDateTime = LocalDateTime.now(zoneId)
 
     val formattedLocalTime = localDateTime
       .toLocalTime
       .format(DateTimeFormatter.ofPattern("HH:mm:ss"))
     val formattedLocalDateTime = localDateTime
       .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-
-    // the LOCALTIME/LOCALTIMESTAMP functions are not deterministic, thus we
-    // use following pattern to check it return SQL timestamp in session time zone UTC
-    testSqlApi(
-      s"TIMESUB(LOCALTIME, TIME '$formattedLocalTime') <= 60000",
-      "true")
-    testSqlApi(
-      s"TIMESTAMPDIFF(SECOND, TIMESTAMP '$formattedLocalDateTime', LOCALTIMESTAMP) <= 60",
-      "true")
-  }
-
-  @Test
-  def testLocalTimestampInShanghai(): Unit = {
-    config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
-    val localDateTime = LocalDateTime.now(ZoneId.of("Asia/Shanghai"))
-
-    val formattedLocalTime = localDateTime
+    val formattedCurrentDate = localDateTime
+      .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    val formattedCurrentTime = localDateTime
       .toLocalTime
       .format(DateTimeFormatter.ofPattern("HH:mm:ss"))
-    val formattedLocalDateTime = localDateTime
+    val formattedCurrentTimestamp = localDateTime
       .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
 
-    // the LOCALTIME/LOCALTIMESTAMP functions are not deterministic, thus we
-    // use following pattern to check it return SQL timestamp in session time zone Shanghai
+    // the LOCALTIME/LOCALTIMESTAMP/CURRENT_DATE/CURRENT_TIME/CURRENT_TIMESTAMP/NOW() functions
+    // are not deterministic, thus we use following pattern to check the returned SQL value
+    // in session time zone
     testSqlApi(
-      s"TIMESUB(LOCALTIME, TIME '$formattedLocalTime') <= 60000",
+      s"TIME_SUB(LOCALTIME, TIME '$formattedLocalTime') <= 60000",
       "true")
     testSqlApi(
       s"TIMESTAMPDIFF(SECOND, TIMESTAMP '$formattedLocalDateTime', LOCALTIMESTAMP) <= 60",
       "true")
-  }
+    testSqlApi(
+      s"DATE_SUB(CURRENT_DATE, DATE '$formattedCurrentDate') >= 0",
+      "true")
 
-  @Test
-  def testLocalTime(): Unit = {
-    testAllApis(
-      localTime().isGreaterOrEqual("00:00:00".toTime),
-      "localTime() >= '00:00:00'.toTime",
-      "LOCALTIME >= TIME '00:00:00'",
+    testSqlApi(
+      s"TIME_SUB(CURRENT_TIME, TIME '$formattedCurrentTime') <= 60000",
+      "true")
+
+    testSqlApi(
+      s"TIMESTAMPDIFF(SECOND, ${timestampLtz(formattedCurrentTimestamp)}, CURRENT_TIMESTAMP) <= 60",
+      "true")
+
+    testSqlApi(
+      s"TIMESTAMPDIFF(SECOND, ${timestampLtz(formattedCurrentTimestamp)}, NOW()) <= 60",
       "true")
   }
 
@@ -136,13 +166,14 @@ class NonDeterministicTests extends ExpressionTestBase {
   override def typeInfo: RowTypeInfo = new RowTypeInfo()
 
   override def functions: Map[String, ScalarFunction] = Map(
-    "TIMESUB" -> TimeDiffFun
+    "TIME_SUB" -> TimeDiffFun,
+    "DATE_SUB" -> DateDiffFun
   )
 }
 
 object TimeDiffFun extends ScalarFunction {
 
-  val millsInDay = 24 * 60 * 60 * 1000L
+  private val millsInDay = 24 * 60 * 60 * 1000L
 
   def eval(t1: Time, t2: Time): Long = {
     // when the two time points crosses two days, e.g:
@@ -154,5 +185,12 @@ object TimeDiffFun extends ScalarFunction {
     else {
       t1.getTime - t2.getTime
     }
+  }
+}
+
+object DateDiffFun extends ScalarFunction {
+
+  def eval(d1: LocalDate, d2: LocalDate): Long = {
+    d1.toEpochDay - d2.toEpochDay
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -878,27 +878,6 @@ class TemporalTypesTest extends ExpressionTestBase {
     //testSqlApi("CEIL(TIMESTAMP '2018-03-20 06:10:31' TO HOUR)", "2018-03-20 07:00:00.000")
   }
 
-  private def timestampLtz(str: String): String = {
-    val precision = extractPrecision(str)
-    timestampLtz(str, precision)
-  }
-
-  private def timestampLtz(str: String, precision: Int): String = {
-    s"CAST(TIMESTAMP '$str' AS TIMESTAMP($precision) WITH LOCAL TIME ZONE)"
-  }
-
-  // According to SQL standard, the length of second fraction is
-  // the precision of the Timestamp literal
-  private def extractPrecision(str: String): Int = {
-    val dot = str.indexOf('.')
-    if (dot == -1) {
-      0
-    } else {
-      str.length - dot - 1
-    }
-  }
-
-
   @Test
   def testTemporalShanghai(): Unit = {
     config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
@@ -1007,14 +986,6 @@ class TemporalTypesTest extends ExpressionTestBase {
     // 1520960523000  "2018-03-14T01:02:03+0800"
     testSqlApi("TIMESTAMPADD(HOUR, +8, TIMESTAMP '2017-11-29 10:58:58.998')",
       "2017-11-29 18:58:58.998")
-
-    val sdf = new SimpleDateFormat("yyyy-MM-dd")
-    sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
-    val currMillis = System.currentTimeMillis()
-    val ts = new Timestamp(currMillis)
-    val currDateStr = sdf.format(ts)
-    testSqlApi("CURRENT_DATE", currDateStr)
-    //testSqlApi("CURRENT_TIME", "")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
@@ -90,7 +90,7 @@ class WindowTableFunctionTest extends TableTestBase {
     util.tableEnv.executeSql(
       """
         |CREATE VIEW v1 AS
-        |SELECT *, CURRENT_TIMESTAMP AS cur_time
+        |SELECT *, LOCALTIMESTAMP AS cur_time
         |FROM MyTable
         |""".stripMargin)
     val sql =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -49,7 +49,7 @@ import org.junit._
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
-import java.time.{LocalDate, LocalDateTime, ZoneId}
+import java.time.{Instant, LocalDate, ZoneId}
 import java.util
 
 import scala.collection.Seq
@@ -1035,8 +1035,8 @@ class CalcITCase extends BatchTestBase {
 
     val table = parseQuery("SELECT CURRENT_TIMESTAMP FROM testTable WHERE a = TRUE")
     val result = executeQuery(table)
-    val ts1 = TimestampData.fromLocalDateTime(
-      result.toList.head.getField(0).asInstanceOf[LocalDateTime]).getMillisecond
+    val ts1 = TimestampData.fromInstant(
+      result.toList.head.getField(0).asInstanceOf[Instant]).getMillisecond
 
     val ts2 = System.currentTimeMillis()
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -708,7 +708,7 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
          |    LAST(A.proctime + INTERVAL '1' second) as calculatedField
          |  PATTERN (A)
          |  DEFINE
-         |    A AS proctime >= (CURRENT_TIMESTAMP - INTERVAL '1' day)
+         |    A AS proctime >= (CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)) - INTERVAL '1' day)
          |) AS T
          |""".stripMargin
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1095,6 +1095,34 @@ public class SqlDateTimeUtils {
     }
 
     // --------------------------------------------------------------------------------------------
+    // TIMESTAMP to  DATE/TIME utils
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Get date from a timestamp.
+     *
+     * @param ts the timestamp in milliseconds.
+     * @return the date in days.
+     */
+    public static int getDateInDays(long ts) {
+        int days = (int) (ts / MILLIS_PER_DAY);
+        if (days < 0) {
+            days = days - 1;
+        }
+        return days;
+    }
+
+    /**
+     * Get time from a timestamp.
+     *
+     * @param ts the timestamp in milliseconds.
+     * @return the time in milliseconds.
+     */
+    public static int getTimeInMills(long ts) {
+        return (int) (ts % MILLIS_PER_DAY);
+    }
+
+    // --------------------------------------------------------------------------------------------
     // UNIX TIME
     // --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyInstantTypeInfo.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LegacyInstantTypeInfo.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * {@link TypeInformation} for {@link Instant}.
  *
  * <p>The different between Types.INSTANT is the TypeInformation holds a precision Reminder:
- * Conversion from DateType to TypeInformation (and back) exists in
+ * Conversion from DataType to TypeInformation (and back) exists in
  * TableSourceUtil.computeIndexMapping, which should be fixed after we remove Legacy TypeInformation
  * TODO: https://issues.apache.org/jira/browse/FLINK-14927
  */


### PR DESCRIPTION
## What is the purpose of the change

* This pull request correct  temporal functions evaluation timepoint and function return type.

## Brief change log
  - Correct CURRENT_TIMESTAMP/NOW() functions' return type to TIMESTAMP_LTZ 
  - Correct CURRENT_TIMESTAMP/CURRENT_TIME/CURRENT_DATE/NOW/LOCALTIME/LOCALTIMESTAMP functions' evaluation timepoint according to execution mode.

## Verifying this change
- Add function tests  in `NonDeterministicTests`

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
