### PR TITLE
[FLINK-20731][connector] Introduce Pulsar Source

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -182,6 +182,10 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
         return splitReader;
     }
 
+    public int fetcherId() {
+        return id;
+    }
+
     /** Shutdown the split fetcher. */
     public void shutdown() {
         if (closed.compareAndSet(false, true)) {

--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-connectors</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.14-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-pulsar_${scala.binary.version}</artifactId>
+	<name>Flink : Connectors : Pulsar</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<pulsar.version>2.8.0</pulsar.version>
+
+		<!-- Test Libraries -->
+		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+		<assertj-core.version>3.20.2</assertj-core.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- Core -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Connectors -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Add Pulsar 2.x as a dependency -->
+
+		<dependency>
+			<groupId>org.apache.pulsar</groupId>
+			<artifactId>pulsar-client-all</artifactId>
+			<version>${pulsar.version}</version>
+		</dependency>
+
+		<!-- Protobuf & Protobuf Native Schema support. Add it to your pom if you need protobuf -->
+
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>${protoc.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Tests -->
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assertj-core.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-tests</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-testing_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- TestContainers for Pulsar environment -->
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>pulsar</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<extensions>
+			<extension>
+				<groupId>kr.motd.maven</groupId>
+				<artifactId>os-maven-plugin</artifactId>
+				<version>1.7.0</version>
+			</extension>
+		</extensions>
+
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<!-- Enforce single fork execution due to heavy mini cluster use in the tests -->
+					<forkCount>1</forkCount>
+					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber}
+						-XX:-UseGCOverheadLimit
+					</argLine>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.xolstice.maven.plugins</groupId>
+				<artifactId>protobuf-maven-plugin</artifactId>
+				<version>${protobuf-maven-plugin.version}</version>
+				<extensions>true</extensions>
+				<configuration>
+					<!-- Currently Flink azure test pipeline would first pre-compile and then upload the compiled
+					 directory, then it download the directory and run the corresponding tests. However, the protoc
+					 executable under the target directory would lost the execution permission bit after downloading.
+					 To solve this issue we would skip generating the target files if they already exist after
+					 downloading. Meanwhile, since the time might be not consistent between the pre-compile and
+					 the actual execution, we need to adjust the timestamp manually, see unpack_build_artifact.sh-->
+					<checkStaleness>true</checkStaleness>
+					<protoTestSourceRoot>${project.basedir}/src/test/resources/protobuf
+					</protoTestSourceRoot>
+					<!-- Generates classes into a separate directory since the generator always removes existing files. -->
+					<outputDirectory>
+						${project.build.directory}/generated-test-sources/protobuf/java
+					</outputDirectory>
+					<protocArtifact>com.google.protobuf:protoc:3.5.1:exe:${os.detected.classifier}
+					</protocArtifact>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Adding protobuf generated classes to test build path -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>
+									${project.build.directory}/generated-test-sources/protobuf/java
+								</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/ConfigurationDataCustomizer.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/ConfigurationDataCustomizer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.Serializable;
+
+/**
+ * Pulsar's config have some non-serializable fields which should be provided by user. You can add
+ * modify the config instance by using this interface.
+ *
+ * @param <T> The class type for related pulsar config.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface ConfigurationDataCustomizer<T> extends Serializable {
+
+    /**
+     * Modify the given config instance, this instance is created from {@link Configuration} and
+     * would be used in the later logic.
+     */
+    void customize(T configurationDate);
+
+    /**
+     * Returns a composed customizer that first applies this customizer to its input, and then
+     * applies the {@code after} customizer to the result.
+     */
+    default ConfigurationDataCustomizer<T> compose(ConfigurationDataCustomizer<T> after) {
+        return data -> {
+            customize(data);
+            // Apply the given customizer.
+            after.customize(data);
+        };
+    }
+
+    /** Return a blank customizer. */
+    static <Y> ConfigurationDataCustomizer<Y> blankCustomizer() {
+        return a -> {};
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarConfigUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarConfigUtils.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.config;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.utils.PulsarJsonUtils;
+import org.apache.flink.connector.pulsar.source.PulsarSourceOptions;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAMS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAM_MAP;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PLUGIN_CLASS_NAME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTO_CERT_REFRESH_TIME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONCURRENT_LOOKUP_REQUEST;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECTIONS_PER_BROKER;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECTION_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_CONNECT_TIMEOUT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_BUSY_WAIT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_TRANSACTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_INITIAL_BACKOFF_INTERVAL_NANOS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_KEEP_ALIVE_INTERVAL_SECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_LISTENER_NAME;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_BACKOFF_INTERVAL_NANOS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_LOOKUP_REDIRECTS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_LOOKUP_REQUEST;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MAX_NUMBER_OF_REJECTED_REQUEST_PER_CONNECTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_MEMORY_LIMIT_BYTES;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_NUM_IO_THREADS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_NUM_LISTENER_THREADS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_OPERATION_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_PROXY_PROTOCOL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_PROXY_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_READ_TIMEOUT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_REQUEST_TIMEOUT;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_REQUEST_TIMEOUT_MS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SSL_PROVIDER;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_STATS_INTERVAL_SECONDS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_ALLOW_INSECURE_CONNECTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_CIPHERS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_HOSTNAME_VERIFICATION_ENABLE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_PROTOCOLS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_CERTS_FILE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_STORE_PASSWORD;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_STORE_PATH;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_TLS_TRUST_STORE_TYPE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_USE_KEY_STORE_TLS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_USE_TCP_NO_DELAY;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_USE_TLS;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarJsonUtils.configMap;
+
+/** The util for creating pulsar configuration class from flink's {@link Configuration}. */
+@Internal
+public final class PulsarConfigUtils {
+
+    private PulsarConfigUtils() {
+        // No need to create instance.
+    }
+
+    /**
+     * Create a common {@link ClientConfigurationData} for both pulsar source and sink connector by
+     * using the given {@link Configuration}. Add the configuration was listed in {@link
+     * PulsarSourceOptions}, and we would parse it one by one.
+     *
+     * @param configuration The flink configuration
+     */
+    public static ClientConfigurationData createClientConfig(
+            Configuration configuration,
+            @Nullable ConfigurationDataCustomizer<ClientConfigurationData> customizer) {
+        ClientConfigurationData data = new ClientConfigurationData();
+
+        // Set the properties one by one.
+        data.setServiceUrl(configuration.get(PULSAR_SERVICE_URL));
+        data.setAuthPluginClassName(configuration.get(PULSAR_AUTH_PLUGIN_CLASS_NAME));
+        data.setAuthParams(configuration.get(PULSAR_AUTH_PARAMS));
+        data.setAuthParamMap(
+                getOptionValue(
+                        configuration,
+                        PULSAR_AUTH_PARAM_MAP,
+                        v -> PulsarJsonUtils.toMap(String.class, String.class, v)));
+        data.setOperationTimeoutMs(configuration.get(PULSAR_OPERATION_TIMEOUT_MS));
+        data.setStatsIntervalSeconds(configuration.get(PULSAR_STATS_INTERVAL_SECONDS));
+        data.setNumIoThreads(configuration.get(PULSAR_NUM_IO_THREADS));
+        data.setNumListenerThreads(configuration.get(PULSAR_NUM_LISTENER_THREADS));
+        data.setConnectionsPerBroker(configuration.get(PULSAR_CONNECTIONS_PER_BROKER));
+        data.setUseTcpNoDelay(configuration.get(PULSAR_USE_TCP_NO_DELAY));
+        data.setUseTls(configuration.get(PULSAR_USE_TLS));
+        data.setTlsTrustCertsFilePath(configuration.get(PULSAR_TLS_TRUST_CERTS_FILE_PATH));
+        data.setTlsAllowInsecureConnection(configuration.get(PULSAR_TLS_ALLOW_INSECURE_CONNECTION));
+        data.setTlsHostnameVerificationEnable(
+                configuration.get(PULSAR_TLS_HOSTNAME_VERIFICATION_ENABLE));
+        data.setConcurrentLookupRequest(configuration.get(PULSAR_CONCURRENT_LOOKUP_REQUEST));
+        data.setMaxLookupRequest(configuration.get(PULSAR_MAX_LOOKUP_REQUEST));
+        data.setMaxLookupRedirects(configuration.get(PULSAR_MAX_LOOKUP_REDIRECTS));
+        data.setMaxNumberOfRejectedRequestPerConnection(
+                configuration.get(PULSAR_MAX_NUMBER_OF_REJECTED_REQUEST_PER_CONNECTION));
+        data.setKeepAliveIntervalSeconds(configuration.get(PULSAR_KEEP_ALIVE_INTERVAL_SECONDS));
+        data.setConnectionTimeoutMs(configuration.get(PULSAR_CONNECTION_TIMEOUT_MS));
+        data.setRequestTimeoutMs(configuration.get(PULSAR_REQUEST_TIMEOUT_MS));
+        data.setInitialBackoffIntervalNanos(
+                configuration.get(PULSAR_INITIAL_BACKOFF_INTERVAL_NANOS));
+        data.setMaxBackoffIntervalNanos(configuration.get(PULSAR_MAX_BACKOFF_INTERVAL_NANOS));
+        data.setEnableBusyWait(configuration.get(PULSAR_ENABLE_BUSY_WAIT));
+        data.setListenerName(configuration.get(PULSAR_LISTENER_NAME));
+        data.setUseKeyStoreTls(configuration.get(PULSAR_USE_KEY_STORE_TLS));
+        data.setSslProvider(configuration.get(PULSAR_SSL_PROVIDER));
+        data.setTlsTrustStoreType(configuration.get(PULSAR_TLS_TRUST_STORE_TYPE));
+        data.setTlsTrustStorePath(configuration.get(PULSAR_TLS_TRUST_STORE_PATH));
+        data.setTlsTrustStorePassword(configuration.get(PULSAR_TLS_TRUST_STORE_PASSWORD));
+        data.setTlsCiphers(
+                getOptionValue(
+                        configuration,
+                        PULSAR_TLS_CIPHERS,
+                        v -> PulsarJsonUtils.toSet(String.class, v)));
+        data.setTlsProtocols(
+                getOptionValue(
+                        configuration,
+                        PULSAR_TLS_PROTOCOLS,
+                        v -> PulsarJsonUtils.toSet(String.class, v)));
+        data.setMemoryLimitBytes(configuration.get(PULSAR_MEMORY_LIMIT_BYTES));
+        data.setProxyServiceUrl(configuration.get(PULSAR_PROXY_SERVICE_URL));
+        data.setProxyProtocol(configuration.get(PULSAR_PROXY_PROTOCOL));
+        data.setEnableTransaction(configuration.get(PULSAR_ENABLE_TRANSACTION));
+        data.setAuthentication(createAuthentication(configuration));
+
+        if (customizer != null) {
+            customizer.customize(data);
+        }
+
+        return data;
+    }
+
+    /**
+     * Create the {@link Authentication} instance for both {@code PulsarClient} and {@code
+     * PulsarAdmin}. If the user didn't provide configuration, a {@link AuthenticationDisabled}
+     * instance would be returned.
+     *
+     * <p>This method behavior is the same as the pulsar command line tools.
+     */
+    public static Authentication createAuthentication(Configuration configuration) {
+        if (configuration.contains(PULSAR_AUTH_PLUGIN_CLASS_NAME)) {
+            String authPluginClassName = configuration.get(PULSAR_AUTH_PLUGIN_CLASS_NAME);
+
+            if (configuration.contains(PULSAR_AUTH_PARAMS)) {
+                String authParamsString = configuration.get(PULSAR_AUTH_PARAMS);
+                return sneakyClient(
+                        () -> AuthenticationFactory.create(authPluginClassName, authParamsString));
+            } else if (configuration.contains(PULSAR_AUTH_PARAM_MAP)) {
+                Map<String, String> paramsMap =
+                        getOptionValue(
+                                configuration,
+                                PULSAR_AUTH_PARAM_MAP,
+                                v -> PulsarJsonUtils.toMap(String.class, String.class, v));
+                return sneakyClient(
+                        () -> AuthenticationFactory.create(authPluginClassName, paramsMap));
+            }
+        }
+
+        return AuthenticationDisabled.INSTANCE;
+    }
+
+    /** Get the option value str from given config, convert it into the real value instance. */
+    public static <F, T> T getOptionValue(
+            Configuration configuration, ConfigOption<F> option, Function<F, T> convertor) {
+        F value = configuration.get(option);
+
+        if (value != null) {
+            return convertor.apply(value);
+        } else {
+            return null;
+        }
+    }
+
+    /** Create a PulsarClient by using the flink Configuration and the config customizer. */
+    public static PulsarClient createClient(
+            Configuration configuration,
+            ConfigurationDataCustomizer<ClientConfigurationData> customizer) {
+        return createClient(createClientConfig(configuration, customizer));
+    }
+
+    /**
+     * Create a PulsarClient by using the given config, all the config could be directly loaded
+     * except the authentication.
+     */
+    public static PulsarClient createClient(ClientConfigurationData config) {
+        // PulsarClientBuilder don't support using the given ClientConfigurationData directly.
+        Map<String, Object> configMap = configMap(config);
+
+        // These two auth config would be serialized to a secret information by default.
+        configMap.put("authParamMap", config.getAuthParamMap());
+        configMap.put("authParams", config.getAuthParams());
+
+        ClientBuilder clientBuilder = PulsarClient.builder().loadConf(configMap);
+
+        // Set some non-serializable fields.
+        if (config.getAuthentication() != null) {
+            clientBuilder.authentication(config.getAuthentication());
+        }
+        if (config.getClock() != null) {
+            clientBuilder.clock(config.getClock());
+        }
+        if (config.getServiceUrlProvider() != null) {
+            clientBuilder.serviceUrlProvider(config.getServiceUrlProvider());
+        }
+
+        return sneakyClient(clientBuilder::build);
+    }
+
+    /**
+     * PulsarAdmin shares almost the same configuration with PulsarClient, but we separate this
+     * create method for directly create it.
+     */
+    public static PulsarAdmin createAdmin(
+            Configuration configuration,
+            ConfigurationDataCustomizer<ClientConfigurationData> customizer) {
+        ClientConfigurationData clientConfig = createClientConfig(configuration, customizer);
+        String adminUrl = configuration.get(PULSAR_ADMIN_URL);
+        int connectionTimeout = Math.toIntExact(configuration.get(PULSAR_CONNECT_TIMEOUT));
+        int readTimeout = Math.toIntExact(configuration.get(PULSAR_READ_TIMEOUT));
+        int requestTimeout = Math.toIntExact(configuration.get(PULSAR_REQUEST_TIMEOUT));
+        int autoCertRefreshTime = Math.toIntExact(configuration.get(PULSAR_AUTO_CERT_REFRESH_TIME));
+
+        PulsarAdminBuilder builder =
+                PulsarAdmin.builder()
+                        .serviceHttpUrl(adminUrl)
+                        .authentication(clientConfig.getAuthentication())
+                        .tlsTrustCertsFilePath(clientConfig.getTlsTrustCertsFilePath())
+                        .allowTlsInsecureConnection(clientConfig.isTlsAllowInsecureConnection())
+                        .enableTlsHostnameVerification(
+                                clientConfig.isTlsHostnameVerificationEnable())
+                        .useKeyStoreTls(clientConfig.isUseKeyStoreTls())
+                        .sslProvider(clientConfig.getSslProvider())
+                        .tlsTrustStoreType(clientConfig.getTlsTrustStoreType())
+                        .tlsTrustStorePath(clientConfig.getTlsTrustStorePath())
+                        .tlsTrustStorePassword(clientConfig.getTlsTrustStorePassword())
+                        .tlsCiphers(clientConfig.getTlsCiphers())
+                        .tlsProtocols(clientConfig.getTlsProtocols())
+                        .connectionTimeout(connectionTimeout, MILLISECONDS)
+                        .readTimeout(readTimeout, MILLISECONDS)
+                        .requestTimeout(requestTimeout, MILLISECONDS)
+                        .autoCertRefreshTime(autoCertRefreshTime, MILLISECONDS);
+
+        return sneakyClient(builder::build);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/config/PulsarOptions.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
+
+import org.apache.pulsar.client.api.ProxyProtocol;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/**
+ * Configuration for Pulsar Client, these config options would be used for both source, sink and
+ * table.
+ */
+@PublicEvolving
+public final class PulsarOptions {
+
+    // Pulsar client API config prefix.
+    private static final String CLIENT_CONFIG_PREFIX = "pulsar.client.";
+    // Pulsar admin API config prefix.
+    private static final String ADMIN_CONFIG_PREFIX = "pulsar.admin.";
+
+    private PulsarOptions() {
+        // This is a constant class
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    //
+    // The configuration for ClientConfigurationData part.
+    // All the configuration listed below should have the pulsar.client prefix.
+    //
+    ///////////////////////////////////////////////////////////////////////////////
+
+    public static final ConfigOption<String> PULSAR_SERVICE_URL =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "serviceUrl")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text("Service URL provider for Pulsar service.")
+                                    .linebreak()
+                                    .text(
+                                            "To connect to Pulsar using client libraries, you need to specify a Pulsar protocol URL.")
+                                    .linebreak()
+                                    .text(
+                                            "You can assign Pulsar protocol URLs to specific clusters and use the %s scheme.",
+                                            code("pulsar"))
+                                    .linebreak()
+                                    .list(
+                                            text(
+                                                    "This is an example of %s: %s.",
+                                                    code("localhost"),
+                                                    code("pulsar://localhost:6650")),
+                                            text(
+                                                    "If you have multiple brokers, the URL is as: %s",
+                                                    code(
+                                                            "pulsar://localhost:6550,localhost:6651,localhost:6652")),
+                                            text(
+                                                    "A URL for a production Pulsar cluster is as: %s",
+                                                    code(
+                                                            "pulsar://pulsar.us-west.example.com:6650")),
+                                            text(
+                                                    "If you use TLS authentication, the URL is as %s",
+                                                    code(
+                                                            "pulsar+ssl://pulsar.us-west.example.com:6651")))
+                                    .build());
+
+    public static final ConfigOption<String> PULSAR_AUTH_PLUGIN_CLASS_NAME =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "authPluginClassName")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Name of the authentication plugin.");
+
+    public static final ConfigOption<String> PULSAR_AUTH_PARAMS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "authParams")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "String represents parameters for the authentication plugin.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text("Example:")
+                                    .linebreak()
+                                    .add(code("key1:val1,key2:val2"))
+                                    .build());
+
+    // The real config type is Map<String, String>, you should provided a json str here.
+    public static final ConfigOption<String> PULSAR_AUTH_PARAM_MAP =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "authParamMap")
+                    .stringType()
+                    .defaultValue("{}");
+
+    public static final ConfigOption<Long> PULSAR_OPERATION_TIMEOUT_MS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "operationTimeoutMs")
+                    .longType()
+                    .defaultValue(30000L)
+                    .withDescription("Operation timeout.");
+
+    public static final ConfigOption<Long> PULSAR_STATS_INTERVAL_SECONDS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "statsIntervalSeconds")
+                    .longType()
+                    .defaultValue(60L)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Interval between each stats info.")
+                                    .linebreak()
+                                    .list(
+                                            text(
+                                                    "Stats is activated with positive %s",
+                                                    code("statsInterval")),
+                                            text(
+                                                    "Set %s to 1 second at least",
+                                                    code("statsIntervalSeconds")))
+                                    .build());
+
+    public static final ConfigOption<Integer> PULSAR_NUM_IO_THREADS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "numIoThreads")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            "The number of threads used for handling connections to brokers.");
+
+    public static final ConfigOption<Integer> PULSAR_NUM_LISTENER_THREADS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "numListenerThreads")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("The number of threads used for handling message listeners.");
+
+    public static final ConfigOption<Integer> PULSAR_CONNECTIONS_PER_BROKER =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "connectionsPerBroker")
+                    .intType()
+                    .defaultValue(1);
+
+    public static final ConfigOption<Boolean> PULSAR_USE_TCP_NO_DELAY =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "useTcpNoDelay")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to use TCP no-delay flag on the connection to disable Nagle algorithm.");
+
+    public static final ConfigOption<Boolean> PULSAR_USE_TLS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "useTls")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to use TLS encryption on the connection.");
+
+    public static final ConfigOption<String> PULSAR_TLS_TRUST_CERTS_FILE_PATH =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsTrustCertsFilePath")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Path to the trusted TLS certificate file.");
+
+    public static final ConfigOption<Boolean> PULSAR_TLS_ALLOW_INSECURE_CONNECTION =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsAllowInsecureConnection")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether the Pulsar client accepts untrusted TLS certificate from broker.");
+
+    public static final ConfigOption<Boolean> PULSAR_TLS_HOSTNAME_VERIFICATION_ENABLE =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsHostnameVerificationEnable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to enable TLS hostname verification.");
+
+    public static final ConfigOption<Integer> PULSAR_CONCURRENT_LOOKUP_REQUEST =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "concurrentLookupRequest")
+                    .intType()
+                    .defaultValue(5000)
+                    .withDescription(
+                            "The number of concurrent lookup requests allowed to send on each broker connection to prevent overload on broker.");
+
+    public static final ConfigOption<Integer> PULSAR_MAX_LOOKUP_REQUEST =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "maxLookupRequest")
+                    .intType()
+                    .defaultValue(50000)
+                    .withDescription(
+                            "The maximum number of lookup requests allowed on each broker connection to prevent overload on broker.");
+
+    public static final ConfigOption<Integer> PULSAR_MAX_LOOKUP_REDIRECTS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "maxLookupRedirects")
+                    .intType()
+                    .defaultValue(20);
+
+    public static final ConfigOption<Integer> PULSAR_MAX_NUMBER_OF_REJECTED_REQUEST_PER_CONNECTION =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "maxNumberOfRejectedRequestPerConnection")
+                    .intType()
+                    .defaultValue(50)
+                    .withDescription(
+                            "The maximum number of rejected requests of a broker in a certain time"
+                                    + " frame (30 seconds) after the current connection is closed and"
+                                    + " the client creates a new connection to connect to a different broker.");
+
+    public static final ConfigOption<Integer> PULSAR_KEEP_ALIVE_INTERVAL_SECONDS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "keepAliveIntervalSeconds")
+                    .intType()
+                    .defaultValue(30)
+                    .withDescription(
+                            "Seconds of keeping alive interval for each client broker connection.");
+
+    public static final ConfigOption<Integer> PULSAR_CONNECTION_TIMEOUT_MS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "connectionTimeoutMs")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Duration of waiting for a connection to a broker to be established.")
+                                    .linebreak()
+                                    .text(
+                                            "If the duration passes without a response from a broker, the connection attempt is dropped.")
+                                    .build());
+
+    public static final ConfigOption<Integer> PULSAR_REQUEST_TIMEOUT_MS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "requestTimeoutMs")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("Maximum duration for completing a request.");
+
+    public static final ConfigOption<Long> PULSAR_INITIAL_BACKOFF_INTERVAL_NANOS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "initialBackoffIntervalNanos")
+                    .longType()
+                    .defaultValue(TimeUnit.MILLISECONDS.toNanos(100))
+                    .withDescription("Default duration for a backoff interval.");
+
+    public static final ConfigOption<Long> PULSAR_MAX_BACKOFF_INTERVAL_NANOS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "maxBackoffIntervalNanos")
+                    .longType()
+                    .defaultValue(TimeUnit.SECONDS.toNanos(60))
+                    .withDescription("Maximum duration for a backoff interval.");
+
+    public static final ConfigOption<Boolean> PULSAR_ENABLE_BUSY_WAIT =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "enableBusyWait")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<String> PULSAR_LISTENER_NAME =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "listenerName").stringType().noDefaultValue();
+
+    public static final ConfigOption<Boolean> PULSAR_USE_KEY_STORE_TLS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "useKeyStoreTls")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<String> PULSAR_SSL_PROVIDER =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "sslProvider").stringType().noDefaultValue();
+
+    public static final ConfigOption<String> PULSAR_TLS_TRUST_STORE_TYPE =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsTrustStoreType")
+                    .stringType()
+                    .defaultValue("JKS");
+
+    public static final ConfigOption<String> PULSAR_TLS_TRUST_STORE_PATH =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsTrustStorePath")
+                    .stringType()
+                    .noDefaultValue();
+
+    public static final ConfigOption<String> PULSAR_TLS_TRUST_STORE_PASSWORD =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsTrustStorePassword")
+                    .stringType()
+                    .noDefaultValue();
+
+    // The real config type is Set<String>, you should provided a json str here.
+    public static final ConfigOption<String> PULSAR_TLS_CIPHERS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsCiphers").stringType().defaultValue("[]");
+
+    // The real config type is Set<String>, you should provided a json str here.
+    public static final ConfigOption<String> PULSAR_TLS_PROTOCOLS =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "tlsProtocols")
+                    .stringType()
+                    .defaultValue("[]");
+
+    public static final ConfigOption<Long> PULSAR_MEMORY_LIMIT_BYTES =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "memoryLimitBytes")
+                    .longType()
+                    .defaultValue(0L);
+
+    public static final ConfigOption<String> PULSAR_PROXY_SERVICE_URL =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "proxyServiceUrl")
+                    .stringType()
+                    .noDefaultValue();
+
+    public static final ConfigOption<ProxyProtocol> PULSAR_PROXY_PROTOCOL =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "proxyProtocol")
+                    .enumType(ProxyProtocol.class)
+                    .noDefaultValue();
+
+    public static final ConfigOption<Boolean> PULSAR_ENABLE_TRANSACTION =
+            ConfigOptions.key(CLIENT_CONFIG_PREFIX + "enableTransaction")
+                    .booleanType()
+                    .defaultValue(false);
+
+    ///////////////////////////////////////////////////////////////////////////////
+    //
+    // The configuration for PulsarAdmin part.
+    // All the configuration listed below should have the pulsar.admin prefix.
+    //
+    ///////////////////////////////////////////////////////////////////////////////
+
+    public static final ConfigOption<String> PULSAR_ADMIN_URL =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "adminUrl")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Admin URL for Pulsar service.");
+
+    // The network connect timeout in millis.
+    public static final ConfigOption<Long> PULSAR_CONNECT_TIMEOUT =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "connectTimeout")
+                    .longType()
+                    .defaultValue(TimeUnit.SECONDS.toMillis(60));
+
+    // The read timeout in millis.
+    public static final ConfigOption<Long> PULSAR_READ_TIMEOUT =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "readTimeout")
+                    .longType()
+                    .defaultValue(TimeUnit.SECONDS.toMillis(60));
+
+    // The request timeout in millis.
+    public static final ConfigOption<Long> PULSAR_REQUEST_TIMEOUT =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "requestTimeout")
+                    .longType()
+                    .defaultValue(TimeUnit.SECONDS.toMillis(300));
+
+    // The auto refresh time for certification in millis.
+    public static final ConfigOption<Long> PULSAR_AUTO_CERT_REFRESH_TIME =
+            ConfigOptions.key(ADMIN_CONFIG_PREFIX + "autoCertRefreshTime")
+                    .longType()
+                    .defaultValue(TimeUnit.SECONDS.toMillis(300));
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.createSchema;
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.encodeClassInfo;
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.haveProtobuf;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.flink.util.ReflectionUtil.getTemplateType1;
+import static org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.decodeKeyValueEncodingType;
+import static org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.decodeKeyValueSchemaInfo;
+import static org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.encodeKeyValueSchemaInfo;
+
+/**
+ * A wrapper for Pulsar {@link Schema}, make it serializable and can be created from {@link
+ * SchemaInfo}.
+ *
+ * <p>General pulsar schema info (avro, json, protobuf and keyvalue) don't contain the require class
+ * info. We have to urge user to provide the related type class and encoded it into schema info.
+ */
+@Internal
+public final class PulsarSchema<T> implements Serializable {
+    private static final long serialVersionUID = -2561088131419607555L;
+
+    private transient Schema<T> schema;
+    private transient SchemaInfo schemaInfo;
+
+    /** Create serializable pulsar schema for primitive types. */
+    public PulsarSchema(Schema<T> schema) {
+        SchemaInfo info = schema.getSchemaInfo();
+        SchemaType type = info.getType();
+        checkArgument(type != SchemaType.JSON, "Json Schema should provide the type class");
+        checkArgument(type != SchemaType.AVRO, "Avro Schema should provide the type class");
+        checkArgument(type != SchemaType.PROTOBUF, "Protobuf Schema should provide the type class");
+        checkArgument(
+                type != SchemaType.PROTOBUF_NATIVE,
+                "Protobuf Native Schema should provide the type class");
+        checkArgument(
+                type != SchemaType.KEY_VALUE,
+                "Key Value Schema should provide the type class of key and value");
+        // Primitive type information could be reflected from the schema class.
+        Class<?> typeClass = getTemplateType1(schema.getClass());
+
+        this.schemaInfo = encodeClassInfo(info, typeClass);
+        this.schema = createSchema(schemaInfo);
+    }
+
+    /**
+     * Create serializable pulsar schema for struct type or primitive types.
+     *
+     * @param schema The schema instance.
+     * @param typeClass The type class of this schema.
+     */
+    public PulsarSchema(Schema<T> schema, Class<T> typeClass) {
+        SchemaInfo info = schema.getSchemaInfo();
+        checkArgument(
+                info.getType() != SchemaType.KEY_VALUE,
+                "Key Value Schema should provide the type classes of key and value");
+        validateSchemaInfo(info);
+
+        this.schemaInfo = encodeClassInfo(info, typeClass);
+        this.schema = createSchema(schemaInfo);
+    }
+
+    /** Create serializable pulsar schema for key value type. */
+    public <K, V> PulsarSchema(
+            Schema<KeyValue<K, V>> kvSchema, Class<K> keyClass, Class<V> valueClass) {
+        SchemaInfo info = kvSchema.getSchemaInfo();
+        checkArgument(
+                info.getType() == SchemaType.KEY_VALUE,
+                "This constructor could only be applied for KeyValueSchema");
+
+        KeyValue<SchemaInfo, SchemaInfo> infoKeyValue = decodeKeyValueSchemaInfo(info);
+
+        SchemaInfo infoKey = encodeClassInfo(infoKeyValue.getKey(), keyClass);
+        validateSchemaInfo(infoKey);
+
+        SchemaInfo infoValue = encodeClassInfo(infoKeyValue.getValue(), valueClass);
+        validateSchemaInfo(infoValue);
+
+        KeyValueEncodingType encodingType = decodeKeyValueEncodingType(info);
+        SchemaInfo encodedInfo =
+                encodeKeyValueSchemaInfo(info.getName(), infoKey, infoValue, encodingType);
+
+        this.schemaInfo = encodeClassInfo(encodedInfo, KeyValue.class);
+        this.schema = createSchema(this.schemaInfo);
+    }
+
+    public Schema<T> getPulsarSchema() {
+        return schema;
+    }
+
+    public SchemaInfo getSchemaInfo() {
+        return schemaInfo;
+    }
+
+    public Class<T> getRecordClass() {
+        return decodeClassInfo(schemaInfo);
+    }
+
+    private void writeObject(ObjectOutputStream oos) throws IOException {
+        // Name
+        oos.writeUTF(schemaInfo.getName());
+
+        // Schema
+        byte[] schemaBytes = schemaInfo.getSchema();
+        oos.writeInt(schemaBytes.length);
+        oos.write(schemaBytes);
+
+        // Type
+        SchemaType type = schemaInfo.getType();
+        oos.writeInt(type.getValue());
+
+        // Properties
+        Map<String, String> properties = schemaInfo.getProperties();
+        oos.writeInt(properties.size());
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            oos.writeUTF(entry.getKey());
+            oos.writeUTF(entry.getValue());
+        }
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        // Name
+        String name = ois.readUTF();
+
+        // Schema
+        int byteLen = ois.readInt();
+        byte[] schemaBytes = new byte[byteLen];
+        int read = ois.read(schemaBytes);
+        checkState(read == byteLen);
+
+        // Type
+        int typeIdx = ois.readInt();
+        SchemaType type = SchemaType.valueOf(typeIdx);
+
+        // Properties
+        int propSize = ois.readInt();
+        Map<String, String> properties = new HashMap<>(propSize);
+        for (int i = 0; i < propSize; i++) {
+            properties.put(ois.readUTF(), ois.readUTF());
+        }
+
+        this.schemaInfo = new SchemaInfoImpl(name, schemaBytes, type, properties);
+        this.schema = createSchema(schemaInfo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SchemaInfo that = ((PulsarSchema<?>) o).getPulsarSchema().getSchemaInfo();
+
+        return Objects.equals(schemaInfo.getType(), that.getType())
+                && Arrays.equals(schemaInfo.getSchema(), that.getSchema())
+                && Objects.equals(schemaInfo.getProperties(), that.getProperties());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                schemaInfo.getType(),
+                Arrays.hashCode(schemaInfo.getSchema()),
+                schemaInfo.getProperties());
+    }
+
+    @Override
+    public String toString() {
+        return schemaInfo.toString();
+    }
+
+    /**
+     * We would throw exception if schema type is protobuf and user don't provide protobuf-java in
+     * class path.
+     */
+    private void validateSchemaInfo(SchemaInfo info) {
+        SchemaType type = info.getType();
+        if (type == SchemaType.PROTOBUF || type == SchemaType.PROTOBUF_NATIVE) {
+            checkState(
+                    haveProtobuf(), "protobuf-java should be provided if you use related schema.");
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+/**
+ * The schema factory for a specified {@link SchemaType}. We add this factory because of pulsar
+ * don't provide a serializable schema and we can't create it directly from {@link SchemaInfo}. So
+ * we have to implement this creation logic.
+ */
+@Internal
+public interface PulsarSchemaFactory<T> {
+
+    /** The supported schema type for this factory. We would classify the factory by the type. */
+    SchemaType type();
+
+    /** Create the schema by the given info. */
+    Schema<T> createSchema(SchemaInfo info);
+
+    /** Create the flink type information by the given schema info. */
+    TypeInformation<T> createTypeInfo(SchemaInfo info);
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeInformation.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeInformation.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.Objects;
+
+/** Wrap the pulsar {@code Schema} into a flink {@code TypeInformation}. */
+@Internal
+public class PulsarSchemaTypeInformation<T> extends TypeInformation<T> {
+    private static final long serialVersionUID = 7284667318651333519L;
+
+    private final PulsarSchema<T> schema;
+
+    public PulsarSchemaTypeInformation(PulsarSchema<T> schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 1;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 1;
+    }
+
+    @Override
+    public Class<T> getTypeClass() {
+        return schema.getRecordClass();
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
+        return new PulsarSchemaTypeSerializer<>(schema);
+    }
+
+    @Override
+    public String toString() {
+        return schema.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PulsarSchemaTypeInformation) {
+            PulsarSchemaTypeInformation<?> that = (PulsarSchemaTypeInformation<?>) obj;
+            return Objects.equals(schema, that.schema);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return schema.hashCode();
+    }
+
+    @Override
+    public boolean canEqual(Object obj) {
+        return obj instanceof PulsarSchemaTypeInformation;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeSerializer.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeSerializer.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.InstantiationUtil;
+
+import com.google.protobuf.Message;
+import org.apache.pulsar.client.api.Schema;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.haveProtobuf;
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.isProtobufTypeClass;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Wrap the pulsar {@code Schema} into a flink {@code TypeSerializer}. */
+@Internal
+public class PulsarSchemaTypeSerializer<T> extends TypeSerializer<T> {
+    private static final long serialVersionUID = 7771153330969433085L;
+
+    private final PulsarSchema<T> schema;
+
+    public PulsarSchemaTypeSerializer(PulsarSchema<T> schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<T> duplicate() {
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T createInstance() {
+        Class<T> recordClass = schema.getRecordClass();
+
+        // No exception wouldn't be thrown here if user don't provide protobuf-java.
+        if (haveProtobuf() && isProtobufTypeClass(recordClass)) {
+            try {
+                Method newBuilderMethod = recordClass.getMethod("newBuilder");
+                Message.Builder builder = (Message.Builder) newBuilderMethod.invoke(null);
+                return (T) builder.build();
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        } else {
+            return InstantiationUtil.instantiate(recordClass);
+        }
+    }
+
+    @Override
+    public T copy(T from) {
+        return from;
+    }
+
+    @Override
+    public T copy(T from, T reuse) {
+        return from;
+    }
+
+    @Override
+    public int getLength() {
+        return 0;
+    }
+
+    @Override
+    public void serialize(T record, DataOutputView target) throws IOException {
+        Schema<T> pulsarSchema = schema.getPulsarSchema();
+        byte[] bytes = pulsarSchema.encode(record);
+
+        target.writeInt(bytes.length);
+        target.write(bytes);
+    }
+
+    @Override
+    public T deserialize(DataInputView source) throws IOException {
+        int len = source.readInt();
+        byte[] bytes = new byte[len];
+        int readLen = source.read(bytes);
+        checkState(len == readLen);
+
+        Schema<T> pulsarSchema = schema.getPulsarSchema();
+        return pulsarSchema.decode(bytes);
+    }
+
+    @Override
+    public T deserialize(T reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        int len = source.readInt();
+        byte[] bytes = new byte[len];
+        int readLen = source.read(bytes);
+        checkState(len == readLen);
+
+        target.writeInt(bytes.length);
+        target.write(bytes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PulsarSchemaTypeSerializer) {
+            PulsarSchemaTypeSerializer<?> that = (PulsarSchemaTypeSerializer<?>) obj;
+            return Objects.equals(schema, that.schema);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return schema.hashCode();
+    }
+
+    @Override
+    public TypeSerializerSnapshot<T> snapshotConfiguration() {
+        return new PulsarSchemaTypeSerializerSnapshot<>(schema);
+    }
+
+    /**
+     * Snapshot for PulsarSchemaTypeSerializer, we only snapshot the SerializablePulsarSchema into
+     * the state.
+     */
+    public static final class PulsarSchemaTypeSerializerSnapshot<T>
+            implements TypeSerializerSnapshot<T> {
+
+        private PulsarSchema<T> schema;
+
+        public PulsarSchemaTypeSerializerSnapshot(PulsarSchema<T> schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public int getCurrentVersion() {
+            return 1;
+        }
+
+        @Override
+        public void writeSnapshot(DataOutputView out) throws IOException {
+            byte[] bytes = InstantiationUtil.serializeObject(schema);
+            out.writeInt(bytes.length);
+            out.write(bytes);
+        }
+
+        @Override
+        public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
+                throws IOException {
+            int len = in.readInt();
+            byte[] bytes = new byte[len];
+            int readLen = in.read(bytes);
+            checkState(readLen == len);
+
+            try {
+                ClassLoader loader = Thread.currentThread().getContextClassLoader();
+                this.schema = InstantiationUtil.deserializeObject(bytes, loader);
+            } catch (ClassNotFoundException e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public TypeSerializer<T> restoreSerializer() {
+            return new PulsarSchemaTypeSerializer<>(schema);
+        }
+
+        @Override
+        public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
+                TypeSerializer<T> newSerializer) {
+            return TypeSerializerSchemaCompatibility.compatibleAsIs();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.factories.AvroSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.factories.JSONSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.factories.KeyValueSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.factories.PrimitiveSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.factories.ProtobufNativeSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.factories.ProtobufSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.factories.StringSchemaFactory;
+
+import com.google.protobuf.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.BooleanSchema;
+import org.apache.pulsar.client.impl.schema.ByteSchema;
+import org.apache.pulsar.client.impl.schema.BytesSchema;
+import org.apache.pulsar.client.impl.schema.DateSchema;
+import org.apache.pulsar.client.impl.schema.DoubleSchema;
+import org.apache.pulsar.client.impl.schema.FloatSchema;
+import org.apache.pulsar.client.impl.schema.InstantSchema;
+import org.apache.pulsar.client.impl.schema.IntSchema;
+import org.apache.pulsar.client.impl.schema.LocalDateSchema;
+import org.apache.pulsar.client.impl.schema.LocalDateTimeSchema;
+import org.apache.pulsar.client.impl.schema.LocalTimeSchema;
+import org.apache.pulsar.client.impl.schema.LongSchema;
+import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
+import org.apache.pulsar.client.impl.schema.ShortSchema;
+import org.apache.pulsar.client.impl.schema.TimeSchema;
+import org.apache.pulsar.client.impl.schema.TimestampSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.DATE_TYPE_INFO;
+import static org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO;
+import static org.apache.flink.api.common.typeinfo.Types.BOOLEAN;
+import static org.apache.flink.api.common.typeinfo.Types.BYTE;
+import static org.apache.flink.api.common.typeinfo.Types.DOUBLE;
+import static org.apache.flink.api.common.typeinfo.Types.FLOAT;
+import static org.apache.flink.api.common.typeinfo.Types.INSTANT;
+import static org.apache.flink.api.common.typeinfo.Types.INT;
+import static org.apache.flink.api.common.typeinfo.Types.LOCAL_DATE;
+import static org.apache.flink.api.common.typeinfo.Types.LOCAL_DATE_TIME;
+import static org.apache.flink.api.common.typeinfo.Types.LOCAL_TIME;
+import static org.apache.flink.api.common.typeinfo.Types.LONG;
+import static org.apache.flink.api.common.typeinfo.Types.SHORT;
+import static org.apache.flink.api.common.typeinfo.Types.SQL_TIME;
+import static org.apache.flink.api.common.typeinfo.Types.SQL_TIMESTAMP;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Util class for pulsar schema. Register all the {@link PulsarSchemaFactory} in this class and
+ * provide the {@link TypeInformation} or {@link PulsarSchema} conversion.
+ */
+@Internal
+@SuppressWarnings("unchecked")
+public final class PulsarSchemaUtils {
+
+    private static final Class<Message> PROTOBUF_MESSAGE_CLASS;
+    // Predefined pulsar schema factory.
+    private static final Map<SchemaType, PulsarSchemaFactory<?>> FACTORY_REGISTER =
+            new EnumMap<>(SchemaType.class);
+
+    public static final String CLASS_INFO_PLACEHOLDER = "INTERNAL.pulsar.schema.type.class.name";
+
+    static {
+        // Initialize protobuf message class.
+        Class<Message> messageClass;
+        try {
+            messageClass = (Class<Message>) Class.forName("com.google.protobuf.Message");
+        } catch (ClassNotFoundException e) {
+            messageClass = null;
+        }
+        PROTOBUF_MESSAGE_CLASS = messageClass;
+
+        // Struct schemas
+        registerSchemaFactory(new AvroSchemaFactory<>());
+        registerSchemaFactory(new JSONSchemaFactory<>());
+        registerSchemaFactory(new KeyValueSchemaFactory<>());
+        if (haveProtobuf()) {
+            // Protobuf type should be supported only when we have protobuf-java.
+            registerSchemaFactory(new ProtobufNativeSchemaFactory<>());
+            registerSchemaFactory(new ProtobufSchemaFactory<>());
+        }
+
+        // Primitive schemas
+        registerSchemaFactory(new StringSchemaFactory());
+        registerSchemaFactory(
+                new PrimitiveSchemaFactory<>(
+                        SchemaType.NONE, BytesSchema.of(), BYTE_PRIMITIVE_ARRAY_TYPE_INFO));
+        registerPrimitiveFactory(BooleanSchema.of(), BOOLEAN);
+        registerPrimitiveFactory(ByteSchema.of(), BYTE);
+        registerPrimitiveFactory(BytesSchema.of(), BYTE_PRIMITIVE_ARRAY_TYPE_INFO);
+        registerPrimitiveFactory(DateSchema.of(), DATE_TYPE_INFO);
+        registerPrimitiveFactory(DoubleSchema.of(), DOUBLE);
+        registerPrimitiveFactory(FloatSchema.of(), FLOAT);
+        registerPrimitiveFactory(InstantSchema.of(), INSTANT);
+        registerPrimitiveFactory(IntSchema.of(), INT);
+        registerPrimitiveFactory(LocalDateSchema.of(), LOCAL_DATE);
+        registerPrimitiveFactory(LocalDateTimeSchema.of(), LOCAL_DATE_TIME);
+        registerPrimitiveFactory(LocalTimeSchema.of(), LOCAL_TIME);
+        registerPrimitiveFactory(LongSchema.of(), LONG);
+        registerPrimitiveFactory(ShortSchema.of(), SHORT);
+        registerPrimitiveFactory(TimeSchema.of(), SQL_TIME);
+        registerPrimitiveFactory(TimestampSchema.of(), SQL_TIMESTAMP);
+    }
+
+    private PulsarSchemaUtils() {
+        // No need to create instance.
+    }
+
+    /** A boolean value for determine if user have protobuf-java in his class path. */
+    public static boolean haveProtobuf() {
+        return PROTOBUF_MESSAGE_CLASS != null;
+    }
+
+    /**
+     * Check if the given class is a protobuf generated class. Since this class would throw NP
+     * exception when you don't provide protobuf-java, use this method with {@link #haveProtobuf()}
+     */
+    public static <T> boolean isProtobufTypeClass(Class<T> clazz) {
+        return checkNotNull(PROTOBUF_MESSAGE_CLASS).isAssignableFrom(clazz);
+    }
+
+    private static <T> void registerPrimitiveFactory(
+            Schema<T> schema, TypeInformation<T> information) {
+        registerSchemaFactory(new PrimitiveSchemaFactory<>(schema, information));
+    }
+
+    private static void registerSchemaFactory(PulsarSchemaFactory<?> factory) {
+        FACTORY_REGISTER.put(factory.type(), factory);
+    }
+
+    /**
+     * Pulsar has a hugh set of built-in schemas. We can create them by the given {@link
+     * SchemaInfo}. This schema info is a wrapped info created by {@link PulsarSchema}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Schema<T> createSchema(SchemaInfo info) {
+        PulsarSchemaFactory<?> factory = FACTORY_REGISTER.get(info.getType());
+        checkNotNull(factory, "This schema info %s is not supported.", info);
+
+        return (Schema<T>) factory.createSchema(info);
+    }
+
+    /**
+     * Convert the {@link SchemaInfo} into a flink manageable {@link TypeInformation}. This schema
+     * info is a wrapped info created by {@link PulsarSchema}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> TypeInformation<T> createTypeInformation(SchemaInfo info) {
+        PulsarSchemaFactory<?> factory = FACTORY_REGISTER.get(info.getType());
+        checkNotNull(factory, "This schema info %s is not supported.", info);
+
+        return (TypeInformation<T>) factory.createTypeInfo(info);
+    }
+
+    public static SchemaInfo encodeClassInfo(SchemaInfo schemaInfo, Class<?> typeClass) {
+        Map<String, String> properties = new HashMap<>(schemaInfo.getProperties());
+        properties.put(CLASS_INFO_PLACEHOLDER, typeClass.getName());
+
+        return new SchemaInfoImpl(
+                schemaInfo.getName(), schemaInfo.getSchema(), schemaInfo.getType(), properties);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Class<T> decodeClassInfo(SchemaInfo schemaInfo) {
+        Map<String, String> properties = schemaInfo.getProperties();
+        String className =
+                checkNotNull(
+                        properties.get(CLASS_INFO_PLACEHOLDER),
+                        "This schema don't contain a class name.");
+
+        try {
+            return (Class<T>) Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Couldn't find the schema class " + className);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/AvroSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/AvroSchemaFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+
+/** The schema factory for pulsar's {@link AvroSchema}. */
+public class AvroSchemaFactory<T> extends BaseStructSchemaFactory<T> {
+
+    @Override
+    public SchemaType type() {
+        return SchemaType.AVRO;
+    }
+
+    @Override
+    public Schema<T> createSchema(SchemaInfo info) {
+        Class<T> typeClass = decodeClassInfo(info);
+        SchemaDefinition<T> definition =
+                SchemaDefinition.<T>builder()
+                        .withPojo(typeClass)
+                        .withProperties(info.getProperties())
+                        .build();
+
+        return AvroSchema.of(definition);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/BaseStructSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/BaseStructSchemaFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+
+/** Implement the common createTypeInfo method for all struct schema factory. */
+public abstract class BaseStructSchemaFactory<T> implements PulsarSchemaFactory<T> {
+
+    @Override
+    public TypeInformation<T> createTypeInfo(SchemaInfo info) {
+        Schema<T> pulsarSchema = createSchema(info);
+        Class<T> typeClass = decodeClassInfo(info);
+        PulsarSchema<T> schema = new PulsarSchema<>(pulsarSchema, typeClass);
+
+        return new PulsarSchemaTypeInformation<>(schema);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+
+/** The schema factory for pulsar's {@link JSONSchema}. */
+public class JSONSchemaFactory<T> extends BaseStructSchemaFactory<T> {
+
+    @Override
+    public SchemaType type() {
+        return SchemaType.JSON;
+    }
+
+    @Override
+    public Schema<T> createSchema(SchemaInfo info) {
+        Class<T> typeClass = decodeClassInfo(info);
+        return JSONSchema.of(typeClass, info.getProperties());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/KeyValueSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/KeyValueSchemaFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaFactory;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.util.Map;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.CLASS_INFO_PLACEHOLDER;
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+import static org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.decodeKeyValueEncodingType;
+import static org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.decodeKeyValueSchemaInfo;
+
+/** The schema factory for pulsar's {@link KeyValueSchemaImpl}. */
+public class KeyValueSchemaFactory<K, V> implements PulsarSchemaFactory<KeyValue<K, V>> {
+
+    @Override
+    public SchemaType type() {
+        return SchemaType.KEY_VALUE;
+    }
+
+    @Override
+    public Schema<KeyValue<K, V>> createSchema(SchemaInfo info) {
+        KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo = decodeKeyValueSchemaInfo(info);
+
+        Schema<K> keySchema = PulsarSchemaUtils.createSchema(kvSchemaInfo.getKey());
+        Schema<V> valueSchema = PulsarSchemaUtils.createSchema(kvSchemaInfo.getValue());
+        KeyValueEncodingType encodingType = decodeKeyValueEncodingType(info);
+
+        Schema<KeyValue<K, V>> schema = KeyValueSchemaImpl.of(keySchema, valueSchema, encodingType);
+
+        // Append extra class name into schema info properties.
+        // KeyValueSchema don't have custom properties builder method, we have to use side effects.
+        SchemaInfo schemaInfo = schema.getSchemaInfo();
+        Map<String, String> properties = schemaInfo.getProperties();
+        properties.put(CLASS_INFO_PLACEHOLDER, KeyValue.class.getName());
+
+        return schema;
+    }
+
+    @Override
+    public TypeInformation<KeyValue<K, V>> createTypeInfo(SchemaInfo info) {
+        KeyValue<SchemaInfo, SchemaInfo> kvSchemaInfo = decodeKeyValueSchemaInfo(info);
+
+        Schema<K> keySchema = PulsarSchemaUtils.createSchema(kvSchemaInfo.getKey());
+        Class<K> keyClass = decodeClassInfo(keySchema.getSchemaInfo());
+
+        Schema<V> valueSchema = PulsarSchemaUtils.createSchema(kvSchemaInfo.getValue());
+        Class<V> valueClass = decodeClassInfo(valueSchema.getSchemaInfo());
+
+        Schema<KeyValue<K, V>> schema = createSchema(info);
+        PulsarSchema<KeyValue<K, V>> pulsarSchema =
+                new PulsarSchema<>(schema, keyClass, valueClass);
+
+        return new PulsarSchemaTypeInformation<>(pulsarSchema);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/PrimitiveSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/PrimitiveSchemaFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaFactory;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * The schema factory for pulsar's primitive types. Currently, Pulsar supports <a
+ * href="https://pulsar.apache.org/docs/en/schema-understand/#primitive-type">these primitive
+ * types</a>.
+ */
+public class PrimitiveSchemaFactory<T> implements PulsarSchemaFactory<T> {
+
+    private static final ImmutableSet<SchemaType> PRIMITIVE_SCHEMA_TYPES =
+            ImmutableSet.<SchemaType>builder()
+                    .add(SchemaType.NONE)
+                    .add(SchemaType.BOOLEAN)
+                    .add(SchemaType.INT8)
+                    .add(SchemaType.INT16)
+                    .add(SchemaType.INT32)
+                    .add(SchemaType.INT64)
+                    .add(SchemaType.FLOAT)
+                    .add(SchemaType.DOUBLE)
+                    .add(SchemaType.BYTES)
+                    .add(SchemaType.STRING)
+                    .add(SchemaType.TIMESTAMP)
+                    .add(SchemaType.TIME)
+                    .add(SchemaType.DATE)
+                    .add(SchemaType.INSTANT)
+                    .add(SchemaType.LOCAL_DATE)
+                    .add(SchemaType.LOCAL_TIME)
+                    .add(SchemaType.LOCAL_DATE_TIME)
+                    .build();
+
+    private final SchemaType type;
+    private final Schema<T> schema;
+    private final TypeInformation<T> typeInformation;
+
+    public PrimitiveSchemaFactory(Schema<T> schema, TypeInformation<T> typeInformation) {
+        this(schema.getSchemaInfo().getType(), schema, typeInformation);
+    }
+
+    public PrimitiveSchemaFactory(
+            SchemaType type, Schema<T> schema, TypeInformation<T> typeInformation) {
+        checkArgument(PRIMITIVE_SCHEMA_TYPES.contains(type));
+
+        this.type = type;
+        this.schema = schema;
+        this.typeInformation = typeInformation;
+    }
+
+    @Override
+    public SchemaType type() {
+        return type;
+    }
+
+    @Override
+    public Schema<T> createSchema(SchemaInfo info) {
+        return schema;
+    }
+
+    @Override
+    public TypeInformation<T> createTypeInfo(SchemaInfo info) {
+        return typeInformation;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufNativeSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufNativeSchemaFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import com.google.protobuf.GeneratedMessageV3;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+
+/** The schema factory for pulsar's {@link ProtobufNativeSchema}. */
+public class ProtobufNativeSchemaFactory<T extends GeneratedMessageV3>
+        extends BaseStructSchemaFactory<T> {
+
+    @Override
+    public SchemaType type() {
+        return SchemaType.PROTOBUF_NATIVE;
+    }
+
+    @Override
+    public Schema<T> createSchema(SchemaInfo info) {
+        Class<T> typeClass = decodeClassInfo(info);
+        return ProtobufNativeSchema.of(typeClass, info.getProperties());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufSchemaFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import com.google.protobuf.GeneratedMessageV3;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.ProtobufSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+
+/** The schema factory for pulsar's {@link ProtobufSchema}. */
+public class ProtobufSchemaFactory<T extends GeneratedMessageV3>
+        extends BaseStructSchemaFactory<T> {
+
+    @Override
+    public SchemaType type() {
+        return SchemaType.PROTOBUF;
+    }
+
+    @Override
+    public Schema<T> createSchema(SchemaInfo info) {
+        Class<T> typeClass = decodeClassInfo(info);
+        return ProtobufSchema.of(typeClass, info.getProperties());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/StringSchemaFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/factories/StringSchemaFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaFactory;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.StringSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+/** The schema factory for pulsar's {@link StringSchema}. */
+public class StringSchemaFactory implements PulsarSchemaFactory<String> {
+
+    @Override
+    public SchemaType type() {
+        return SchemaType.STRING;
+    }
+
+    @Override
+    public Schema<String> createSchema(SchemaInfo info) {
+        // SchemaInfo contains the string encode type.
+        return StringSchema.fromSchemaInfo(info);
+    }
+
+    @Override
+    public TypeInformation<String> createTypeInfo(SchemaInfo info) {
+        return Types.STRING;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarExceptionUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarExceptionUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.function.SupplierWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+/**
+ * Util class for pulsar checked exceptions. Sneaky throw {@link PulsarAdminException} and {@link
+ * PulsarClientException}.
+ */
+@Internal
+public final class PulsarExceptionUtils {
+
+    private PulsarExceptionUtils() {
+        // No public constructor.
+    }
+
+    public static <R extends PulsarClientException> void sneakyClient(
+            ThrowingRunnable<R> runnable) {
+        sneaky(runnable);
+    }
+
+    public static <T, R extends PulsarClientException> T sneakyClient(
+            SupplierWithException<T, R> supplier) {
+        return sneaky(supplier);
+    }
+
+    public static <R extends PulsarAdminException> void sneakyAdmin(ThrowingRunnable<R> runnable) {
+        sneaky(runnable);
+    }
+
+    public static <T, R extends PulsarAdminException> T sneakyAdmin(
+            SupplierWithException<T, R> supplier) {
+        return sneaky(supplier);
+    }
+
+    private static <R extends Exception> void sneaky(ThrowingRunnable<R> runnable) {
+        try {
+            runnable.run();
+        } catch (Exception r) {
+            sneakyThrow(r);
+        }
+    }
+
+    /** Catch the throwable exception and rethrow it without try catch. */
+    private static <T, R extends Exception> T sneaky(SupplierWithException<T, R> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception r) {
+            sneakyThrow(r);
+        }
+
+        // This method wouldn't be executed.
+        throw new RuntimeException("Never throw here.");
+    }
+
+    /** javac hack for unchecking the checked exception. */
+    @SuppressWarnings("unchecked")
+    public static <T extends Exception> void sneakyThrow(Exception t) throws T {
+        throw (T) t;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarJsonUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarJsonUtils.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.utils;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.shade.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pulsar.shade.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.pulsar.shade.com.fasterxml.jackson.databind.type.CollectionType;
+import org.apache.pulsar.shade.com.fasterxml.jackson.databind.type.MapType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/** json util for pulsar configuration. */
+@Internal
+public final class PulsarJsonUtils {
+
+    /**
+     * Pulsar client shade a jackson and use jackson annotation in its config class. We have to use
+     * this shaded jackson here.
+     */
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private PulsarJsonUtils() {
+        // No need to create instance.
+    }
+
+    public static <K, V> Map<K, V> toMap(Class<K> kClass, Class<V> vClass, String json) {
+        return toMap(HashMap.class, kClass, vClass, json);
+    }
+
+    public static <K, V> Map<K, V> toMap(
+            Class<? extends Map> mapClass, Class<K> kClass, Class<V> vClass, String json) {
+        MapType mapType = mapper.getTypeFactory().constructMapType(mapClass, kClass, vClass);
+        try {
+            return mapper.readValue(json, mapType);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static <T> Set<T> toSet(Class<T> clazz, String json) {
+        return toSet(TreeSet.class, clazz, json);
+    }
+
+    public static <T> Set<T> toSet(Class<? extends Set> setClass, Class<T> clazz, String json) {
+        CollectionType collectionType =
+                mapper.getTypeFactory().constructCollectionType(setClass, clazz);
+        try {
+            return mapper.readValue(json, collectionType);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static <T> List<T> toList(Class<T> clazz, String json) {
+        return toList(ArrayList.class, clazz, json);
+    }
+
+    public static <T> List<T> toList(Class<? extends List> listClass, Class<T> clazz, String json) {
+        CollectionType collectionType =
+                mapper.getTypeFactory().constructCollectionType(listClass, clazz);
+        try {
+            return mapper.readValue(json, collectionType);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static String toString(Object o) {
+        try {
+            return mapper.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Pulsar's consumer builder use {@link ConsumerBuilder#loadConf(Map)} for user to customize
+     * their conf. We have to convert the configure instance into a common config map.
+     */
+    public static Map<String, Object> configMap(Object config) {
+        try {
+            String json = mapper.writeValueAsString(config);
+            return toMap(String.class, Object.class, json);
+        } catch (JsonProcessingException e) {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarSerdeUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarSerdeUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Util for serialize and deserialize. */
+@Internal
+public final class PulsarSerdeUtils {
+
+    private PulsarSerdeUtils() {
+        // No public constructor.
+    }
+
+    // Bytes serialization.
+
+    public static void serializeBytes(DataOutputStream out, byte[] bytes) throws IOException {
+        out.writeInt(bytes.length);
+        out.write(bytes);
+    }
+
+    public static byte[] deserializeBytes(DataInputStream in) throws IOException {
+        int size = in.readInt();
+        byte[] bytes = new byte[size];
+        int result = in.read(bytes);
+        if (result < 0) {
+            throw new IOException("Couldn't deserialize the object, wrong byte buffer.");
+        }
+
+        return bytes;
+    }
+
+    // Common Object serialization.
+
+    public static void serializeObject(DataOutputStream out, Object obj) throws IOException {
+        Preconditions.checkNotNull(obj);
+
+        byte[] objectBytes = InstantiationUtil.serializeObject(obj);
+        serializeBytes(out, objectBytes);
+    }
+
+    public static <T> T deserializeObject(DataInputStream in) throws IOException {
+        byte[] objectBytes = deserializeBytes(in);
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+
+        try {
+            return InstantiationUtil.deserializeObject(objectBytes, loader);
+        } catch (ClassNotFoundException e) {
+            throw new IOException(e);
+        }
+    }
+
+    // Common Set serialization.
+
+    public static <T> void serializeSet(
+            DataOutputStream out,
+            Set<T> set,
+            BiConsumerWithException<DataOutputStream, T, IOException> serializer)
+            throws IOException {
+        out.writeInt(set.size());
+        for (T t : set) {
+            serializer.accept(out, t);
+        }
+    }
+
+    public static <T> Set<T> deserializeSet(
+            DataInputStream in, FunctionWithException<DataInputStream, T, IOException> deserializer)
+            throws IOException {
+        int size = in.readInt();
+        Set<T> set = new HashSet<>(size);
+        for (int i = 0; i < size; i++) {
+            T t = deserializer.apply(in);
+            set.add(t);
+        }
+
+        return set;
+    }
+
+    // Common Map serialization.
+
+    public static <K, V> void serializeMap(
+            DataOutputStream out,
+            Map<K, V> map,
+            BiConsumerWithException<DataOutputStream, K, IOException> keySerializer,
+            BiConsumerWithException<DataOutputStream, V, IOException> valueSerializer)
+            throws IOException {
+        out.writeInt(map.size());
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            keySerializer.accept(out, entry.getKey());
+            valueSerializer.accept(out, entry.getValue());
+        }
+    }
+
+    public static <K, V> Map<K, V> deserializeMap(
+            DataInputStream in,
+            FunctionWithException<DataInputStream, K, IOException> keyDeserializer,
+            FunctionWithException<DataInputStream, V, IOException> valueDeserializer)
+            throws IOException {
+        int size = in.readInt();
+        Map<K, V> result = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            K key = keyDeserializer.apply(in);
+            V value = valueDeserializer.apply(in);
+            result.put(key, value);
+        }
+        return result;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarTransactionUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarTransactionUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.utils;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.client.impl.transaction.TransactionImpl;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Transaction was introduced into pulsar since 2.7.0, but the interface {@link Transaction} didn't
+ * provide a id method until 2.8.1. We have to add this util for acquiring the {@link TxnID} for
+ * compatible consideration.
+ *
+ * <p>TODO Remove this hack after pulsar 2.8.1 release.
+ */
+@Internal
+@SuppressWarnings("java:S3011")
+public final class PulsarTransactionUtils {
+
+    private static volatile Field mostBitsField;
+    private static volatile Field leastBitsField;
+
+    private PulsarTransactionUtils() {
+        // No public constructor
+    }
+
+    public static TxnID getId(Transaction transaction) {
+        // 2.8.1 and after.
+        try {
+            Method getId = Transaction.class.getDeclaredMethod("getTxnID");
+            return (TxnID) getId.invoke(transaction);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            // 2.8.0 and before.
+            TransactionImpl impl = (TransactionImpl) transaction;
+            Long txnIdMostBits = getTxnIdMostBits(impl);
+            Long txnIdLeastBits = getTxnIdLeastBits(impl);
+
+            checkNotNull(txnIdMostBits, "Failed to get txnIdMostBits");
+            checkNotNull(txnIdLeastBits, "Failed to get txnIdLeastBits");
+
+            return new TxnID(txnIdMostBits, txnIdLeastBits);
+        }
+    }
+
+    private static Long getTxnIdMostBits(TransactionImpl transaction) {
+        if (mostBitsField == null) {
+            synchronized (PulsarTransactionUtils.class) {
+                if (mostBitsField == null) {
+                    try {
+                        mostBitsField = TransactionImpl.class.getDeclaredField("txnIdMostBits");
+                        mostBitsField.setAccessible(true);
+                    } catch (NoSuchFieldException e) {
+                        // Nothing to do for this exception.
+                    }
+                }
+            }
+        }
+
+        if (mostBitsField != null) {
+            try {
+                return (Long) mostBitsField.get(transaction);
+            } catch (IllegalAccessException e) {
+                // Nothing to do for this exception.
+            }
+        }
+
+        return null;
+    }
+
+    private static Long getTxnIdLeastBits(TransactionImpl transaction) {
+        if (leastBitsField == null) {
+            synchronized (PulsarTransactionUtils.class) {
+                if (leastBitsField == null) {
+                    try {
+                        leastBitsField = TransactionImpl.class.getDeclaredField("txnIdLeastBits");
+                        leastBitsField.setAccessible(true);
+                    } catch (NoSuchFieldException e) {
+                        // Nothing to do for this exception.
+                    }
+                }
+            }
+        }
+
+        if (leastBitsField != null) {
+            try {
+                return (Long) leastBitsField.get(transaction);
+            } catch (IllegalAccessException e) {
+                // Nothing to do for this exception.
+            }
+        }
+
+        return null;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
+import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumStateSerializer;
+import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumerator;
+import org.apache.flink.connector.pulsar.source.enumerator.SplitsAssignmentState;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+import org.apache.flink.connector.pulsar.source.reader.PulsarSourceReaderFactory;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchemaInitializationContext;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+
+/**
+ * The Source implementation of Pulsar. Please use a {@link PulsarSourceBuilder} to construct a
+ * {@link PulsarSource}. The following example shows how to create a PulsarSource emitting records
+ * of <code>String</code> type.
+ *
+ * <pre>{@code
+ * PulsarSource<String> source = PulsarSource
+ *     .builder()
+ *     .setTopics(TOPIC1， TOPIC2)
+ *     .setServiceUrl(getServiceUrl())
+ *     .setAdminUrl(getAdminUrl())
+ *     .setSubscriptionName("test")
+ *     .setDeserializationSchema(PulsarDeserializationSchema.flinkSchema(new SimpleStringSchema()))
+ *     .setBounded(StopCursor::defaultStopCursor)
+ *     .build();
+ * }</pre>
+ *
+ * <p>See {@link PulsarSourceBuilder} for more details.
+ *
+ * @param <OUT> The output type of the source.
+ */
+@PublicEvolving
+public final class PulsarSource<OUT>
+        implements Source<OUT, PulsarPartitionSplit, PulsarSourceEnumState>,
+                ResultTypeQueryable<OUT> {
+    private static final long serialVersionUID = 7773108631275567433L;
+
+    /**
+     * The common configuration for pulsar source, we don't support the pulsar's configuration class
+     * directly.
+     */
+    private final Configuration configuration;
+
+    private final SourceConfiguration sourceConfiguration;
+
+    private final PulsarSubscriber subscriber;
+
+    private final RangeGenerator rangeGenerator;
+
+    private final StartCursor startCursor;
+
+    private final StopCursor stopCursor;
+
+    private final Boundedness boundedness;
+
+    /** The pulsar deserialization schema used for deserializing message. */
+    private final PulsarDeserializationSchema<OUT> deserializationSchema;
+
+    /** Modify the flink generated {@link ClientConfigurationData}. */
+    private final ConfigurationDataCustomizer<ClientConfigurationData>
+            clientConfigurationCustomizer;
+
+    /** Modify the flink generated {@link ConsumerConfigurationData}. */
+    private final ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+            consumerConfigurationCustomizer;
+
+    /**
+     * The constructor for PulsarSource, it's package protected for forcing using {@link
+     * PulsarSourceBuilder}.
+     */
+    PulsarSource(
+            Configuration configuration,
+            PulsarSubscriber subscriber,
+            RangeGenerator rangeGenerator,
+            StartCursor startCursor,
+            StopCursor stopCursor,
+            Boundedness boundedness,
+            PulsarDeserializationSchema<OUT> deserializationSchema,
+            ConfigurationDataCustomizer<ClientConfigurationData> clientConfigurationCustomizer,
+            ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+                    consumerConfigurationCustomizer) {
+
+        this.configuration = configuration;
+        this.sourceConfiguration = new SourceConfiguration(configuration);
+        this.subscriber = subscriber;
+        this.rangeGenerator = rangeGenerator;
+        this.startCursor = startCursor;
+        this.stopCursor = stopCursor;
+        this.boundedness = boundedness;
+        this.deserializationSchema = deserializationSchema;
+        this.clientConfigurationCustomizer = clientConfigurationCustomizer;
+        this.consumerConfigurationCustomizer = consumerConfigurationCustomizer;
+    }
+
+    /**
+     * Get a PulsarSourceBuilder to builder a {@link PulsarSource}.
+     *
+     * @return a Pulsar source builder.
+     */
+    @SuppressWarnings("java:S4977")
+    public static <OUT> PulsarSourceBuilder<OUT> builder() {
+        return new PulsarSourceBuilder<>();
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return boundedness;
+    }
+
+    @Override
+    public SourceReader<OUT, PulsarPartitionSplit> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        // Initialize the deserialization schema before creating the pulsar reader.
+        deserializationSchema.open(
+                new PulsarDeserializationSchemaInitializationContext(readerContext));
+
+        return PulsarSourceReaderFactory.create(
+                readerContext,
+                deserializationSchema,
+                configuration,
+                sourceConfiguration,
+                clientConfigurationCustomizer,
+                consumerConfigurationCustomizer);
+    }
+
+    @Override
+    public SplitEnumerator<PulsarPartitionSplit, PulsarSourceEnumState> createEnumerator(
+            SplitEnumeratorContext<PulsarPartitionSplit> enumContext) {
+        SplitsAssignmentState assignmentState =
+                new SplitsAssignmentState(startCursor, stopCursor, sourceConfiguration);
+        return new PulsarSourceEnumerator(
+                subscriber,
+                rangeGenerator,
+                configuration,
+                sourceConfiguration,
+                clientConfigurationCustomizer,
+                enumContext,
+                assignmentState);
+    }
+
+    @Override
+    public SplitEnumerator<PulsarPartitionSplit, PulsarSourceEnumState> restoreEnumerator(
+            SplitEnumeratorContext<PulsarPartitionSplit> enumContext,
+            PulsarSourceEnumState checkpoint) {
+        SplitsAssignmentState assignmentState =
+                new SplitsAssignmentState(startCursor, stopCursor, sourceConfiguration, checkpoint);
+        return new PulsarSourceEnumerator(
+                subscriber,
+                rangeGenerator,
+                configuration,
+                sourceConfiguration,
+                clientConfigurationCustomizer,
+                enumContext,
+                assignmentState);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<PulsarPartitionSplit> getSplitSerializer() {
+        return PulsarPartitionSplitSerializer.INSTANCE;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<PulsarSourceEnumState> getEnumeratorCheckpointSerializer() {
+        return PulsarSourceEnumStateSerializer.INSTANCE;
+    }
+
+    @Override
+    public TypeInformation<OUT> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
@@ -1,0 +1,616 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.common.utils.PulsarJsonUtils;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.FullRangeGenerator;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.UniformRangeGenerator;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import static java.lang.Boolean.FALSE;
+import static org.apache.flink.api.common.ExecutionConfig.ClosureCleanerLevel.RECURSIVE;
+import static org.apache.flink.connector.pulsar.common.config.PulsarConfigUtils.getOptionValue;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ENABLE_TRANSACTION;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_REGEX_SUBSCRIPTION_MODE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_TYPE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TOPICS_PATTERN;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TOPIC_NAMES;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TRANSACTION_TIMEOUT_MILLIS;
+import static org.apache.flink.connector.pulsar.source.config.PulsarSourceConfigUtils.checkConfigurations;
+import static org.apache.flink.util.InstantiationUtil.isSerializable;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The builder class for {@link PulsarSource} to make it easier for the users to construct a {@link
+ * PulsarSource}.
+ *
+ * <p>The following example shows the minimum setup to create a PulsarSource that reads the String
+ * values from a Pulsar topic.
+ *
+ * <pre>{@code
+ * PulsarSource<String> source = PulsarSource
+ *     .builder()
+ *     .setServiceUrl(PULSAR_BROKER_URL)
+ *     .setAdminUrl(PULSAR_BROKER_HTTP_URL)
+ *     .setSubscriptionName("flink-source-1")
+ *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
+ *     .setDeserializationSchema(PulsarDeserializationSchema.flinkSchema(new SimpleStringSchema()))
+ *     .build();
+ * }</pre>
+ *
+ * <p>The service url, admin url, subscription name, topics to consume, and the record deserializer
+ * are required fields that must be set.
+ *
+ * <p>To specify the starting position of PulsarSource, one can call {@link
+ * #setStartCursor(StartCursor)}.
+ *
+ * <p>By default the PulsarSource runs in an {@link Boundedness#CONTINUOUS_UNBOUNDED} mode and never
+ * stop until the Flink job is canceled or fails. To let the PulsarSource run in {@link
+ * Boundedness#CONTINUOUS_UNBOUNDED} but stops at some given offsets, one can call {@link
+ * #setUnboundedStopCursor(StopCursor)}. For example the following PulsarSource stops after it
+ * consumes up to a event time when the Flink started.
+ *
+ * <pre>{@code
+ * PulsarSource<String> source = PulsarSource
+ *     .builder()
+ *     .setServiceUrl(PULSAR_BROKER_URL)
+ *     .setAdminUrl(PULSAR_BROKER_HTTP_URL)
+ *     .setSubscriptionName("flink-source-1")
+ *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
+ *     .setDeserializationSchema(PulsarDeserializationSchema.flinkSchema(new SimpleStringSchema()))
+ *     .setUnbounded(StopCursor.atEventTime(System.currentTimeMillis()))
+ *     .build();
+ * }</pre>
+ *
+ * @param <OUT> The output type of the source.
+ */
+@PublicEvolving
+public final class PulsarSourceBuilder<OUT> {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarSourceBuilder.class);
+
+    private final Configuration configuration;
+    private PulsarSubscriber subscriber;
+    private RangeGenerator rangeGenerator;
+    private StartCursor startCursor = StartCursor.defaultStartCursor();
+    private StopCursor stopCursor = StopCursor.defaultStopCursor();
+    private Boundedness boundedness;
+    private PulsarDeserializationSchema<OUT> deserializationSchema;
+    private ConfigurationDataCustomizer<ClientConfigurationData> clientConfigurationCustomizer;
+    private ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+            consumerConfigurationCustomizer;
+
+    // private builder constructor.
+    PulsarSourceBuilder() {
+        // The default configuration holder.
+        this.configuration = new Configuration();
+    }
+
+    /**
+     * Sets the admin endpoint for the PulsarAdmin of the PulsarSource.
+     *
+     * @param adminUrl the url for the PulsarAdmin.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setAdminUrl(String adminUrl) {
+        setConfiguration(PULSAR_ADMIN_URL, adminUrl);
+        return this;
+    }
+
+    /**
+     * Sets the server's link for the PulsarConsumer of the PulsarSource.
+     *
+     * @param serviceUrl the server url of the Pulsar cluster.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setServiceUrl(String serviceUrl) {
+        setConfiguration(PULSAR_SERVICE_URL, serviceUrl);
+        return this;
+    }
+
+    /**
+     * Sets the name for this pulsar subscription.
+     *
+     * @param subscriptionName the server url of the Pulsar cluster.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setSubscriptionName(String subscriptionName) {
+        setConfiguration(PULSAR_SUBSCRIPTION_NAME, subscriptionName);
+        return this;
+    }
+
+    /**
+     * {@link SubscriptionType} is the consuming behavior for pulsar, we would generator different
+     * split by the given subscription type. Please take some time to consider which subscription
+     * type matches your application best. Default is {@link SubscriptionType#Shared}.
+     *
+     * @param subscriptionType The type of subscription.
+     * @return this PulsarSourceBuilder.
+     * @see <a href="https://pulsar.apache.org/docs/en/concepts-messaging/#subscriptions">Pulsar
+     *     Subscriptions</a>
+     */
+    public PulsarSourceBuilder<OUT> setSubscriptionType(SubscriptionType subscriptionType) {
+        if (configuration.contains(PULSAR_SUBSCRIPTION_TYPE)) {
+            SubscriptionType existedType = configuration.get(PULSAR_SUBSCRIPTION_TYPE);
+            checkArgument(
+                    existedType == subscriptionType,
+                    "Can't override the subscription type %s with a new type %s",
+                    existedType,
+                    subscriptionType);
+        } else {
+            configuration.set(PULSAR_SUBSCRIPTION_TYPE, subscriptionType);
+        }
+        return this;
+    }
+
+    /**
+     * Set a pulsar topic list for flink source. Some topic may not exist currently, consuming this
+     * non-existed topic wouldn't throw any exception. But the best solution is just consuming by
+     * using a topic regex. You can set topics once either with {@link #setTopics} or {@link
+     * #setTopicPattern} in this builder.
+     *
+     * @param topics The topic list you would like to consume message.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setTopics(String... topics) {
+        return setTopics(Arrays.asList(topics));
+    }
+
+    /**
+     * Set a pulsar topic list for flink source. Some topic may not exist currently, consuming this
+     * non-existed topic wouldn't throw any exception. But the best solution is just consuming by
+     * using a topic regex. You can set topics once either with {@link #setTopics} or {@link
+     * #setTopicPattern} in this builder.
+     *
+     * @param topics The topic list you would like to consume message.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setTopics(List<String> topics) {
+        ensureSubscriberIsNull("topics");
+        configuration.set(PULSAR_TOPIC_NAMES, PulsarJsonUtils.toString(topics));
+        this.subscriber = PulsarSubscriber.getTopicListSubscriber(topics);
+        return this;
+    }
+
+    /**
+     * Set a topic pattern to consume from the java regex str. You can set topics once either with
+     * {@link #setTopics} or {@link #setTopicPattern} in this builder.
+     *
+     * @param topicsPattern the pattern of the topic name to consume from.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setTopicPattern(String topicsPattern) {
+        return setTopicPattern(Pattern.compile(topicsPattern));
+    }
+
+    /**
+     * Set a topic pattern to consume from the java {@link Pattern}. You can set topics once either
+     * with {@link #setTopics} or {@link #setTopicPattern} in this builder.
+     *
+     * @param topicsPattern the pattern of the topic name to consume from.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setTopicPattern(Pattern topicsPattern) {
+        return setTopicPattern(topicsPattern, RegexSubscriptionMode.AllTopics);
+    }
+
+    /**
+     * Set a topic pattern to consume from the java regex str. You can set topics once either with
+     * {@link #setTopics} or {@link #setTopicPattern} in this builder.
+     *
+     * @param topicsPattern the pattern of the topic name to consume from.
+     * @param regexSubscriptionMode The topic filter for regex subscription.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setTopicPattern(
+            String topicsPattern, RegexSubscriptionMode regexSubscriptionMode) {
+        return setTopicPattern(Pattern.compile(topicsPattern), regexSubscriptionMode);
+    }
+
+    /**
+     * Set a topic pattern to consume from the java {@link Pattern}. You can set topics once either
+     * with {@link #setTopics} or {@link #setTopicPattern} in this builder.
+     *
+     * @param topicsPattern the pattern of the topic name to consume from.
+     * @param regexSubscriptionMode The topic filter for regex subscription.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setTopicPattern(
+            Pattern topicsPattern, RegexSubscriptionMode regexSubscriptionMode) {
+        ensureSubscriberIsNull("topic pattern");
+        configuration.set(PULSAR_TOPICS_PATTERN, topicsPattern.toString());
+        configuration.set(PULSAR_REGEX_SUBSCRIPTION_MODE, regexSubscriptionMode);
+        this.subscriber =
+                PulsarSubscriber.getTopicPatternSubscriber(topicsPattern, regexSubscriptionMode);
+        return this;
+    }
+
+    /**
+     * Set a topic range generator for Key_Shared subscription.
+     *
+     * @param rangeGenerator A generator which would generate a set of {@link TopicRange} for given
+     *     topic.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setRangeGenerator(RangeGenerator rangeGenerator) {
+        if (configuration.contains(PULSAR_SUBSCRIPTION_TYPE)) {
+            SubscriptionType subscriptionType = configuration.get(PULSAR_SUBSCRIPTION_TYPE);
+            checkArgument(
+                    subscriptionType == SubscriptionType.Key_Shared,
+                    "Key_Shared subscription should be used for custom rangeGenerator instead of %s",
+                    subscriptionType);
+        } else {
+            LOG.warn("No subscription type provided, set it to Key_Shared.");
+            setSubscriptionType(SubscriptionType.Key_Shared);
+        }
+        this.rangeGenerator = rangeGenerator;
+        return this;
+    }
+
+    /**
+     * Specify from which offsets the PulsarSource should start consume from by providing an {@link
+     * StartCursor}.
+     *
+     * @param startCursor set the starting offsets for the Source.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setStartCursor(StartCursor startCursor) {
+        this.startCursor = checkNotNull(startCursor);
+        return this;
+    }
+
+    /**
+     * By default the PulsarSource is set to run in {@link Boundedness#CONTINUOUS_UNBOUNDED} manner
+     * and thus never stops until the Flink job fails or is canceled. To let the PulsarSource run as
+     * a streaming source but still stops at some point, one can set an {@link StopCursor} to
+     * specify the stopping offsets for each partition. When all the partitions have reached their
+     * stopping offsets, the PulsarSource will then exit.
+     *
+     * <p>This method is different from {@link #setBoundedStopCursor(StopCursor)} that after setting
+     * the stopping offsets with this method, {@link PulsarSource#getBoundedness()} will still
+     * return {@link Boundedness#CONTINUOUS_UNBOUNDED} even though it will stop at the stopping
+     * offsets specified by the stopping offsets {@link StopCursor}.
+     *
+     * @param stopCursor The {@link StopCursor} to specify the stopping offset.
+     * @return this PulsarSourceBuilder.
+     * @see #setBoundedStopCursor(StopCursor)
+     */
+    public PulsarSourceBuilder<OUT> setUnboundedStopCursor(StopCursor stopCursor) {
+        this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
+        this.stopCursor = checkNotNull(stopCursor);
+        return this;
+    }
+
+    /**
+     * By default the PulsarSource is set to run in {@link Boundedness#CONTINUOUS_UNBOUNDED} manner
+     * and thus never stops until the Flink job fails or is canceled. To let the PulsarSource run in
+     * {@link Boundedness#BOUNDED} manner and stops at some point, one can set an {@link StopCursor}
+     * to specify the stopping offsets for each partition. When all the partitions have reached
+     * their stopping offsets, the PulsarSource will then exit.
+     *
+     * <p>This method is different from {@link #setUnboundedStopCursor(StopCursor)} that after
+     * setting the stopping offsets with this method, {@link PulsarSource#getBoundedness()} will
+     * return {@link Boundedness#BOUNDED} instead of {@link Boundedness#CONTINUOUS_UNBOUNDED}.
+     *
+     * @param stopCursor the {@link StopCursor} to specify the stopping offsets.
+     * @return this PulsarSourceBuilder.
+     * @see #setUnboundedStopCursor(StopCursor)
+     */
+    public PulsarSourceBuilder<OUT> setBoundedStopCursor(StopCursor stopCursor) {
+        this.boundedness = Boundedness.BOUNDED;
+        this.stopCursor = checkNotNull(stopCursor);
+        return this;
+    }
+
+    /**
+     * DeserializationSchema is required for getting the {@link Schema} for deserialize message from
+     * pulsar and getting the {@link TypeInformation} for message serialization in flink.
+     *
+     * <p>We have defined a set of implementations, using {@code
+     * PulsarDeserializationSchema#pulsarSchema} or {@code PulsarDeserializationSchema#flinkSchema}
+     * for creating the desired schema.
+     */
+    public <T extends OUT> PulsarSourceBuilder<T> setDeserializationSchema(
+            PulsarDeserializationSchema<T> deserializationSchema) {
+        PulsarSourceBuilder<T> self = specialized();
+        self.deserializationSchema = deserializationSchema;
+        return self;
+    }
+
+    /**
+     * {@link ClientConfigurationData} is created from {@link Properties}, but you can just using
+     * its setter method for programmatic update a config instance.
+     *
+     * @param consumer Modify the ClientConfigurationData instance in this consumer.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> modifyClientConfig(Consumer<ClientConfigurationData> consumer) {
+        if (clientConfigurationCustomizer == null) {
+            this.clientConfigurationCustomizer = consumer::accept;
+        } else {
+            this.clientConfigurationCustomizer =
+                    clientConfigurationCustomizer.compose(consumer::accept);
+        }
+        return this;
+    }
+
+    /**
+     * {@link ConsumerConfigurationData} is created from {@link Properties}, but you can just using
+     * its setter method for programmatic update a config instance.
+     *
+     * @param consumer Modify the ConsumerConfigurationData instance in this consumer.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> modifyConsumerConfig(
+            Consumer<ConsumerConfigurationData<byte[]>> consumer) {
+        if (consumerConfigurationCustomizer == null) {
+            this.consumerConfigurationCustomizer = consumer::accept;
+        } else {
+            this.consumerConfigurationCustomizer =
+                    consumerConfigurationCustomizer.compose(consumer::accept);
+        }
+        return this;
+    }
+
+    /**
+     * Set an arbitrary property for the PulsarSource and PulsarConsumer. The valid keys can be
+     * found in {@link PulsarSourceOptions}.
+     *
+     * @param key the key of the property.
+     * @param value the value of the property.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setProperty(String key, String value) {
+        checkNotNull(key);
+        checkNotNull(value);
+        if (configuration.containsKey(key)) {
+            ConfigOption<String> rawOption = ConfigOptions.key(key).stringType().noDefaultValue();
+            LOG.warn(
+                    "Config option {} already has a value {}, override to new value {}",
+                    key,
+                    configuration.getString(rawOption),
+                    value);
+        }
+        configuration.setString(key, value);
+        return this;
+    }
+
+    /**
+     * Set an arbitrary property for the PulsarSource and PulsarConsumer. The valid keys can be
+     * found in {@link PulsarSourceOptions}.
+     *
+     * @param key the key of the property.
+     * @param value the value of the property.
+     * @return this PulsarSourceBuilder.
+     */
+    public <T> PulsarSourceBuilder<OUT> setProperty(ConfigOption<T> key, T value) {
+        checkNotNull(key);
+        checkNotNull(value);
+        if (configuration.contains(key)) {
+            T oldValue = configuration.get(key);
+            LOG.warn(
+                    "Config option {} already has a value {}, override to new value {}",
+                    key,
+                    oldValue,
+                    value);
+        }
+        configuration.set(key, value);
+        return this;
+    }
+
+    /**
+     * Set arbitrary properties for the PulsarSource and PulsarConsumer. The valid keys can be found
+     * in {@link PulsarSourceOptions}.
+     *
+     * @param properties the properties to set for the PulsarSource.
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setProperties(Properties properties) {
+        for (String name : properties.stringPropertyNames()) {
+            String value = properties.getProperty(name);
+            if (value != null) {
+                setProperty(name, value);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Build the {@link PulsarSource}.
+     *
+     * @return a PulsarSource with the settings made for this builder.
+     */
+    @SuppressWarnings("java:S3776")
+    public PulsarSource<OUT> build() {
+        // Check builder configuration.
+        checkConfigurations(configuration);
+
+        SubscriptionType subscriptionType = configuration.get(PULSAR_SUBSCRIPTION_TYPE);
+
+        // Ensure the topic subscriber for pulsar.
+        if (subscriber == null) {
+            if (configuration.contains(PULSAR_TOPIC_NAMES)) {
+                List<String> topics =
+                        getOptionValue(
+                                configuration,
+                                PULSAR_TOPIC_NAMES,
+                                names -> PulsarJsonUtils.toList(String.class, names));
+                this.subscriber = PulsarSubscriber.getTopicListSubscriber(topics);
+            } else if (configuration.contains(PULSAR_TOPICS_PATTERN)) {
+                String topicPatternStr = configuration.get(PULSAR_TOPICS_PATTERN);
+                Pattern topicPattern = Pattern.compile(topicPatternStr);
+                RegexSubscriptionMode regexSubscriptionMode =
+                        configuration.get(PULSAR_REGEX_SUBSCRIPTION_MODE);
+
+                this.subscriber =
+                        PulsarSubscriber.getTopicPatternSubscriber(
+                                topicPattern, regexSubscriptionMode);
+            } else {
+                throw new IllegalArgumentException(
+                        "No "
+                                + PULSAR_TOPIC_NAMES.key()
+                                + " or "
+                                + PULSAR_TOPICS_PATTERN.key()
+                                + " was provided.");
+            }
+        }
+        if (subscriptionType == SubscriptionType.Key_Shared) {
+            if (rangeGenerator == null) {
+                LOG.warn(
+                        "No range generator provided for key_shared subscription,"
+                                + " we would use the DivideRangeGenerator as the default range generator.");
+                this.rangeGenerator = new UniformRangeGenerator();
+            }
+        } else {
+            // Override the range generator.
+            this.rangeGenerator = new FullRangeGenerator();
+        }
+
+        if (boundedness == null) {
+            LOG.warn("No boundedness was set, mark it as a endless stream.");
+            this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
+        }
+        if (boundedness == Boundedness.BOUNDED
+                && configuration.get(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS) >= 0) {
+            LOG.warn(
+                    "{} property is overridden to -1 because the source is bounded.",
+                    PULSAR_PARTITION_DISCOVERY_INTERVAL_MS);
+            configuration.set(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, -1L);
+        }
+
+        checkNotNull(deserializationSchema, "deserializationSchema should be set.");
+
+        if (clientConfigurationCustomizer == null) {
+            this.clientConfigurationCustomizer = ConfigurationDataCustomizer.blankCustomizer();
+        }
+
+        if (consumerConfigurationCustomizer == null) {
+            this.consumerConfigurationCustomizer = ConfigurationDataCustomizer.blankCustomizer();
+        }
+
+        // Enable transaction if the cursor auto commit is disabled for Key_Shared & Shared.
+        if (FALSE.equals(configuration.get(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE))
+                && (subscriptionType == SubscriptionType.Key_Shared
+                        || subscriptionType == SubscriptionType.Shared)) {
+            LOG.info(
+                    "Pulsar cursor auto commit is disabled, make sure checkpoint is enabled "
+                            + "and your pulsar cluster is support the transaction.");
+            configuration.set(PULSAR_ENABLE_TRANSACTION, true);
+
+            if (!configuration.contains(PULSAR_TRANSACTION_TIMEOUT_MILLIS)) {
+                LOG.warn(
+                        "The default pulsar transaction timeout is 3 hours, "
+                                + "make sure it was greater than your checkpoint interval.");
+            } else {
+                Long timeout = configuration.get(PULSAR_TRANSACTION_TIMEOUT_MILLIS);
+                LOG.warn(
+                        "The configured transaction timeout is {} mille seconds, "
+                                + "make sure it was greater than your checkpoint interval.",
+                        timeout);
+            }
+        }
+
+        // Since these implementation could be a lambda, make sure they are serializable.
+        checkState(isSerializable(startCursor), "StartCursor isn't serializable");
+        checkState(isSerializable(stopCursor), "StopCursor isn't serializable");
+        ClosureCleaner.clean(clientConfigurationCustomizer, RECURSIVE, true);
+        ClosureCleaner.clean(consumerConfigurationCustomizer, RECURSIVE, true);
+
+        // Make the configuration unmodifiable.
+        UnmodifiableConfiguration config = new UnmodifiableConfiguration(configuration);
+
+        return new PulsarSource<>(
+                config,
+                subscriber,
+                rangeGenerator,
+                startCursor,
+                stopCursor,
+                boundedness,
+                deserializationSchema,
+                clientConfigurationCustomizer,
+                consumerConfigurationCustomizer);
+    }
+
+    // ------------- private helpers  --------------
+
+    /** Make sure this option is set only once or with same value. */
+    private <T> void setConfiguration(ConfigOption<T> option, T value) {
+        if (configuration.contains(option)) {
+            T oldValue = configuration.get(option);
+            checkArgument(
+                    Objects.equals(oldValue, value),
+                    "This option %s has been set to value %s.",
+                    option.key(),
+                    oldValue);
+        } else {
+            configuration.set(option, value);
+        }
+    }
+
+    /** Helper method for java compiler recognize the generic type. */
+    @SuppressWarnings("unchecked")
+    private <T extends OUT> PulsarSourceBuilder<T> specialized() {
+        return (PulsarSourceBuilder<T>) this;
+    }
+
+    /** Topic name and topic pattern is conflict, make sure they are set only once. */
+    private void ensureSubscriberIsNull(String attemptingSubscribeMode) {
+        if (subscriber != null) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Cannot use %s for consumption because a %s is already set for consumption.",
+                            attemptingSubscribeMode, subscriber.getClass().getSimpleName()));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
@@ -1,0 +1,536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.connector.pulsar.common.config.PulsarOptions;
+import org.apache.flink.connector.pulsar.source.config.CursorVerification;
+
+import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/**
+ * Configurations for PulsarSource. All the options list here could be configured in {@link
+ * PulsarSourceBuilder#setProperty(ConfigOption, Object)}. The {@link PulsarOptions} is also
+ * required for pulsar source.
+ *
+ * @see PulsarOptions
+ */
+@PublicEvolving
+public final class PulsarSourceOptions {
+
+    // Pulsar source connector config prefix.
+    private static final String SOURCE_CONFIG_PREFIX = "pulsar.source.";
+    // Pulsar consumer API config prefix.
+    private static final String CONSUMER_CONFIG_PREFIX = "pulsar.consumer.";
+
+    private PulsarSourceOptions() {
+        // This is a constant class
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    //
+    // The configuration for pulsar source part.
+    // All the configuration listed below should have the pulsar.source prefix.
+    //
+    ///////////////////////////////////////////////////////////////////////////////
+
+    public static final ConfigOption<Long> PULSAR_PARTITION_DISCOVERY_INTERVAL_MS =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "partitionDiscoveryIntervalMs")
+                    .longType()
+                    .defaultValue(Duration.ofSeconds(30).toMillis())
+                    .withDescription(
+                            "The interval in milliseconds for the Pulsar source to discover "
+                                    + "the new partitions. A non-positive value disables the partition discovery.");
+
+    public static final ConfigOption<Boolean> PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "enableAutoAcknowledgeMessage")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Flink commits the consuming position with pulsar transactions on checkpoint.")
+                                    .linebreak()
+                                    .text(
+                                            "However, if you have disabled the flink checkpoint or your pulsar cluster disabled the transaction,"
+                                                    + " make sure you have set this option to %s.",
+                                            code("true"))
+                                    .text(
+                                            "The source would use pulsar client's internal mechanism and commit cursor in two ways.")
+                                    .list(
+                                            text(
+                                                    "For Key_Shared and Shared subscription: the cursor would be committed once the message is consumed."),
+                                            text(
+                                                    "For Exclusive and Failover subscription: the cursor would be committed in a fixed interval."))
+                                    .build());
+
+    public static final ConfigOption<Long> PULSAR_AUTO_COMMIT_CURSOR_INTERVAL =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "autoCommitCursorInterval")
+                    .longType()
+                    .defaultValue(Duration.ofSeconds(5).toMillis())
+                    .withDescription(
+                            "This option is used only when user disabled checkpoint"
+                                    + " and using Exclusive or Failover subscription");
+
+    public static final ConfigOption<Long> PULSAR_TRANSACTION_TIMEOUT_MILLIS =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "transactionTimeoutMillis")
+                    .longType()
+                    .defaultValue(Duration.ofHours(3).toMillis())
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "This option is used for when using Shared or Key_Shared subscription."
+                                                    + " You should set this option when you didn't enable the %s option.",
+                                            code("pulsar.source.enableAutoAcknowledgeMessage"))
+                                    .linebreak()
+                                    .text(
+                                            "This value should be greater than the checkpoint interval.")
+                                    .build());
+
+    public static final ConfigOption<Long> PULSAR_MAX_FETCH_TIME =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "maxFetchTime")
+                    .longType()
+                    .defaultValue(Duration.ofSeconds(10).toMillis())
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The max time to wait when fetching records. "
+                                                    + "A longer time increases throughput but also latency. "
+                                                    + "A fetch batch might be finished earlier because of %s.",
+                                            code("pulsar.source.maxFetchRecords"))
+                                    .build());
+
+    public static final ConfigOption<Integer> PULSAR_MAX_FETCH_RECORDS =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "maxFetchRecords")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The max number of records to fetch to wait when polling. "
+                                                    + "A longer time increases throughput but also latency."
+                                                    + "A fetch batch might be finished earlier because of %s.",
+                                            code("pulsar.source.maxFetchTime"))
+                                    .build());
+
+    public static final ConfigOption<CursorVerification> PULSAR_VERIFY_INITIAL_OFFSETS =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "verifyInitialOffsets")
+                    .enumType(CursorVerification.class)
+                    .defaultValue(CursorVerification.WARN_ON_MISMATCH)
+                    .withDescription(
+                            "Upon (re)starting the source checks whether the expected message can be read. "
+                                    + "If failure is enabled the application fails, else it logs a warning. "
+                                    + "A possible solution is to adjust the retention settings in pulsar or ignoring the check result.");
+
+    ///////////////////////////////////////////////////////////////////////////////
+    //
+    // The configuration for ConsumerConfigurationData part.
+    // All the configuration listed below should have the pulsar.consumer prefix.
+    //
+    ///////////////////////////////////////////////////////////////////////////////
+
+    public static final ConfigOption<String> PULSAR_TOPIC_NAMES =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "topicNames")
+                    .stringType()
+                    .defaultValue("[]")
+                    .withDescription("Topic name.");
+
+    public static final ConfigOption<String> PULSAR_TOPICS_PATTERN =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "topicsPattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Topic pattern.");
+
+    public static final ConfigOption<String> PULSAR_SUBSCRIPTION_NAME =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "subscriptionName")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Subscription name.");
+
+    public static final ConfigOption<SubscriptionType> PULSAR_SUBSCRIPTION_TYPE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "subscriptionType")
+                    .enumType(SubscriptionType.class)
+                    .defaultValue(SubscriptionType.Shared)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Subscription type.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text("Four subscription types are available:")
+                                    .list(
+                                            text("Exclusive"),
+                                            text("Failover"),
+                                            text("Shared"),
+                                            text("Key_Shared"))
+                                    .build());
+
+    public static final ConfigOption<SubscriptionMode> PULSAR_SUBSCRIPTION_MODE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "subscriptionMode")
+                    .enumType(SubscriptionMode.class)
+                    .defaultValue(SubscriptionMode.Durable);
+
+    public static final ConfigOption<Integer> PULSAR_RECEIVER_QUEUE_SIZE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "receiverQueueSize")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Size of a consumer's receiver queue.")
+                                    .linebreak()
+                                    .text(
+                                            "For example, the number of messages accumulated by a consumer before an application calls %s.",
+                                            code("Receive"))
+                                    .linebreak()
+                                    .text(
+                                            "A value higher than the default value increases consumer throughput, though at the expense of more memory utilization.")
+                                    .build());
+
+    public static final ConfigOption<Long> PULSAR_ACKNOWLEDGEMENTS_GROUP_TIME_MICROS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "acknowledgementsGroupTimeMicros")
+                    .longType()
+                    .defaultValue(TimeUnit.MILLISECONDS.toMicros(100))
+                    .withDescription(
+                            Description.builder()
+                                    .text("Group a consumer acknowledgment for a specified time.")
+                                    .linebreak()
+                                    .text(
+                                            "By default, a consumer uses 100ms grouping time to send out acknowledgments to a broker.")
+                                    .linebreak()
+                                    .text(
+                                            "Setting a group time of 0 sends out acknowledgments immediately.")
+                                    .linebreak()
+                                    .text(
+                                            "A longer ack group time is more efficient at the expense of a slight increase in message re-deliveries after a failure.")
+                                    .build());
+
+    public static final ConfigOption<Long> PULSAR_NEGATIVE_ACK_REDELIVERY_DELAY_MICROS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "negativeAckRedeliveryDelayMicros")
+                    .longType()
+                    .defaultValue(TimeUnit.MINUTES.toMicros(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Delay to wait before redelivering messages that failed to be processed.")
+                                    .linebreak()
+                                    .text(
+                                            "When an application uses %s, failed messages are redelivered after a fixed timeout.",
+                                            code("Consumer#negativeAcknowledge(Message)"))
+                                    .build());
+
+    public static final ConfigOption<Integer>
+            PULSAR_MAX_TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS =
+                    ConfigOptions.key(
+                                    CONSUMER_CONFIG_PREFIX
+                                            + "maxTotalReceiverQueueSizeAcrossPartitions")
+                            .intType()
+                            .defaultValue(50000)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "The max total receiver queue size across partitions.")
+                                            .linebreak()
+                                            .text(
+                                                    "This setting reduces the receiver queue size for individual partitions if the total receiver queue size exceeds this value.")
+                                            .build());
+
+    public static final ConfigOption<String> PULSAR_CONSUMER_NAME =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "consumerName")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Consumer name.");
+
+    public static final ConfigOption<Long> PULSAR_ACK_TIMEOUT_MILLIS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "ackTimeoutMillis")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription("Timeout of unacknowledged messages.");
+
+    public static final ConfigOption<Long> PULSAR_TICK_DURATION_MILLIS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "tickDurationMillis")
+                    .longType()
+                    .defaultValue(1000L)
+                    .withDescription(
+                            Description.builder()
+                                    .text("Granularity of the ack-timeout redelivery.")
+                                    .linebreak()
+                                    .text(
+                                            "Using an higher %s reduces the memory overhead to track messages when setting ack-timeout to a bigger value (for example, 1 hour).",
+                                            code("tickDurationMillis"))
+                                    .build());
+
+    public static final ConfigOption<Integer> PULSAR_PRIORITY_LEVEL =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "priorityLevel")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Priority level for a consumer to which a broker gives more priority while dispatching messages in the shared subscription mode.")
+                                    .linebreak()
+                                    .text(
+                                            "The broker follows descending priorities. For example, 0=max-priority, 1, 2,...")
+                                    .linebreak()
+                                    .text(
+                                            "In shared subscription mode, the broker first dispatches messages to the max priority level consumers if they have permits. Otherwise, the broker considers next priority level consumers.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text("Example 1")
+                                    .linebreak()
+                                    .text(
+                                            "If a subscription has consumerA with %s 0 and consumerB with %s 1, then the broker only dispatches messages to consumerA until it runs out permits and then starts dispatching messages to consumerB.",
+                                            code("priorityLevel"), code("priorityLevel"))
+                                    .linebreak()
+                                    .text("Example 2")
+                                    .linebreak()
+                                    .text(
+                                            "Consumer Priority, Level, Permits\n"
+                                                    + "C1, 0, 2\n"
+                                                    + "C2, 0, 1\n"
+                                                    + "C3, 0, 1\n"
+                                                    + "C4, 1, 2\n"
+                                                    + "C5, 1, 1\n")
+                                    .linebreak()
+                                    .text(
+                                            "Order in which a broker dispatches messages to consumers is: C1, C2, C3, C1, C4, C5, C4.")
+                                    .build());
+
+    public static final ConfigOption<Integer> PULSAR_MAX_PENDING_CHUNKED_MESSAGE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "maxPendingChunkedMessage")
+                    .intType()
+                    .defaultValue(10);
+
+    public static final ConfigOption<Boolean> PULSAR_AUTO_ACK_OLDEST_CHUNKED_MESSAGE_ON_QUEUE_FULL =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "autoAckOldestChunkedMessageOnQueueFull")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<Long> PULSAR_EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE_MILLIS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "expireTimeOfIncompleteChunkedMessageMillis")
+                    .longType()
+                    .defaultValue(60 * 1000L);
+
+    public static final ConfigOption<ConsumerCryptoFailureAction> PULSAR_CRYPTO_FAILURE_ACTION =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "cryptoFailureAction")
+                    .enumType(ConsumerCryptoFailureAction.class)
+                    .defaultValue(ConsumerCryptoFailureAction.FAIL)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Consumer should take action when it receives a message that can not be decrypted.")
+                                    .list(
+                                            text(
+                                                    "FAIL: this is the default option to fail messages until crypto succeeds."),
+                                            text(
+                                                    "DISCARD: silently acknowledge and not deliver message to an application."),
+                                            text(
+                                                    "CONSUME: deliver encrypted messages to applications. It is the application's responsibility to decrypt the message."))
+                                    .linebreak()
+                                    .text("The decompression of message fails.")
+                                    .linebreak()
+                                    .text(
+                                            "If messages contain batch messages, a client is not be able to retrieve individual messages in batch.")
+                                    .linebreak()
+                                    .text(
+                                            "Delivered encrypted message contains %s which contains encryption and compression information in it using which application can decrypt consumed message payload.",
+                                            code("EncryptionContext"))
+                                    .build());
+
+    public static final ConfigOption<String> PULSAR_CONSUMER_PROPERTIES =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "properties")
+                    .stringType()
+                    .defaultValue("{}")
+                    .withDescription(
+                            Description.builder()
+                                    .text("A name or value property of this consumer.")
+                                    .linebreak()
+                                    .text(
+                                            "%s is application defined metadata attached to a consumer.",
+                                            code("properties"))
+                                    .linebreak()
+                                    .text(
+                                            "When getting a topic stats, associate this metadata with the consumer stats for easier identification.")
+                                    .build());
+
+    public static final ConfigOption<Boolean> PULSAR_READ_COMPACTED =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "readCompacted") // NOSONAR
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If enabling %s, a consumer reads messages from a compacted topic rather than reading a full message backlog of a topic.",
+                                            code("readCompacted"))
+                                    .linebreak()
+                                    .text(
+                                            "A consumer only sees the latest value for each key in the compacted topic, up until reaching the point in the topic message when compacting backlog. Beyond that point, send messages as normal.")
+                                    .linebreak()
+                                    .text(
+                                            "Only enabling %s on subscriptions to persistent topics, which have a single active consumer (like failure or exclusive subscriptions).",
+                                            code("readCompacted"))
+                                    .linebreak()
+                                    .text(
+                                            "Attempting to enable it on subscriptions to non-persistent topics or on shared subscriptions leads to a subscription call throwing a %s.",
+                                            code("PulsarClientException"))
+                                    .build());
+
+    public static final ConfigOption<SubscriptionInitialPosition>
+            PULSAR_SUBSCRIPTION_INITIAL_POSITION =
+                    ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "subscriptionInitialPosition")
+                            .enumType(SubscriptionInitialPosition.class)
+                            .defaultValue(SubscriptionInitialPosition.Latest)
+                            .withDescription(
+                                    "Initial position at which to set cursor when subscribing to a topic at first time.");
+
+    public static final ConfigOption<Integer> PULSAR_PATTERN_AUTO_DISCOVERY_PERIOD =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "patternAutoDiscoveryPeriod")
+                    .intType()
+                    .defaultValue(60)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Topic auto discovery period when using a pattern for topic's consumer.")
+                                    .linebreak()
+                                    .text("The default and minimum value is 1 minute.")
+                                    .build());
+
+    public static final ConfigOption<RegexSubscriptionMode> PULSAR_REGEX_SUBSCRIPTION_MODE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "regexSubscriptionMode")
+                    .enumType(RegexSubscriptionMode.class)
+                    .defaultValue(RegexSubscriptionMode.PersistentOnly)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "When subscribing to a topic using a regular expression, you can pick a certain type of topics.")
+                                    .list(
+                                            text(
+                                                    "PersistentOnly: only subscribe to persistent topics."),
+                                            text(
+                                                    "NonPersistentOnly: only subscribe to non-persistent topics."),
+                                            text(
+                                                    "AllTopics: subscribe to both persistent and non-persistent topics."))
+                                    .build());
+
+    // The config set for DeadLetterPolicy
+
+    /**
+     * Dead letter policy for consumers.
+     *
+     * <p>By default, some messages are probably redelivered many times, even to the extent that it
+     * never stops.
+     *
+     * <p>By using the dead letter mechanism, messages have the max redelivery count. When exceeding
+     * the maximum number of redeliveries, messages are sent to the Dead Letter Topic and
+     * acknowledged automatically.
+     *
+     * <p>You can enable the dead letter mechanism by setting deadLetterPolicy.
+     *
+     * <p>Example <code>pulsar.consumer.deadLetterPolicy.maxRedeliverCount = 10</code> Default dead
+     * letter topic name is <strong>{TopicName}-{Subscription}-DLQ</strong>.
+     *
+     * <p>To set a custom dead letter topic name:
+     *
+     * <pre><code>
+     * pulsar.consumer.deadLetterPolicy.maxRedeliverCount = 10
+     * pulsar.consumer.deadLetterPolicy.deadLetterTopic = your-topic-name
+     * </code></pre>
+     *
+     * <p>When specifying the dead letter policy while not specifying ackTimeoutMillis, you can set
+     * the ack timeout to 30000 millisecond.
+     */
+    public static final ConfigOption<Integer> PULSAR_MAX_REDELIVER_COUNT =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "deadLetterPolicy.maxRedeliverCount")
+                    .intType()
+                    .defaultValue(0);
+
+    public static final ConfigOption<String> PULSAR_RETRY_LETTER_TOPIC =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "deadLetterPolicy.retryLetterTopic")
+                    .stringType()
+                    .noDefaultValue();
+    public static final ConfigOption<String> PULSAR_DEAD_LETTER_TOPIC =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "deadLetterPolicy.deadLetterTopic")
+                    .stringType()
+                    .noDefaultValue();
+
+    public static final ConfigOption<Boolean> PULSAR_RETRY_ENABLE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "retryEnable")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<Boolean> PULSAR_AUTO_UPDATE_PARTITIONS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "autoUpdatePartitions")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If %s is enabled, a consumer subscribes to partition increase automatically.",
+                                            code("autoUpdatePartitions"))
+                                    .linebreak()
+                                    .text("Note: this is only for partitioned consumers.\t")
+                                    .build());
+
+    public static final ConfigOption<Long> PULSAR_AUTO_UPDATE_PARTITIONS_INTERVAL_SECONDS =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "autoUpdatePartitionsIntervalSeconds")
+                    .longType()
+                    .defaultValue(60L);
+
+    public static final ConfigOption<Boolean> PULSAR_REPLICATE_SUBSCRIPTION_STATE =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "replicateSubscriptionState")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "If %s is enabled, a subscription state is replicated to geo-replicated clusters.",
+                                            code("replicateSubscriptionState"))
+                                    .build());
+
+    public static final ConfigOption<Boolean> PULSAR_RESET_INCLUDE_HEAD =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "resetIncludeHead")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<Boolean> PULSAR_BATCH_INDEX_ACK_ENABLED =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "batchIndexAckEnabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<Boolean> PULSAR_ACK_RECEIPT_ENABLED =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "ackReceiptEnabled")
+                    .booleanType()
+                    .defaultValue(false);
+
+    public static final ConfigOption<Boolean> PULSAR_POOL_MESSAGES =
+            ConfigOptions.key(CONSUMER_CONFIG_PREFIX + "poolMessages")
+                    .booleanType()
+                    .defaultValue(false);
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/CursorVerification.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/CursorVerification.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/** The enum class for defining the cursor verify behavior. */
+@PublicEvolving
+public enum CursorVerification {
+
+    /** We would just fail the consuming. */
+    FAIL_ON_MISMATCH,
+
+    /** Print a warn message and start consuming from the valid offset. */
+    WARN_ON_MISMATCH,
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/PulsarSourceConfigUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/PulsarSourceConfigUtils.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.config;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.common.utils.PulsarJsonUtils;
+import org.apache.flink.connector.pulsar.source.PulsarSourceOptions;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.connector.pulsar.common.config.PulsarConfigUtils.getOptionValue;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAMS;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_AUTH_PARAM_MAP;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarJsonUtils.configMap;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ACKNOWLEDGEMENTS_GROUP_TIME_MICROS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ACK_RECEIPT_ENABLED;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ACK_TIMEOUT_MILLIS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_AUTO_ACK_OLDEST_CHUNKED_MESSAGE_ON_QUEUE_FULL;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_AUTO_UPDATE_PARTITIONS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_AUTO_UPDATE_PARTITIONS_INTERVAL_SECONDS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_BATCH_INDEX_ACK_ENABLED;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_CONSUMER_NAME;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_CONSUMER_PROPERTIES;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_CRYPTO_FAILURE_ACTION;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_DEAD_LETTER_TOPIC;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE_MILLIS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_PENDING_CHUNKED_MESSAGE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_REDELIVER_COUNT;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_NEGATIVE_ACK_REDELIVERY_DELAY_MICROS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PATTERN_AUTO_DISCOVERY_PERIOD;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_POOL_MESSAGES;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PRIORITY_LEVEL;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_READ_COMPACTED;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_RECEIVER_QUEUE_SIZE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_REGEX_SUBSCRIPTION_MODE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_REPLICATE_SUBSCRIPTION_STATE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_RESET_INCLUDE_HEAD;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_RETRY_ENABLE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_RETRY_LETTER_TOPIC;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_INITIAL_POSITION;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_MODE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_TYPE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TICK_DURATION_MILLIS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TOPICS_PATTERN;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TOPIC_NAMES;
+
+/** Create source related {@link Consumer} and validate config. */
+@Internal
+public final class PulsarSourceConfigUtils {
+
+    private PulsarSourceConfigUtils() {
+        // No need to create instance.
+    }
+
+    private static final List<Set<ConfigOption<?>>> CONFLICT_SOURCE_OPTIONS =
+            ImmutableList.<Set<ConfigOption<?>>>builder()
+                    .add(ImmutableSet.of(PULSAR_AUTH_PARAMS, PULSAR_AUTH_PARAM_MAP))
+                    .add(ImmutableSet.of(PULSAR_TOPIC_NAMES, PULSAR_TOPICS_PATTERN))
+                    .build();
+
+    private static final Set<ConfigOption<?>> REQUIRED_SOURCE_OPTIONS =
+            ImmutableSet.<ConfigOption<?>>builder()
+                    .add(PULSAR_SERVICE_URL)
+                    .add(PULSAR_ADMIN_URL)
+                    .add(PULSAR_SUBSCRIPTION_NAME)
+                    .build();
+
+    /**
+     * Helper method for checking client related config options. We would validate:
+     *
+     * <ul>
+     *   <li>If user have provided the required client config options.
+     *   <li>If user have provided some conflict options.
+     * </ul>
+     */
+    public static void checkConfigurations(Configuration configuration) {
+        REQUIRED_SOURCE_OPTIONS.forEach(
+                option ->
+                        Preconditions.checkArgument(
+                                configuration.contains(option),
+                                "Config option %s is not provided for pulsar source.",
+                                option));
+
+        CONFLICT_SOURCE_OPTIONS.forEach(
+                options -> {
+                    long nums = options.stream().filter(configuration::contains).count();
+                    Preconditions.checkArgument(
+                            nums <= 1,
+                            "Conflict config options %s were provided, we only support one of them for creating pulsar source.",
+                            options);
+                });
+    }
+
+    /**
+     * Create a {@link ConsumerConfigurationData} by using the given {@link Configuration}. Add the
+     * configuration was listed in {@link PulsarSourceOptions}, and we would parse it one by one.
+     *
+     * @param configuration The flink configuration
+     * @param <T> The type of the pulsar message, this type is ignored.
+     */
+    public static <T> ConsumerConfigurationData<T> createConsumerConfig(
+            Configuration configuration,
+            @Nullable ConfigurationDataCustomizer<ConsumerConfigurationData<T>> customizer) {
+        ConsumerConfigurationData<T> data = new ConsumerConfigurationData<>();
+
+        // Set the properties one by one.
+        data.setTopicNames(
+                getOptionValue(
+                        configuration,
+                        PULSAR_TOPIC_NAMES,
+                        v -> PulsarJsonUtils.toSet(String.class, v)));
+        data.setTopicsPattern(
+                getOptionValue(configuration, PULSAR_TOPICS_PATTERN, Pattern::compile));
+        data.setSubscriptionName(configuration.get(PULSAR_SUBSCRIPTION_NAME));
+        data.setSubscriptionType(configuration.get(PULSAR_SUBSCRIPTION_TYPE));
+
+        data.setSubscriptionMode(configuration.get(PULSAR_SUBSCRIPTION_MODE));
+        data.setReceiverQueueSize(configuration.get(PULSAR_RECEIVER_QUEUE_SIZE));
+        data.setAcknowledgementsGroupTimeMicros(
+                configuration.get(PULSAR_ACKNOWLEDGEMENTS_GROUP_TIME_MICROS));
+        data.setNegativeAckRedeliveryDelayMicros(
+                configuration.get(PULSAR_NEGATIVE_ACK_REDELIVERY_DELAY_MICROS));
+        data.setMaxTotalReceiverQueueSizeAcrossPartitions(
+                configuration.get(PULSAR_MAX_TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS));
+        data.setConsumerName(configuration.get(PULSAR_CONSUMER_NAME));
+        data.setAckTimeoutMillis(configuration.get(PULSAR_ACK_TIMEOUT_MILLIS));
+        data.setTickDurationMillis(configuration.get(PULSAR_TICK_DURATION_MILLIS));
+        data.setPriorityLevel(configuration.get(PULSAR_PRIORITY_LEVEL));
+
+        // This method is deprecated in 2.8.0, we use this method for backward compatible.
+        data.setMaxPendingChunkedMessage(configuration.get(PULSAR_MAX_PENDING_CHUNKED_MESSAGE));
+        data.setAutoAckOldestChunkedMessageOnQueueFull(
+                configuration.get(PULSAR_AUTO_ACK_OLDEST_CHUNKED_MESSAGE_ON_QUEUE_FULL));
+        data.setExpireTimeOfIncompleteChunkedMessageMillis(
+                configuration.get(PULSAR_EXPIRE_TIME_OF_INCOMPLETE_CHUNKED_MESSAGE_MILLIS));
+        data.setCryptoFailureAction(configuration.get(PULSAR_CRYPTO_FAILURE_ACTION));
+        data.setProperties(
+                getOptionValue(
+                        configuration,
+                        PULSAR_CONSUMER_PROPERTIES,
+                        v ->
+                                (SortedMap<String, String>)
+                                        PulsarJsonUtils.toMap(
+                                                TreeMap.class, String.class, String.class, v)));
+        data.setReadCompacted(configuration.get(PULSAR_READ_COMPACTED));
+        data.setSubscriptionInitialPosition(
+                configuration.get(PULSAR_SUBSCRIPTION_INITIAL_POSITION));
+        data.setPatternAutoDiscoveryPeriod(configuration.get(PULSAR_PATTERN_AUTO_DISCOVERY_PERIOD));
+        data.setRegexSubscriptionMode(configuration.get(PULSAR_REGEX_SUBSCRIPTION_MODE));
+
+        // Set dead letter policy
+        if (configuration.contains(PULSAR_MAX_REDELIVER_COUNT)
+                || configuration.contains(PULSAR_RETRY_LETTER_TOPIC)
+                || configuration.contains(PULSAR_DEAD_LETTER_TOPIC)) {
+            DeadLetterPolicy deadLetterPolicy =
+                    DeadLetterPolicy.builder()
+                            .maxRedeliverCount(configuration.get(PULSAR_MAX_REDELIVER_COUNT))
+                            .retryLetterTopic(configuration.get(PULSAR_RETRY_LETTER_TOPIC))
+                            .deadLetterTopic(configuration.get(PULSAR_DEAD_LETTER_TOPIC))
+                            .build();
+            data.setDeadLetterPolicy(deadLetterPolicy);
+        }
+
+        data.setRetryEnable(configuration.get(PULSAR_RETRY_ENABLE));
+        data.setAutoUpdatePartitions(configuration.get(PULSAR_AUTO_UPDATE_PARTITIONS));
+        data.setAutoUpdatePartitionsIntervalSeconds(
+                configuration.get(PULSAR_AUTO_UPDATE_PARTITIONS_INTERVAL_SECONDS));
+        data.setReplicateSubscriptionState(configuration.get(PULSAR_REPLICATE_SUBSCRIPTION_STATE));
+        data.setResetIncludeHead(configuration.get(PULSAR_RESET_INCLUDE_HEAD));
+        data.setBatchIndexAckEnabled(configuration.get(PULSAR_BATCH_INDEX_ACK_ENABLED));
+        data.setAckReceiptEnabled(configuration.get(PULSAR_ACK_RECEIPT_ENABLED));
+        data.setPoolMessages(configuration.get(PULSAR_POOL_MESSAGES));
+
+        if (customizer != null) {
+            customizer.customize(data);
+        }
+
+        return data;
+    }
+
+    /** Create a Pulsar Consumer by using the flink Configuration and the config customizer. */
+    public static <T> Consumer<T> createConsumer(
+            PulsarClient client,
+            Schema<T> schema,
+            Configuration configuration,
+            ConfigurationDataCustomizer<ConsumerConfigurationData<T>> customizer)
+            throws PulsarClientException {
+        return createConsumer(client, schema, createConsumerConfig(configuration, customizer));
+    }
+
+    /** Create a pulsar consumer by using the given ConsumerConfigurationData and PulsarClient. */
+    public static <T> Consumer<T> createConsumer(
+            PulsarClient client, Schema<T> schema, ConsumerConfigurationData<T> config)
+            throws PulsarClientException {
+        // ConsumerBuilder don't support using the given ConsumerConfigurationData directly.
+        ConsumerBuilder<T> consumerBuilder = client.newConsumer(schema).loadConf(configMap(config));
+
+        // Set some non-serializable fields.
+        if (config.getMessageListener() != null) {
+            consumerBuilder.messageListener(config.getMessageListener());
+        }
+        if (config.getConsumerEventListener() != null) {
+            consumerBuilder.consumerEventListener(config.getConsumerEventListener());
+        }
+        if (config.getCryptoKeyReader() != null) {
+            consumerBuilder.cryptoKeyReader(config.getCryptoKeyReader());
+        }
+        if (config.getMessageCrypto() != null) {
+            consumerBuilder.messageCrypto(config.getMessageCrypto());
+        }
+        if (config.getBatchReceivePolicy() != null) {
+            consumerBuilder.batchReceivePolicy(config.getBatchReceivePolicy());
+        }
+
+        return consumerBuilder.subscribe();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.SubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+import static org.apache.flink.connector.pulsar.common.config.PulsarConfigUtils.getOptionValue;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_AUTO_COMMIT_CURSOR_INTERVAL;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_MODE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_TYPE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TRANSACTION_TIMEOUT_MILLIS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_VERIFY_INITIAL_OFFSETS;
+
+/** The configure class for pulsar source. */
+@PublicEvolving
+public class SourceConfiguration implements Serializable {
+    private static final long serialVersionUID = 8488507275800787580L;
+
+    /** The interval in millis for flink querying topic partition information. */
+    private final long partitionDiscoveryIntervalMs;
+
+    /**
+     * This is used for all subscription type. But the behavior may not be the same among them. If
+     * you don't enable the flink checkpoint, make sure this option is set to true.
+     *
+     * <ul>
+     *   <li>{@link SubscriptionType#Shared} and {@link SubscriptionType#Key_Shared} would
+     *       immediately acknowledge the message after consuming it.
+     *   <li>{@link SubscriptionType#Failover} and {@link SubscriptionType#Exclusive} would perform
+     *       a incremental acknowledge in a fixed {@link #autoCommitCursorInterval}.
+     * </ul>
+     */
+    private final boolean enableAutoAcknowledgeMessage;
+
+    /**
+     * The interval in millis for acknowledge message when you enable {@link
+     * #enableAutoAcknowledgeMessage} and use {@link SubscriptionType#Failover} or {@link
+     * SubscriptionType#Exclusive} as your consuming subscription type.
+     */
+    private final long autoCommitCursorInterval;
+
+    /**
+     * Pulsar's transaction have a timeout mechanism for uncommitted transaction. We use transaction
+     * for {@link SubscriptionType#Shared} and {@link SubscriptionType#Key_Shared} when user disable
+     * {@link #enableAutoAcknowledgeMessage} and enable flink checkpoint. Since the checkpoint
+     * interval couldn't be acquired from {@link SourceReaderContext#getConfiguration()}, we have to
+     * expose this option. Make sure this value is greater than the checkpoint interval.
+     */
+    private final long transactionTimeoutMillis;
+
+    /**
+     * The fetch time for flink split reader polling message. We would stop polling message and
+     * return the message in {@link RecordsWithSplitIds} when timeout or exceed the {@link
+     * #maxFetchRecords}.
+     */
+    private final Duration maxFetchTime;
+
+    /**
+     * The fetch counts for a split reader. We would stop polling message and return the message in
+     * {@link RecordsWithSplitIds} when timeout {@link #maxFetchTime} or exceed this value.
+     */
+    private final int maxFetchRecords;
+
+    /** Validate the {@link CursorPosition} generated by {@link StartCursor}. */
+    private final CursorVerification verifyInitialOffsets;
+
+    /**
+     * The pulsar's subscription name for this flink source. All the readers would share this
+     * subscription name.
+     *
+     * @see ConsumerBuilder#subscriptionName
+     */
+    private final String subscriptionName;
+
+    /**
+     * The pulsar's subscription type for this flink source. All the readers would share this
+     * subscription type.
+     *
+     * @see SubscriptionType
+     */
+    private final SubscriptionType subscriptionType;
+
+    /**
+     * The pulsar's subscription mode for this flink source. All the readers would share this
+     * subscription mode.
+     *
+     * @see SubscriptionMode
+     */
+    private final SubscriptionMode subscriptionMode;
+
+    public SourceConfiguration(Configuration configuration) {
+        this.partitionDiscoveryIntervalMs =
+                configuration.get(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS);
+        this.enableAutoAcknowledgeMessage =
+                configuration.get(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE);
+        this.autoCommitCursorInterval = configuration.get(PULSAR_AUTO_COMMIT_CURSOR_INTERVAL);
+        this.transactionTimeoutMillis = configuration.get(PULSAR_TRANSACTION_TIMEOUT_MILLIS);
+        this.maxFetchTime =
+                getOptionValue(configuration, PULSAR_MAX_FETCH_TIME, Duration::ofMillis);
+        this.maxFetchRecords = configuration.get(PULSAR_MAX_FETCH_RECORDS);
+        this.verifyInitialOffsets = configuration.get(PULSAR_VERIFY_INITIAL_OFFSETS);
+        this.subscriptionName = configuration.get(PULSAR_SUBSCRIPTION_NAME);
+        this.subscriptionType = configuration.get(PULSAR_SUBSCRIPTION_TYPE);
+        this.subscriptionMode = configuration.get(PULSAR_SUBSCRIPTION_MODE);
+    }
+
+    public boolean enablePartitionDiscovery() {
+        return partitionDiscoveryIntervalMs > 0;
+    }
+
+    public long getPartitionDiscoveryIntervalMs() {
+        return partitionDiscoveryIntervalMs;
+    }
+
+    public boolean isEnableAutoAcknowledgeMessage() {
+        return enableAutoAcknowledgeMessage;
+    }
+
+    public long getAutoCommitCursorInterval() {
+        return autoCommitCursorInterval;
+    }
+
+    public long getTransactionTimeoutMillis() {
+        return transactionTimeoutMillis;
+    }
+
+    public Duration getMaxFetchTime() {
+        return maxFetchTime;
+    }
+
+    public int getMaxFetchRecords() {
+        return maxFetchRecords;
+    }
+
+    public CursorVerification getVerifyInitialOffsets() {
+        return verifyInitialOffsets;
+    }
+
+    public String getSubscriptionName() {
+        return subscriptionName;
+    }
+
+    public SubscriptionType getSubscriptionType() {
+        return subscriptionType;
+    }
+
+    public SubscriptionMode getSubscriptionMode() {
+        return subscriptionMode;
+    }
+
+    /** Convert the subscription into a readable str. */
+    public String getSubscriptionDesc() {
+        return getSubscriptionName()
+                + "("
+                + getSubscriptionType()
+                + ","
+                + getSubscriptionMode()
+                + ")";
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumState.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumState.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The state class for pulsar source enumerator, used for storing the split state. This class is
+ * managed and controlled by {@link SplitsAssignmentState}.
+ */
+public class PulsarSourceEnumState {
+
+    /** The topic partitions that have been appended to this source. */
+    private final Set<TopicPartition> appendedPartitions;
+
+    /**
+     * We convert the topic partition into a split and add to this pending list for assigning to a
+     * reader. It is used for Key_Shared, Failover, Exclusive subscription.
+     */
+    private final Set<PulsarPartitionSplit> pendingPartitionSplits;
+
+    /**
+     * It is used for Shared subscription. When a reader is crashed in Shared subscription, its
+     * splits would be put in here.
+     */
+    private final Map<Integer, Set<PulsarPartitionSplit>> sharedPendingPartitionSplits;
+
+    /**
+     * A {@link PulsarPartitionSplit} should be assigned for all flink readers. Using this map for
+     * recording assign status.
+     */
+    private final Map<Integer, Set<String>> readerAssignedSplits;
+
+    private final boolean initialized;
+
+    public PulsarSourceEnumState(
+            Set<TopicPartition> appendedPartitions,
+            Set<PulsarPartitionSplit> pendingPartitionSplits,
+            Map<Integer, Set<PulsarPartitionSplit>> pendingSharedPartitionSplits,
+            Map<Integer, Set<String>> readerAssignedSplits,
+            boolean initialized) {
+        this.appendedPartitions = appendedPartitions;
+        this.pendingPartitionSplits = pendingPartitionSplits;
+        this.sharedPendingPartitionSplits = pendingSharedPartitionSplits;
+        this.readerAssignedSplits = readerAssignedSplits;
+        this.initialized = initialized;
+    }
+
+    public Set<TopicPartition> getAppendedPartitions() {
+        return appendedPartitions;
+    }
+
+    public Set<PulsarPartitionSplit> getPendingPartitionSplits() {
+        return pendingPartitionSplits;
+    }
+
+    public Map<Integer, Set<PulsarPartitionSplit>> getSharedPendingPartitionSplits() {
+        return sharedPendingPartitionSplits;
+    }
+
+    public Map<Integer, Set<String>> getReaderAssignedSplits() {
+        return readerAssignedSplits;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumStateSerializer.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumStateSerializer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarSerdeUtils.deserializeMap;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarSerdeUtils.deserializeSet;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarSerdeUtils.serializeMap;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarSerdeUtils.serializeSet;
+
+/** The {@link SimpleVersionedSerializer Serializer} for the enumerator state of Pulsar source. */
+public class PulsarSourceEnumStateSerializer
+        implements SimpleVersionedSerializer<PulsarSourceEnumState> {
+
+    public static final PulsarSourceEnumStateSerializer INSTANCE =
+            new PulsarSourceEnumStateSerializer();
+
+    private static final PulsarPartitionSplitSerializer SPLIT_SERIALIZER =
+            PulsarPartitionSplitSerializer.INSTANCE;
+
+    private PulsarSourceEnumStateSerializer() {
+        // Singleton instance.
+    }
+
+    @Override
+    public int getVersion() {
+        // We use PulsarPartitionSplitSerializer's version because we use reuse this class.
+        return PulsarPartitionSplitSerializer.CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(PulsarSourceEnumState obj) throws IOException {
+        // VERSION 0 serialization
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            serializeSet(
+                    out, obj.getAppendedPartitions(), SPLIT_SERIALIZER::serializeTopicPartition);
+            serializeSet(
+                    out,
+                    obj.getPendingPartitionSplits(),
+                    SPLIT_SERIALIZER::serializePulsarPartitionSplit);
+            serializeMap(
+                    out,
+                    obj.getSharedPendingPartitionSplits(),
+                    DataOutputStream::writeInt,
+                    (o, v) -> serializeSet(o, v, SPLIT_SERIALIZER::serializePulsarPartitionSplit));
+            serializeMap(
+                    out,
+                    obj.getReaderAssignedSplits(),
+                    DataOutputStream::writeInt,
+                    (o, v) -> serializeSet(o, v, DataOutputStream::writeUTF));
+            out.writeBoolean(obj.isInitialized());
+
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public PulsarSourceEnumState deserialize(int version, byte[] serialized) throws IOException {
+        // VERSION 0 deserialization
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            Set<TopicPartition> partitions = deserializeSet(in, deserializePartition(version));
+            Set<PulsarPartitionSplit> splits = deserializeSet(in, deserializeSplit(version));
+            Map<Integer, Set<PulsarPartitionSplit>> sharedSplits =
+                    deserializeMap(
+                            in,
+                            DataInput::readInt,
+                            i -> deserializeSet(i, deserializeSplit(version)));
+            Map<Integer, Set<String>> mapping =
+                    deserializeMap(
+                            in, DataInput::readInt, i -> deserializeSet(i, DataInput::readUTF));
+            boolean initialized = in.readBoolean();
+
+            return new PulsarSourceEnumState(
+                    partitions, splits, sharedSplits, mapping, initialized);
+        }
+    }
+
+    // ----------------- private methods -------------------
+
+    private FunctionWithException<DataInputStream, TopicPartition, IOException>
+            deserializePartition(int version) {
+        return in -> SPLIT_SERIALIZER.deserializeTopicPartition(version, in);
+    }
+
+    private FunctionWithException<DataInputStream, PulsarPartitionSplit, IOException>
+            deserializeSplit(int version) {
+        return in -> SPLIT_SERIALIZER.deserializePulsarPartitionSplit(version, in);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.connector.pulsar.common.config.PulsarConfigUtils.createAdmin;
+
+/** The enumerator class for pulsar source. */
+@Internal
+public class PulsarSourceEnumerator
+        implements SplitEnumerator<PulsarPartitionSplit, PulsarSourceEnumState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarSourceEnumerator.class);
+
+    /** The admin interface for pulsar. */
+    private final PulsarAdmin pulsarAdmin;
+
+    private final PulsarSubscriber subscriber;
+    private final RangeGenerator rangeGenerator;
+    private final Configuration configuration;
+    private final SourceConfiguration sourceConfiguration;
+    private final SplitEnumeratorContext<PulsarPartitionSplit> context;
+    private final SplitsAssignmentState assignmentState;
+
+    public PulsarSourceEnumerator(
+            PulsarSubscriber subscriber,
+            RangeGenerator rangeGenerator,
+            Configuration configuration,
+            SourceConfiguration sourceConfiguration,
+            ConfigurationDataCustomizer<ClientConfigurationData> clientConfigurationCustomizer,
+            SplitEnumeratorContext<PulsarPartitionSplit> context,
+            SplitsAssignmentState assignmentState) {
+        this.pulsarAdmin = createAdmin(configuration, clientConfigurationCustomizer);
+        this.subscriber = subscriber;
+        this.rangeGenerator = rangeGenerator;
+        this.configuration = configuration;
+        this.sourceConfiguration = sourceConfiguration;
+        this.context = context;
+        this.assignmentState = assignmentState;
+    }
+
+    @Override
+    public void start() {
+        rangeGenerator.open(configuration, sourceConfiguration);
+
+        // Check the pulsar topic information and convert it into source split.
+        if (sourceConfiguration.enablePartitionDiscovery()) {
+            LOG.info(
+                    "Starting the PulsarSourceEnumerator for subscription {} "
+                            + "with partition discovery interval of {} ms.",
+                    sourceConfiguration.getSubscriptionDesc(),
+                    sourceConfiguration.getPartitionDiscoveryIntervalMs());
+            context.callAsync(
+                    this::getSubscribedTopicPartitions,
+                    this::checkPartitionChanges,
+                    0,
+                    sourceConfiguration.getPartitionDiscoveryIntervalMs());
+        } else {
+            LOG.info(
+                    "Starting the PulsarSourceEnumerator for subscription {} "
+                            + "without periodic partition discovery.",
+                    sourceConfiguration.getSubscriptionDesc());
+            context.callAsync(this::getSubscribedTopicPartitions, this::checkPartitionChanges);
+        }
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        // the pulsar source pushes splits eagerly, rather than act upon split requests.
+    }
+
+    @Override
+    public void addSplitsBack(List<PulsarPartitionSplit> splits, int subtaskId) {
+        // Put the split back to current pending splits.
+        assignmentState.putSplitsBackToPendingList(splits, subtaskId);
+
+        // If the failed subtask has already restarted, we need to assign pending splits to it
+        if (context.registeredReaders().containsKey(subtaskId)) {
+            assignPendingPartitionSplits(singletonList(subtaskId));
+        }
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        LOG.debug(
+                "Adding reader {} to PulsarSourceEnumerator for subscription {}.",
+                subtaskId,
+                sourceConfiguration.getSubscriptionDesc());
+        assignPendingPartitionSplits(singletonList(subtaskId));
+    }
+
+    @Override
+    public PulsarSourceEnumState snapshotState(long checkpointId) {
+        return assignmentState.snapshotState();
+    }
+
+    @Override
+    public void close() {
+        if (pulsarAdmin != null) {
+            pulsarAdmin.close();
+        }
+    }
+
+    // ----------------- private methods -------------------
+
+    /**
+     * List subscribed topic partitions on Pulsar cluster.
+     *
+     * <p>NOTE: This method should only be invoked in the worker executor thread, because it
+     * requires network I/O with Pulsar cluster.
+     *
+     * @return Set of subscribed {@link TopicPartition}s
+     */
+    private Set<TopicPartition> getSubscribedTopicPartitions() {
+        return subscriber.getSubscribedTopicPartitions(
+                pulsarAdmin, rangeGenerator, context.currentParallelism());
+    }
+
+    /**
+     * Check if there's any partition changes within subscribed topic partitions fetched by worker
+     * thread, and convert them to splits the assign them to pulsar readers.
+     *
+     * <p>NOTE: This method should only be invoked in the coordinator executor thread.
+     *
+     * @param fetchedPartitions Map from topic name to its description
+     * @param throwable Exception in worker thread
+     */
+    private void checkPartitionChanges(Set<TopicPartition> fetchedPartitions, Throwable throwable) {
+        if (throwable != null) {
+            throw new FlinkRuntimeException(
+                    "Failed to list subscribed topic partitions due to ", throwable);
+        }
+
+        // Append the partitions into current assignment state.
+        assignmentState.appendTopicPartitions(fetchedPartitions);
+        List<Integer> registeredReaders = new ArrayList<>(context.registeredReaders().keySet());
+
+        // Assign the new readers.
+        assignPendingPartitionSplits(registeredReaders);
+    }
+
+    private void assignPendingPartitionSplits(List<Integer> pendingReaders) {
+        // Validate the reader.
+        pendingReaders.forEach(
+                reader -> {
+                    if (!context.registeredReaders().containsKey(reader)) {
+                        throw new IllegalStateException(
+                                "Reader " + reader + " is not registered to source coordinator");
+                    }
+                });
+
+        // Assign splits to downstream readers.
+        assignmentState.assignSplits(pendingReaders).ifPresent(context::assignSplits);
+
+        // If periodically partition discovery is disabled and the initializing discovery has done,
+        // signal NoMoreSplitsEvent to pending readers
+        if (assignmentState.noMoreNewPartitionSplits()) {
+            LOG.debug(
+                    "No more PulsarPartitionSplits to assign."
+                            + " Sending NoMoreSplitsEvent to reader {} in subscription {}.",
+                    pendingReaders,
+                    sourceConfiguration.getSubscriptionDesc());
+            pendingReaders.forEach(this.context::signalNoMoreSplits);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/SplitsAssignmentState.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/SplitsAssignmentState.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/** The state class for recording the split assignment. */
+@Internal
+public class SplitsAssignmentState {
+
+    private final StartCursor startCursor;
+    private final StopCursor stopCursor;
+    private final SourceConfiguration sourceConfiguration;
+
+    // The dynamic states for checkpoint.
+    private final Set<TopicPartition> appendedPartitions;
+    // This pending splits is used for Key_Shared, Failover, Exclusive subscription.
+    private final Set<PulsarPartitionSplit> pendingPartitionSplits;
+    // These two fields are used for Shared subscription.
+    private final Map<Integer, Set<PulsarPartitionSplit>> sharedPendingPartitionSplits;
+    private final Map<Integer, Set<String>> readerAssignedSplits;
+    private boolean initialized;
+
+    public SplitsAssignmentState(
+            StartCursor startCursor,
+            StopCursor stopCursor,
+            SourceConfiguration sourceConfiguration) {
+        this.startCursor = startCursor;
+        this.stopCursor = stopCursor;
+        this.sourceConfiguration = sourceConfiguration;
+        this.appendedPartitions = new HashSet<>();
+        this.pendingPartitionSplits = new HashSet<>();
+        this.sharedPendingPartitionSplits = new HashMap<>();
+        this.readerAssignedSplits = new HashMap<>();
+        this.initialized = false;
+    }
+
+    public SplitsAssignmentState(
+            StartCursor startCursor,
+            StopCursor stopCursor,
+            SourceConfiguration sourceConfiguration,
+            PulsarSourceEnumState sourceEnumState) {
+        this.startCursor = startCursor;
+        this.stopCursor = stopCursor;
+        this.sourceConfiguration = sourceConfiguration;
+        this.appendedPartitions = sourceEnumState.getAppendedPartitions();
+        this.pendingPartitionSplits = sourceEnumState.getPendingPartitionSplits();
+        this.sharedPendingPartitionSplits = sourceEnumState.getSharedPendingPartitionSplits();
+        this.readerAssignedSplits = sourceEnumState.getReaderAssignedSplits();
+        this.initialized = sourceEnumState.isInitialized();
+    }
+
+    public PulsarSourceEnumState snapshotState() {
+        return new PulsarSourceEnumState(
+                appendedPartitions,
+                pendingPartitionSplits,
+                sharedPendingPartitionSplits,
+                readerAssignedSplits,
+                initialized);
+    }
+
+    /**
+     * Append the new fetched partitions to current state. We would generate pending source split
+     * for downstream pulsar readers. Since the {@link SplitEnumeratorContext} don't support put the
+     * split back to enumerator, we don't support partition deletion.
+     *
+     * @param fetchedPartitions The partitions from the {@link PulsarSubscriber}.
+     */
+    public void appendTopicPartitions(Set<TopicPartition> fetchedPartitions) {
+        for (TopicPartition partition : fetchedPartitions) {
+            // If this partition is a new partition.
+            if (!appendedPartitions.contains(partition)) {
+                if (!sharePartition()) {
+                    // Create a split and add it to pending list.
+                    pendingPartitionSplits.add(createSplit(partition));
+                }
+
+                // Shared subscription don't create splits, we just register partitions.
+                appendedPartitions.add(partition);
+            }
+        }
+
+        // Update this initialize flag.
+        if (!initialized) {
+            this.initialized = true;
+        }
+    }
+
+    /** Put these splits back to pending list. */
+    public void putSplitsBackToPendingList(List<PulsarPartitionSplit> splits, int readerId) {
+        if (!sharePartition()) {
+            // Put these splits back to normal pending list.
+            pendingPartitionSplits.addAll(splits);
+        } else {
+            // Put the splits back to shared pending list.
+            Set<PulsarPartitionSplit> pending =
+                    sharedPendingPartitionSplits.computeIfAbsent(readerId, id -> new HashSet<>());
+            pending.addAll(splits);
+        }
+    }
+
+    public Optional<SplitsAssignment<PulsarPartitionSplit>> assignSplits(
+            List<Integer> pendingReaders) {
+        // Avoid empty readers assign.
+        if (pendingReaders.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<Integer, List<PulsarPartitionSplit>> assignMap;
+
+        // We extract the assign logic into two method for better readability.
+        if (!sharePartition()) {
+            assignMap = assignNormalSplits(pendingReaders);
+        } else {
+            assignMap = assignSharedSplits(pendingReaders);
+        }
+
+        if (assignMap.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new SplitsAssignment<>(assignMap));
+        }
+    }
+
+    /**
+     * @return It would return true only if periodically partition discovery is disabled, the
+     *     initializing partition discovery has finished AND there is no pending splits for
+     *     assignment.
+     */
+    public boolean noMoreNewPartitionSplits() {
+        return !sourceConfiguration.enablePartitionDiscovery()
+                && initialized
+                && pendingPartitionSplits.isEmpty();
+    }
+
+    // ----------------- private methods -------------------
+
+    /** The splits don't shared for all the readers. */
+    private Map<Integer, List<PulsarPartitionSplit>> assignNormalSplits(
+            List<Integer> pendingReaders) {
+        Map<Integer, List<PulsarPartitionSplit>> assignMap = new HashMap<>();
+
+        // Drain a list of splits.
+        List<PulsarPartitionSplit> pendingSplits = drainPendingPartitionsSplits();
+        for (int i = 0; i < pendingSplits.size(); i++) {
+            PulsarPartitionSplit split = pendingSplits.get(i);
+            int readerId = pendingReaders.get(i % pendingReaders.size());
+            assignMap.computeIfAbsent(readerId, id -> new ArrayList<>()).add(split);
+        }
+
+        return assignMap;
+    }
+
+    /** Every split would be shared among available readers. */
+    private Map<Integer, List<PulsarPartitionSplit>> assignSharedSplits(
+            List<Integer> pendingReaders) {
+        Map<Integer, List<PulsarPartitionSplit>> assignMap = new HashMap<>();
+
+        // Drain the splits from share pending list.
+        for (Integer reader : pendingReaders) {
+            Set<PulsarPartitionSplit> pendingSplits = sharedPendingPartitionSplits.remove(reader);
+            if (pendingSplits == null) {
+                pendingSplits = new HashSet<>();
+            }
+
+            Set<String> assignedSplits =
+                    readerAssignedSplits.computeIfAbsent(reader, r -> new HashSet<>());
+
+            for (TopicPartition partition : appendedPartitions) {
+                String partitionName = partition.toString();
+                if (!assignedSplits.contains(partitionName)) {
+                    pendingSplits.add(createSplit(partition));
+                    assignedSplits.add(partitionName);
+                }
+            }
+
+            if (!pendingSplits.isEmpty()) {
+                assignMap.put(reader, new ArrayList<>(pendingSplits));
+            }
+        }
+
+        return assignMap;
+    }
+
+    private PulsarPartitionSplit createSplit(TopicPartition partition) {
+        try {
+            StartCursor start = InstantiationUtil.clone(this.startCursor);
+            StopCursor stop = InstantiationUtil.clone(stopCursor);
+
+            return new PulsarPartitionSplit(partition, start, stop);
+        } catch (IOException | ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private List<PulsarPartitionSplit> drainPendingPartitionsSplits() {
+        List<PulsarPartitionSplit> splits = new ArrayList<>(pendingPartitionSplits);
+        pendingPartitionSplits.clear();
+
+        return splits;
+    }
+
+    /** {@link SubscriptionType#Shared} mode should share a same split for all the readers. */
+    private boolean sharePartition() {
+        return sourceConfiguration.getSubscriptionType() == SubscriptionType.Shared;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/CursorPosition.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/CursorPosition.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/** The class for defining the start or stop position. */
+@PublicEvolving
+public final class CursorPosition implements Serializable {
+    private static final long serialVersionUID = -802405183307684549L;
+
+    private final Type type;
+
+    private final MessageId messageId;
+
+    private final Long timestamp;
+
+    public CursorPosition(@Nullable MessageId messageId) {
+        this.type = Type.MESSAGE_ID;
+        this.messageId = messageId;
+        this.timestamp = null;
+    }
+
+    public CursorPosition(@Nullable Long timestamp) {
+        this.type = Type.TIMESTAMP;
+        this.messageId = null;
+        this.timestamp = timestamp;
+    }
+
+    @VisibleForTesting
+    public MessageId getMessageId() {
+        return messageId;
+    }
+
+    /** Pulsar consumer could be subscribed by the position. */
+    public void seekPosition(Consumer<?> consumer) throws PulsarClientException {
+        if (type == Type.MESSAGE_ID) {
+            consumer.seek(messageId);
+        } else {
+            if (timestamp != null) {
+                consumer.seek(timestamp);
+            } else {
+                consumer.seek(System.currentTimeMillis());
+            }
+        }
+    }
+
+    /**
+     * The position type for reader to choose whether timestamp or message id as the start position.
+     */
+    public enum Type {
+        TIMESTAMP,
+
+        MESSAGE_ID
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StartCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StartCursor.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.start.MessageIdStartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.start.TimestampStartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.io.Serializable;
+
+/**
+ * A interface for users to specify the start position of a pulsar subscription. Since it would be
+ * serialized into split. The implementation for this interface should be well considered. I don't
+ * recommend adding extra internal state for this implementation.
+ *
+ * <p>This class would be used only for {@link SubscriptionType#Exclusive} and {@link
+ * SubscriptionType#Failover}.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface StartCursor extends Serializable {
+
+    /** The open method for the cursor initializer. This method could be executed multiple times. */
+    default void open(PulsarAdmin admin, TopicPartition partition) {}
+
+    CursorPosition position(PulsarPartitionSplit split);
+
+    // --------------------------- Static Factory Methods -----------------------------
+
+    static StartCursor defaultStartCursor() {
+        return earliest();
+    }
+
+    static StartCursor earliest() {
+        return fromMessageId(MessageId.earliest);
+    }
+
+    static StartCursor latest() {
+        return fromMessageId(MessageId.latest);
+    }
+
+    static StartCursor fromMessageId(MessageId messageId) {
+        return fromMessageId(messageId, true);
+    }
+
+    /**
+     * @param messageId Find the available message id and start consuming from it.
+     * @param inclusive {@code ture} would include the given message id.
+     */
+    static StartCursor fromMessageId(MessageId messageId, boolean inclusive) {
+        return new MessageIdStartCursor(messageId, inclusive);
+    }
+
+    static StartCursor fromMessageTime(long timestamp) {
+        return new TimestampStartCursor(timestamp);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StopCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StopCursor.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.stop.LatestMessageStopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.stop.MessageIdStopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.stop.NeverStopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.stop.TimestampStopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+import java.io.Serializable;
+
+/**
+ * A interface for users to specify the stop position of a pulsar subscription. Since it would be
+ * serialized into split. The implementation for this interface should be well considered. I don't
+ * recommend adding extra internal state for this implementation.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface StopCursor extends Serializable {
+
+    /** The open method for the cursor initializer. This method could be executed multiple times. */
+    default void open(PulsarAdmin admin, TopicPartition partition) {}
+
+    /**
+     * Determine whether to pause consumption on the current message by the returned boolean value.
+     * The message presented in method argument wouldn't be consumed if the return result is true.
+     */
+    boolean shouldStop(Message<?> message);
+
+    // --------------------------- Static Factory Methods -----------------------------
+
+    static StopCursor defaultStopCursor() {
+        return never();
+    }
+
+    static StopCursor never() {
+        return new NeverStopCursor();
+    }
+
+    static StopCursor latest() {
+        return new LatestMessageStopCursor();
+    }
+
+    static StopCursor atMessageId(MessageId messageId) {
+        return new MessageIdStopCursor(messageId);
+    }
+
+    static StopCursor afterMessageId(MessageId messageId) {
+        return new MessageIdStopCursor(messageId, false);
+    }
+
+    static StopCursor atEventTime(long timestamp) {
+        return new TimestampStopCursor(timestamp);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/start/MessageIdStartCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/start/MessageIdStartCursor.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor.start;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** This cursor would left pulsar start consuming from a specific message id. */
+public class MessageIdStartCursor implements StartCursor {
+    private static final long serialVersionUID = -8057345435887170111L;
+
+    private final MessageId messageId;
+
+    /**
+     * The default {@code inclusive} behavior should be controlled in {@link
+     * ConsumerBuilder#startMessageIdInclusive}. But pulsar has a bug and don't support this
+     * currently. We have to use {@code entry + 1} policy for consuming the next available message.
+     * If the message id entry is not valid. Pulsar would automatically find next valid message id.
+     * Please referer <a
+     * href="https://github.com/apache/pulsar/blob/36d5738412bb1ed9018178007bf63d9202b675db/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java#L1151">this
+     * code</a> for understanding pulsar internal logic.
+     *
+     * @param messageId The message id for start position.
+     * @param inclusive Should we include the start message id in consuming result.
+     */
+    public MessageIdStartCursor(MessageId messageId, boolean inclusive) {
+        if (inclusive) {
+            this.messageId = messageId;
+        } else {
+            checkState(
+                    messageId instanceof MessageIdImpl,
+                    "We only support normal message id and batch message id.");
+            MessageIdImpl id = (MessageIdImpl) messageId;
+            this.messageId =
+                    new MessageIdImpl(
+                            id.getLedgerId(), id.getEntryId() + 1, id.getPartitionIndex());
+        }
+    }
+
+    @Override
+    public CursorPosition position(PulsarPartitionSplit split) {
+        return new CursorPosition(messageId);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/start/TimestampStartCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/start/TimestampStartCursor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor.start;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+/** This cursor would left pulsar start consuming from a specific timestamp. */
+public class TimestampStartCursor implements StartCursor {
+    private static final long serialVersionUID = 5170578885838095320L;
+
+    private final long timestamp;
+
+    public TimestampStartCursor(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public CursorPosition position(PulsarPartitionSplit split) {
+        return new CursorPosition(timestamp);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/LatestMessageStopCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/LatestMessageStopCursor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor.stop;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyAdmin;
+
+/**
+ * A stop cursor that initialize the position to the latest message id. The offsets initialization
+ * are taken care of by the {@code PulsarPartitionSplitReaderBase} instead of by the {@code
+ * PulsarSourceEnumerator}.
+ */
+public class LatestMessageStopCursor implements StopCursor {
+
+    private MessageId messageId;
+
+    @Override
+    public void open(PulsarAdmin admin, TopicPartition partition) {
+        if (messageId == null) {
+            String topic = partition.getFullTopicName();
+            messageId = sneakyAdmin(() -> admin.topics().getLastMessageId(topic));
+        }
+    }
+
+    @Override
+    public boolean shouldStop(Message<?> message) {
+        MessageId id = message.getMessageId();
+        return id.compareTo(messageId) >= 0;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/MessageIdStopCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/MessageIdStopCursor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor.stop;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+/**
+ * Stop consuming message at a given message id. We use the {@link MessageId#compareTo(Object)} for
+ * compare the consuming message with the given message id.
+ */
+public class MessageIdStopCursor implements StopCursor {
+    private static final long serialVersionUID = -3990454110809274542L;
+
+    private final MessageId messageId;
+
+    private final boolean exclusive;
+
+    public MessageIdStopCursor(MessageId messageId) {
+        this(messageId, true);
+    }
+
+    public MessageIdStopCursor(MessageId messageId, boolean exclusive) {
+        this.messageId = messageId;
+        this.exclusive = exclusive;
+    }
+
+    @Override
+    public boolean shouldStop(Message<?> message) {
+        MessageId id = message.getMessageId();
+        if (exclusive) {
+            return id.compareTo(messageId) > 0;
+        } else {
+            return id.compareTo(messageId) >= 0;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/NeverStopCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/NeverStopCursor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor.stop;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+
+import org.apache.pulsar.client.api.Message;
+
+/** A implementation which wouldn't stop forever. */
+public class NeverStopCursor implements StopCursor {
+    private static final long serialVersionUID = -3113601090292771786L;
+
+    @Override
+    public boolean shouldStop(Message<?> message) {
+        return false;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/TimestampStopCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/TimestampStopCursor.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.cursor.stop;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+
+import org.apache.pulsar.client.api.Message;
+
+/** Stop consuming message at the given event time. */
+public class TimestampStopCursor implements StopCursor {
+    private static final long serialVersionUID = 3381576769339353027L;
+
+    private final long timestamp;
+
+    public TimestampStopCursor(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean shouldStop(Message<?> message) {
+        return message.getEventTime() >= timestamp;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriber.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.subscriber;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl.TopicListSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl.TopicPatternSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Pulsar consumer allows a few different ways to consume from the topics, including:
+ *
+ * <ol>
+ *   <li>Subscribe from a collection of topics.
+ *   <li>Subscribe to a topic pattern using Java {@code Regex}.
+ * </ol>
+ *
+ * <p>The PulsarSubscriber provides a unified interface for the Pulsar source to support all these
+ * two types of subscribing mode.
+ */
+@Internal
+public interface PulsarSubscriber extends Serializable {
+
+    /**
+     * Get a set of subscribed {@link TopicPartition}s. The method could throw {@link
+     * IllegalStateException}, a extra try catch is required.
+     *
+     * @param pulsarAdmin The admin interface used to retrieve subscribed topic partitions.
+     * @param rangeGenerator The range for different partitions.
+     * @param parallelism The parallelism of flink source.
+     * @return A subscribed {@link TopicPartition} for each pulsar topic partition.
+     */
+    Set<TopicPartition> getSubscribedTopicPartitions(
+            PulsarAdmin pulsarAdmin, RangeGenerator rangeGenerator, int parallelism);
+
+    // ----------------- factory methods --------------
+
+    static PulsarSubscriber getTopicListSubscriber(List<String> topics) {
+        return new TopicListSubscriber(topics);
+    }
+
+    static PulsarSubscriber getTopicPatternSubscriber(
+            Pattern topicPattern, RegexSubscriptionMode subscriptionMode) {
+        return new TopicPatternSubscriber(topicPattern, subscriptionMode);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/BasePulsarSubscriber.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
+
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+/** PulsarSubscriber abstract class to simplify Pulsar admin related operations. */
+public abstract class BasePulsarSubscriber implements PulsarSubscriber {
+    private static final long serialVersionUID = 2053021503331058888L;
+
+    protected TopicMetadata queryTopicMetadata(PulsarAdmin pulsarAdmin, String topicName) {
+        // Drop the complete topic name for a clean partitioned topic name.
+        String completeTopicName = TopicNameUtils.topicName(topicName);
+        try {
+            PartitionedTopicMetadata metadata =
+                    pulsarAdmin.topics().getPartitionedTopicMetadata(completeTopicName);
+            return new TopicMetadata(topicName, metadata.partitions);
+        } catch (PulsarAdminException e) {
+            if (e.getStatusCode() == 404) {
+                // Return null for skipping the topic metadata query.
+                return null;
+            } else {
+                // This method would cause the failure for subscriber.
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    protected List<TopicPartition> toTopicPartitions(
+            TopicMetadata metadata, int parallelism, RangeGenerator rangeGenerator) {
+        if (!metadata.isPartitioned()) {
+            // For non-partitioned topic.
+            return rangeGenerator.range(metadata, parallelism).stream()
+                    .map(range -> new TopicPartition(metadata.getName(), -1, range))
+                    .collect(toList());
+        } else {
+            return IntStream.range(0, metadata.getPartitionSize())
+                    .boxed()
+                    .flatMap(
+                            partitionId ->
+                                    rangeGenerator.range(metadata, parallelism).stream()
+                                            .map(
+                                                    range ->
+                                                            new TopicPartition(
+                                                                    metadata.getName(),
+                                                                    partitionId,
+                                                                    range)))
+                    .collect(toList());
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicListSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicListSubscriber.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+/** the implements of consuming multiple topics. */
+public class TopicListSubscriber extends BasePulsarSubscriber {
+    private static final long serialVersionUID = 6473918213832993116L;
+
+    private final List<String> topics;
+
+    public TopicListSubscriber(List<String> topics) {
+        this.topics = topics;
+    }
+
+    @Override
+    public Set<TopicPartition> getSubscribedTopicPartitions(
+            PulsarAdmin pulsarAdmin, RangeGenerator rangeGenerator, int parallelism) {
+
+        return topics.parallelStream()
+                .map(topic -> queryTopicMetadata(pulsarAdmin, topic))
+                .filter(Objects::nonNull)
+                .flatMap(
+                        metadata ->
+                                toTopicPartitions(metadata, parallelism, rangeGenerator).stream())
+                .collect(toSet());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.toSet;
+
+/** Subscribe to matching topics based on topic pattern. */
+public class TopicPatternSubscriber extends BasePulsarSubscriber {
+    private static final long serialVersionUID = 3307710093243745104L;
+
+    private final Pattern topicPattern;
+    private final RegexSubscriptionMode subscriptionMode;
+    private final String namespace;
+
+    public TopicPatternSubscriber(Pattern topicPattern, RegexSubscriptionMode subscriptionMode) {
+        this.topicPattern = topicPattern;
+        this.subscriptionMode = subscriptionMode;
+
+        // Extract the namespace from topic pattern regex.
+        // If no namespace provided in the regex, we would directly use "default" as the namespace.
+        TopicName destination = TopicName.get(topicPattern.toString());
+        NamespaceName namespaceName = destination.getNamespaceObject();
+        this.namespace = namespaceName.toString();
+    }
+
+    @Override
+    public Set<TopicPartition> getSubscribedTopicPartitions(
+            PulsarAdmin pulsarAdmin, RangeGenerator rangeGenerator, int parallelism) {
+        try {
+            return pulsarAdmin
+                    .namespaces()
+                    .getTopics(namespace)
+                    .parallelStream()
+                    .filter(this::matchesSubscriptionMode)
+                    .filter(topic -> topicPattern.matcher(topic).find())
+                    .map(topic -> queryTopicMetadata(pulsarAdmin, topic))
+                    .filter(Objects::nonNull)
+                    .flatMap(
+                            metadata ->
+                                    toTopicPartitions(metadata, parallelism, rangeGenerator)
+                                            .stream())
+                    .collect(toSet());
+        } catch (PulsarAdminException e) {
+            if (e.getStatusCode() == 404) {
+                // Skip the topic metadata query.
+                return Collections.emptySet();
+            } else {
+                // This method would cause the failure for subscriber.
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    /**
+     * Filter the topic by regex subscription mode. This logic is the same as pulsar consumer's
+     * regex subscription.
+     */
+    private boolean matchesSubscriptionMode(String topic) {
+        TopicName topicName = TopicName.get(topic);
+        // Filter the topic persistence.
+        switch (subscriptionMode) {
+            case PersistentOnly:
+                return topicName.isPersistent();
+            case NonPersistentOnly:
+                return !topicName.isPersistent();
+            default:
+                // RegexSubscriptionMode.AllTopics
+                return true;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicMetadata.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicMetadata.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.pulsar.common.partition.PartitionedTopicMetadata.NON_PARTITIONED;
+
+/** The pojo class for pulsar topic metadata information. */
+@PublicEvolving
+public final class TopicMetadata {
+
+    /**
+     * The name of the topic, it would be a {@link TopicNameUtils#topicName(String)} which don't
+     * contain partition information.
+     */
+    private final String name;
+
+    /** The size for a partitioned topic. It would be zero for non-partitioned topic. */
+    private final int partitionSize;
+
+    public TopicMetadata(String name, int partitionSize) {
+        checkArgument(partitionSize >= 0);
+
+        this.name = name;
+        this.partitionSize = partitionSize;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isPartitioned() {
+        return partitionSize != NON_PARTITIONED;
+    }
+
+    public int getPartitionSize() {
+        return partitionSize;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.pulsar.common.naming.TopicName;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** util for topic name. */
+@Internal
+public final class TopicNameUtils {
+
+    private TopicNameUtils() {
+        // No public constructor.
+    }
+
+    /** Ensure the given topic name should be a topic without partition information. */
+    public static String topicName(String topic) {
+        return TopicName.get(topic).getPartitionedTopicName();
+    }
+
+    /** Create a topic name with partition information. */
+    public static String topicNameWithPartition(String topic, int partitionId) {
+        checkArgument(partitionId >= 0, "Illegal partition id %s", partitionId);
+        return TopicName.get(topic).getPartition(partitionId).toString();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicPartition.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicPartition.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+
+import org.apache.pulsar.client.api.Range;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicName;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Topic partition is the basic topic information used by {@link SplitReader}, we create this topic
+ * metas for a specified topic by subscription type and convert it into a partition split.
+ */
+@Internal
+public class TopicPartition implements Serializable {
+    private static final long serialVersionUID = -1474354741550810953L;
+
+    /**
+     * The topic name of the pulsar. It would be a full topic name, if your don't provide the tenant
+     * and namespace, we would add them automatically.
+     */
+    private final String topic;
+
+    /**
+     * Index of partition for the topic. It would be natural number for partitioned topic with a
+     * non-key_shared subscription.
+     */
+    private final int partitionId;
+
+    /**
+     * The ranges for this topic, used for limiting consume scope. It would be a {@link
+     * TopicRange#createFullRange()} full range for all the subscription type except {@link
+     * SubscriptionType#Key_Shared}.
+     */
+    private final TopicRange range;
+
+    public TopicPartition(String topic, int partitionId, TopicRange range) {
+        this.topic = topicName(checkNotNull(topic));
+        this.partitionId = partitionId;
+        this.range = checkNotNull(range);
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public int getPartitionId() {
+        return partitionId;
+    }
+
+    /**
+     * Pulsar split the topic partition into a bunch of small topics, we would get the real topic
+     * name by using this method.
+     */
+    public String getFullTopicName() {
+        if (partitionId >= 0) {
+            return topicNameWithPartition(topic, partitionId);
+        } else {
+            return topic;
+        }
+    }
+
+    public TopicRange getRange() {
+        return range;
+    }
+
+    public Range getPulsarRange() {
+        return range.toPulsarRange();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopicPartition that = (TopicPartition) o;
+        return partitionId == that.partitionId
+                && topic.equals(that.topic)
+                && range.equals(that.range);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topic, partitionId, range);
+    }
+
+    @Override
+    public String toString() {
+        return getFullTopicName() + "|" + range;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRange.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRange.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.Range;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * This class is used to define the range for KeyShared subscription.
+ *
+ * <p>{@link Range} is a hash scope for pulsar message key. The total hash range size is 65536, so
+ * the end of the range should be 65535, the start the range should be 0.
+ *
+ * @see KeySharedPolicy.KeySharedPolicySticky
+ */
+@PublicEvolving
+public class TopicRange implements Serializable {
+    private static final long serialVersionUID = 3176938692775594400L;
+
+    public static final int RANGE_SIZE = KeySharedPolicy.DEFAULT_HASH_RANGE_SIZE;
+
+    /** The start position for hash range. */
+    public static final int MIN_RANGE = 0;
+
+    /** The end position for hash range, it's 65535. */
+    public static final int MAX_RANGE = RANGE_SIZE - 1;
+
+    /** The start of the range, default is zero. */
+    private final int start;
+
+    /** The end of the range, included. */
+    private final int end;
+
+    public TopicRange(int start, int end) {
+        checkArgument(start >= MIN_RANGE, "Start range %s shouldn't below zero.", start);
+        checkArgument(end <= MAX_RANGE, "End range %s shouldn't exceed 65535.", end);
+        this.start = start;
+        this.end = end;
+    }
+
+    /** Convert to pulsar's {@link Range} API for consuming in client. */
+    public Range toPulsarRange() {
+        return new Range(start, end);
+    }
+
+    /** Create a topic range which contains the fully hash range. */
+    public static TopicRange createFullRange() {
+        return new TopicRange(MIN_RANGE, MAX_RANGE);
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopicRange that = (TopicRange) o;
+        return start == that.start && end == that.end;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end);
+    }
+
+    @Override
+    public String toString() {
+        return getStart() + "-" + getEnd();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/range/FullRangeGenerator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/range/FullRangeGenerator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic.range;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default implementation for {@link SubscriptionType#Shared}, {@link SubscriptionType#Failover} and
+ * {@link SubscriptionType#Exclusive} subscription.
+ */
+public class FullRangeGenerator implements RangeGenerator {
+    private static final long serialVersionUID = -4571731955155036216L;
+
+    @Override
+    public List<TopicRange> range(TopicMetadata metadata, int parallelism) {
+        return Collections.singletonList(TopicRange.createFullRange());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/range/RangeGenerator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/range/RangeGenerator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic.range;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+
+import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A generator for generating the {@link TopicRange} for given topic. It was used for pulsar's
+ * {@link SubscriptionType#Key_Shared} mode. {@link TopicRange} would be used in {@link
+ * KeySharedPolicy} for different pulsar source readers.
+ *
+ * <p>If you implement this interface, make sure that each {@link TopicRange} would be assigned to a
+ * specified source reader. Since flink parallelism is provided, make sure the pulsar message key's
+ * hashcode is evenly distributed among these topic ranges.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface RangeGenerator extends Serializable {
+
+    /**
+     * Generate range for the given topic.
+     *
+     * @param metadata The metadata of the topic.
+     * @param parallelism The reader size for this topic.
+     */
+    List<TopicRange> range(TopicMetadata metadata, int parallelism);
+
+    default void open(Configuration configuration, SourceConfiguration sourceConfiguration) {
+        // This method is used for user implementation.
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/range/UniformRangeGenerator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/range/UniformRangeGenerator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic.range;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicMetadata;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.MAX_RANGE;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.RANGE_SIZE;
+
+/**
+ * This range generator would divide the range by the flink source parallelism. It would be the
+ * default implementation for {@link SubscriptionType#Key_Shared} subscription.
+ */
+public class UniformRangeGenerator implements RangeGenerator {
+    private static final long serialVersionUID = -7292650922683609268L;
+
+    @Override
+    public List<TopicRange> range(TopicMetadata metadata, int parallelism) {
+        List<TopicRange> results = new ArrayList<>(parallelism);
+
+        int startRange = 0;
+        for (int i = 1; i < parallelism; i++) {
+            int nextStartRange = i * RANGE_SIZE / parallelism;
+            results.add(new TopicRange(startRange, nextStartRange - 1));
+            startRange = nextStartRange;
+        }
+        results.add(new TopicRange(startRange, MAX_RANGE));
+
+        return results;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderFactory.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarOrderedSourceReader;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarUnorderedSourceReader;
+import org.apache.flink.connector.pulsar.source.reader.split.PulsarOrderedPartitionSplitReader;
+import org.apache.flink.connector.pulsar.source.reader.split.PulsarUnorderedPartitionSplitReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+
+import java.util.function.Supplier;
+
+import static org.apache.flink.connector.base.source.reader.SourceReaderOptions.ELEMENT_QUEUE_CAPACITY;
+import static org.apache.flink.connector.pulsar.common.config.PulsarConfigUtils.createAdmin;
+import static org.apache.flink.connector.pulsar.common.config.PulsarConfigUtils.createClient;
+
+/**
+ * This factory class is used for creating different types of source reader for different
+ * subscription type.
+ *
+ * <ol>
+ *   <li>Failover, Exclusive: We would create {@link PulsarOrderedSourceReader}.
+ *   <li>Shared, Key_Shared: We would create {@link PulsarUnorderedSourceReader}.
+ * </ol>
+ */
+@Internal
+public final class PulsarSourceReaderFactory {
+
+    private PulsarSourceReaderFactory() {
+        // No public constructor.
+    }
+
+    @SuppressWarnings("java:S2095")
+    public static <OUT> SourceReader<OUT, PulsarPartitionSplit> create(
+            SourceReaderContext readerContext,
+            PulsarDeserializationSchema<OUT> deserializationSchema,
+            Configuration configuration,
+            SourceConfiguration sourceConfiguration,
+            ConfigurationDataCustomizer<ClientConfigurationData> clientConfigurationCustomizer,
+            ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+                    consumerConfigurationCustomizer) {
+
+        PulsarClient pulsarClient = createClient(configuration, clientConfigurationCustomizer);
+        PulsarAdmin pulsarAdmin = createAdmin(configuration, clientConfigurationCustomizer);
+
+        // Create a message queue with the predefined source option.
+        int queueSize = configuration.getInteger(ELEMENT_QUEUE_CAPACITY);
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<OUT>>> elementsQueue =
+                new FutureCompletingBlockingQueue<>(queueSize);
+
+        // Create different pulsar source reader by subscription type.
+        SubscriptionType subscriptionType = sourceConfiguration.getSubscriptionType();
+        if (subscriptionType == SubscriptionType.Failover
+                || subscriptionType == SubscriptionType.Exclusive) {
+            // Create a ordered split reader supplier.
+            Supplier<PulsarOrderedPartitionSplitReader<OUT>> splitReaderSupplier =
+                    () ->
+                            new PulsarOrderedPartitionSplitReader<>(
+                                    pulsarClient,
+                                    pulsarAdmin,
+                                    configuration,
+                                    sourceConfiguration,
+                                    consumerConfigurationCustomizer,
+                                    deserializationSchema);
+
+            return new PulsarOrderedSourceReader<>(
+                    elementsQueue,
+                    splitReaderSupplier,
+                    configuration,
+                    readerContext,
+                    sourceConfiguration,
+                    pulsarClient,
+                    pulsarAdmin);
+        } else if (subscriptionType == SubscriptionType.Shared
+                || subscriptionType == SubscriptionType.Key_Shared) {
+            TransactionCoordinatorClient coordinatorClient =
+                    ((PulsarClientImpl) pulsarClient).getTcClient();
+            if (coordinatorClient == null
+                    && !sourceConfiguration.isEnableAutoAcknowledgeMessage()) {
+                throw new IllegalStateException("Transaction is required but didn't enabled");
+            }
+
+            Supplier<PulsarUnorderedPartitionSplitReader<OUT>> splitReaderSupplier =
+                    () ->
+                            new PulsarUnorderedPartitionSplitReader<>(
+                                    pulsarClient,
+                                    pulsarAdmin,
+                                    configuration,
+                                    sourceConfiguration,
+                                    consumerConfigurationCustomizer,
+                                    deserializationSchema,
+                                    coordinatorClient);
+
+            return new PulsarUnorderedSourceReader<>(
+                    elementsQueue,
+                    splitReaderSupplier,
+                    configuration,
+                    readerContext,
+                    sourceConfiguration,
+                    pulsarClient,
+                    pulsarAdmin,
+                    coordinatorClient);
+        } else {
+            throw new UnsupportedOperationException(
+                    "This subscription type is not " + subscriptionType + " supported currently.");
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchema.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.deserializer;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.DeserializationSchema.InitializationContext;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.util.Collector;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.KeyValue;
+
+import java.io.Serializable;
+
+/**
+ * A schema bridge for deserializing the pulsar's {@code Message<byte[]>} into a flink managed
+ * instance. We support both the pulsar's self managed schema and flink managed schema.
+ *
+ * @param <T> The output message type for sinking to downstream flink operator.
+ */
+@PublicEvolving
+public interface PulsarDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+    /**
+     * Initialization method for the schema. It is called before the actual working methods {@link
+     * #deserialize} and thus suitable for one time setup work.
+     *
+     * <p>The provided {@link InitializationContext} can be used to access additional features such
+     * as e.g. registering user metrics.
+     *
+     * @param context Contextual information that can be used during initialization.
+     */
+    default void open(InitializationContext context) throws Exception {
+        // Nothing to do here for the default implementation.
+    }
+
+    /**
+     * Deserializes the pulsar message. This message could be a raw byte message or some parsed
+     * message which decoded by pulsar schema.
+     *
+     * <p>You can output multiple message by using the {@link Collector}. Note that number and size
+     * of the produced records should be relatively small. Depending on the source implementation
+     * records can be buffered in memory or collecting records might delay emitting checkpoint
+     * barrier.
+     *
+     * @param message The message decoded by pulsar.
+     * @param out The collector to put the resulting messages.
+     */
+    void deserialize(Message<byte[]> message, Collector<T> out) throws Exception;
+
+    /**
+     * Create a PulsarDeserializationSchema by using the flink's {@link DeserializationSchema}. It
+     * would consume the pulsar message as byte array and decode the message by using flink's logic.
+     */
+    static <T> PulsarDeserializationSchema<T> flinkSchema(
+            DeserializationSchema<T> deserializationSchema) {
+        return new PulsarDeserializationSchemaWrapper<>(deserializationSchema);
+    }
+
+    /**
+     * Create a PulsarDeserializationSchema by using the Pulsar {@link Schema} instance. The message
+     * bytes must be encoded by pulsar Schema.
+     *
+     * <p>We only support <a
+     * href="https://pulsar.apache.org/docs/en/schema-understand/#primitive-type">primitive
+     * types</a> here.
+     */
+    static <T> PulsarDeserializationSchema<T> pulsarSchema(Schema<T> schema) {
+        PulsarSchema<T> pulsarSchema = new PulsarSchema<>(schema);
+        return new PulsarSchemaWrapper<>(pulsarSchema);
+    }
+
+    /**
+     * Create a PulsarDeserializationSchema by using the Pulsar {@link Schema} instance. The message
+     * bytes must be encoded by pulsar Schema.
+     *
+     * <p>We only support <a
+     * href="https://pulsar.apache.org/docs/en/schema-understand/#struct">struct types</a> here.
+     */
+    static <T> PulsarDeserializationSchema<T> pulsarSchema(Schema<T> schema, Class<T> typeClass) {
+        PulsarSchema<T> pulsarSchema = new PulsarSchema<>(schema, typeClass);
+        return new PulsarSchemaWrapper<>(pulsarSchema);
+    }
+
+    /**
+     * Create a PulsarDeserializationSchema by using the Pulsar {@link Schema} instance. The message
+     * bytes must be encoded by pulsar Schema.
+     *
+     * <p>We only support <a
+     * href="https://pulsar.apache.org/docs/en/schema-understand/#keyvalue">keyvalue types</a> here.
+     */
+    static <K, V> PulsarDeserializationSchema<KeyValue<K, V>> pulsarSchema(
+            Schema<KeyValue<K, V>> schema, Class<K> keyClass, Class<V> valueClass) {
+        PulsarSchema<KeyValue<K, V>> pulsarSchema =
+                new PulsarSchema<>(schema, keyClass, valueClass);
+        return new PulsarSchemaWrapper<>(pulsarSchema);
+    }
+
+    /**
+     * Create a PulsarDeserializationSchema by using the given {@link TypeInformation}. This method
+     * is only used for treating message that was written into pulsar by {@link TypeInformation}.
+     */
+    static <T> PulsarDeserializationSchema<T> flinkTypeInfo(
+            TypeInformation<T> information, ExecutionConfig config) {
+        return new PulsarTypeInformationWrapper<>(information, config);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaInitializationContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaInitializationContext.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.deserializer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.UserCodeClassLoader;
+
+/**
+ * Convert the {@link SourceReaderContext} into a {@link
+ * DeserializationSchema.InitializationContext}, we would use a pulsar named metric group for this
+ * content.
+ */
+@Internal
+public class PulsarDeserializationSchemaInitializationContext
+        implements DeserializationSchema.InitializationContext {
+
+    private final SourceReaderContext readerContext;
+
+    public PulsarDeserializationSchemaInitializationContext(SourceReaderContext readerContext) {
+        this.readerContext = readerContext;
+    }
+
+    @Override
+    public MetricGroup getMetricGroup() {
+        return readerContext.metricGroup().addGroup("pulsarDeserializer");
+    }
+
+    @Override
+    public UserCodeClassLoader getUserCodeClassLoader() {
+        return readerContext.getUserCodeClassLoader();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaWrapper.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.deserializer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.DeserializationSchema.InitializationContext;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import org.apache.pulsar.client.api.Message;
+
+/**
+ * A {@link PulsarDeserializationSchema} implementation which based on the given flink's {@link
+ * DeserializationSchema}. We would consume the message as byte array from pulsar and deserialize it
+ * by using flink serialization logic.
+ *
+ * @param <T> The output type of the message.
+ */
+@Internal
+class PulsarDeserializationSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
+    private static final long serialVersionUID = -630646912412751300L;
+
+    private final DeserializationSchema<T> deserializationSchema;
+
+    public PulsarDeserializationSchemaWrapper(DeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        // Initialize it for some custom logic.
+        deserializationSchema.open(context);
+    }
+
+    @Override
+    public void deserialize(Message<byte[]> message, Collector<T> out) throws Exception {
+        byte[] bytes = message.getData();
+        T instance = deserializationSchema.deserialize(bytes);
+
+        out.collect(instance);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarSchemaWrapper.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.deserializer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema.InitializationContext;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.util.Collector;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.createTypeInformation;
+
+/**
+ * The deserialization schema wrapper for pulsar original {@link Schema}. Pulsar would deserialize
+ * the message and pass it to flink with a auto generate or given {@link TypeInformation}.
+ *
+ * @param <T> The output type of the message.
+ */
+@Internal
+class PulsarSchemaWrapper<T> implements PulsarDeserializationSchema<T> {
+    private static final long serialVersionUID = -4864701207257059158L;
+
+    /** The serializable pulsar schema, it wrap the schema with type class. */
+    private final PulsarSchema<T> pulsarSchema;
+
+    @SuppressWarnings("java:S2065")
+    private transient Schema<T> schema;
+
+    public PulsarSchemaWrapper(PulsarSchema<T> pulsarSchema) {
+        this.pulsarSchema = pulsarSchema;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        if (schema == null) {
+            this.schema = pulsarSchema.getPulsarSchema();
+        }
+    }
+
+    @Override
+    public void deserialize(Message<byte[]> message, Collector<T> out) throws Exception {
+        byte[] bytes = message.getData();
+        T instance = schema.decode(bytes);
+
+        out.collect(instance);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        SchemaInfo info = pulsarSchema.getSchemaInfo();
+        return createTypeInformation(info);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarTypeInformationWrapper.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarTypeInformationWrapper.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.deserializer;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.util.Collector;
+
+import org.apache.pulsar.client.api.Message;
+
+/**
+ * Wrap the flink TypeInformation into a {@code PulsarDeserializationSchema}. We would create a
+ * flink {@code TypeSerializer} by using given ExecutionConfig. This execution config could be
+ * {@link ExecutionEnvironment#getConfig()}.
+ */
+public class PulsarTypeInformationWrapper<T> implements PulsarDeserializationSchema<T> {
+    private static final long serialVersionUID = 6647084180084963022L;
+
+    /**
+     * PulsarDeserializationSchema would be shared for multiple SplitReaders in different fetcher
+     * thread. Use a thread-local DataInputDeserializer would be better.
+     */
+    @SuppressWarnings("java:S5164")
+    private static final ThreadLocal<DataInputDeserializer> DESERIALIZER =
+            ThreadLocal.withInitial(DataInputDeserializer::new);
+
+    private final TypeInformation<T> information;
+    private final TypeSerializer<T> serializer;
+
+    public PulsarTypeInformationWrapper(TypeInformation<T> information, ExecutionConfig config) {
+        this.information = information;
+        this.serializer = information.createSerializer(config);
+    }
+
+    @Override
+    public void deserialize(Message<byte[]> message, Collector<T> out) throws Exception {
+        DataInputDeserializer dis = DESERIALIZER.get();
+        dis.setBuffer(message.getData());
+        T instance = serializer.deserialize(dis);
+
+        out.collect(instance);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return information;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/emitter/PulsarRecordEmitter.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/emitter/PulsarRecordEmitter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.emitter;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarOrderedSourceReader;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarUnorderedSourceReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
+
+/**
+ * The {@link RecordEmitter} implementation for both {@link PulsarOrderedSourceReader} and {@link
+ * PulsarUnorderedSourceReader}. We would always update the last consumed message id in this
+ * emitter.
+ */
+public class PulsarRecordEmitter<T>
+        implements RecordEmitter<PulsarMessage<T>, T, PulsarPartitionSplitState> {
+
+    @Override
+    public void emitRecord(
+            PulsarMessage<T> element, SourceOutput<T> output, PulsarPartitionSplitState splitState)
+            throws Exception {
+        // Sink the record to source output.
+        output.collect(element.getValue(), element.getEventTime());
+        // Update the split state.
+        splitState.setLatestConsumedId(element.getId());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarFetcherManagerBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarFetcherManagerBase.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.fetcher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Common fetcher manager abstraction for both ordered & unordered message.
+ *
+ * @param <T> The decoded message type for flink.
+ */
+@Internal
+public abstract class PulsarFetcherManagerBase<T>
+        extends SingleThreadFetcherManager<PulsarMessage<T>, PulsarPartitionSplit> {
+
+    private final Map<String, Integer> splitFetcherMapping = new HashMap<>();
+    private final Map<Integer, Boolean> fetcherStatus = new HashMap<>();
+
+    /**
+     * Creates a new SplitFetcherManager with multiple I/O threads.
+     *
+     * @param elementsQueue The queue that is used to hand over data from the I/O thread (the
+     *     fetchers) to the reader (which emits the records and book-keeps the state. This must be
+     *     the same queue instance that is also passed to the {@link SourceReaderBase}.
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     */
+    protected PulsarFetcherManagerBase(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<T>>> elementsQueue,
+            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier) {
+        super(elementsQueue, splitReaderSupplier);
+    }
+
+    /**
+     * Override this method for supporting multiple thread fetching, one fetcher thread for one
+     * split.
+     */
+    @Override
+    public void addSplits(List<PulsarPartitionSplit> splitsToAdd) {
+        for (PulsarPartitionSplit split : splitsToAdd) {
+            SplitFetcher<PulsarMessage<T>, PulsarPartitionSplit> fetcher =
+                    getOrCreateFetcher(split.splitId());
+            fetcher.addSplits(singletonList(split));
+            // This method could be executed multiple times.
+            startFetcher(fetcher);
+        }
+    }
+
+    @Override
+    protected void startFetcher(SplitFetcher<PulsarMessage<T>, PulsarPartitionSplit> fetcher) {
+        if (fetcherStatus.get(fetcher.fetcherId()) != Boolean.TRUE) {
+            fetcherStatus.put(fetcher.fetcherId(), true);
+            super.startFetcher(fetcher);
+        }
+    }
+
+    protected SplitFetcher<PulsarMessage<T>, PulsarPartitionSplit> getOrCreateFetcher(
+            String splitId) {
+        SplitFetcher<PulsarMessage<T>, PulsarPartitionSplit> fetcher;
+        Integer fetcherId = splitFetcherMapping.get(splitId);
+
+        if (fetcherId == null) {
+            fetcher = createSplitFetcher();
+        } else {
+            fetcher = fetchers.get(fetcherId);
+            // This fetcher has been stopped.
+            if (fetcher == null) {
+                fetcherStatus.remove(fetcherId);
+                fetcher = createSplitFetcher();
+            }
+        }
+        splitFetcherMapping.put(splitId, fetcher.fetcherId());
+
+        return fetcher;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarOrderedFetcherManager.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarOrderedFetcherManager.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.fetcher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.split.PulsarOrderedPartitionSplitReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Pulsar's FetcherManager implementation for ordered consuming. This class is needed to help
+ * acknowledge the message to Pulsar using the {@link Consumer} inside the {@link
+ * PulsarOrderedPartitionSplitReader}.
+ *
+ * @param <T> The message type for pulsar decoded message.
+ */
+@Internal
+public class PulsarOrderedFetcherManager<T> extends PulsarFetcherManagerBase<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarOrderedFetcherManager.class);
+
+    public PulsarOrderedFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<T>>> elementsQueue,
+            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier) {
+        super(elementsQueue, splitReaderSupplier);
+    }
+
+    public void acknowledgeMessages(Map<TopicPartition, MessageId> cursorsToCommit) {
+        LOG.debug("Acknowledge messages {}", cursorsToCommit);
+        cursorsToCommit.forEach(
+                (partition, messageId) -> {
+                    SplitFetcher<PulsarMessage<T>, PulsarPartitionSplit> fetcher =
+                            getOrCreateFetcher(partition.toString());
+                    triggerAcknowledge(fetcher, partition, messageId);
+                });
+    }
+
+    private void triggerAcknowledge(
+            SplitFetcher<PulsarMessage<T>, PulsarPartitionSplit> splitFetcher,
+            TopicPartition partition,
+            MessageId messageId) {
+        PulsarOrderedPartitionSplitReader<T> splitReader =
+                (PulsarOrderedPartitionSplitReader<T>) splitFetcher.getSplitReader();
+        splitReader.notifyCheckpointComplete(partition, messageId);
+        startFetcher(splitFetcher);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarUnorderedFetcherManager.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarUnorderedFetcherManager.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.fetcher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.split.PulsarUnorderedPartitionSplitReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.api.Consumer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static java.util.stream.Collectors.toCollection;
+
+/**
+ * Pulsar's FetcherManager implementation for unordered consuming. This class is needed to help
+ * acknowledge the message to Pulsar using the {@link Consumer} inside the {@link
+ * PulsarUnorderedPartitionSplitReader}.
+ *
+ * @param <T> The message type for pulsar decoded message.
+ */
+@Internal
+public class PulsarUnorderedFetcherManager<T> extends PulsarFetcherManagerBase<T> {
+
+    public PulsarUnorderedFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<T>>> elementsQueue,
+            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier) {
+        super(elementsQueue, splitReaderSupplier);
+    }
+
+    public List<PulsarPartitionSplit> snapshotState(long checkpointId) {
+        return fetchers.values().stream()
+                .map(SplitFetcher::getSplitReader)
+                .map(splitReader -> snapshotReader(checkpointId, splitReader))
+                .collect(toCollection(() -> new ArrayList<>(fetchers.size())));
+    }
+
+    private PulsarPartitionSplit snapshotReader(
+            long checkpointId, SplitReader<PulsarMessage<T>, PulsarPartitionSplit> splitReader) {
+        return ((PulsarUnorderedPartitionSplitReader<T>) splitReader)
+                .snapshotState(checkpointId)
+                .toPulsarPartitionSplit();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/message/PulsarMessage.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/message/PulsarMessage.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.message;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+/**
+ * The message instance that contains the required information which would be used for committing
+ * the consuming status.
+ */
+@Internal
+public class PulsarMessage<T> {
+
+    /**
+     * The id of a given message. This id could be same for multiple {@link PulsarMessage}, although
+     * it is unique for every {@link Message}.
+     */
+    private final MessageId id;
+
+    /** The value which deserialized by {@link PulsarDeserializationSchema}. */
+    private final T value;
+
+    /** The produce time for this message, it's a event time. */
+    private final long eventTime;
+
+    public PulsarMessage(MessageId id, T value, long eventTime) {
+        this.id = id;
+        this.value = value;
+        this.eventTime = eventTime;
+    }
+
+    public MessageId getId() {
+        return id;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public long getEventTime() {
+        return eventTime;
+    }
+
+    @Override
+    public String toString() {
+        return "PulsarMessage{"
+                + "id="
+                + id
+                + ", value="
+                + value
+                + ", eventTime="
+                + eventTime
+                + '}';
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/message/PulsarMessageCollector.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/message/PulsarMessageCollector.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.message;
+
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+import org.apache.flink.util.Collector;
+
+import org.apache.pulsar.client.api.Message;
+
+/**
+ * This collector supplier is providing the {@link Collector} for accepting the deserialized {@link
+ * PulsarMessage} from pulsar {@link PulsarDeserializationSchema}.
+ *
+ * @param <T> The deserialized pulsar message type, aka the source message type.
+ */
+public class PulsarMessageCollector<T> implements Collector<T> {
+
+    private final String splitId;
+    private final RecordsBySplits.Builder<PulsarMessage<T>> builder;
+    private Message<?> message;
+
+    public PulsarMessageCollector(
+            String splitId, RecordsBySplits.Builder<PulsarMessage<T>> builder) {
+        this.splitId = splitId;
+        this.builder = builder;
+    }
+
+    public void setMessage(Message<?> message) {
+        this.message = message;
+    }
+
+    @Override
+    public void collect(T t) {
+        PulsarMessage<T> result =
+                new PulsarMessage<>(message.getMessageId(), t, message.getEventTime());
+        builder.add(splitId, result);
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do for this collector.
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarOrderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarOrderedSourceReader.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.reader.fetcher.PulsarOrderedFetcherManager;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.split.PulsarOrderedPartitionSplitReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
+import org.apache.flink.core.io.InputStatus;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * The source reader for pulsar subscription Failover and Exclusive, which consumes the ordered
+ * messages.
+ */
+@Internal
+public class PulsarOrderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT> {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarOrderedSourceReader.class);
+
+    private final SortedMap<Long, Map<TopicPartition, MessageId>> cursorsToCommit;
+    private final ConcurrentMap<TopicPartition, MessageId> cursorsOfFinishedSplits;
+    private final AtomicReference<Throwable> cursorCommitThrowable = new AtomicReference<>();
+    private ScheduledExecutorService cursorScheduler;
+
+    public PulsarOrderedSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<OUT>>> elementsQueue,
+            Supplier<PulsarOrderedPartitionSplitReader<OUT>> splitReaderSupplier,
+            Configuration configuration,
+            SourceReaderContext context,
+            SourceConfiguration sourceConfiguration,
+            PulsarClient pulsarClient,
+            PulsarAdmin pulsarAdmin) {
+        super(
+                elementsQueue,
+                new PulsarOrderedFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                configuration,
+                context,
+                sourceConfiguration,
+                pulsarClient,
+                pulsarAdmin);
+
+        this.cursorsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
+        this.cursorsOfFinishedSplits = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        if (sourceConfiguration.isEnableAutoAcknowledgeMessage()) {
+            this.cursorScheduler = Executors.newSingleThreadScheduledExecutor();
+
+            // Auto commit cursor, this could be enabled when checkpoint is also enabled.
+            cursorScheduler.scheduleAtFixedRate(
+                    this::cumulativeAcknowledgmentMessage,
+                    sourceConfiguration.getMaxFetchTime().toMillis(),
+                    sourceConfiguration.getAutoCommitCursorInterval(),
+                    TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public InputStatus pollNext(ReaderOutput<OUT> output) throws Exception {
+        checkErrorAndRethrow();
+        return super.pollNext(output);
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, PulsarPartitionSplitState> finishedSplitIds) {
+        // We don't require new splits, all the splits are pre-assigned by source enumerator.
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("onSplitFinished event: {}", finishedSplitIds);
+        }
+
+        for (Map.Entry<String, PulsarPartitionSplitState> entry : finishedSplitIds.entrySet()) {
+            PulsarPartitionSplitState state = entry.getValue();
+            MessageId latestConsumedId = state.getLatestConsumedId();
+            if (latestConsumedId != null) {
+                cursorsOfFinishedSplits.put(state.getPartition(), latestConsumedId);
+            }
+        }
+    }
+
+    @Override
+    public List<PulsarPartitionSplit> snapshotState(long checkpointId) {
+        List<PulsarPartitionSplit> splits = super.snapshotState(checkpointId);
+
+        // Perform a snapshot for these splits.
+        Map<TopicPartition, MessageId> cursors =
+                cursorsToCommit.computeIfAbsent(checkpointId, id -> new HashMap<>());
+        // Put the cursors of the active splits.
+        for (PulsarPartitionSplit split : splits) {
+            MessageId latestConsumedId = split.getLatestConsumedId();
+            if (latestConsumedId != null) {
+                cursors.put(split.getPartition(), latestConsumedId);
+            }
+        }
+        // Put cursors of all the finished splits.
+        cursors.putAll(cursorsOfFinishedSplits);
+
+        return splits;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        LOG.debug("Committing cursors for checkpoint {}", checkpointId);
+        Map<TopicPartition, MessageId> cursors = cursorsToCommit.get(checkpointId);
+        try {
+            ((PulsarOrderedFetcherManager<OUT>) splitFetcherManager).acknowledgeMessages(cursors);
+            LOG.debug("Successfully acknowledge cursors for checkpoint {}", checkpointId);
+
+            // Clean up the cursors.
+            cursorsOfFinishedSplits.keySet().removeAll(cursors.keySet());
+            cursorsToCommit.headMap(checkpointId + 1).clear();
+        } catch (Exception e) {
+            LOG.error("Failed to acknowledge cursors for checkpoint {}", checkpointId, e);
+            cursorCommitThrowable.compareAndSet(null, e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (cursorScheduler != null) {
+            cursorScheduler.shutdown();
+        }
+
+        super.close();
+    }
+
+    // ----------------- helper methods --------------
+
+    private void checkErrorAndRethrow() {
+        Throwable cause = cursorCommitThrowable.get();
+        if (cause != null) {
+            throw new RuntimeException("An error occurred in acknowledge message.", cause);
+        }
+    }
+
+    /** Acknowledge the pulsar topic partition cursor by the last consumed message id. */
+    private void cumulativeAcknowledgmentMessage() {
+        Map<TopicPartition, MessageId> cursors = new HashMap<>(cursorsOfFinishedSplits);
+
+        // We reuse snapshotState for acquiring a consume status snapshot.
+        // So the checkpoint didn't really happen, so we just pass a fake checkpoint id.
+        List<PulsarPartitionSplit> splits = super.snapshotState(1L);
+        for (PulsarPartitionSplit split : splits) {
+            MessageId latestConsumedId = split.getLatestConsumedId();
+            if (latestConsumedId != null) {
+                cursors.put(split.getPartition(), latestConsumedId);
+            }
+        }
+
+        try {
+            ((PulsarOrderedFetcherManager<OUT>) splitFetcherManager).acknowledgeMessages(cursors);
+            // Clean up the finish splits.
+            cursorsOfFinishedSplits.keySet().removeAll(cursors.keySet());
+        } catch (Exception e) {
+            LOG.error("Fail in auto cursor commit.", e);
+            cursorCommitThrowable.compareAndSet(null, e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.source;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.reader.emitter.PulsarRecordEmitter;
+import org.apache.flink.connector.pulsar.source.reader.fetcher.PulsarFetcherManagerBase;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+
+/**
+ * The common pulsar source reader for both ordered & unordered message consuming.
+ *
+ * @param <OUT> The output message type for flink.
+ */
+abstract class PulsarSourceReaderBase<OUT>
+        extends SingleThreadMultiplexSourceReaderBase<
+                PulsarMessage<OUT>, OUT, PulsarPartitionSplit, PulsarPartitionSplitState> {
+
+    protected final SourceConfiguration sourceConfiguration;
+    protected final PulsarClient pulsarClient;
+    protected final PulsarAdmin pulsarAdmin;
+
+    protected PulsarSourceReaderBase(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<OUT>>> elementsQueue,
+            PulsarFetcherManagerBase<OUT> splitFetcherManager,
+            Configuration configuration,
+            SourceReaderContext context,
+            SourceConfiguration sourceConfiguration,
+            PulsarClient pulsarClient,
+            PulsarAdmin pulsarAdmin) {
+        super(
+                elementsQueue,
+                splitFetcherManager,
+                new PulsarRecordEmitter<>(),
+                configuration,
+                context);
+
+        this.sourceConfiguration = sourceConfiguration;
+        this.pulsarClient = pulsarClient;
+        this.pulsarAdmin = pulsarAdmin;
+    }
+
+    @Override
+    protected PulsarPartitionSplitState initializedState(PulsarPartitionSplit split) {
+        return new PulsarPartitionSplitState(split);
+    }
+
+    @Override
+    protected PulsarPartitionSplit toSplitType(
+            String splitId, PulsarPartitionSplitState splitState) {
+        return splitState.toPulsarPartitionSplit();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // Close shared pulsar resources.
+        pulsarClient.close();
+        pulsarAdmin.close();
+
+        super.close();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.reader.fetcher.PulsarUnorderedFetcherManager;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.split.PulsarUnorderedPartitionSplitReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+/**
+ * The source reader for pulsar subscription Shared and Key_Shared, which consumes the unordered
+ * messages.
+ */
+@Internal
+public class PulsarUnorderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT> {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarUnorderedSourceReader.class);
+
+    @Nullable private final TransactionCoordinatorClient coordinatorClient;
+    private final SortedMap<Long, List<TxnID>> transactionsToCommit;
+    private final List<TxnID> transactionsOfFinishedSplits;
+
+    public PulsarUnorderedSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<OUT>>> elementsQueue,
+            Supplier<PulsarUnorderedPartitionSplitReader<OUT>> splitReaderSupplier,
+            Configuration configuration,
+            SourceReaderContext context,
+            SourceConfiguration sourceConfiguration,
+            PulsarClient pulsarClient,
+            PulsarAdmin pulsarAdmin,
+            @Nullable TransactionCoordinatorClient coordinatorClient) {
+        super(
+                elementsQueue,
+                new PulsarUnorderedFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                configuration,
+                context,
+                sourceConfiguration,
+                pulsarClient,
+                pulsarAdmin);
+
+        this.coordinatorClient = coordinatorClient;
+        this.transactionsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
+        this.transactionsOfFinishedSplits = Collections.synchronizedList(new ArrayList<>());
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, PulsarPartitionSplitState> finishedSplitIds) {
+        // We don't require new splits, all the splits are pre-assigned by source enumerator.
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("onSplitFinished event: {}", finishedSplitIds);
+        }
+
+        if (coordinatorClient != null) {
+            // Commit the uncommitted transaction
+            for (Map.Entry<String, PulsarPartitionSplitState> entry : finishedSplitIds.entrySet()) {
+                PulsarPartitionSplitState state = entry.getValue();
+                TxnID uncommittedTransactionId = state.getUncommittedTransactionId();
+                if (uncommittedTransactionId != null) {
+                    transactionsOfFinishedSplits.add(uncommittedTransactionId);
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<PulsarPartitionSplit> snapshotState(long checkpointId) {
+        LOG.debug("Trigger the new transaction for downstream readers.");
+        List<PulsarPartitionSplit> splits =
+                ((PulsarUnorderedFetcherManager<OUT>) splitFetcherManager)
+                        .snapshotState(checkpointId);
+
+        if (coordinatorClient != null) {
+            // Snapshot the transaction status and commit it after checkpoint finished.
+            List<TxnID> txnIDs =
+                    transactionsToCommit.computeIfAbsent(checkpointId, id -> new ArrayList<>());
+            for (PulsarPartitionSplit split : splits) {
+                TxnID uncommittedTransactionId = split.getUncommittedTransactionId();
+                if (uncommittedTransactionId != null) {
+                    txnIDs.add(uncommittedTransactionId);
+                }
+            }
+        }
+
+        return splits;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        LOG.debug("Committing transactions for checkpoint {}", checkpointId);
+
+        if (coordinatorClient != null) {
+            for (Map.Entry<Long, List<TxnID>> entry : transactionsToCommit.entrySet()) {
+                Long currentCheckpointId = entry.getKey();
+                if (currentCheckpointId > checkpointId) {
+                    continue;
+                }
+
+                List<TxnID> transactions = entry.getValue();
+                for (TxnID transaction : transactions) {
+                    coordinatorClient.commit(transaction);
+                    transactionsOfFinishedSplits.remove(transaction);
+                }
+
+                transactionsToCommit.remove(currentCheckpointId);
+            }
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarOrderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarOrderedPartitionSplitReader.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarOrderedSourceReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+
+/**
+ * The split reader a given {@link PulsarPartitionSplit}, it would be closed once the {@link
+ * PulsarOrderedSourceReader} is closed.
+ *
+ * @param <OUT> the type of the pulsar source message that would be serialized to downstream.
+ */
+@Internal
+public class PulsarOrderedPartitionSplitReader<OUT> extends PulsarPartitionSplitReaderBase<OUT> {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PulsarOrderedPartitionSplitReader.class);
+
+    public PulsarOrderedPartitionSplitReader(
+            PulsarClient pulsarClient,
+            PulsarAdmin pulsarAdmin,
+            Configuration configuration,
+            SourceConfiguration sourceConfiguration,
+            ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+                    consumerConfigurationCustomizer,
+            PulsarDeserializationSchema<OUT> deserializationSchema) {
+        super(
+                pulsarClient,
+                pulsarAdmin,
+                configuration,
+                sourceConfiguration,
+                consumerConfigurationCustomizer,
+                deserializationSchema);
+    }
+
+    @Override
+    protected Message<byte[]> pollMessage(Duration timeout)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        return pulsarConsumer.receiveAsync().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected void finishedPollMessage(Message<byte[]> message) {
+        // Nothing to do here.
+        LOG.debug("Finished polling message {}", message);
+    }
+
+    @Override
+    protected void startConsumer(PulsarPartitionSplit split, Consumer<byte[]> consumer) {
+        initialStartPosition(split, consumer);
+    }
+
+    public void notifyCheckpointComplete(TopicPartition partition, MessageId offsetsToCommit) {
+        if (pulsarConsumer == null) {
+            this.pulsarConsumer = createPulsarConsumer(partition);
+        }
+
+        sneakyClient(() -> pulsarConsumer.acknowledgeCumulative(offsetsToCommit));
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.split;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
+import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessageCollector;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.KeySharedPolicy;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Collections.singleton;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+import static org.apache.flink.connector.pulsar.source.config.CursorVerification.FAIL_ON_MISMATCH;
+import static org.apache.flink.connector.pulsar.source.config.PulsarSourceConfigUtils.createConsumer;
+
+/**
+ * The common partition split reader.
+ *
+ * @param <OUT> the type of the pulsar source message that would be serialized to downstream.
+ */
+abstract class PulsarPartitionSplitReaderBase<OUT>
+        implements SplitReader<PulsarMessage<OUT>, PulsarPartitionSplit> {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarPartitionSplitReaderBase.class);
+
+    protected final PulsarClient pulsarClient;
+    protected final PulsarAdmin pulsarAdmin;
+    protected final Configuration configuration;
+    protected final SourceConfiguration sourceConfiguration;
+    protected final ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+            consumerConfigurationCustomizer;
+    protected final PulsarDeserializationSchema<OUT> deserializationSchema;
+    protected final AtomicBoolean wakeup;
+
+    protected Consumer<byte[]> pulsarConsumer;
+    protected PulsarPartitionSplit registeredSplit;
+
+    protected PulsarPartitionSplitReaderBase(
+            PulsarClient pulsarClient,
+            PulsarAdmin pulsarAdmin,
+            Configuration configuration,
+            SourceConfiguration sourceConfiguration,
+            ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+                    consumerConfigurationCustomizer,
+            PulsarDeserializationSchema<OUT> deserializationSchema) {
+        this.pulsarClient = pulsarClient;
+        this.pulsarAdmin = pulsarAdmin;
+        this.configuration = configuration;
+        this.sourceConfiguration = sourceConfiguration;
+        this.consumerConfigurationCustomizer = consumerConfigurationCustomizer;
+        this.deserializationSchema = deserializationSchema;
+        this.wakeup = new AtomicBoolean(false);
+    }
+
+    @Override
+    public RecordsWithSplitIds<PulsarMessage<OUT>> fetch() throws IOException {
+        RecordsBySplits.Builder<PulsarMessage<OUT>> builder = new RecordsBySplits.Builder<>();
+
+        // Return when no split registered to this reader.
+        if (pulsarConsumer == null || registeredSplit == null) {
+            return builder.build();
+        }
+
+        // Set wakeup to false for start consuming.
+        wakeup.compareAndSet(true, false);
+
+        StopCursor stopCursor = registeredSplit.getStopCursor();
+        String splitId = registeredSplit.splitId();
+        PulsarMessageCollector<OUT> collector = new PulsarMessageCollector<>(splitId, builder);
+        Deadline deadline = Deadline.fromNow(sourceConfiguration.getMaxFetchTime());
+
+        // Consume message from pulsar until it was woke up by flink reader.
+        for (int messageNum = 0;
+                messageNum < sourceConfiguration.getMaxFetchRecords()
+                        && deadline.hasTimeLeft()
+                        && isNotWakeup();
+                messageNum++) {
+            try {
+                Duration timeout = deadline.timeLeftIfAny();
+                Message<byte[]> message = pollMessage(timeout);
+
+                // Deserialize message.
+                collector.setMessage(message);
+                deserializationSchema.deserialize(message, collector);
+
+                // Acknowledge message if need.
+                finishedPollMessage(message);
+
+                if (stopCursor.shouldStop(message)) {
+                    builder.addFinishedSplit(splitId);
+                    break;
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (TimeoutException e) {
+                break;
+            } catch (ExecutionException e) {
+                LOG.error("Error in polling message from pulsar consumer.", e);
+                break;
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<PulsarPartitionSplit> splitsChanges) {
+        LOG.debug("Handle split changes {}", splitsChanges);
+
+        // Get all the partition assignments and stopping offsets.
+        if (!(splitsChanges instanceof SplitsAddition)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The SplitChange type of %s is not supported.",
+                            splitsChanges.getClass()));
+        }
+
+        if (registeredSplit != null) {
+            throw new IllegalStateException("This split reader have assigned split.");
+        }
+
+        List<PulsarPartitionSplit> newSplits = splitsChanges.splits();
+        Preconditions.checkArgument(
+                newSplits.size() == 1, "This pulsar split reader only support one split.");
+        PulsarPartitionSplit newSplit = newSplits.get(0);
+
+        // Create pulsar consumer.
+        Consumer<byte[]> consumer = createPulsarConsumer(newSplit);
+
+        // Open start & stop cursor.
+        newSplit.open(pulsarAdmin);
+
+        // Start Consumer.
+        startConsumer(newSplit, consumer);
+
+        LOG.info("Register split {} consumer for current reader.", newSplit);
+        this.registeredSplit = newSplit;
+        this.pulsarConsumer = consumer;
+    }
+
+    @Override
+    public void wakeUp() {
+        wakeup.compareAndSet(false, true);
+    }
+
+    @Override
+    public void close() {
+        if (pulsarConsumer != null) {
+            sneakyClient(() -> pulsarConsumer.close());
+        }
+    }
+
+    protected abstract Message<byte[]> pollMessage(Duration timeout)
+            throws ExecutionException, InterruptedException, TimeoutException;
+
+    protected abstract void finishedPollMessage(Message<byte[]> message);
+
+    protected abstract void startConsumer(PulsarPartitionSplit split, Consumer<byte[]> consumer);
+
+    // --------------------------- Helper Methods -----------------------------
+
+    protected void initialStartPosition(PulsarPartitionSplit split, Consumer<byte[]> consumer) {
+        StartCursor startCursor = split.getStartCursor();
+        // Seek start consuming position for assigned split.
+        CursorPosition position = startCursor.position(split);
+
+        // Set position for current consumer. We don't need to use
+        // consumer.redeliverUnacknowledgedMessages()
+        try {
+            position.seekPosition(consumer);
+        } catch (PulsarClientException e) {
+            if (sourceConfiguration.getVerifyInitialOffsets() == FAIL_ON_MISMATCH) {
+                throw new IllegalArgumentException(e);
+            } else {
+                // WARN_ON_MISMATCH would just print this warning message.
+                // No need to print the stacktrace.
+                LOG.warn(e.getMessage());
+            }
+        }
+    }
+
+    protected boolean isNotWakeup() {
+        return !wakeup.get();
+    }
+
+    /** Create a specified {@link Consumer} by the given split information. */
+    protected Consumer<byte[]> createPulsarConsumer(PulsarPartitionSplit split) {
+        return createPulsarConsumer(split.getPartition());
+    }
+
+    /** Create a specified {@link Consumer} by the given topic partition. */
+    protected Consumer<byte[]> createPulsarConsumer(TopicPartition partition) {
+        ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>> customizer =
+                consumerConfigurationCustomizer.compose(
+                        config -> {
+                            // Override the configuration by the split information.
+                            config.setTopicsPattern(null);
+                            config.setTopicNames(singleton(partition.getFullTopicName()));
+
+                            // Add KeySharedPolicy for Key_Shared subscription.
+                            if (sourceConfiguration.getSubscriptionType()
+                                    == SubscriptionType.Key_Shared) {
+                                KeySharedPolicy policy =
+                                        KeySharedPolicy.stickyHashRange()
+                                                .ranges(partition.getPulsarRange());
+                                config.setKeySharedPolicy(policy);
+                            }
+                        });
+
+        // Create the consumer configuration by using common utils.
+        return sneakyClient(
+                () -> createConsumer(pulsarClient, Schema.BYTES, configuration, customizer));
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer;
+import org.apache.flink.connector.pulsar.common.utils.PulsarTransactionUtils;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarUnorderedSourceReader;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.transaction.Transaction;
+import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
+import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClientException;
+import org.apache.pulsar.client.api.transaction.TxnID;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+
+/**
+ * The split reader a given {@link PulsarPartitionSplit}, it would be closed once the {@link
+ * PulsarUnorderedSourceReader} is closed.
+ *
+ * @param <OUT> the type of the pulsar source message that would be serialized to downstream.
+ */
+@Internal
+public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSplitReaderBase<OUT> {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(PulsarUnorderedPartitionSplitReader.class);
+
+    private static final Duration REDELIVER_TIME = Duration.ofSeconds(3);
+
+    private final TransactionCoordinatorClient coordinatorClient;
+
+    private Transaction uncommittedTransaction;
+
+    public PulsarUnorderedPartitionSplitReader(
+            PulsarClient pulsarClient,
+            PulsarAdmin pulsarAdmin,
+            Configuration configuration,
+            SourceConfiguration sourceConfiguration,
+            ConfigurationDataCustomizer<ConsumerConfigurationData<byte[]>>
+                    consumerConfigurationCustomizer,
+            PulsarDeserializationSchema<OUT> deserializationSchema,
+            TransactionCoordinatorClient coordinatorClient) {
+        super(
+                pulsarClient,
+                pulsarAdmin,
+                configuration,
+                sourceConfiguration,
+                consumerConfigurationCustomizer,
+                deserializationSchema);
+
+        this.coordinatorClient = coordinatorClient;
+    }
+
+    @Override
+    protected Message<byte[]> pollMessage(Duration timeout)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        Message<byte[]> message =
+                pulsarConsumer.receiveAsync().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+
+        if (!sourceConfiguration.isEnableAutoAcknowledgeMessage()) {
+            if (uncommittedTransaction == null) {
+                // Create a transaction.
+                this.uncommittedTransaction = newTransaction();
+            }
+
+            try {
+                // Add this message into transaction.
+                pulsarConsumer
+                        .acknowledgeAsync(message.getMessageId(), uncommittedTransaction)
+                        .get();
+            } catch (InterruptedException e) {
+                sneakyClient(
+                        () ->
+                                pulsarConsumer.reconsumeLater(
+                                        message, REDELIVER_TIME.toMillis(), TimeUnit.MILLISECONDS));
+                Thread.currentThread().interrupt();
+                throw e;
+            } catch (ExecutionException e) {
+                sneakyClient(
+                        () ->
+                                pulsarConsumer.reconsumeLater(
+                                        message, REDELIVER_TIME.toMillis(), TimeUnit.MILLISECONDS));
+                throw e;
+            }
+        }
+
+        return message;
+    }
+
+    @Override
+    protected void finishedPollMessage(Message<byte[]> message) {
+        if (sourceConfiguration.isEnableAutoAcknowledgeMessage()) {
+            sneakyClient(() -> pulsarConsumer.acknowledge(message));
+        }
+    }
+
+    @Override
+    protected void startConsumer(PulsarPartitionSplit split, Consumer<byte[]> consumer) {
+        TxnID uncommittedTransactionId = split.getUncommittedTransactionId();
+
+        // Abort the uncommitted pulsar transaction.
+        if (uncommittedTransactionId != null) {
+            if (coordinatorClient != null) {
+                try {
+                    coordinatorClient.abort(uncommittedTransactionId);
+                } catch (TransactionCoordinatorClientException e) {
+                    LOG.error(
+                            "Failed to abort the uncommitted transaction {} when restart the reader",
+                            uncommittedTransactionId,
+                            e);
+                }
+            }
+
+            // Redeliver unacknowledged messages because of the message is out of order.
+            consumer.redeliverUnacknowledgedMessages();
+        } else {
+            initialStartPosition(split, consumer);
+        }
+    }
+
+    public PulsarPartitionSplitState snapshotState(long checkpointId) {
+        TxnID txnID = PulsarTransactionUtils.getId(uncommittedTransaction);
+        this.uncommittedTransaction = newTransaction();
+        PulsarPartitionSplitState state = new PulsarPartitionSplitState(registeredSplit);
+        state.setUncommittedTransactionId(txnID);
+
+        return state;
+    }
+
+    private Transaction newTransaction() {
+        long timeoutMillis = sourceConfiguration.getTransactionTimeoutMillis();
+        CompletableFuture<Transaction> future =
+                sneakyClient(pulsarClient::newTransaction)
+                        .withTransactionTimeout(timeoutMillis, TimeUnit.MILLISECONDS)
+                        .build();
+
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplit.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplit.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.reader.source.PulsarOrderedSourceReader;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.transaction.TxnID;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A {@link SourceSplit} implementation for a Pulsar's partition. */
+@Internal
+public class PulsarPartitionSplit implements SourceSplit {
+
+    private final TopicPartition partition;
+
+    private final StartCursor startCursor;
+
+    private final StopCursor stopCursor;
+
+    /**
+     * Since this field in only used in {@link PulsarOrderedSourceReader#snapshotState(long)}, it's
+     * no need to serialize this field into flink checkpoint state.
+     */
+    @Nullable private final MessageId latestConsumedId;
+
+    @Nullable private final TxnID uncommittedTransactionId;
+
+    public PulsarPartitionSplit(
+            TopicPartition partition, StartCursor startCursor, StopCursor stopCursor) {
+        this.partition = partition;
+        this.startCursor = checkNotNull(startCursor);
+        this.stopCursor = checkNotNull(stopCursor);
+        this.latestConsumedId = null;
+        this.uncommittedTransactionId = null;
+    }
+
+    public PulsarPartitionSplit(
+            TopicPartition partition,
+            StartCursor startCursor,
+            StopCursor stopCursor,
+            MessageId latestConsumedId,
+            TxnID uncommittedTransactionId) {
+        this.partition = partition;
+        this.startCursor =
+                latestConsumedId == null
+                        ? checkNotNull(startCursor)
+                        : StartCursor.fromMessageId(latestConsumedId, false);
+        this.stopCursor = checkNotNull(stopCursor);
+        this.latestConsumedId = latestConsumedId;
+        this.uncommittedTransactionId = uncommittedTransactionId;
+    }
+
+    @Override
+    public String splitId() {
+        return partition.toString();
+    }
+
+    public TopicPartition getPartition() {
+        return partition;
+    }
+
+    public StartCursor getStartCursor() {
+        return startCursor;
+    }
+
+    public StopCursor getStopCursor() {
+        return stopCursor;
+    }
+
+    @Nullable
+    public MessageId getLatestConsumedId() {
+        return latestConsumedId;
+    }
+
+    @Nullable
+    public TxnID getUncommittedTransactionId() {
+        return uncommittedTransactionId;
+    }
+
+    /** Open start & stop cursor. */
+    public void open(PulsarAdmin admin) {
+        startCursor.open(admin, partition);
+        stopCursor.open(admin, partition);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PulsarPartitionSplit that = (PulsarPartitionSplit) o;
+        return partition.equals(that.partition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partition);
+    }
+
+    @Override
+    public String toString() {
+        return "PulsarPartitionSplit{partition=" + partition + '}';
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitSerializer.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitSerializer.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.split;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.apache.pulsar.client.api.transaction.TxnID;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarSerdeUtils.deserializeObject;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarSerdeUtils.serializeObject;
+
+/** The {@link SimpleVersionedSerializer serializer} for {@link PulsarPartitionSplit}. */
+public class PulsarPartitionSplitSerializer
+        implements SimpleVersionedSerializer<PulsarPartitionSplit> {
+
+    public static final PulsarPartitionSplitSerializer INSTANCE =
+            new PulsarPartitionSplitSerializer();
+
+    // This version should be bumped after modifying the PulsarPartitionSplit.
+    public static final int CURRENT_VERSION = 0;
+
+    private PulsarPartitionSplitSerializer() {
+        // Singleton instance.
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(PulsarPartitionSplit obj) throws IOException {
+        // VERSION 0 serialization
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            serializePulsarPartitionSplit(out, obj);
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public PulsarPartitionSplit deserialize(int version, byte[] serialized) throws IOException {
+        // VERSION 0 deserialization
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            return deserializePulsarPartitionSplit(version, in);
+        }
+    }
+
+    // ----------------- helper methods --------------
+
+    public void serializePulsarPartitionSplit(DataOutputStream out, PulsarPartitionSplit split)
+            throws IOException {
+        // partition
+        serializeTopicPartition(out, split.getPartition());
+
+        // startCursor
+        serializeObject(out, split.getStartCursor());
+
+        // stopCursor
+        serializeObject(out, split.getStopCursor());
+
+        // uncommittedTransactionId
+        TxnID uncommittedTransactionId = split.getUncommittedTransactionId();
+        if (uncommittedTransactionId == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeLong(uncommittedTransactionId.getMostSigBits());
+            out.writeLong(uncommittedTransactionId.getLeastSigBits());
+        }
+    }
+
+    public PulsarPartitionSplit deserializePulsarPartitionSplit(int version, DataInputStream in)
+            throws IOException {
+        // partition
+        TopicPartition partition = deserializeTopicPartition(version, in);
+
+        // startCursor
+        StartCursor startCursor = deserializeObject(in);
+
+        // stopCursor
+        StopCursor stopCursor = deserializeObject(in);
+
+        // uncommittedTransactionId
+        TxnID uncommittedTransactionId = null;
+        if (in.readBoolean()) {
+            long mostSigBits = in.readLong();
+            long leastSigBits = in.readLong();
+            uncommittedTransactionId = new TxnID(mostSigBits, leastSigBits);
+        }
+
+        // Creation
+        return new PulsarPartitionSplit(
+                partition, startCursor, stopCursor, null, uncommittedTransactionId);
+    }
+
+    public void serializeTopicPartition(DataOutputStream out, TopicPartition partition)
+            throws IOException {
+        // VERSION 0 serialization
+        TopicRange range = partition.getRange();
+        out.writeUTF(partition.getTopic());
+        out.writeInt(partition.getPartitionId());
+        out.writeInt(range.getStart());
+        out.writeInt(range.getEnd());
+    }
+
+    public TopicPartition deserializeTopicPartition(int version, DataInputStream in)
+            throws IOException {
+        // VERSION 0 deserialization
+        String topic = in.readUTF();
+        int partitionId = in.readInt();
+        int start = in.readInt();
+        int end = in.readInt();
+
+        TopicRange range = new TopicRange(start, end);
+        return new TopicPartition(topic, partitionId, range);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitState.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitState.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.split;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.transaction.TxnID;
+
+import javax.annotation.Nullable;
+
+/** Pulsar partition split state. */
+public class PulsarPartitionSplitState {
+
+    private final PulsarPartitionSplit split;
+
+    @Nullable private TxnID uncommittedTransactionId;
+
+    @Nullable private MessageId latestConsumedId;
+
+    public PulsarPartitionSplitState(PulsarPartitionSplit split) {
+        this.split = split;
+    }
+
+    /**
+     * Create a partition split which contains the latest consumed message id as the start position.
+     */
+    public PulsarPartitionSplit toPulsarPartitionSplit() {
+        return new PulsarPartitionSplit(
+                split.getPartition(),
+                split.getStartCursor(),
+                split.getStopCursor(),
+                latestConsumedId,
+                uncommittedTransactionId);
+    }
+
+    public TopicPartition getPartition() {
+        return split.getPartition();
+    }
+
+    @Nullable
+    public TxnID getUncommittedTransactionId() {
+        return uncommittedTransactionId;
+    }
+
+    public void setUncommittedTransactionId(@Nullable TxnID uncommittedTransactionId) {
+        this.uncommittedTransactionId = uncommittedTransactionId;
+    }
+
+    @Nullable
+    public MessageId getLatestConsumedId() {
+        return latestConsumedId;
+    }
+
+    public void setLatestConsumedId(@Nullable MessageId latestConsumedId) {
+        this.latestConsumedId = latestConsumedId;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.connector.pulsar.SampleMessage.SubMessage;
+import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Bar;
+import org.apache.flink.connector.pulsar.testutils.SampleData.FA;
+import org.apache.flink.connector.pulsar.testutils.SampleData.FL;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Foo;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchema;
+import org.apache.pulsar.client.impl.schema.ProtobufSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit tests for {@link PulsarSchema}. */
+class PulsarSchemaTest {
+
+    private static final JSONSchema<FL> JSON = JSONSchema.of(FL.class);
+    private static final AvroSchema<Bar> AVRO = AvroSchema.of(Bar.class);
+    private static final ProtobufSchema<TestMessage> PROTO = ProtobufSchema.of(TestMessage.class);
+    private static final ProtobufNativeSchema<SubMessage> PROTO_N =
+            ProtobufNativeSchema.of(SubMessage.class);
+    private static final Schema<KeyValue<Foo, FA>> KV =
+            KeyValueSchemaImpl.of(Foo.class, FA.class, SchemaType.JSON);
+
+    @Test
+    void pulsarSchemaCreation() {
+        assertAll(
+                "Primitive schemas creation",
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.BYTES)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.STRING)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.INT8)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.INT16)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.INT32)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.INT64)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.BOOL)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.FLOAT)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.DOUBLE)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.DATE)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.TIME)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.TIMESTAMP)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.INSTANT)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.LOCAL_DATE)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.LOCAL_TIME)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(Schema.LOCAL_DATE_TIME)));
+
+        assertAll(
+                "Struct & KeyValue schema creation",
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(JSON, FL.class)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(AVRO, Bar.class)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(PROTO, TestMessage.class)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(PROTO_N, SubMessage.class)),
+                () -> assertDoesNotThrow(() -> new PulsarSchema<>(KV, Foo.class, FA.class)));
+    }
+
+    @Test
+    void invalidPulsarSchemaCreationWithoutClassType() {
+        assertThrows(IllegalArgumentException.class, () -> new PulsarSchema<>(AVRO));
+        assertThrows(IllegalArgumentException.class, () -> new PulsarSchema<>(JSON));
+        assertThrows(IllegalArgumentException.class, () -> new PulsarSchema<>(PROTO));
+        assertThrows(IllegalArgumentException.class, () -> new PulsarSchema<>(PROTO_N));
+        assertThrows(IllegalArgumentException.class, () -> new PulsarSchema<>(KV));
+        assertThrows(IllegalArgumentException.class, () -> new PulsarSchema(KV, KeyValue.class));
+    }
+
+    @Test
+    void pulsarSchemaSerialization() throws Exception {
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.BYTES));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.STRING));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.INT8));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.INT16));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.INT32));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.INT64));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.BOOL));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.FLOAT));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.DOUBLE));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.DATE));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.TIME));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.TIMESTAMP));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.INSTANT));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.LOCAL_DATE));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.LOCAL_TIME));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(Schema.LOCAL_DATE_TIME));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(JSON, FL.class));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(AVRO, Bar.class));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(PROTO, TestMessage.class));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(PROTO_N, SubMessage.class));
+        assertPulsarSchemaIsSerializable(new PulsarSchema<>(KV, Foo.class, FA.class));
+    }
+
+    private <T> void assertPulsarSchemaIsSerializable(PulsarSchema<T> schema) throws Exception {
+        PulsarSchema<T> clonedSchema = InstantiationUtil.clone(schema);
+        assertEquals(clonedSchema.getSchemaInfo(), schema.getSchemaInfo());
+        assertEquals(clonedSchema.getRecordClass(), schema.getRecordClass());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeInformationTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeInformationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Bar;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.Schema;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/** Unit tests for {@link PulsarSchemaTypeInformation}. */
+class PulsarSchemaTypeInformationTest {
+
+    @Test
+    void pulsarTypeInfoSerializationAndCreation() throws Exception {
+        PulsarSchema<Bar> schema = new PulsarSchema<>(Schema.AVRO(Bar.class), Bar.class);
+        PulsarSchemaTypeInformation<Bar> info = new PulsarSchemaTypeInformation<>(schema);
+        assertDoesNotThrow(() -> InstantiationUtil.clone(info));
+
+        PulsarSchemaTypeInformation<Bar> clonedInfo = InstantiationUtil.clone(info);
+        assertEquals(info, clonedInfo);
+        assertNotSame(info, clonedInfo);
+
+        assertDoesNotThrow(() -> info.createSerializer(new ExecutionConfig()));
+
+        assertEquals(info.getTypeClass(), clonedInfo.getTypeClass());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeSerializerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTypeSerializerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestInputView;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestOutputView;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.connector.pulsar.SampleMessage.TestEnum;
+import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.util.Collections.nCopies;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.pulsar.client.api.Schema.PROTOBUF_NATIVE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** Unit tests for {@link PulsarSchemaTypeSerializer}. */
+class PulsarSchemaTypeSerializerTest {
+
+    private final PulsarSchemaTypeSerializer<TestMessage> serializer =
+            new PulsarSchemaTypeSerializer<>(
+                    new PulsarSchema<>(PROTOBUF_NATIVE(TestMessage.class), TestMessage.class));
+
+    private final TestMessage message =
+            TestMessage.newBuilder()
+                    .setStringField(randomAlphabetic(10))
+                    .setDoubleField(ThreadLocalRandom.current().nextDouble())
+                    .setIntField(ThreadLocalRandom.current().nextInt())
+                    .setTestEnum(TestEnum.SHARED)
+                    .addAllRepeatedField(nCopies(10, randomAlphabetic(13)))
+                    .build();
+
+    @Test
+    void createDeserializeRecordInstance() {
+        // Protobuf class creation
+        assertNotNull(serializer.createInstance());
+    }
+
+    @Test
+    void serializeAndDeserializeInstance() throws Exception {
+        TestOutputView output = new TestOutputView();
+        serializer.serialize(message, output);
+
+        TestInputView input = output.getInputView();
+        TestMessage message1 = serializer.deserialize(input);
+
+        assertEquals(message, message1);
+    }
+
+    @Test
+    void copyValueAmongDataView() throws Exception {
+        TestOutputView output1 = new TestOutputView();
+        serializer.serialize(message, output1);
+
+        // Copy bytes among view.
+        TestInputView input1 = output1.getInputView();
+        TestOutputView output2 = new TestOutputView();
+        serializer.copy(input1, output2);
+
+        TestInputView input2 = output2.getInputView();
+        TestMessage message1 = serializer.deserialize(input2);
+        assertEquals(message, message1);
+    }
+
+    @Test
+    void snapshotSerializerAndRecreateIt() throws Exception {
+        TypeSerializerSnapshot<TestMessage> snapshot = serializer.snapshotConfiguration();
+
+        // Snapshot
+        TestOutputView output = new TestOutputView();
+        snapshot.writeSnapshot(output);
+
+        // Restore from snapshot
+        snapshot.readSnapshot(
+                snapshot.getCurrentVersion(),
+                output.getInputView(),
+                PulsarSchemaTypeSerializerTest.class.getClassLoader());
+
+        TypeSerializer<TestMessage> serializer1 = snapshot.restoreSerializer();
+        assertEquals(serializer, serializer1);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtilsTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtilsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema;
+
+import org.apache.flink.connector.pulsar.SampleMessage.SubMessage;
+import org.apache.flink.connector.pulsar.SampleMessage.SubMessage.NestedMessage;
+import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Bar;
+import org.apache.flink.connector.pulsar.testutils.SampleData.FL;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Foo;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link PulsarSchemaUtils}. */
+class PulsarSchemaUtilsTest {
+
+    @Test
+    void haveProtobufShouldReturnTrueIfWeProvidedIt() {
+        assertTrue(PulsarSchemaUtils.haveProtobuf());
+    }
+
+    @Test
+    void protobufClassValidation() {
+        assertTrue(PulsarSchemaUtils.isProtobufTypeClass(TestMessage.class));
+        assertTrue(PulsarSchemaUtils.isProtobufTypeClass(SubMessage.class));
+        assertTrue(PulsarSchemaUtils.isProtobufTypeClass(NestedMessage.class));
+
+        assertFalse(PulsarSchemaUtils.isProtobufTypeClass(Bar.class));
+        assertFalse(PulsarSchemaUtils.isProtobufTypeClass(FL.class));
+        assertFalse(PulsarSchemaUtils.isProtobufTypeClass(Foo.class));
+    }
+
+    @Test
+    @SuppressWarnings("java:S5778")
+    void createSchemaForComplexSchema() {
+        // Avro
+        Schema<Foo> avro1 = Schema.AVRO(Foo.class);
+        PulsarSchema<Foo> avro2 = new PulsarSchema<>(avro1, Foo.class);
+        assertThrows(
+                NullPointerException.class,
+                () -> PulsarSchemaUtils.createSchema(avro1.getSchemaInfo()));
+
+        Schema<Foo> schema = PulsarSchemaUtils.createSchema(avro2.getSchemaInfo());
+        assertNotEquals(schema.getSchemaInfo(), avro1.getSchemaInfo());
+        assertEquals(schema.getSchemaInfo(), avro2.getSchemaInfo());
+
+        // JSON
+        Schema<FL> json1 = Schema.JSON(FL.class);
+        PulsarSchema<FL> json2 = new PulsarSchema<>(json1, FL.class);
+        Schema<FL> json3 = PulsarSchemaUtils.createSchema(json2.getSchemaInfo());
+        assertNotEquals(json3.getSchemaInfo(), json1.getSchemaInfo());
+        assertEquals(json3.getSchemaInfo(), json2.getSchemaInfo());
+
+        // Protobuf Native
+        Schema<TestMessage> proto1 = Schema.PROTOBUF_NATIVE(TestMessage.class);
+        PulsarSchema<TestMessage> proto2 = new PulsarSchema<>(proto1, TestMessage.class);
+        Schema<TestMessage> proto3 = PulsarSchemaUtils.createSchema(proto2.getSchemaInfo());
+        assertNotEquals(proto3.getSchemaInfo(), proto1.getSchemaInfo());
+        assertEquals(proto3.getSchemaInfo(), proto2.getSchemaInfo());
+
+        // KeyValue
+        Schema<KeyValue<byte[], byte[]>> kvBytes1 = Schema.KV_BYTES();
+        PulsarSchema<KeyValue<byte[], byte[]>> kvBytes2 =
+                new PulsarSchema<>(kvBytes1, byte[].class, byte[].class);
+        Schema<KeyValue<byte[], byte[]>> kvBytes3 =
+                PulsarSchemaUtils.createSchema(kvBytes2.getSchemaInfo());
+        assertNotEquals(kvBytes3.getSchemaInfo(), kvBytes1.getSchemaInfo());
+    }
+
+    @Test
+    void encodeAndDecodeClassInfo() {
+        Schema<Foo> schema = Schema.AVRO(Foo.class);
+        SchemaInfo info = schema.getSchemaInfo();
+        SchemaInfo newInfo = PulsarSchemaUtils.encodeClassInfo(info, Foo.class);
+        assertDoesNotThrow(() -> PulsarSchemaUtils.decodeClassInfo(newInfo));
+
+        Class<Foo> clazz = PulsarSchemaUtils.decodeClassInfo(newInfo);
+        assertEquals(clazz, Foo.class);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/AvroSchemaFactoryTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/AvroSchemaFactoryTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestInputView;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase.TestOutputView;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.avro.reflect.AvroDefault;
+import org.apache.avro.reflect.Nullable;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit tests for {@link AvroSchemaFactory}. */
+class AvroSchemaFactoryTest {
+
+    private final AvroSchemaFactory<?> factory = new AvroSchemaFactory<>();
+
+    @Test
+    void createAvroSchemaFromSchemaInfo() {
+        AvroSchema<DefaultStruct> schema1 = AvroSchema.of(DefaultStruct.class);
+
+        // AvroSchema should provide type class
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new PulsarSchema<>(schema1),
+                "Avro Schema should provide the type class");
+
+        PulsarSchema<DefaultStruct> pulsarSchema = new PulsarSchema<>(schema1, DefaultStruct.class);
+        AvroSchemaFactory<DefaultStruct> factory = new AvroSchemaFactory<>();
+        Schema<DefaultStruct> schema2 = factory.createSchema(pulsarSchema.getSchemaInfo());
+
+        assertThat(schema2)
+                .isInstanceOf(AvroSchema.class)
+                .hasFieldOrPropertyWithValue("schemaInfo", pulsarSchema.getSchemaInfo());
+
+        // Serialize and deserialize.
+        DefaultStruct struct1 = new DefaultStruct();
+        struct1.setField1(ThreadLocalRandom.current().nextInt());
+        struct1.setField2(randomAlphabetic(10));
+        struct1.setField3(ThreadLocalRandom.current().nextLong());
+
+        byte[] bytes = schema1.encode(struct1);
+        DefaultStruct struct2 = schema2.decode(bytes);
+
+        assertEquals(struct1, struct2);
+    }
+
+    @Test
+    void createAvroTypeInformationAndSerializeValues() throws Exception {
+        AvroSchema<StructWithAnnotations> schema = AvroSchema.of(StructWithAnnotations.class);
+        PulsarSchema<StructWithAnnotations> pulsarSchema =
+                new PulsarSchema<>(schema, StructWithAnnotations.class);
+
+        StructWithAnnotations struct1 = new StructWithAnnotations();
+        struct1.setField1(5678);
+
+        AvroSchemaFactory<StructWithAnnotations> factory = new AvroSchemaFactory<>();
+        TypeInformation<StructWithAnnotations> information =
+                factory.createTypeInfo(pulsarSchema.getSchemaInfo());
+        assertThat(information)
+                .isInstanceOf(PulsarSchemaTypeInformation.class)
+                .hasFieldOrPropertyWithValue("typeClass", StructWithAnnotations.class);
+
+        // Serialize by type information.
+        TypeSerializer<StructWithAnnotations> serializer =
+                information.createSerializer(new ExecutionConfig());
+        // TypeInformation serialization.
+        assertDoesNotThrow(() -> InstantiationUtil.clone(information));
+        assertDoesNotThrow(() -> InstantiationUtil.clone(serializer));
+
+        TestOutputView output = new TestOutputView();
+        serializer.serialize(struct1, output);
+
+        TestInputView input = output.getInputView();
+        StructWithAnnotations struct2 = serializer.deserialize(input);
+
+        assertThat(struct2)
+                .hasFieldOrPropertyWithValue("field1", struct1.getField1())
+                .hasFieldOrPropertyWithValue("field2", null)
+                .hasFieldOrPropertyWithValue("field3", null);
+    }
+
+    private static class DefaultStruct {
+        int field1;
+        String field2;
+        Long field3;
+
+        public int getField1() {
+            return field1;
+        }
+
+        public void setField1(int field1) {
+            this.field1 = field1;
+        }
+
+        public String getField2() {
+            return field2;
+        }
+
+        public void setField2(String field2) {
+            this.field2 = field2;
+        }
+
+        public Long getField3() {
+            return field3;
+        }
+
+        public void setField3(Long field3) {
+            this.field3 = field3;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DefaultStruct that = (DefaultStruct) o;
+            return field1 == that.field1
+                    && Objects.equals(field2, that.field2)
+                    && Objects.equals(field3, that.field3);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(field1, field2, field3);
+        }
+    }
+
+    private static class StructWithAnnotations {
+        int field1;
+        @Nullable String field2;
+
+        @AvroDefault("\"1000\"")
+        Long field3;
+
+        public int getField1() {
+            return field1;
+        }
+
+        public void setField1(int field1) {
+            this.field1 = field1;
+        }
+
+        public String getField2() {
+            return field2;
+        }
+
+        public void setField2(String field2) {
+            this.field2 = field2;
+        }
+
+        public Long getField3() {
+            return field3;
+        }
+
+        public void setField3(Long field3) {
+            this.field3 = field3;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            StructWithAnnotations that = (StructWithAnnotations) o;
+            return field1 == that.field1
+                    && Objects.equals(field2, that.field2)
+                    && Objects.equals(field3, that.field3);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(field1, field2, field3);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactoryTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/JSONSchemaFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+import org.apache.flink.connector.pulsar.testutils.SampleData.FL;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Foo;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/** Unit tests for {@link JSONSchemaFactory}. */
+class JSONSchemaFactoryTest {
+
+    @Test
+    void createJSONSchemaFromSchemaInfo() {
+        JSONSchema<Foo> schema =
+                JSONSchema.of(
+                        SchemaDefinition.<Foo>builder()
+                                .withPojo(Foo.class)
+                                .withAlwaysAllowNull(false)
+                                .build());
+        PulsarSchema<Foo> pulsarSchema = new PulsarSchema<>(schema, Foo.class);
+        JSONSchemaFactory<Foo> factory = new JSONSchemaFactory<>();
+        Schema<Foo> decodedSchema = factory.createSchema(pulsarSchema.getSchemaInfo());
+
+        assertThat(decodedSchema)
+                .isInstanceOf(JSONSchema.class)
+                .hasFieldOrPropertyWithValue("schemaInfo", pulsarSchema.getSchemaInfo())
+                .hasFieldOrPropertyWithValue("pojo", Foo.class);
+    }
+
+    @Test
+    void createJSONTypeInformationFromSchemaInfo() {
+        JSONSchema<FL> schema = JSONSchema.of(FL.class);
+        PulsarSchema<FL> pulsarSchema = new PulsarSchema<>(schema, FL.class);
+        JSONSchemaFactory<FL> factory = new JSONSchemaFactory<>();
+        TypeInformation<FL> typeInfo = factory.createTypeInfo(pulsarSchema.getSchemaInfo());
+
+        assertThat(typeInfo)
+                .isInstanceOf(PulsarSchemaTypeInformation.class)
+                .hasFieldOrPropertyWithValue("typeClass", FL.class);
+
+        // TypeInformation serialization.
+        assertDoesNotThrow(() -> InstantiationUtil.clone(typeInfo));
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/KeyValueSchemaFactoryTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/KeyValueSchemaFactoryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+import org.apache.flink.connector.pulsar.testutils.SampleData.Bar;
+import org.apache.flink.connector.pulsar.testutils.SampleData.FA;
+import org.apache.flink.connector.pulsar.testutils.SampleData.FM;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.KeyValueSchemaImpl;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/** Unit tests for {@link KeyValueSchemaFactory}. */
+class KeyValueSchemaFactoryTest {
+
+    @Test
+    void createKeyValueSchemaFromSchemaInfo() {
+        Schema<KeyValue<FM, FA>> schema1 =
+                KeyValueSchemaImpl.of(FM.class, FA.class, SchemaType.AVRO);
+        PulsarSchema<KeyValue<FM, FA>> pulsarSchema =
+                new PulsarSchema<>(schema1, FM.class, FA.class);
+        KeyValueSchemaFactory<FM, FA> factory = new KeyValueSchemaFactory<>();
+
+        Schema<KeyValue<FM, FA>> schema2 = factory.createSchema(pulsarSchema.getSchemaInfo());
+        assertThat(schema2)
+                .isInstanceOf(KeyValueSchemaImpl.class)
+                .hasFieldOrPropertyWithValue("schemaInfo", pulsarSchema.getSchemaInfo());
+
+        KeyValueSchemaImpl<FM, FA> schema3 = (KeyValueSchemaImpl<FM, FA>) schema2;
+        assertThat(schema3.getKeySchema()).isInstanceOf(AvroSchema.class);
+        assertThat(schema3.getValueSchema()).isInstanceOf(AvroSchema.class);
+    }
+
+    @Test
+    void createKeyValueTypeInformationFromSchemaInfo() throws Exception {
+        Schema<KeyValue<Bar, FA>> schema1 =
+                KeyValueSchemaImpl.of(Bar.class, FA.class, SchemaType.JSON);
+        PulsarSchema<KeyValue<Bar, FA>> pulsarSchema =
+                new PulsarSchema<>(schema1, Bar.class, FA.class);
+        KeyValueSchemaFactory<Bar, FA> factory = new KeyValueSchemaFactory<>();
+
+        TypeInformation<KeyValue<Bar, FA>> info =
+                factory.createTypeInfo(pulsarSchema.getSchemaInfo());
+        // TypeInformation serialization.
+        assertDoesNotThrow(() -> InstantiationUtil.clone(info));
+        assertThat(InstantiationUtil.clone(info))
+                .isInstanceOf(PulsarSchemaTypeInformation.class)
+                .hasFieldOrPropertyWithValue("typeClass", KeyValue.class);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufNativeSchemaFactoryTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufNativeSchemaFactoryTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.SampleMessage.SubMessage;
+import org.apache.flink.connector.pulsar.SampleMessage.SubMessage.NestedMessage;
+import org.apache.flink.connector.pulsar.SampleMessage.TestEnum;
+import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.ProtobufNativeSchema;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for {@link ProtobufNativeSchemaFactory}. */
+class ProtobufNativeSchemaFactoryTest {
+
+    @Test
+    void createProtobufNativeSchemaFromSchemaInfo() {
+        ProtobufNativeSchema<TestMessage> schema1 = ProtobufNativeSchema.of(TestMessage.class);
+        PulsarSchema<TestMessage> pulsarSchema = new PulsarSchema<>(schema1, TestMessage.class);
+        ProtobufNativeSchemaFactory<TestMessage> factory = new ProtobufNativeSchemaFactory<>();
+
+        Schema<TestMessage> schema2 = factory.createSchema(pulsarSchema.getSchemaInfo());
+        assertThat(schema2)
+                .hasFieldOrPropertyWithValue("schemaInfo", pulsarSchema.getSchemaInfo())
+                .isInstanceOf(ProtobufNativeSchema.class);
+
+        // Encode by original schema and decode by new schema
+        TestMessage message =
+                TestMessage.newBuilder()
+                        .setStringField(randomAlphabetic(10))
+                        .setDoubleField(ThreadLocalRandom.current().nextDouble())
+                        .setIntField(ThreadLocalRandom.current().nextInt())
+                        .setTestEnum(TestEnum.SHARED)
+                        .setNestedField(
+                                SubMessage.newBuilder()
+                                        .setFoo(randomAlphabetic(10))
+                                        .setBar(ThreadLocalRandom.current().nextDouble())
+                                        .build())
+                        .addRepeatedField(randomAlphabetic(13))
+                        .build();
+        byte[] bytes = schema1.encode(message);
+        TestMessage message1 = schema2.decode(bytes);
+
+        assertEquals(message, message1);
+    }
+
+    @Test
+    void createProtobufNativeTypeInfoFromSchemaInfo() {
+        ProtobufNativeSchema<NestedMessage> schema1 = ProtobufNativeSchema.of(NestedMessage.class);
+        PulsarSchema<NestedMessage> pulsarSchema = new PulsarSchema<>(schema1, NestedMessage.class);
+        ProtobufNativeSchemaFactory<NestedMessage> factory = new ProtobufNativeSchemaFactory<>();
+
+        TypeInformation<NestedMessage> typeInfo =
+                factory.createTypeInfo(pulsarSchema.getSchemaInfo());
+        assertDoesNotThrow(() -> InstantiationUtil.clone(typeInfo));
+
+        assertThat(typeInfo)
+                .isInstanceOf(PulsarSchemaTypeInformation.class)
+                .hasFieldOrPropertyWithValue("typeClass", NestedMessage.class);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufSchemaFactoryTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/factories/ProtobufSchemaFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.common.schema.factories;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.pulsar.SampleMessage.SubMessage;
+import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchema;
+import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaTypeInformation;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.ProtobufSchema;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils.decodeClassInfo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/** Unit tests for {@link ProtobufSchemaFactory}. */
+class ProtobufSchemaFactoryTest {
+
+    @Test
+    void createProtobufSchemaFromSchemaInfo() {
+        ProtobufSchema<SubMessage> schema = ProtobufSchema.of(SubMessage.class);
+        PulsarSchema<SubMessage> pulsarSchema = new PulsarSchema<>(schema, SubMessage.class);
+        ProtobufSchemaFactory<SubMessage> factory = new ProtobufSchemaFactory<>();
+
+        Schema<SubMessage> schema2 = factory.createSchema(pulsarSchema.getSchemaInfo());
+        assertThat(schema2)
+                .hasFieldOrPropertyWithValue("schemaInfo", pulsarSchema.getSchemaInfo())
+                .isInstanceOf(ProtobufSchema.class);
+
+        assertEquals(decodeClassInfo(schema2.getSchemaInfo()), SubMessage.class);
+        assertNotSame(schema, schema2);
+    }
+
+    @Test
+    void createProtobufTypeInfoFromSchemaInfo() {
+        ProtobufSchema<TestMessage> schema = ProtobufSchema.of(TestMessage.class);
+        PulsarSchema<TestMessage> pulsarSchema = new PulsarSchema<>(schema, TestMessage.class);
+        ProtobufSchemaFactory<TestMessage> factory = new ProtobufSchemaFactory<>();
+
+        TypeInformation<TestMessage> typeInfo =
+                factory.createTypeInfo(pulsarSchema.getSchemaInfo());
+        assertDoesNotThrow(() -> InstantiationUtil.clone(typeInfo));
+        assertThat(typeInfo)
+                .isInstanceOf(PulsarSchemaTypeInformation.class)
+                .hasFieldOrPropertyWithValue("typeClass", TestMessage.class);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilderTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.UniformRangeGenerator;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit tests for {@link PulsarSourceBuilder}. */
+@SuppressWarnings("java:S5778")
+class PulsarSourceBuilderTest {
+
+    @Test
+    void someSetterMethodCouldOnlyBeCalledOnce() {
+        PulsarSourceBuilder<String> builder = new PulsarSourceBuilder<>();
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> builder.setAdminUrl("admin-url").setAdminUrl("admin-url2"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> builder.setServiceUrl("service-url").setServiceUrl("service-url2"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        builder.setSubscriptionName("set_subscription_name")
+                                .setSubscriptionName("set_subscription_name2"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        builder.setSubscriptionType(SubscriptionType.Exclusive)
+                                .setSubscriptionType(SubscriptionType.Shared));
+    }
+
+    @Test
+    void topicPatternAndListCouldChooseOnlyOne() {
+        PulsarSourceBuilder<String> builder = new PulsarSourceBuilder<>();
+        builder.setTopics("a", "b", "c");
+
+        assertThrows(IllegalStateException.class, () -> builder.setTopicPattern("a-a-a"));
+    }
+
+    @Test
+    void rangeGeneratorRequiresKeyShared() {
+        PulsarSourceBuilder<String> builder = new PulsarSourceBuilder<>();
+        builder.setSubscriptionType(SubscriptionType.Shared);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> builder.setRangeGenerator(new UniformRangeGenerator()));
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.connector.pulsar.testutils.PulsarContainerContextFactory;
+import org.apache.flink.connector.pulsar.testutils.PulsarContainerEnvironment;
+import org.apache.flink.connector.pulsar.testutils.cases.MultipleTopicConsumingContext;
+import org.apache.flink.connector.pulsar.testutils.cases.SingleTopicConsumingContext;
+import org.apache.flink.connectors.test.common.environment.MiniClusterTestEnvironment;
+import org.apache.flink.connectors.test.common.junit.annotations.ExternalContextFactory;
+import org.apache.flink.connectors.test.common.junit.annotations.ExternalSystem;
+import org.apache.flink.connectors.test.common.junit.annotations.TestEnv;
+import org.apache.flink.connectors.test.common.testsuites.SourceTestSuiteBase;
+
+/** Unite test class for {@link PulsarSource}. */
+@SuppressWarnings("unused")
+class PulsarSourceITCase extends SourceTestSuiteBase<String> {
+
+    // Defines test environment on Flink MiniCluster
+    @TestEnv MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+
+    // Defines pulsar running environment
+    @ExternalSystem PulsarContainerEnvironment pulsar = new PulsarContainerEnvironment();
+
+    // Defines a external context Factories,
+    // so test cases will be invoked using this external contexts.
+    @ExternalContextFactory
+    PulsarContainerContextFactory<String, SingleTopicConsumingContext> singleTopic =
+            new PulsarContainerContextFactory<>(pulsar, SingleTopicConsumingContext::new);
+
+    @ExternalContextFactory
+    PulsarContainerContextFactory<String, MultipleTopicConsumingContext> multipleTopic =
+            new PulsarContainerContextFactory<>(pulsar, MultipleTopicConsumingContext::new);
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumStateSerializerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumStateSerializerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumStateSerializer.INSTANCE;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/** Unit tests for {@link PulsarSourceEnumStateSerializer}. */
+class PulsarSourceEnumStateSerializerTest {
+
+    @Test
+    void serializeAndDeserializePulsarSourceEnumState() throws Exception {
+        Set<TopicPartition> partitions =
+                Sets.newHashSet(
+                        new TopicPartition(randomAlphabetic(10), 2, new TopicRange(1, 30)),
+                        new TopicPartition(randomAlphabetic(10), 1, createFullRange()));
+        Set<PulsarPartitionSplit> splits =
+                Collections.singleton(
+                        new PulsarPartitionSplit(
+                                new TopicPartition(randomAlphabetic(10), 10, createFullRange()),
+                                StartCursor.defaultStartCursor(),
+                                StopCursor.defaultStopCursor()));
+        Map<Integer, Set<PulsarPartitionSplit>> shared = Collections.singletonMap(5, splits);
+        Map<Integer, Set<String>> mapping =
+                ImmutableMap.of(
+                        1, Sets.newHashSet(randomAlphabetic(10), randomAlphabetic(10)),
+                        2, Sets.newHashSet(randomAlphabetic(10), randomAlphabetic(10)));
+
+        PulsarSourceEnumState state =
+                new PulsarSourceEnumState(partitions, splits, shared, mapping, true);
+
+        byte[] bytes = INSTANCE.serialize(state);
+        PulsarSourceEnumState state1 = INSTANCE.deserialize(INSTANCE.getVersion(), bytes);
+
+        assertEquals(state.getAppendedPartitions(), state1.getAppendedPartitions());
+        assertEquals(state.getPendingPartitionSplits(), state1.getPendingPartitionSplits());
+        assertEquals(state.getReaderAssignedSplits(), state1.getReaderAssignedSplits());
+        assertEquals(state.isInitialized(), state1.isInitialized());
+
+        assertNotSame(state, state1);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumeratorTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumeratorTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.common.utils.PulsarJsonUtils;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.FullRangeGenerator;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.connector.pulsar.common.config.ConfigurationDataCustomizer.blankCustomizer;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
+import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_TYPE;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_TOPIC_NAMES;
+import static org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor.earliest;
+import static org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor.latest;
+import static org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber.getTopicPatternSubscriber;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link PulsarSourceEnumerator}. */
+class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
+
+    private static final int NUM_SUBTASKS = 3;
+    private static final String DYNAMIC_TOPIC_NAME = "dynamic_topic";
+    private static final String TOPIC1 = "topic";
+    private static final String TOPIC2 = "pattern-topic";
+    private static final Set<String> PRE_EXISTING_TOPICS = Sets.newHashSet(TOPIC1, TOPIC2);
+    private static final boolean ENABLE_PERIODIC_PARTITION_DISCOVERY = true;
+    private static final boolean DISABLE_PERIODIC_PARTITION_DISCOVERY = false;
+    private static final boolean INCLUDE_DYNAMIC_TOPIC = true;
+    private static final boolean EXCLUDE_DYNAMIC_TOPIC = false;
+
+    // @TestInstance(TestInstance.Lifecycle.PER_CLASS) is annotated in PulsarTestSuitBase, so this
+    // method could be non-static.
+    @BeforeAll
+    void beforeAll() {
+        setupTopic(TOPIC1);
+        setupTopic(TOPIC2);
+    }
+
+    @AfterAll
+    void afterAll() {
+        deleteTopic(TOPIC1, true);
+        deleteTopic(TOPIC2, true);
+    }
+
+    @Test
+    void startWithDiscoverPartitionsOnce() throws Exception {
+        try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                PulsarSourceEnumerator enumerator =
+                        createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+            // Start the enumerator and it should schedule a one time task to discover and assign
+            // partitions.
+            enumerator.start();
+            assertTrue(context.getPeriodicCallables().isEmpty());
+            assertEquals(
+                    1,
+                    context.getOneTimeCallables().size(),
+                    "A one time partition discovery callable should have been scheduled");
+        }
+    }
+
+    @Test
+    void startWithPeriodicPartitionDiscovery() throws Exception {
+        try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                PulsarSourceEnumerator enumerator =
+                        createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+            // Start the enumerator and it should schedule a one time task to discover and assign
+            // partitions.
+            enumerator.start();
+            assertTrue(context.getOneTimeCallables().isEmpty());
+            assertEquals(
+                    1,
+                    context.getPeriodicCallables().size(),
+                    "A periodic partition discovery callable should have been scheduled");
+        }
+    }
+
+    private PulsarSourceEnumerator createEnumerator(
+            MockSplitEnumeratorContext<PulsarPartitionSplit> context,
+            boolean enablePeriodicPartitionDiscovery) {
+        return createEnumerator(context, enablePeriodicPartitionDiscovery, EXCLUDE_DYNAMIC_TOPIC);
+    }
+
+    private PulsarSourceEnumerator createEnumerator(
+            MockSplitEnumeratorContext<PulsarPartitionSplit> enumContext,
+            boolean enablePeriodicPartitionDiscovery,
+            boolean includeDynamicTopic) {
+        List<String> topics = new ArrayList<>(PRE_EXISTING_TOPICS);
+        if (includeDynamicTopic) {
+            topics.add(DYNAMIC_TOPIC_NAME);
+        }
+        Configuration configuration = new Configuration();
+        configuration.set(PULSAR_ADMIN_URL, adminUrl());
+        configuration.set(PULSAR_SERVICE_URL, serviceUrl());
+        configuration.set(PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Failover);
+        configuration.set(PULSAR_TOPIC_NAMES, PulsarJsonUtils.toString(topics));
+
+        PulsarSourceEnumState sourceEnumState =
+                new PulsarSourceEnumState(
+                        Sets.newHashSet(),
+                        Sets.newHashSet(),
+                        Maps.newHashMap(),
+                        Maps.newHashMap(),
+                        false);
+
+        return createEnumerator(
+                enumContext,
+                enablePeriodicPartitionDiscovery,
+                topics,
+                sourceEnumState,
+                configuration);
+    }
+
+    /**
+     * Create the enumerator. For the purpose of the tests in this class we don't care about the
+     * subscriber and offsets initializer, so just use arbitrary settings.
+     */
+    private PulsarSourceEnumerator createEnumerator(
+            MockSplitEnumeratorContext<PulsarPartitionSplit> enumContext,
+            boolean enablePeriodicPartitionDiscovery,
+            Collection<String> topicsToSubscribe,
+            PulsarSourceEnumState sourceEnumState,
+            Configuration configuration) {
+        // Use a TopicPatternSubscriber so that no exception if a subscribed topic hasn't been
+        // created yet.
+        StringJoiner topicNameJoiner = new StringJoiner("|");
+        topicsToSubscribe.forEach(topicNameJoiner::add);
+        Pattern topicPattern = Pattern.compile(topicNameJoiner.toString());
+        PulsarSubscriber subscriber =
+                getTopicPatternSubscriber(topicPattern, RegexSubscriptionMode.AllTopics);
+        if (enablePeriodicPartitionDiscovery) {
+            configuration.set(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, 60L);
+        } else {
+            configuration.set(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, -1L);
+        }
+        SourceConfiguration sourceConfiguration = new SourceConfiguration(configuration);
+        SplitsAssignmentState assignmentState =
+                new SplitsAssignmentState(
+                        earliest(), latest(), sourceConfiguration, sourceEnumState);
+
+        return new PulsarSourceEnumerator(
+                subscriber,
+                new FullRangeGenerator(),
+                configuration,
+                sourceConfiguration,
+                blankCustomizer(),
+                enumContext,
+                assignmentState);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/SplitsAssignmentStateTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/SplitsAssignmentStateTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator;
+
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_TYPE;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.MAX_RANGE;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
+
+/** Unit tests for {@link SplitsAssignmentState}. */
+class SplitsAssignmentStateTest {
+
+    private final Set<TopicPartition> partitions =
+            Sets.newHashSet(
+                    new TopicPartition("some-topic", 1, new TopicRange(1, 30)),
+                    new TopicPartition("some-topic", 2, new TopicRange(31, 60)),
+                    new TopicPartition("some-topic", 3, new TopicRange(61, MAX_RANGE)),
+                    new TopicPartition(randomAlphabetic(10), -1, createFullRange()));
+
+    @Test
+    void assignSplitsForSharedSubscription() {
+        SplitsAssignmentState state1 =
+                new SplitsAssignmentState(
+                        StartCursor.defaultStartCursor(),
+                        StopCursor.defaultStopCursor(),
+                        createConfig(SubscriptionType.Shared));
+        state1.appendTopicPartitions(partitions);
+        Optional<SplitsAssignment<PulsarPartitionSplit>> assignment1 =
+                state1.assignSplits(Lists.newArrayList(0, 1, 2, 3, 4));
+
+        assertThat(assignment1)
+                .isPresent()
+                .get()
+                .extracting(SplitsAssignment::assignment)
+                .asInstanceOf(map(Integer.class, List.class))
+                .hasSize(5)
+                .allSatisfy((idx, list) -> assertThat(list).hasSize(4));
+
+        Optional<SplitsAssignment<PulsarPartitionSplit>> assignment2 =
+                state1.assignSplits(Lists.newArrayList(0, 1, 2, 3, 4));
+        assertThat(assignment2).isNotPresent();
+
+        // Reassign reader 3.
+        state1.putSplitsBackToPendingList(assignment1.get().assignment().get(3), 3);
+        Optional<SplitsAssignment<PulsarPartitionSplit>> assignment3 =
+                state1.assignSplits(Lists.newArrayList(0, 1, 2, 4));
+        assertThat(assignment3).isNotPresent();
+
+        Optional<SplitsAssignment<PulsarPartitionSplit>> assignment4 =
+                state1.assignSplits(singletonList(3));
+        assertThat(assignment4)
+                .isPresent()
+                .get()
+                .extracting(SplitsAssignment::assignment)
+                .asInstanceOf(map(Integer.class, List.class))
+                .hasSize(1);
+    }
+
+    @Test
+    void assignSplitsForExclusiveSubscription() {
+        SplitsAssignmentState state1 =
+                new SplitsAssignmentState(
+                        StartCursor.defaultStartCursor(),
+                        StopCursor.defaultStopCursor(),
+                        createConfig(SubscriptionType.Exclusive));
+        state1.appendTopicPartitions(partitions);
+        Optional<SplitsAssignment<PulsarPartitionSplit>> assignment1 =
+                state1.assignSplits(Lists.newArrayList(0, 1, 2, 3, 4));
+
+        assertThat(assignment1).isPresent();
+        assertThat(assignment1.get().assignment())
+                .hasSize(4)
+                .allSatisfy((idx, list) -> assertThat(list).hasSize(1));
+
+        Optional<SplitsAssignment<PulsarPartitionSplit>> assignment2 =
+                state1.assignSplits(Lists.newArrayList(0, 1, 2, 3, 4));
+        assertThat(assignment2).isNotPresent();
+    }
+
+    private SourceConfiguration createConfig(SubscriptionType type) {
+        Configuration configuration = new Configuration();
+        configuration.set(PULSAR_SUBSCRIPTION_TYPE, type);
+
+        return new SourceConfiguration(configuration);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriberTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/PulsarSubscriberTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.subscriber;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.range.FullRangeGenerator;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber.getTopicListSubscriber;
+import static org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber.getTopicPatternSubscriber;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.apache.pulsar.client.api.RegexSubscriptionMode.AllTopics;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for {@link PulsarSubscriber}. */
+class PulsarSubscriberTest extends PulsarTestSuiteBase {
+
+    private static final String TOPIC1 = TopicNameUtils.topicName("topic1");
+    private static final String TOPIC2 = TopicNameUtils.topicName("pattern-topic");
+    private static final String TOPIC3 = TopicNameUtils.topicName("topic2");
+
+    private static final int NUM_PARTITIONS_PER_TOPIC = 5;
+    private static final int NUM_PARALLELISM = 10;
+
+    @Test
+    void topicListSubscriber() {
+        createTopic(TOPIC1, NUM_PARTITIONS_PER_TOPIC);
+        createTopic(TOPIC2, NUM_PARTITIONS_PER_TOPIC);
+
+        PulsarSubscriber subscriber = getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2));
+        Set<TopicPartition> topicPartitions =
+                subscriber.getSubscribedTopicPartitions(
+                        admin(), new FullRangeGenerator(), NUM_PARALLELISM);
+        Set<TopicPartition> expectedPartitions = new HashSet<>();
+
+        for (int i = 0; i < NUM_PARTITIONS_PER_TOPIC; i++) {
+            expectedPartitions.add(new TopicPartition(TOPIC1, i, createFullRange()));
+            expectedPartitions.add(new TopicPartition(TOPIC2, i, createFullRange()));
+        }
+
+        assertEquals(expectedPartitions, topicPartitions);
+
+        deleteTopic(TOPIC1, true);
+        deleteTopic(TOPIC2, true);
+    }
+
+    @Test
+    void topicPatternSubscriber() {
+        createTopic(TOPIC1, NUM_PARTITIONS_PER_TOPIC);
+        createTopic(TOPIC2, NUM_PARTITIONS_PER_TOPIC);
+        createTopic(TOPIC3, NUM_PARTITIONS_PER_TOPIC);
+
+        PulsarSubscriber subscriber =
+                getTopicPatternSubscriber(
+                        Pattern.compile("persistent://public/default/topic*?"), AllTopics);
+
+        Set<TopicPartition> topicPartitions =
+                subscriber.getSubscribedTopicPartitions(
+                        admin(), new FullRangeGenerator(), NUM_PARALLELISM);
+
+        Set<TopicPartition> expectedPartitions = new HashSet<>();
+
+        for (int i = 0; i < NUM_PARTITIONS_PER_TOPIC; i++) {
+            expectedPartitions.add(new TopicPartition(TOPIC1, i, createFullRange()));
+            expectedPartitions.add(new TopicPartition(TOPIC3, i, createFullRange()));
+        }
+
+        assertEquals(expectedPartitions, topicPartitions);
+
+        deleteTopic(TOPIC1, true);
+        deleteTopic(TOPIC2, true);
+        deleteTopic(TOPIC3, true);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtilsTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit tests for {@link TopicNameUtils}. */
+class TopicNameUtilsTest {
+
+    private static final String fullTopicName = "persistent://tenant/cluster/namespace/topic";
+    private static final String topicNameWithLocal =
+            "persistent://tenant/cluster/namespace/ns-abc/table/1";
+    private static final String shortTopicName = "short-topic";
+    private static final String topicNameWithoutCluster = "persistent://tenant/namespace/topic";
+
+    @Test
+    void topicNameWouldReturnACleanTopicNameWithTenant() {
+        String name1 = TopicNameUtils.topicName(fullTopicName + "-partition-1");
+        assertEquals(name1, fullTopicName);
+
+        String name2 = TopicNameUtils.topicName(topicNameWithLocal);
+        assertEquals(name2, topicNameWithLocal);
+
+        String name3 = TopicNameUtils.topicName(shortTopicName + "-partition-1");
+        assertEquals(name3, "persistent://public/default/short-topic");
+
+        String name4 = TopicNameUtils.topicName(shortTopicName);
+        assertEquals(name4, "persistent://public/default/short-topic");
+
+        String name5 = TopicNameUtils.topicName(topicNameWithoutCluster + "-partition-1");
+        assertEquals(name5, topicNameWithoutCluster);
+    }
+
+    @Test
+    void topicNameWithPartitionInfo() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> TopicNameUtils.topicNameWithPartition(shortTopicName, -3));
+
+        String name1 = TopicNameUtils.topicNameWithPartition(fullTopicName, 4);
+        assertEquals(name1, fullTopicName + "-partition-4");
+
+        String name2 = TopicNameUtils.topicNameWithPartition(topicNameWithLocal, 3);
+        assertEquals(name2, topicNameWithLocal + "-partition-3");
+
+        String name3 = TopicNameUtils.topicNameWithPartition(shortTopicName, 5);
+        assertEquals(name3, "persistent://public/default/short-topic-partition-5");
+
+        String name4 = TopicNameUtils.topicNameWithPartition(topicNameWithoutCluster, 8);
+        assertEquals(name4, topicNameWithoutCluster + "-partition-8");
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicPartitionTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicPartitionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for {@link TopicPartition}. */
+class TopicPartitionTest {
+
+    @Test
+    void topicNameForPartitionedAndNonPartitionedTopic() {
+        // For partitioned topic
+        TopicPartition partition = new TopicPartition("test-name", 12, createFullRange());
+        assertEquals(
+                partition.getFullTopicName(), "persistent://public/default/test-name-partition-12");
+
+        // For non-partitioned topic
+        TopicPartition partition1 = new TopicPartition("test-topic", -1, createFullRange());
+        assertEquals(partition1.getFullTopicName(), "persistent://public/default/test-topic");
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRangeTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicRangeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.topic;
+
+import org.apache.flink.util.InstantiationUtil;
+
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.MAX_RANGE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/** Unit tests for {@link TopicRange}. */
+class TopicRangeTest {
+
+    private final Random random = new Random(System.currentTimeMillis());
+
+    @RepeatedTest(10)
+    @SuppressWarnings("java:S5778")
+    void rangeCreationHaveALimitedScope() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TopicRange(-1, random.nextInt(MAX_RANGE)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TopicRange(1, MAX_RANGE + random.nextInt(10000)));
+
+        assertDoesNotThrow(() -> new TopicRange(1, random.nextInt(MAX_RANGE)));
+    }
+
+    @Test
+    void topicRangeIsSerializable() throws Exception {
+        TopicRange range = new TopicRange(10, random.nextInt(MAX_RANGE));
+        TopicRange cloneRange = InstantiationUtil.clone(range);
+
+        assertEquals(range, cloneRange);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/deserializer/PulsarDeserializationSchemaTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.reader.deserializer;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.connector.pulsar.SampleMessage.TestMessage;
+import org.apache.flink.connector.testutils.source.deserialization.TestingDeserializationContext;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.types.StringValue;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.flinkSchema;
+import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.flinkTypeInfo;
+import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.pulsarSchema;
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.pulsar.client.api.Schema.PROTOBUF_NATIVE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** Unit tests for {@link PulsarDeserializationSchema}. */
+class PulsarDeserializationSchemaTest {
+
+    @Test
+    void createFromFlinkDeserializationSchema() throws Exception {
+        PulsarDeserializationSchema<String> schema = flinkSchema(new SimpleStringSchema());
+        schema.open(new TestingDeserializationContext());
+        assertDoesNotThrow(() -> InstantiationUtil.clone(schema));
+
+        Message<byte[]> message = getMessage("some-sample-message", String::getBytes);
+        SingleMessageCollector<String> collector = new SingleMessageCollector<>();
+        schema.deserialize(message, collector);
+
+        assertNotNull(collector.result);
+        assertEquals(collector.result, "some-sample-message");
+    }
+
+    @Test
+    void createFromPulsarSchema() throws Exception {
+        Schema<TestMessage> schema1 = PROTOBUF_NATIVE(TestMessage.class);
+        PulsarDeserializationSchema<TestMessage> schema2 = pulsarSchema(schema1, TestMessage.class);
+        schema2.open(new TestingDeserializationContext());
+        assertDoesNotThrow(() -> InstantiationUtil.clone(schema2));
+
+        TestMessage message1 =
+                TestMessage.newBuilder()
+                        .setStringField(randomAlphabetic(10))
+                        .setDoubleField(ThreadLocalRandom.current().nextDouble())
+                        .setIntField(ThreadLocalRandom.current().nextInt())
+                        .build();
+        Message<byte[]> message2 = getMessage(message1, schema1::encode);
+        SingleMessageCollector<TestMessage> collector = new SingleMessageCollector<>();
+        schema2.deserialize(message2, collector);
+
+        assertNotNull(collector.result);
+        assertEquals(collector.result, message1);
+    }
+
+    @Test
+    void createFromFlinkTypeInformation() throws Exception {
+        PulsarDeserializationSchema<String> schema = flinkTypeInfo(Types.STRING, null);
+        schema.open(new TestingDeserializationContext());
+        assertDoesNotThrow(() -> InstantiationUtil.clone(schema));
+
+        Message<byte[]> message =
+                getMessage(
+                        "test-content",
+                        s -> {
+                            DataOutputSerializer serializer = new DataOutputSerializer(10);
+                            StringValue.writeString(s, serializer);
+                            return serializer.getSharedBuffer();
+                        });
+        SingleMessageCollector<String> collector = new SingleMessageCollector<>();
+        schema.deserialize(message, collector);
+
+        assertNotNull(collector.result);
+        assertEquals(collector.result, "test-content");
+    }
+
+    /** Create a test message by given bytes. The message don't contains any meta data. */
+    private <T> Message<byte[]> getMessage(
+            T message, FunctionWithException<T, byte[], Exception> decoder) throws Exception {
+        byte[] bytes = decoder.apply(message);
+        MessageMetadata metadata = new MessageMetadata();
+        ByteBuffer payload = ByteBuffer.wrap(bytes);
+
+        return MessageImpl.create(metadata, payload, Schema.BYTES);
+    }
+
+    /** This collector is used for collecting only one message. Used for test purpose. */
+    private static class SingleMessageCollector<T> implements Collector<T> {
+
+        private T result;
+
+        @Override
+        public void collect(T record) {
+            checkState(result == null);
+            this.result = record;
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitSerializerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.split;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitSerializer.INSTANCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/** Unit tests for {@link PulsarPartitionSplitSerializer}. */
+class PulsarPartitionSplitSerializerTest {
+
+    @Test
+    void serializeAndDeserializePulsarPartitionSplit() throws Exception {
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(
+                        new TopicPartition(randomAlphabetic(10), 10, createFullRange()),
+                        StartCursor.defaultStartCursor(),
+                        StopCursor.defaultStopCursor());
+
+        byte[] bytes = INSTANCE.serialize(split);
+        PulsarPartitionSplit split1 = INSTANCE.deserialize(INSTANCE.getVersion(), bytes);
+
+        assertEquals(split, split1);
+        assertNotSame(split, split1);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/split/PulsarPartitionSplitTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.split;
+
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor.defaultStartCursor;
+import static org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor.defaultStopCursor;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Unit tests for {@link PulsarPartitionSplit}. */
+class PulsarPartitionSplitTest {
+
+    @Test
+    void partitionSplitWouldHaveANewStartCursorWhenCheckpointing() {
+        TopicPartition partition = new TopicPartition(randomAlphabetic(10), 1, createFullRange());
+
+        MessageIdImpl messageId = new MessageIdImpl(12, 1, 3);
+        PulsarPartitionSplit split =
+                new PulsarPartitionSplit(
+                        partition, defaultStartCursor(), defaultStopCursor(), messageId, null);
+
+        StartCursor cursor = split.getStartCursor();
+        CursorPosition position = cursor.position(split);
+        MessageIdImpl newMessageId = (MessageIdImpl) position.getMessageId();
+
+        assertEquals(messageId.getEntryId() + 1, newMessageId.getEntryId());
+        assertEquals(messageId.getPartitionIndex(), newMessageId.getPartitionIndex());
+        assertEquals(messageId.getLedgerId(), newMessageId.getLedgerId());
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerContext.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connectors.test.common.external.ExternalContext;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+
+/** Common test context for pulsar container based test. */
+public abstract class PulsarContainerContext<T> implements ExternalContext<T> {
+
+    private static final int NUM_RECORDS_UPPER_BOUND = 500;
+    private static final int NUM_RECORDS_LOWER_BOUND = 100;
+
+    private final String displayName;
+    protected final PulsarContainerOperator operator;
+
+    protected PulsarContainerContext(String displayName, PulsarContainerEnvironment environment) {
+        this.displayName = displayName;
+        this.operator = environment.operator();
+    }
+
+    // Helper methods for generating data.
+
+    protected List<String> generateStringTestData(long seed) {
+        Random random = new Random(seed);
+        int recordNum =
+                random.nextInt(NUM_RECORDS_UPPER_BOUND - NUM_RECORDS_LOWER_BOUND)
+                        + NUM_RECORDS_LOWER_BOUND;
+        List<String> records = new ArrayList<>(recordNum);
+
+        for (int i = 0; i < recordNum; i++) {
+            int stringLength = random.nextInt(50) + 1;
+            records.add(randomAlphanumeric(stringLength));
+        }
+
+        return records;
+    }
+
+    // Helper methods for operating pulsar.
+
+    protected void setupTopic(String topic) {
+        operator.setupTopic(topic);
+    }
+
+    protected void setupTopic(String topic, Schema<T> schema, Supplier<T> supplier) {
+        operator.setupTopic(topic, schema, supplier);
+    }
+
+    protected void createTopic(String topic, int numberOfPartitions) {
+        operator.createTopic(topic, numberOfPartitions);
+    }
+
+    protected void increaseTopicPartitions(String topic, int newPartitionsNum) {
+        operator.increaseTopicPartitions(topic, newPartitionsNum);
+    }
+
+    protected void deleteTopic(String topic, boolean isPartitioned) {
+        operator.deleteTopic(topic, isPartitioned);
+    }
+
+    protected List<TopicPartition> topicInfo(String topic) {
+        return operator.topicInfo(topic);
+    }
+
+    protected List<TopicPartition> topicsInfo(Collection<String> topics) {
+        return operator.topicsInfo(topics);
+    }
+
+    protected MessageId sendMessage(String topic, Schema<T> schema, T message) {
+        return operator.sendMessage(topic, schema, message);
+    }
+
+    protected List<MessageId> sendMessages(String topic, Schema<T> schema, Collection<T> messages) {
+        return operator.sendMessages(topic, schema, messages);
+    }
+
+    protected String serviceUrl() {
+        return operator.serviceUrl();
+    }
+
+    protected String adminUrl() {
+        return operator.adminUrl();
+    }
+
+    protected PulsarClient client() {
+        return operator.client();
+    }
+
+    protected PulsarAdmin admin() {
+        return operator.admin();
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerContextFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerContextFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connectors.test.common.external.ExternalContext;
+import org.apache.flink.runtime.util.SerializableFunction;
+
+/**
+ * Factory for creating all the test context that extends {@link PulsarContainerContext}. Test
+ * context class should have a constructor with {@link PulsarContainerEnvironment} arg.
+ */
+public class PulsarContainerContextFactory<F, T extends PulsarContainerContext<F>>
+        implements ExternalContext.Factory<F> {
+
+    private final PulsarContainerEnvironment environment;
+    private final SerializableFunction<PulsarContainerEnvironment, T> contextFactory;
+
+    public PulsarContainerContextFactory(
+            PulsarContainerEnvironment environment,
+            SerializableFunction<PulsarContainerEnvironment, T> contextFactory) {
+        this.environment = environment;
+        this.contextFactory = contextFactory;
+    }
+
+    @Override
+    public ExternalContext<F> createExternalContext() {
+        return contextFactory.apply(environment);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerEnvironment.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerEnvironment.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connectors.test.common.TestResource;
+import org.apache.flink.connectors.test.common.junit.annotations.ExternalSystem;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+import static org.apache.flink.util.DockerImageVersions.PULSAR;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.testcontainers.containers.PulsarContainer.BROKER_HTTP_PORT;
+
+/**
+ * A JUnit 5 {@link Extension} for supporting running of pulsar test container. This class is also a
+ * {@link ExternalSystem} for {@code flink-connector-testing} tools.
+ *
+ * <p>Some old flink tests are based on JUint 4, this class is also support it. The follow code
+ * snippet shows how to use this class in JUnit 4.
+ *
+ * <pre>{@code
+ * @ClassRule
+ * public static PulsarContainerEnvironment environment = new PulsarContainerEnvironment();
+ * }</pre>
+ *
+ * <p>If you want to use this class in JUnit 5, just simply extends {@link PulsarTestSuiteBase}, all
+ * the helper methods in {@code PulsarContainerOperator} is also exposing there.
+ */
+public class PulsarContainerEnvironment extends ExternalResource
+        implements BeforeAllCallback, AfterAllCallback, TestResource {
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarContainerEnvironment.class);
+
+    private PulsarContainer container;
+    private PulsarContainerOperator operator;
+
+    /** JUnit 4 Rule setup method. */
+    @Override
+    protected void before() {
+        startUp();
+    }
+
+    /** JUnit 5 Extension setup method. */
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        startUp();
+    }
+
+    /** flink-connector-testing setup method. */
+    @Override
+    public void startUp() {
+        DockerImageName imageName = DockerImageName.parse(PULSAR);
+        this.container = new PulsarContainer(imageName);
+
+        // Prepare Pulsar Container.
+        container.withClasspathResourceMapping(
+                "containers/txnStandalone.conf",
+                "/pulsar/conf/standalone.conf",
+                BindMode.READ_ONLY);
+        container.addExposedPort(2181);
+        container.waitingFor(
+                new HttpWaitStrategy()
+                        .forPort(BROKER_HTTP_PORT)
+                        .forStatusCode(200)
+                        .forPath("/admin/v2/namespaces/public/default")
+                        .withStartupTimeout(Duration.ofMinutes(5)));
+
+        // Start Pulsar Container.
+        container.start();
+        container.followOutput(new Slf4jLogConsumer(LOG).withSeparateOutputStreams());
+
+        this.operator =
+                new PulsarContainerOperator(
+                        container.getPulsarBrokerUrl(), container.getHttpServiceUrl());
+    }
+
+    /** JUnit 4 Rule shutdown method. */
+    @Override
+    protected void after() {
+        try {
+            tearDown();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** JUnit 5 Extension shutdown method. */
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        tearDown();
+    }
+
+    /** flink-connector-testing shutdown method. */
+    @Override
+    public void tearDown() throws Exception {
+        container.stop();
+        operator.close();
+    }
+
+    /** Get a common supported set of method for operating pulsar which is in container. */
+    public PulsarContainerOperator operator() {
+        return checkNotNull(operator, "You should start the pulsar container first.");
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerOperator.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarContainerOperator.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
+import org.apache.flink.connectors.test.common.external.ExternalContext;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyAdmin;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyThrow;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A pulsar container operator for operating pulsar instance. It's serializable for using in {@link
+ * ExternalContext}.
+ */
+public class PulsarContainerOperator implements Serializable, Closeable {
+    private static final long serialVersionUID = -630646912412751301L;
+
+    public static final int DEFAULT_PARTITIONS = 10;
+    public static final int NUM_RECORDS_PER_PARTITION = 20;
+
+    private String serviceUrl;
+    private String adminUrl;
+
+    private transient PulsarClient client;
+    private transient PulsarAdmin admin;
+
+    public PulsarContainerOperator(String serviceUrl, String adminUrl) {
+        this.serviceUrl = serviceUrl;
+        this.adminUrl = adminUrl;
+        initializeClients();
+    }
+
+    /**
+     * Create a topic with default {@link #DEFAULT_PARTITIONS} partitions and send a fixed number
+     * {@link #NUM_RECORDS_PER_PARTITION} of records to this topic.
+     */
+    public void setupTopic(String topic) {
+        Random random = new Random(System.currentTimeMillis());
+        setupTopic(topic, Schema.STRING, () -> randomAlphanumeric(10 + random.nextInt(20)));
+    }
+
+    public <T> void setupTopic(String topic, Schema<T> schema, Supplier<T> supplier) {
+        createTopic(topic, DEFAULT_PARTITIONS);
+
+        // Make sure every topic partition has message.
+        for (int i = 0; i < DEFAULT_PARTITIONS; i++) {
+            String partitionName = TopicNameUtils.topicNameWithPartition(topic, i);
+            List<T> messages =
+                    Stream.generate(supplier).limit(NUM_RECORDS_PER_PARTITION).collect(toList());
+
+            sendMessages(partitionName, schema, messages);
+        }
+    }
+
+    public void createTopic(String topic, int numberOfPartitions) {
+        checkArgument(numberOfPartitions >= 0);
+        if (numberOfPartitions == 0) {
+            createNonPartitionedTopic(topic);
+        } else {
+            createPartitionedTopic(topic, numberOfPartitions);
+        }
+    }
+
+    public void increaseTopicPartitions(String topic, int newPartitionsNum) {
+        sneakyAdmin(() -> admin().topics().updatePartitionedTopic(topic, newPartitionsNum));
+    }
+
+    public void deleteTopic(String topic, boolean isPartitioned) {
+        if (isPartitioned) {
+            sneakyAdmin(() -> admin().topics().deletePartitionedTopic(topic));
+        } else {
+            sneakyAdmin(() -> admin().topics().delete(topic));
+        }
+    }
+
+    public List<TopicPartition> topicInfo(String topic) {
+        try {
+            return client().getPartitionsForTopic(topic).get().stream()
+                    .map(
+                            p ->
+                                    new TopicPartition(
+                                            topic,
+                                            TopicName.getPartitionIndex(p),
+                                            TopicRange.createFullRange()))
+                    .collect(toList());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    protected List<TopicPartition> topicsInfo(Collection<String> topics) {
+        return topics.stream().flatMap(s -> topicInfo(s).stream()).collect(toList());
+    }
+
+    public <T> MessageId sendMessage(String topic, Schema<T> schema, T message) {
+        List<MessageId> messageIds = sendMessages(topic, schema, singletonList(message));
+        checkArgument(messageIds.size() == 1);
+
+        return messageIds.get(0);
+    }
+
+    public <T> List<MessageId> sendMessages(
+            String topic, Schema<T> schema, Collection<T> messages) {
+        try (Producer<T> producer = client().newProducer(schema).topic(topic).create()) {
+            List<MessageId> messageIds = new ArrayList<>(messages.size());
+
+            for (T message : messages) {
+                MessageId messageId = producer.newMessage().value(message).send();
+                messageIds.add(messageId);
+            }
+
+            return messageIds;
+        } catch (PulsarClientException e) {
+            sneakyThrow(e);
+            return emptyList();
+        }
+    }
+
+    public String serviceUrl() {
+        return serviceUrl;
+    }
+
+    public String adminUrl() {
+        return adminUrl;
+    }
+
+    public PulsarClient client() {
+        return client;
+    }
+
+    public PulsarAdmin admin() {
+        return admin;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (admin != null) {
+            admin.close();
+        }
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    // --------------------------- Private Methods -----------------------------
+
+    private void createNonPartitionedTopic(String topic) {
+        try {
+            admin().lookups().lookupTopic(topic);
+            sneakyAdmin(() -> admin().topics().expireMessagesForAllSubscriptions(topic, 0));
+        } catch (PulsarAdminException e) {
+            sneakyAdmin(() -> admin().topics().createNonPartitionedTopic(topic));
+        }
+    }
+
+    private void createPartitionedTopic(String topic, int numberOfPartitions) {
+        try {
+            admin().lookups().lookupPartitionedTopic(topic);
+            sneakyAdmin(() -> admin().topics().expireMessagesForAllSubscriptionsAsync(topic, 0));
+        } catch (PulsarAdminException e) {
+            sneakyAdmin(() -> admin().topics().createPartitionedTopic(topic, numberOfPartitions));
+        }
+    }
+
+    private void initializeClients() {
+        this.client = sneakyClient(() -> PulsarClient.builder().serviceUrl(serviceUrl).build());
+        this.admin = sneakyClient(() -> PulsarAdmin.builder().serviceHttpUrl(adminUrl).build());
+    }
+
+    // --------------------------- Serialization Logic -----------------------------
+
+    private void writeObject(ObjectOutputStream oos) throws IOException {
+        oos.writeUTF(serviceUrl);
+        oos.writeUTF(adminUrl);
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        this.serviceUrl = ois.readUTF();
+        this.adminUrl = ois.readUTF();
+        initializeClients();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarPartitionDataWriter.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarPartitionDataWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+
+import java.util.Collection;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+
+/** Source split data writer for writing test data into a Pulsar topic partition. */
+public class PulsarPartitionDataWriter implements SourceSplitDataWriter<String> {
+
+    private final Producer<String> producer;
+
+    public PulsarPartitionDataWriter(PulsarClient client, TopicPartition partition) {
+        this.producer =
+                sneakyClient(
+                        () ->
+                                client.newProducer(Schema.STRING)
+                                        .topic(partition.getFullTopicName())
+                                        .create());
+    }
+
+    @Override
+    public void writeRecords(Collection<String> records) {
+        for (String record : records) {
+            sneakyClient(() -> producer.newMessage().value(record).send());
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        producer.close();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarTestSuiteBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarTestSuiteBase.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connectors.test.common.junit.extensions.TestLoggerExtension;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * The base class for the all Pulsar related test sites. It brings up:
+ *
+ * <ul>
+ *   <li>A Zookeeper cluster.
+ *   <li>Pulsar Broker.
+ *   <li>A Bookkeeper cluster.
+ * </ul>
+ *
+ * <p>You just need to write a JUnit 5 test class and extends this suite class. All the helper
+ * method list below would be ready.
+ *
+ * <p>{@code PulsarSourceEnumeratorTest} would be a test example for how to use this base class. If
+ * you have some setup logic, such as create topic or send message, just place then in a setup
+ * method with annotation {@code @BeforeAll}. This setup method would not require {@code static}.
+ *
+ * @see PulsarContainerOperator for how to use the helper methods in this class.
+ */
+@ExtendWith(TestLoggerExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class PulsarTestSuiteBase {
+
+    @RegisterExtension
+    final PulsarContainerEnvironment environment = new PulsarContainerEnvironment();
+
+    // Helper method for real test classes.
+
+    protected void setupTopic(String topic) {
+        environment.operator().setupTopic(topic);
+    }
+
+    public <T> void setupTopic(String topic, Schema<T> schema, Supplier<T> supplier) {
+        environment.operator().setupTopic(topic, schema, supplier);
+    }
+
+    protected void createTopic(String topic, int numberOfPartitions) {
+        environment.operator().createTopic(topic, numberOfPartitions);
+    }
+
+    protected void increaseTopicPartitions(String topic, int newPartitionsNum) {
+        environment.operator().increaseTopicPartitions(topic, newPartitionsNum);
+    }
+
+    protected void deleteTopic(String topic, boolean isPartitioned) {
+        environment.operator().deleteTopic(topic, isPartitioned);
+    }
+
+    protected List<TopicPartition> topicInfo(String topic) {
+        return environment.operator().topicInfo(topic);
+    }
+
+    protected List<TopicPartition> topicsInfo(Collection<String> topics) {
+        return environment.operator().topicsInfo(topics);
+    }
+
+    protected <T> MessageId sendMessage(String topic, Schema<T> schema, T message) {
+        return environment.operator().sendMessage(topic, schema, message);
+    }
+
+    protected <T> List<MessageId> sendMessages(
+            String topic, Schema<T> schema, Collection<T> messages) {
+        return environment.operator().sendMessages(topic, schema, messages);
+    }
+
+    protected String serviceUrl() {
+        return environment.operator().serviceUrl();
+    }
+
+    protected String adminUrl() {
+        return environment.operator().adminUrl();
+    }
+
+    protected PulsarClient client() {
+        return environment.operator().client();
+    }
+
+    protected PulsarAdmin admin() {
+        return environment.operator().admin();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/SampleData.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/SampleData.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Stream.generate;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.commons.lang3.RandomStringUtils.randomAscii;
+import static org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList.toImmutableList;
+import static org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap.toImmutableMap;
+
+/** Sample data for various test cases. */
+public class SampleData {
+
+    private static final Random RAND = new Random(System.currentTimeMillis());
+    private static final Supplier<Integer> LIST_SIZE = () -> RAND.nextInt(10) + 5;
+    private static final long MIN_DAY = LocalDate.of(2000, 1, 1).toEpochDay();
+    private static final long MAX_DAY = LocalDate.of(2040, 12, 31).toEpochDay();
+    private static final Supplier<Bar> BAR_SUPPLIER =
+            () -> new Bar(RAND.nextBoolean(), randomAlphanumeric(10));
+    private static final Supplier<List<Bar>> BAR_LIST_SUPPLIER =
+            () -> generate(BAR_SUPPLIER).limit(LIST_SIZE.get()).collect(toImmutableList());
+    private static final Supplier<Map<String, Bar>> BAR_MAP_SUPPLIER =
+            () ->
+                    generate(BAR_SUPPLIER)
+                            .limit(LIST_SIZE.get())
+                            .collect(toImmutableMap(Bar::toString, identity()));
+
+    // --------------------------------//
+    //                                 //
+    // Random sample data for tests.   //
+    //                                 //
+    // --------------------------------//
+
+    public static final List<Boolean> BOOLEAN_LIST =
+            generate(RAND::nextBoolean).limit(LIST_SIZE.get()).collect(toImmutableList());
+
+    public static final List<Integer> INTEGER_LIST =
+            generate(RAND::nextInt).limit(LIST_SIZE.get()).collect(toImmutableList());
+
+    public static final List<byte[]> BYTES_LIST =
+            generate(() -> randomAscii(8))
+                    .limit(LIST_SIZE.get())
+                    .map(s -> s.getBytes(StandardCharsets.UTF_8))
+                    .collect(toImmutableList());
+
+    public static final List<Byte> INT_8_LIST =
+            generate(RAND::nextInt)
+                    .limit(LIST_SIZE.get())
+                    .map(Integer::byteValue)
+                    .collect(toImmutableList());
+
+    public static final List<Short> INT_16_LIST =
+            generate(RAND::nextInt)
+                    .limit(LIST_SIZE.get())
+                    .map(Integer::shortValue)
+                    .collect(toImmutableList());
+
+    public static final List<Long> INT_64_LIST =
+            generate(RAND::nextLong).limit(LIST_SIZE.get()).collect(toImmutableList());
+
+    public static final List<Double> DOUBLE_LIST =
+            generate(RAND::nextDouble).limit(LIST_SIZE.get()).collect(toImmutableList());
+
+    public static final List<Float> FLOAT_LIST =
+            generate(RAND::nextFloat).limit(LIST_SIZE.get()).collect(toImmutableList());
+
+    public static final List<String> STRING_LIST =
+            generate(() -> randomAlphanumeric(8)).limit(LIST_SIZE.get()).collect(toImmutableList());
+
+    public static final List<LocalDate> LOCAL_DATE_LIST =
+            generate(() -> ThreadLocalRandom.current().nextLong(MIN_DAY, MAX_DAY))
+                    .limit(LIST_SIZE.get())
+                    .map(LocalDate::ofEpochDay)
+                    .collect(toImmutableList());
+
+    public static final List<LocalDateTime> LOCAL_DATE_TIME_LIST =
+            generate(() -> ThreadLocalRandom.current().nextLong(MIN_DAY, MAX_DAY))
+                    .limit(LIST_SIZE.get())
+                    .map(LocalDate::ofEpochDay)
+                    .map(LocalDate::atStartOfDay)
+                    .collect(toImmutableList());
+
+    public static final List<FA> FA_LIST =
+            generate(() -> new FA(BAR_LIST_SUPPLIER.get().toArray(new Bar[0])))
+                    .limit(LIST_SIZE.get())
+                    .collect(toImmutableList());
+
+    public static final List<Foo> FOO_LIST =
+            generate(() -> new Foo(RAND.nextInt(), RAND.nextFloat(), BAR_SUPPLIER.get()))
+                    .limit(LIST_SIZE.get())
+                    .collect(toImmutableList());
+
+    public static final List<FL> FL_LIST =
+            generate(() -> new FL(BAR_LIST_SUPPLIER.get()))
+                    .limit(LIST_SIZE.get())
+                    .collect(toImmutableList());
+
+    public static final List<FM> FM_LIST =
+            generate(() -> new FM(BAR_MAP_SUPPLIER.get()))
+                    .limit(LIST_SIZE.get())
+                    .collect(toImmutableList());
+
+    /** Foo type. */
+    public static class Foo {
+        public int i;
+        public float f;
+        public Bar bar;
+
+        public Foo(int i, float f, Bar bar) {
+            this.i = i;
+            this.f = f;
+            this.bar = bar;
+        }
+
+        public Foo() {}
+
+        @Override
+        public String toString() {
+            return "" + i + "," + f + "," + (bar == null ? "null" : bar.toString());
+        }
+
+        public int getI() {
+            return this.i;
+        }
+
+        public float getF() {
+            return this.f;
+        }
+
+        public Bar getBar() {
+            return this.bar;
+        }
+
+        public void setI(int i) {
+            this.i = i;
+        }
+
+        public void setF(float f) {
+            this.f = f;
+        }
+
+        public void setBar(Bar bar) {
+            this.bar = bar;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Foo)) {
+                return false;
+            }
+            Foo foo = (Foo) o;
+            return i == foo.i && Float.compare(foo.f, f) == 0 && Objects.equals(bar, foo.bar);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(i, f, bar);
+        }
+    }
+
+    /** Bar type. */
+    public static class Bar {
+        public boolean b;
+        public String s;
+
+        public Bar(boolean b, String s) {
+            this.b = b;
+            this.s = s;
+        }
+
+        public Bar() {}
+
+        @Override
+        public String toString() {
+            return "" + b + "," + s;
+        }
+
+        public boolean isB() {
+            return this.b;
+        }
+
+        public String getS() {
+            return this.s;
+        }
+
+        public void setB(boolean b) {
+            this.b = b;
+        }
+
+        public void setS(String s) {
+            this.s = s;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Bar)) {
+                return false;
+            }
+            Bar bar = (Bar) o;
+            return b == bar.b && Objects.equals(s, bar.s);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(b, s);
+        }
+    }
+
+    /** FL type. */
+    public static class FL {
+        public List<Bar> l;
+
+        public FL(List<Bar> l) {
+            this.l = l;
+        }
+
+        public FL() {}
+
+        @Override
+        public String toString() {
+            if (l == null) {
+                return "null";
+            } else {
+                StringBuilder sb = new StringBuilder();
+
+                for (int i = 0; i < l.size(); i++) {
+                    if (i != 0) {
+                        sb.append(",");
+                    }
+                    sb.append("[");
+                    sb.append(l.get(i));
+                    sb.append("]");
+                }
+
+                return sb.toString();
+            }
+        }
+
+        public List<Bar> getL() {
+            return this.l;
+        }
+
+        public void setL(List<Bar> l) {
+            this.l = l;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof FL)) {
+                return false;
+            }
+            FL fl = (FL) o;
+            return Objects.equals(l, fl.l);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(l);
+        }
+    }
+
+    /** FA type. */
+    public static class FA {
+        public Bar[] l;
+
+        public FA(Bar[] l) {
+            this.l = l;
+        }
+
+        public FA() {}
+
+        @Override
+        public String toString() {
+            if (l == null) {
+                return "null";
+            } else {
+                StringBuilder sb = new StringBuilder();
+
+                for (int i = 0; i < l.length; i++) {
+                    if (i != 0) {
+                        sb.append(",");
+                    }
+                    sb.append("[");
+                    sb.append(l[i]);
+                    sb.append("]");
+                }
+
+                return sb.toString();
+            }
+        }
+
+        public Bar[] getL() {
+            return this.l;
+        }
+
+        public void setL(Bar[] l) {
+            this.l = l;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof FA)) {
+                return false;
+            }
+            FA fa = (FA) o;
+            return Arrays.equals(l, fa.l);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(l);
+        }
+    }
+
+    /** FM type. */
+    public static class FM {
+        public Map<String, Bar> m;
+
+        public FM(Map<String, Bar> m) {
+            this.m = m;
+        }
+
+        public FM() {}
+
+        @Override
+        public String toString() {
+            if (m == null) {
+                return "null";
+            } else {
+                StringBuilder sb = new StringBuilder();
+
+                Iterator<Map.Entry<String, Bar>> iterator = m.entrySet().iterator();
+                int i = 0;
+                while (iterator.hasNext()) {
+                    if (i != 0) {
+                        sb.append(",");
+                    }
+
+                    sb.append("{");
+                    sb.append(iterator.next());
+                    sb.append("}");
+                    i += 1;
+                }
+
+                return sb.toString();
+            }
+        }
+
+        public Map<String, Bar> getM() {
+            return this.m;
+        }
+
+        public void setM(Map<String, Bar> m) {
+            this.m = m;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof FM)) {
+                return false;
+            }
+            FM fm = (FM) o;
+            return Objects.equals(m, fm.m);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(m);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/cases/MultipleTopicConsumingContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/cases/MultipleTopicConsumingContext.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.cases;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.pulsar.source.PulsarSource;
+import org.apache.flink.connector.pulsar.source.PulsarSourceBuilder;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.testutils.PulsarContainerContext;
+import org.apache.flink.connector.pulsar.testutils.PulsarContainerEnvironment;
+import org.apache.flink.connector.pulsar.testutils.PulsarPartitionDataWriter;
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import org.apache.pulsar.client.api.RegexSubscriptionMode;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.pulsarSchema;
+import static org.apache.pulsar.client.api.Schema.STRING;
+import static org.apache.pulsar.client.api.SubscriptionType.Exclusive;
+
+/**
+ * Pulsar external context that will create multiple topics with only one partitions as source
+ * splits.
+ */
+public class MultipleTopicConsumingContext extends PulsarContainerContext<String> {
+
+    private int numTopics = 0;
+
+    private final String topicPattern;
+
+    private final Map<String, SourceSplitDataWriter<String>> topicNameToSplitWriters =
+            new HashMap<>();
+
+    public MultipleTopicConsumingContext(PulsarContainerEnvironment environment) {
+        super("consuming message on multiple topic", environment);
+        this.topicPattern =
+                "pulsar-multiple-topic-[0-9]+-"
+                        + ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    }
+
+    @Override
+    public Source<String, ?, ?> createSource(Boundedness boundedness) {
+        PulsarSourceBuilder<String> builder =
+                PulsarSource.builder()
+                        .setDeserializationSchema(pulsarSchema(STRING))
+                        .setServiceUrl(serviceUrl())
+                        .setAdminUrl(adminUrl())
+                        .setTopicPattern(topicPattern, RegexSubscriptionMode.AllTopics)
+                        .setSubscriptionType(Exclusive)
+                        .setSubscriptionName("flink-pulsar-multiple-topic-test");
+        if (boundedness == Boundedness.BOUNDED) {
+            // Using latest stop cursor for making sure the source could be stopped.
+            // This is required for SourceTestSuiteBase.
+            builder.setBoundedStopCursor(StopCursor.latest());
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public SourceSplitDataWriter<String> createSourceSplitDataWriter() {
+        String topicName = topicPattern.replace("[0-9]+", String.valueOf(numTopics));
+        createTopic(topicName, 1);
+
+        String partitionName = TopicNameUtils.topicNameWithPartition(topicName, 0);
+        TopicPartition partition = new TopicPartition(partitionName, 0, createFullRange());
+        PulsarPartitionDataWriter writer = new PulsarPartitionDataWriter(client(), partition);
+
+        topicNameToSplitWriters.put(partitionName, writer);
+        numTopics++;
+
+        return writer;
+    }
+
+    @Override
+    public Collection<String> generateTestData(long seed) {
+        return generateStringTestData(seed);
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (SourceSplitDataWriter<String> writer : topicNameToSplitWriters.values()) {
+            writer.close();
+        }
+
+        topicNameToSplitWriters.clear();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/cases/SingleTopicConsumingContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/cases/SingleTopicConsumingContext.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.cases;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.pulsar.source.PulsarSource;
+import org.apache.flink.connector.pulsar.source.PulsarSourceBuilder;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.testutils.PulsarContainerContext;
+import org.apache.flink.connector.pulsar.testutils.PulsarContainerEnvironment;
+import org.apache.flink.connector.pulsar.testutils.PulsarPartitionDataWriter;
+import org.apache.flink.connectors.test.common.external.SourceSplitDataWriter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.pulsarSchema;
+import static org.apache.pulsar.client.api.Schema.STRING;
+import static org.apache.pulsar.client.api.SubscriptionType.Exclusive;
+
+/**
+ * A Pulsar external context that will create only one topic and use partitions in that topic as
+ * source splits.
+ */
+public class SingleTopicConsumingContext extends PulsarContainerContext<String> {
+
+    private static final String TOPIC_NAME_PREFIX = "pulsar-single-topic";
+    private final String topicName;
+    private final Map<Integer, SourceSplitDataWriter<String>> partitionToSplitWriter =
+            new HashMap<>();
+
+    private int numSplits = 0;
+
+    public SingleTopicConsumingContext(PulsarContainerEnvironment environment) {
+        super("consuming message on single topic", environment);
+        this.topicName =
+                TOPIC_NAME_PREFIX + "-" + ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    }
+
+    @Override
+    public Source<String, ?, ?> createSource(Boundedness boundedness) {
+        PulsarSourceBuilder<String> builder =
+                PulsarSource.builder()
+                        .setDeserializationSchema(pulsarSchema(STRING))
+                        .setServiceUrl(serviceUrl())
+                        .setAdminUrl(adminUrl())
+                        .setTopics(topicName)
+                        .setSubscriptionType(Exclusive)
+                        .setSubscriptionName("pulsar-single-topic");
+        if (boundedness == Boundedness.BOUNDED) {
+            // Using latest stop cursor for making sure the source could be stopped.
+            // This is required for SourceTestSuiteBase.
+            builder.setBoundedStopCursor(StopCursor.latest());
+        }
+
+        return builder.build();
+    }
+
+    @Override
+    public SourceSplitDataWriter<String> createSourceSplitDataWriter() {
+        if (numSplits == 0) {
+            // Create the topic first.
+            createTopic(topicName, 1);
+            numSplits++;
+        } else {
+            numSplits++;
+            increaseTopicPartitions(topicName, numSplits);
+        }
+
+        TopicPartition partition = new TopicPartition(topicName, numSplits - 1, createFullRange());
+        PulsarPartitionDataWriter writer = new PulsarPartitionDataWriter(client(), partition);
+        partitionToSplitWriter.put(numSplits - 1, writer);
+
+        return writer;
+    }
+
+    @Override
+    public Collection<String> generateTestData(long seed) {
+        return generateStringTestData(seed);
+    }
+
+    @Override
+    public void close() throws Exception {
+        // Close writer.
+        for (SourceSplitDataWriter<String> writer : partitionToSplitWriter.values()) {
+            writer.close();
+        }
+
+        partitionToSplitWriter.clear();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/containers/txnStandalone.conf
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/containers/txnStandalone.conf
@@ -1,0 +1,980 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+### --- General broker settings --- ###
+
+# Zookeeper quorum connection string
+zookeeperServers=
+
+# Configuration Store connection string
+configurationStoreServers=
+
+brokerServicePort=6650
+
+# Port to use to server HTTP request
+webServicePort=8080
+
+# Hostname or IP address the service binds on, default is 0.0.0.0.
+bindAddress=0.0.0.0
+
+# Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
+advertisedAddress=
+
+# Enable or disable the HAProxy protocol.
+haProxyProtocolEnabled=false
+
+# Number of threads to use for Netty IO. Default is set to 2 * Runtime.getRuntime().availableProcessors()
+numIOThreads=
+
+# Number of threads to use for ordered executor. The ordered executor is used to operate with zookeeper,
+# such as init zookeeper client, get namespace policies from zookeeper etc. It also used to split bundle. Default is 8
+numOrderedExecutorThreads=8
+
+# Number of threads to use for HTTP requests processing. Default is set to 2 * Runtime.getRuntime().availableProcessors()
+numHttpServerThreads=
+
+# Number of thread pool size to use for pulsar broker service.
+# The executor in thread pool will do basic broker operation like load/unload bundle, update managedLedgerConfig,
+# update topic/subscription/replicator message dispatch rate, do leader election etc.
+# Default is Runtime.getRuntime().availableProcessors()
+numExecutorThreadPoolSize=
+
+# Number of thread pool size to use for pulsar zookeeper callback service
+# The cache executor thread pool is used for restarting global zookeeper session.
+# Default is 10
+numCacheExecutorThreadPoolSize=10
+
+# Max concurrent web requests
+maxConcurrentHttpRequests=1024
+
+# Name of the cluster to which this broker belongs to
+clusterName=standalone
+
+# Enable cluster's failure-domain which can distribute brokers into logical region
+failureDomainsEnabled=false
+
+# Zookeeper session timeout in milliseconds
+zooKeeperSessionTimeoutMillis=30000
+
+# ZooKeeper operation timeout in seconds
+zooKeeperOperationTimeoutSeconds=30
+
+# ZooKeeper cache expiry time in seconds
+zooKeeperCacheExpirySeconds=300
+
+# Time to wait for broker graceful shutdown. After this time elapses, the process will be killed
+brokerShutdownTimeoutMs=60000
+
+# Flag to skip broker shutdown when broker handles Out of memory error
+skipBrokerShutdownOnOOM=false
+
+# Enable backlog quota check. Enforces action on topic when the quota is reached
+backlogQuotaCheckEnabled=true
+
+# How often to check for topics that have reached the quota
+backlogQuotaCheckIntervalInSeconds=60
+
+# Default per-topic backlog quota limit
+backlogQuotaDefaultLimitGB=10
+
+# Default per-topic backlog quota time limit in second, less than 0 means no limitation. default is -1.
+backlogQuotaDefaultLimitSecond=-1
+
+# Default ttl for namespaces if ttl is not already configured at namespace policies. (disable default-ttl with value 0)
+ttlDurationDefaultInSeconds=0
+
+# Enable the deletion of inactive topics
+brokerDeleteInactiveTopicsEnabled=true
+
+# How often to check for inactive topics
+brokerDeleteInactiveTopicsFrequencySeconds=60
+
+# Max pending publish requests per connection to avoid keeping large number of pending
+# requests in memory. Default: 1000
+maxPendingPublishRequestsPerConnection=1000
+
+# How frequently to proactively check and purge expired messages
+messageExpiryCheckIntervalInMinutes=5
+
+# How long to delay rewinding cursor and dispatching messages when active consumer is changed
+activeConsumerFailoverDelayTimeMillis=1000
+
+# How long to delete inactive subscriptions from last consuming
+# When it is 0, inactive subscriptions are not deleted automatically
+subscriptionExpirationTimeMinutes=0
+
+# Enable subscription message redelivery tracker to send redelivery count to consumer (default is enabled)
+subscriptionRedeliveryTrackerEnabled=true
+
+# On KeyShared subscriptions, with default AUTO_SPLIT mode, use splitting ranges or
+# consistent hashing to reassign keys to new consumers
+subscriptionKeySharedUseConsistentHashing=false
+
+# On KeyShared subscriptions, number of points in the consistent-hashing ring.
+# The higher the number, the more equal the assignment of keys to consumers
+subscriptionKeySharedConsistentHashingReplicaPoints=100
+
+# How frequently to proactively check and purge expired subscription
+subscriptionExpiryCheckIntervalInMinutes=5
+
+# Set the default behavior for message deduplication in the broker
+# This can be overridden per-namespace. If enabled, broker will reject
+# messages that were already stored in the topic
+brokerDeduplicationEnabled=false
+
+# Maximum number of producer information that it's going to be
+# persisted for deduplication purposes
+brokerDeduplicationMaxNumberOfProducers=10000
+
+# Number of entries after which a dedup info snapshot is taken.
+# A bigger interval will lead to less snapshots being taken though it would
+# increase the topic recovery time, when the entries published after the
+# snapshot need to be replayed
+brokerDeduplicationEntriesInterval=1000
+
+# Time of inactivity after which the broker will discard the deduplication information
+# relative to a disconnected producer. Default is 6 hours.
+brokerDeduplicationProducerInactivityTimeoutMinutes=360
+
+# When a namespace is created without specifying the number of bundle, this
+# value will be used as the default
+defaultNumberOfNamespaceBundles=4
+
+# Max number of topics allowed to be created in the namespace. When the topics reach the max topics of the namespace,
+# the broker should reject the new topic request(include topic auto-created by the producer or consumer)
+# until the number of connected consumers decrease.
+# Using a value of 0, is disabling maxTopicsPerNamespace-limit check.
+maxTopicsPerNamespace=0
+
+# Enable check for minimum allowed client library version
+clientLibraryVersionCheckEnabled=false
+
+# Path for the file used to determine the rotation status for the broker when responding
+# to service discovery health checks
+statusFilePath=/usr/local/apache/htdocs
+
+# Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
+# messages to consumer once, this limit reaches until consumer starts acknowledging messages back
+# Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
+maxUnackedMessagesPerConsumer=50000
+
+# Max number of unacknowledged messages allowed per shared subscription. Broker will stop dispatching messages to
+# all consumers of the subscription once this limit reaches until consumer starts acknowledging messages back and
+# unack count reaches to limit/2. Using a value of 0, is disabling unackedMessage-limit
+# check and dispatcher can dispatch messages without any restriction
+maxUnackedMessagesPerSubscription=200000
+
+# Max number of unacknowledged messages allowed per broker. Once this limit reaches, broker will stop dispatching
+# messages to all shared subscription which has higher number of unack messages until subscriptions start
+# acknowledging messages back and unack count reaches to limit/2. Using a value of 0, is disabling
+# unackedMessage-limit check and broker doesn't block dispatchers
+maxUnackedMessagesPerBroker=0
+
+# Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
+# than this percentage limit and subscription will not receive any new messages until that subscription acks back
+# limit/2 messages
+maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
+
+# Tick time to schedule task that checks topic publish rate limiting across all topics
+# Reducing to lower value can give more accuracy while throttling publish but
+# it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
+topicPublisherThrottlingTickTimeMillis=2
+
+# Enable precise rate limit for topic publish
+preciseTopicPublishRateLimiterEnable=false
+
+# Tick time to schedule task that checks broker publish rate limiting across all topics
+# Reducing to lower value can give more accuracy while throttling publish but
+# it uses more CPU to perform frequent check. (Disable publish throttling with value 0)
+brokerPublisherThrottlingTickTimeMillis=50
+
+# Max Rate(in 1 seconds) of Message allowed to publish for a broker if broker publish rate limiting enabled
+# (Disable message rate limit with value 0)
+brokerPublisherThrottlingMaxMessageRate=0
+
+# Max Rate(in 1 seconds) of Byte allowed to publish for a broker if broker publish rate limiting enabled
+# (Disable byte rate limit with value 0)
+brokerPublisherThrottlingMaxByteRate=0
+
+# Default messages per second dispatch throttling-limit for every topic. Using a value of 0, is disabling default
+# message dispatch-throttling
+dispatchThrottlingRatePerTopicInMsg=0
+
+# Default bytes per second dispatch throttling-limit for every topic. Using a value of 0, is disabling
+# default message-byte dispatch-throttling
+dispatchThrottlingRatePerTopicInByte=0
+
+# Dispatch rate-limiting relative to publish rate.
+# (Enabling flag will make broker to dynamically update dispatch-rate relatively to publish-rate:
+# throttle-dispatch-rate = (publish-rate + configured dispatch-rate).
+dispatchThrottlingRateRelativeToPublishRate=false
+
+# By default we enable dispatch-throttling for both caught up consumers as well as consumers who have
+# backlog.
+dispatchThrottlingOnNonBacklogConsumerEnabled=true
+
+# Precise dispathcer flow control according to history message number of each entry
+preciseDispatcherFlowControl=false
+
+# Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
+maxConcurrentLookupRequest=50000
+
+# Max number of concurrent topic loading request broker allows to control number of zk-operations
+maxConcurrentTopicLoadRequest=5000
+
+# Max concurrent non-persistent message can be processed per connection
+maxConcurrentNonPersistentMessagePerConnection=1000
+
+# Number of worker threads to serve non-persistent topic
+numWorkerThreadsForNonPersistentTopic=8
+
+# Enable broker to load persistent topics
+enablePersistentTopics=true
+
+# Enable broker to load non-persistent topics
+enableNonPersistentTopics=true
+
+# Max number of producers allowed to connect to topic. Once this limit reaches, Broker will reject new producers
+# until the number of connected producers decrease.
+# Using a value of 0, is disabling maxProducersPerTopic-limit check.
+maxProducersPerTopic=0
+
+# Max number of producers with the same IP address allowed to connect to topic.
+# Once this limit reaches, Broker will reject new producers until the number of
+# connected producers with the same IP address decrease.
+# Using a value of 0, is disabling maxSameAddressProducersPerTopic-limit check.
+maxSameAddressProducersPerTopic=0
+
+# Enforce producer to publish encrypted messages.(default disable).
+encryptionRequireOnProducer=false
+
+# Max number of consumers allowed to connect to topic. Once this limit reaches, Broker will reject new consumers
+# until the number of connected consumers decrease.
+# Using a value of 0, is disabling maxConsumersPerTopic-limit check.
+maxConsumersPerTopic=0
+
+# Max number of consumers with the same IP address allowed to connect to topic.
+# Once this limit reaches, Broker will reject new consumers until the number of
+# connected consumers with the same IP address decrease.
+# Using a value of 0, is disabling maxSameAddressConsumersPerTopic-limit check.
+maxSameAddressConsumersPerTopic=0
+
+# Max number of subscriptions allowed to subscribe to topic. Once this limit reaches, broker will reject
+# new subscription until the number of subscribed subscriptions decrease.
+# Using a value of 0, is disabling maxSubscriptionsPerTopic limit check.
+maxSubscriptionsPerTopic=0
+
+# Max number of consumers allowed to connect to subscription. Once this limit reaches, Broker will reject new consumers
+# until the number of connected consumers decrease.
+# Using a value of 0, is disabling maxConsumersPerSubscription-limit check.
+maxConsumersPerSubscription=0
+
+# Max number of partitions per partitioned topic
+# Use 0 or negative number to disable the check
+maxNumPartitionsPerPartitionedTopic=0
+
+### --- TLS --- ###
+# Deprecated - Use webServicePortTls and brokerServicePortTls instead
+tlsEnabled=false
+
+# Tls cert refresh duration in seconds (set 0 to check on every new connection)
+tlsCertRefreshCheckDurationSec=300
+
+# Path for the TLS certificate file
+tlsCertificateFilePath=
+
+# Path for the TLS private key file
+tlsKeyFilePath=
+
+# Path for the trusted TLS certificate file.
+# This cert is used to verify that any certs presented by connecting clients
+# are signed by a certificate authority. If this verification
+# fails, then the certs are untrusted and the connections are dropped.
+tlsTrustCertsFilePath=
+
+# Accept untrusted TLS certificate from client.
+# If true, a client with a cert which cannot be verified with the
+# 'tlsTrustCertsFilePath' cert will allowed to connect to the server,
+# though the cert will not be used for client authentication.
+tlsAllowInsecureConnection=false
+
+# Specify the tls protocols the broker will use to negotiate during TLS handshake
+# (a comma-separated list of protocol names).
+# Examples:- [TLSv1.3, TLSv1.2]
+tlsProtocols=
+
+# Specify the tls cipher the broker will use to negotiate during TLS Handshake
+# (a comma-separated list of ciphers).
+# Examples:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+tlsCiphers=
+
+# Trusted client certificates are required for to connect TLS
+# Reject the Connection if the Client Certificate is not trusted.
+# In effect, this requires that all connecting clients perform TLS client
+# authentication.
+tlsRequireTrustedClientCertOnConnect=false
+
+### --- KeyStore TLS config variables --- ###
+# Enable TLS with KeyStore type configuration in broker.
+tlsEnabledWithKeyStore=false
+
+# TLS Provider for KeyStore type
+tlsProvider=
+
+# TLS KeyStore type configuration in broker: JKS, PKCS12
+tlsKeyStoreType=JKS
+
+# TLS KeyStore path in broker
+tlsKeyStore=
+
+# TLS KeyStore password for broker
+tlsKeyStorePassword=
+
+# TLS TrustStore type configuration in broker: JKS, PKCS12
+tlsTrustStoreType=JKS
+
+# TLS TrustStore path in broker
+tlsTrustStore=
+
+# TLS TrustStore password for broker
+tlsTrustStorePassword=
+
+# Whether internal client use KeyStore type to authenticate with Pulsar brokers
+brokerClientTlsEnabledWithKeyStore=false
+
+# The TLS Provider used by internal client to authenticate with other Pulsar brokers
+brokerClientSslProvider=
+
+# TLS TrustStore type configuration for internal client: JKS, PKCS12
+# used by the internal client to authenticate with Pulsar brokers
+brokerClientTlsTrustStoreType=JKS
+
+# TLS TrustStore path for internal client
+# used by the internal client to authenticate with Pulsar brokers
+brokerClientTlsTrustStore=
+
+# TLS TrustStore password for internal client,
+# used by the internal client to authenticate with Pulsar brokers
+brokerClientTlsTrustStorePassword=
+
+# Specify the tls cipher the internal client will use to negotiate during TLS Handshake
+# (a comma-separated list of ciphers)
+# e.g.  [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256].
+# used by the internal client to authenticate with Pulsar brokers
+brokerClientTlsCiphers=
+
+# Specify the tls protocols the broker will use to negotiate during TLS handshake
+# (a comma-separated list of protocol names).
+# e.g.  [TLSv1.3, TLSv1.2]
+# used by the internal client to authenticate with Pulsar brokers
+brokerClientTlsProtocols=
+
+# Enable or disable system topic
+systemTopicEnabled=true
+
+# Enable or disable topic level policies, topic level policies depends on the system topic
+# Please enable the system topic first.
+topicLevelPoliciesEnabled=false
+
+# If a topic remains fenced for this number of seconds, it will be closed forcefully.
+# If it is set to 0 or a negative number, the fenced topic will not be closed.
+topicFencingTimeoutSeconds=0
+
+### --- Authentication --- ###
+# Role names that are treated as "proxy roles". If the broker sees a request with
+#role as proxyRoles - it will demand to see a valid original principal.
+proxyRoles=
+
+# If this flag is set then the broker authenticates the original Auth data
+# else it just accepts the originalPrincipal and authorizes it (if required).
+authenticateOriginalAuthData=false
+
+# Enable authentication
+authenticationEnabled=false
+
+# Authentication provider name list, which is comma separated list of class names
+authenticationProviders=
+
+# Enforce authorization
+authorizationEnabled=false
+
+# Authorization provider fully qualified class-name
+authorizationProvider=org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
+
+# Allow wildcard matching in authorization
+# (wildcard matching only applicable if wildcard-char:
+# * presents at first or last position eg: *.pulsar.service, pulsar.service.*)
+authorizationAllowWildcardsMatching=false
+
+# Role names that are treated as "super-user", meaning they will be able to do all admin
+# operations and publish/consume from all topics
+superUserRoles=
+
+# Authentication settings of the broker itself. Used when the broker connects to other brokers,
+# either in same or other clusters
+brokerClientAuthenticationPlugin=
+brokerClientAuthenticationParameters=
+
+# Supported Athenz provider domain names(comma separated) for authentication
+athenzDomainNames=
+
+# When this parameter is not empty, unauthenticated users perform as anonymousUserRole
+anonymousUserRole=
+
+
+### --- Token Authentication Provider --- ###
+
+## Symmetric key
+# Configure the secret key to be used to validate auth tokens
+# The key can be specified like:
+# tokenSecretKey=data:;base64,xxxxxxxxx
+# tokenSecretKey=file:///my/secret.key  ( Note: key file must be DER-encoded )
+tokenSecretKey=
+
+## Asymmetric public/private key pair
+# Configure the public key to be used to validate auth tokens
+# The key can be specified like:
+# tokenPublicKey=data:;base64,xxxxxxxxx
+# tokenPublicKey=file:///my/public.key    ( Note: key file must be DER-encoded )
+tokenPublicKey=
+
+
+# The token "claim" that will be interpreted as the authentication "role" or "principal" by AuthenticationProviderToken (defaults to "sub" if blank)
+tokenAuthClaim=
+
+# The token audience "claim" name, e.g. "aud", that will be used to get the audience from token.
+# If not set, audience will not be verified.
+tokenAudienceClaim=
+
+# The token audience stands for this broker. The field `tokenAudienceClaim` of a valid token, need contains this.
+tokenAudience=
+
+### --- BookKeeper Client --- ###
+
+# Authentication plugin to use when connecting to bookies
+bookkeeperClientAuthenticationPlugin=
+
+# BookKeeper auth plugin implementatation specifics parameters name and values
+bookkeeperClientAuthenticationParametersName=
+bookkeeperClientAuthenticationParameters=
+
+# Timeout for BK add / read operations
+bookkeeperClientTimeoutInSeconds=30
+
+# Number of BookKeeper client worker threads
+# Default is Runtime.getRuntime().availableProcessors()
+bookkeeperClientNumWorkerThreads=
+
+# Speculative reads are initiated if a read request doesn't complete within a certain time
+# Using a value of 0, is disabling the speculative reads
+bookkeeperClientSpeculativeReadTimeoutInMillis=0
+
+# Number of channels per bookie
+bookkeeperNumberOfChannelsPerBookie=16
+
+# Enable bookies health check. Bookies that have more than the configured number of failure within
+# the interval will be quarantined for some time. During this period, new ledgers won't be created
+# on these bookies
+bookkeeperClientHealthCheckEnabled=true
+bookkeeperClientHealthCheckIntervalSeconds=60
+bookkeeperClientHealthCheckErrorThresholdPerInterval=5
+bookkeeperClientHealthCheckQuarantineTimeInSeconds=1800
+
+#bookie quarantine ratio to avoid all clients quarantine the high pressure bookie servers at the same time
+bookkeeperClientQuarantineRatio=1.0
+
+# Enable rack-aware bookie selection policy. BK will chose bookies from different racks when
+# forming a new bookie ensemble
+# This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy
+# should be set to org.apache.bookkeeper.client.RackawareEnsemblePlacementPolicy
+bookkeeperClientRackawarePolicyEnabled=true
+
+# Enable region-aware bookie selection policy. BK will chose bookies from
+# different regions and racks when forming a new bookie ensemble.
+# If enabled, the value of bookkeeperClientRackawarePolicyEnabled is ignored
+# This parameter related to ensemblePlacementPolicy in conf/bookkeeper.conf, if enabled, ensemblePlacementPolicy
+# should be set to org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy
+bookkeeperClientRegionawarePolicyEnabled=false
+
+# Minimum number of racks per write quorum. BK rack-aware bookie selection policy will try to
+# get bookies from at least 'bookkeeperClientMinNumRacksPerWriteQuorum' racks for a write quorum.
+bookkeeperClientMinNumRacksPerWriteQuorum=1
+
+# Enforces rack-aware bookie selection policy to pick bookies from 'bookkeeperClientMinNumRacksPerWriteQuorum'
+# racks for a writeQuorum.
+# If BK can't find bookie then it would throw BKNotEnoughBookiesException instead of picking random one.
+bookkeeperClientEnforceMinNumRacksPerWriteQuorum=false
+
+# Enable/disable reordering read sequence on reading entries.
+bookkeeperClientReorderReadSequenceEnabled=false
+
+# Enable bookie isolation by specifying a list of bookie groups to choose from. Any bookie
+# outside the specified groups will not be used by the broker
+bookkeeperClientIsolationGroups=
+
+# Enable bookie secondary-isolation group if bookkeeperClientIsolationGroups doesn't
+# have enough bookie available.
+bookkeeperClientSecondaryIsolationGroups=
+
+# Minimum bookies that should be available as part of bookkeeperClientIsolationGroups
+# else broker will include bookkeeperClientSecondaryIsolationGroups bookies in isolated list.
+bookkeeperClientMinAvailableBookiesInIsolationGroups=
+
+# Set the client security provider factory class name.
+# Default: org.apache.bookkeeper.tls.TLSContextFactory
+bookkeeperTLSProviderFactoryClass=org.apache.bookkeeper.tls.TLSContextFactory
+
+# Enable tls authentication with bookie
+bookkeeperTLSClientAuthentication=false
+
+# Supported type: PEM, JKS, PKCS12. Default value: PEM
+bookkeeperTLSKeyFileType=PEM
+
+#Supported type: PEM, JKS, PKCS12. Default value: PEM
+bookkeeperTLSTrustCertTypes=PEM
+
+# Path to file containing keystore password, if the client keystore is password protected.
+bookkeeperTLSKeyStorePasswordPath=
+
+# Path to file containing truststore password, if the client truststore is password protected.
+bookkeeperTLSTrustStorePasswordPath=
+
+# Path for the TLS private key file
+bookkeeperTLSKeyFilePath=
+
+# Path for the TLS certificate file
+bookkeeperTLSCertificateFilePath=
+
+# Path for the trusted TLS certificate file
+bookkeeperTLSTrustCertsFilePath=
+
+# Enable/disable disk weight based placement. Default is false
+bookkeeperDiskWeightBasedPlacementEnabled=false
+
+# Set the interval to check the need for sending an explicit LAC
+# A value of '0' disables sending any explicit LACs. Default is 0.
+bookkeeperExplicitLacIntervalInMills=0
+
+# Use older Bookkeeper wire protocol with bookie
+bookkeeperUseV2WireProtocol=true
+
+# Expose bookkeeper client managed ledger stats to prometheus. default is false
+# bookkeeperClientExposeStatsToPrometheus=false
+
+### --- Managed Ledger --- ###
+
+# Number of bookies to use when creating a ledger
+managedLedgerDefaultEnsembleSize=1
+
+# Number of copies to store for each message
+managedLedgerDefaultWriteQuorum=1
+
+# Number of guaranteed copies (acks to wait before write is complete)
+managedLedgerDefaultAckQuorum=1
+
+# How frequently to flush the cursor positions that were accumulated due to rate limiting. (seconds).
+# Default is 60 seconds
+managedLedgerCursorPositionFlushSeconds = 60
+
+# Default type of checksum to use when writing to BookKeeper. Default is "CRC32C"
+# Other possible options are "CRC32", "MAC" or "DUMMY" (no checksum).
+managedLedgerDigestType=CRC32C
+
+# Number of threads to be used for managed ledger tasks dispatching
+managedLedgerNumWorkerThreads=4
+
+# Number of threads to be used for managed ledger scheduled tasks
+managedLedgerNumSchedulerThreads=4
+
+# Amount of memory to use for caching data payload in managed ledger. This memory
+# is allocated from JVM direct memory and it's shared across all the topics
+# running  in the same broker. By default, uses 1/5th of available direct memory
+managedLedgerCacheSizeMB=
+
+# Whether we should make a copy of the entry payloads when inserting in cache
+managedLedgerCacheCopyEntries=false
+
+# Threshold to which bring down the cache level when eviction is triggered
+managedLedgerCacheEvictionWatermark=0.9
+
+# Configure the cache eviction frequency for the managed ledger cache (evictions/sec)
+managedLedgerCacheEvictionFrequency=100.0
+
+# All entries that have stayed in cache for more than the configured time, will be evicted
+managedLedgerCacheEvictionTimeThresholdMillis=1000
+
+# Configure the threshold (in number of entries) from where a cursor should be considered 'backlogged'
+# and thus should be set as inactive.
+managedLedgerCursorBackloggedThreshold=1000
+
+# Rate limit the amount of writes generated by consumer acking the messages
+managedLedgerDefaultMarkDeleteRateLimit=0.1
+
+# Max number of entries to append to a ledger before triggering a rollover
+# A ledger rollover is triggered on these conditions
+#  * Either the max rollover time has been reached
+#  * or max entries have been written to the ledger and at least min-time
+#    has passed
+managedLedgerMaxEntriesPerLedger=50000
+
+# Minimum time between ledger rollover for a topic
+managedLedgerMinLedgerRolloverTimeMinutes=10
+
+# Maximum time before forcing a ledger rollover for a topic
+managedLedgerMaxLedgerRolloverTimeMinutes=240
+
+# Max number of entries to append to a cursor ledger
+managedLedgerCursorMaxEntriesPerLedger=50000
+
+# Max time before triggering a rollover on a cursor ledger
+managedLedgerCursorRolloverTimeInSeconds=14400
+
+# Maximum ledger size before triggering a rollover for a topic (MB)
+managedLedgerMaxSizePerLedgerMbytes=2048
+
+# Max number of "acknowledgment holes" that are going to be persistently stored.
+# When acknowledging out of order, a consumer will leave holes that are supposed
+# to be quickly filled by acking all the messages. The information of which
+# messages are acknowledged is persisted by compressing in "ranges" of messages
+# that were acknowledged. After the max number of ranges is reached, the information
+# will only be tracked in memory and messages will be redelivered in case of
+# crashes.
+managedLedgerMaxUnackedRangesToPersist=10000
+
+# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# zookeeper.
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
+
+# Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
+# corrupted at bookkeeper and managed-cursor is stuck at that ledger.
+autoSkipNonRecoverableData=false
+
+# operation timeout while updating managed-ledger metadata.
+managedLedgerMetadataOperationsTimeoutSeconds=60
+
+# Read entries timeout when broker tries to read messages from bookkeeper.
+managedLedgerReadEntryTimeoutSeconds=0
+
+# Add entry timeout when broker tries to publish message to bookkeeper (0 to disable it).
+managedLedgerAddEntryTimeoutSeconds=0
+
+# New entries check delay for the cursor under the managed ledger.
+# If no new messages in the topic, the cursor will try to check again after the delay time.
+# For consumption latency sensitive scenario, can set to a smaller value or set to 0.
+# Of course, use a smaller value may degrade consumption throughput. Default is 10ms.
+managedLedgerNewEntriesCheckDelayInMillis=10
+
+# Use Open Range-Set to cache unacked messages
+managedLedgerUnackedRangesOpenCacheSetEnabled=true
+
+# Managed ledger prometheus stats latency rollover seconds (default: 60s)
+managedLedgerPrometheusStatsLatencyRolloverSeconds=60
+
+# Whether trace managed ledger task execution time
+managedLedgerTraceTaskExecution=true
+
+# If you want to custom bookie ID or use a dynamic network address for the bookie,
+# you can set this option.
+# Bookie advertises itself using bookieId rather than
+# BookieSocketAddress (hostname:port or IP:port).
+# bookieId is a non empty string that can contain ASCII digits and letters ([a-zA-Z9-0]),
+# colons, dashes, and dots.
+# For more information about bookieId, see http://bookkeeper.apache.org/bps/BP-41-bookieid/.
+# bookieId=
+
+### --- Load balancer --- ###
+
+loadManagerClassName=org.apache.pulsar.broker.loadbalance.NoopLoadManager
+
+# Enable load balancer
+loadBalancerEnabled=false
+
+# Percentage of change to trigger load report update
+loadBalancerReportUpdateThresholdPercentage=10
+
+# maximum interval to update load report
+loadBalancerReportUpdateMaxIntervalMinutes=15
+
+# Frequency of report to collect
+loadBalancerHostUsageCheckIntervalMinutes=1
+
+# Load shedding interval. Broker periodically checks whether some traffic should be offload from
+# some over-loaded broker to other under-loaded brokers
+loadBalancerSheddingIntervalMinutes=1
+
+# Prevent the same topics to be shed and moved to other broker more that once within this timeframe
+loadBalancerSheddingGracePeriodMinutes=30
+
+# Usage threshold to allocate max number of topics to broker
+loadBalancerBrokerMaxTopics=50000
+
+# Interval to flush dynamic resource quota to ZooKeeper
+loadBalancerResourceQuotaUpdateIntervalMinutes=15
+
+# enable/disable namespace bundle auto split
+loadBalancerAutoBundleSplitEnabled=true
+
+# enable/disable automatic unloading of split bundles
+loadBalancerAutoUnloadSplitBundlesEnabled=true
+
+# maximum topics in a bundle, otherwise bundle split will be triggered
+loadBalancerNamespaceBundleMaxTopics=1000
+
+# maximum sessions (producers + consumers) in a bundle, otherwise bundle split will be triggered
+loadBalancerNamespaceBundleMaxSessions=1000
+
+# maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
+loadBalancerNamespaceBundleMaxMsgRate=30000
+
+# maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
+loadBalancerNamespaceBundleMaxBandwidthMbytes=100
+
+# maximum number of bundles in a namespace
+loadBalancerNamespaceMaximumBundles=128
+
+# The broker resource usage threshold.
+# When the broker resource usage is greater than the pulsar cluster average resource usage,
+# the threshold shedder will be triggered to offload bundles from the broker.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerBrokerThresholdShedderPercentage=10
+
+# When calculating new resource usage, the history usage accounts for.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerHistoryResourcePercentage=0.9
+
+# The BandWithIn usage weight when calculating new resource usage.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerBandwithInResourceWeight=1.0
+
+# The BandWithOut usage weight when calculating new resource usage.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerBandwithOutResourceWeight=1.0
+
+# The CPU usage weight when calculating new resource usage.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerCPUResourceWeight=1.0
+
+# The heap memory usage weight when calculating new resource usage.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerMemoryResourceWeight=1.0
+
+# The direct memory usage weight when calculating new resource usage.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerDirectMemoryResourceWeight=1.0
+
+# Bundle unload minimum throughput threshold (MB), avoiding bundle unload frequently.
+# It only takes effect in the ThresholdShedder strategy.
+loadBalancerBundleUnloadMinThroughputThreshold=10
+
+### --- Replication --- ###
+
+# Enable replication metrics
+replicationMetricsEnabled=true
+
+# Max number of connections to open for each broker in a remote cluster
+# More connections host-to-host lead to better throughput over high-latency
+# links.
+replicationConnectionsPerBroker=16
+
+# Replicator producer queue size
+replicationProducerQueueSize=1000
+
+# Duration to check replication policy to avoid replicator inconsistency
+# due to missing ZooKeeper watch (disable with value 0)
+replicationPolicyCheckDurationSeconds=600
+
+# Default message retention time
+defaultRetentionTimeInMinutes=0
+
+# Default retention size
+defaultRetentionSizeInMB=0
+
+# How often to check whether the connections are still alive
+keepAliveIntervalSeconds=30
+
+### --- WebSocket --- ###
+
+# Enable the WebSocket API service in broker
+webSocketServiceEnabled=true
+
+# Number of IO threads in Pulsar Client used in WebSocket proxy
+webSocketNumIoThreads=8
+
+# Number of connections per Broker in Pulsar Client used in WebSocket proxy
+webSocketConnectionsPerBroker=8
+
+# Time in milliseconds that idle WebSocket session times out
+webSocketSessionIdleTimeoutMillis=300000
+
+# The maximum size of a text message during parsing in WebSocket proxy
+webSocketMaxTextFrameSize=1048576
+
+### --- Metrics --- ###
+
+# Enable topic level metrics
+exposeTopicLevelMetricsInPrometheus=true
+
+# Time in milliseconds that metrics endpoint would time out. Default is 30s.
+# Increase it if there are a lot of topics to expose topic-level metrics.
+# Set it to 0 to disable timeout.
+metricsServletTimeoutMs=30000
+
+# Classname of Pluggable JVM GC metrics logger that can log GC specific metrics
+# jvmGCMetricsLoggerClassName=
+
+### --- Broker Web Stats --- ###
+
+# Enable topic level metrics
+exposePublisherStats=true
+
+# Enable expose the precise backlog stats.
+# Set false to use published counter and consumed counter to calculate, this would be more efficient but may be inaccurate.
+# Default is false.
+exposePreciseBacklogInPrometheus=false
+
+### --- Deprecated config variables --- ###
+
+# Deprecated. Use configurationStoreServers
+globalZookeeperServers=
+
+# Deprecated. Use brokerDeleteInactiveTopicsFrequencySeconds
+brokerServicePurgeInactiveFrequencyInSeconds=60
+
+### --- BookKeeper Configuration --- #####
+
+ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage
+
+# The maximum netty frame size in bytes. Any message received larger than this will be rejected. The default value is 5MB.
+nettyMaxFrameSizeBytes=5253120
+
+# Size of Write Cache. Memory is allocated from JVM direct memory.
+# Write cache is used to buffer entries before flushing into the entry log
+# For good performance, it should be big enough to hold a substantial amount
+# of entries in the flush interval
+# By default it will be allocated to 1/4th of the available direct memory
+dbStorage_writeCacheMaxSizeMb=
+
+# Size of Read cache. Memory is allocated from JVM direct memory.
+# This read cache is pre-filled doing read-ahead whenever a cache miss happens
+# By default it will be allocated to 1/4th of the available direct memory
+dbStorage_readAheadCacheMaxSizeMb=
+
+# How many entries to pre-fill in cache after a read cache miss
+dbStorage_readAheadCacheBatchSize=1000
+
+flushInterval=60000
+
+## RocksDB specific configurations
+## DbLedgerStorage uses RocksDB to store the indexes from
+## (ledgerId, entryId) -> (entryLog, offset)
+
+# Size of RocksDB block-cache. For best performance, this cache
+# should be big enough to hold a significant portion of the index
+# database which can reach ~2GB in some cases
+# Default is to use 10% of the direct memory size
+dbStorage_rocksDB_blockCacheSize=
+
+# Other RocksDB specific tunables
+dbStorage_rocksDB_writeBufferSizeMB=4
+dbStorage_rocksDB_sstSizeInMB=4
+dbStorage_rocksDB_blockSize=4096
+dbStorage_rocksDB_bloomFilterBitsPerKey=10
+dbStorage_rocksDB_numLevels=-1
+dbStorage_rocksDB_numFilesInLevel0=4
+dbStorage_rocksDB_maxSizeInLevel1MB=256
+
+# Maximum latency to impose on a journal write to achieve grouping
+journalMaxGroupWaitMSec=1
+
+# Should the data be fsynced on journal before acknowledgment.
+journalSyncData=false
+
+
+# For each ledger dir, maximum disk space which can be used.
+# Default is 0.95f. i.e. 95% of disk can be used at most after which nothing will
+# be written to that partition. If all ledger dir partions are full, then bookie
+# will turn to readonly mode if 'readOnlyModeEnabled=true' is set, else it will
+# shutdown.
+# Valid values should be in between 0 and 1 (exclusive).
+diskUsageThreshold=0.99
+
+# The disk free space low water mark threshold.
+# Disk is considered full when usage threshold is exceeded.
+# Disk returns back to non-full state when usage is below low water mark threshold.
+# This prevents it from going back and forth between these states frequently
+# when concurrent writes and compaction are happening. This also prevent bookie from
+# switching frequently between read-only and read-writes states in the same cases.
+diskUsageWarnThreshold=0.99
+
+# Whether the bookie allowed to use a loopback interface as its primary
+# interface(i.e. the interface it uses to establish its identity)?
+# By default, loopback interfaces are not allowed as the primary
+# interface.
+# Using a loopback interface as the primary interface usually indicates
+# a configuration error. For example, its fairly common in some VPS setups
+# to not configure a hostname, or to have the hostname resolve to
+# 127.0.0.1. If this is the case, then all bookies in the cluster will
+# establish their identities as 127.0.0.1:3181, and only one will be able
+# to join the cluster. For VPSs configured like this, you should explicitly
+# set the listening interface.
+allowLoopback=true
+
+# How long the interval to trigger next garbage collection, in milliseconds
+# Since garbage collection is running in background, too frequent gc
+# will heart performance. It is better to give a higher number of gc
+# interval if there is enough disk capacity.
+gcWaitTime=300000
+
+# Enable topic auto creation if new producer or consumer connected (disable auto creation with value false)
+allowAutoTopicCreation=true
+
+# The type of topic that is allowed to be automatically created.(partitioned/non-partitioned)
+allowAutoTopicCreationType=non-partitioned
+
+# Enable subscription auto creation if new consumer connected (disable auto creation with value false)
+allowAutoSubscriptionCreation=true
+
+# The number of partitioned topics that is allowed to be automatically created if allowAutoTopicCreationType is partitioned.
+defaultNumPartitions=1
+
+### --- Transaction config variables --- ###
+# Enable transaction coordinator in broker
+transactionCoordinatorEnabled=true
+; transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.MLTransactionMetadataStoreProvider
+transactionMetadataStoreProviderClassName=org.apache.pulsar.transaction.coordinator.impl.InMemTransactionMetadataStoreProvider
+
+# Transaction buffer take snapshot transaction count
+transactionBufferSnapshotMaxTransactionCount=1000
+
+# Transaction buffer take snapshot interval time
+# Unit : millisecond
+transactionBufferSnapshotMinTimeInMillis=5000
+
+### --- Packages management service configuration variables (begin) --- ###
+
+# Enable the packages management service or not
+enablePackagesManagement=false
+
+# The packages management service storage service provide
+packagesManagementStorageProvider=org.apache.pulsar.packages.management.storage.bookkeeper.BookKeeperPackagesStorageProvider
+
+# When the packages storage provider is bookkeeper, you can use this configuration to
+# control the number of replicas for storing the package
+packagesReplicas=1
+
+# The bookkeeper ledger root path
+packagesManagementLedgerRootPath=/ledgers
+
+### --- Packages management service configuration variables (end) --- ###

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/log4j2-test.properties
@@ -1,0 +1,35 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=OFF
+rootLogger.appenderRef.test.ref=TestLogger
+appender.testlogger.name=TestLogger
+appender.testlogger.type=CONSOLE
+appender.testlogger.target=SYSTEM_ERR
+appender.testlogger.layout.type=PatternLayout
+appender.testlogger.layout.pattern=%-4r [%t] %-5p %c %x - %m%n
+
+# Logger for pulsar.
+logger.pulsar.name=org.apache.pulsar
+logger.pulsar.level=OFF
+
+# Logger for pulsar connector.
+logger.pulsar.connector.name=org.apache.flink.connector.pulsar
+logger.pulsar.connector.level=OFF

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/protobuf/sample_message.proto
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/protobuf/sample_message.proto
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+
+package org.apache.flink.connector.pulsar;
+
+enum TestEnum {
+    SHARED = 0;
+    FAILOVER = 1;
+}
+
+message SubMessage {
+    string foo = 1;
+    double bar = 2;
+    message NestedMessage {
+        string url = 1;
+        string title = 2;
+        repeated string snippets = 3;
+    }
+}
+
+message TestMessage {
+    string stringField = 1;
+    double doubleField = 2;
+    int32 intField = 6;
+    TestEnum testEnum = 4;
+    SubMessage nestedField = 5;
+    repeated string repeatedField = 10;
+}

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -57,6 +57,7 @@ under the License.
 		<module>flink-connector-base</module>
 		<module>flink-file-sink-common</module>
 		<module>flink-connector-files</module>
+		<module>flink-connector-pulsar</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up

--- a/flink-test-utils-parent/flink-connector-testing/src/main/java/org/apache/flink/connectors/test/common/environment/MiniClusterTestEnvironment.java
+++ b/flink-test-utils-parent/flink-connector-testing/src/main/java/org/apache/flink/connectors/test/common/environment/MiniClusterTestEnvironment.java
@@ -87,7 +87,7 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
         CommonTestUtils.waitForJobStatus(
                 jobClient,
                 Arrays.asList(JobStatus.FAILING, JobStatus.FAILED, JobStatus.RESTARTING),
-                Deadline.fromNow(Duration.ofSeconds(30)));
+                Deadline.fromNow(Duration.ofMinutes(5)));
         afterFailAction.run();
         startTaskManager();
     }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -35,4 +35,6 @@ public class DockerImageVersions {
     public static final String RABBITMQ = "rabbitmq:3.7.25-management-alpine";
 
     public static final String KINESALITE = "instructure/kinesalite:latest";
+
+    public static final String PULSAR = "apachepulsar/pulsar:2.8.0";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1457,6 +1457,7 @@ under the License.
 						<exclude>flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/query/*</exclude>
 						<exclude>flink-connectors/flink-connector-kinesis/src/test/resources/profile</exclude>
 						<exclude>flink-table/flink-table-code-splitter/src/test/resources/**</exclude>
+						<exclude>flink-connectors/flink-connector-pulsar/src/test/resources/**</exclude>
 
 						<!-- snapshots -->
 						<exclude>**/src/test/resources/serializer-snapshot-*</exclude>


### PR DESCRIPTION
## What is the purpose of the change

Add the `Source` implementation of Pulsar to the connector.

## Brief change log

- Add Pulsar Source implementation
- Supports exactly-one
- Support dynamic discovery of Topic
- Implementation is similar to kafka


## Verifying this change

This change added tests and can be verified as follows:

- Adding basic tests for Source (start, stop, snapshot, checkpoint)
- Pulsar service based on testcontainers
- Pulsar client cache tests
- Watermark function testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)

The main design and implementation of the source functionality was done by  @AHeise and we are grateful for his support