### PR TITLE
[FLINK-21890][table-planner-blink] Rename DAGProcessor to ExecNodeGraphProcessor

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DeadlockBreakupProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DeadlockBreakupProcessor.java
@@ -26,15 +26,15 @@ import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.processor.utils.InputPriorityConflictResolver;
 
 /**
- * A {@link DAGProcessor} that finds out all deadlocks in the {@link ExecNodeGraph} and resolves
- * them.
+ * A {@link ExecNodeGraphProcessor} that finds out all deadlocks in the {@link ExecNodeGraph} and
+ * resolves them.
  *
  * <p>NOTE: This processor can be only applied on {@link BatchExecNode} DAG.
  */
-public class DeadlockBreakupProcessor implements DAGProcessor {
+public class DeadlockBreakupProcessor implements ExecNodeGraphProcessor {
 
     @Override
-    public ExecNodeGraph process(ExecNodeGraph execGraph, DAGProcessContext context) {
+    public ExecNodeGraph process(ExecNodeGraph execGraph, ProcessorContext context) {
         if (!execGraph.getRootNodes().stream().allMatch(r -> r instanceof BatchExecNode)) {
             throw new TableException("Only BatchExecNode DAG are supported now.");
         }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ExecNodeGraphProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ExecNodeGraphProcessor.java
@@ -18,23 +18,14 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.processor;
 
-import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 
-/** Context for processors to process dag. */
-public class DAGProcessContext {
+/**
+ * {@link ExecNodeGraphProcessor} plugin, use it can change or update the given {@link
+ * ExecNodeGraph}.
+ */
+public interface ExecNodeGraphProcessor {
 
-    private final PlannerBase planner;
-
-    public DAGProcessContext(PlannerBase planner) {
-        this.planner = planner;
-    }
-
-    /**
-     * Gets {@link PlannerBase}, {@link org.apache.flink.table.planner.delegation.BatchPlanner} for
-     * batch job. and {@link org.apache.flink.table.planner.delegation.StreamPlanner} for stream
-     * job.
-     */
-    public PlannerBase getPlanner() {
-        return planner;
-    }
+    /** Given an {@link ExecNodeGraph}, process it and return the result {@link ExecNodeGraph}. */
+    ExecNodeGraph process(ExecNodeGraph execGraph, ProcessorContext context);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
@@ -51,13 +51,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A {@link DAGProcessor} which organize {@link ExecNode}s into multiple input nodes.
+ * A {@link ExecNodeGraphProcessor} which organize {@link ExecNode}s into multiple input nodes.
  *
  * <p>For a detailed explanation of the algorithm, see appendix of the <a
  * href="https://docs.google.com/document/d/1qKVohV12qn-bM51cBZ8Hcgp31ntwClxjoiNBUOqVHsI">design
  * doc</a>.
  */
-public class MultipleInputNodeCreationProcessor implements DAGProcessor {
+public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcessor {
 
     private final boolean isStreaming;
 
@@ -66,7 +66,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
     }
 
     @Override
-    public ExecNodeGraph process(ExecNodeGraph execGraph, DAGProcessContext context) {
+    public ExecNodeGraph process(ExecNodeGraph execGraph, ProcessorContext context) {
         if (!isStreaming) {
             // As multiple input nodes use function call to deliver records between sub-operators,
             // we cannot rely on network buffers to buffer records not yet ready to be read,
@@ -228,7 +228,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
     // --------------------------------------------------------------------------------
 
     private void optimizeMultipleInputGroups(
-            List<ExecNodeWrapper> orderedWrappers, DAGProcessContext context) {
+            List<ExecNodeWrapper> orderedWrappers, ProcessorContext context) {
         // wrappers are checked in topological order from sources to sinks
         for (int i = orderedWrappers.size() - 1; i >= 0; i--) {
             ExecNodeWrapper wrapper = orderedWrappers.get(i);
@@ -429,7 +429,7 @@ public class MultipleInputNodeCreationProcessor implements DAGProcessor {
     }
 
     @VisibleForTesting
-    static boolean isChainableSource(ExecNode<?> node, DAGProcessContext context) {
+    static boolean isChainableSource(ExecNode<?> node, ProcessorContext context) {
         if (node instanceof BatchExecBoundedStreamScan) {
             BatchExecBoundedStreamScan scan = (BatchExecBoundedStreamScan) node;
             return scan.getDataStream().getTransformation() instanceof SourceTransformation;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ProcessorContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ProcessorContext.java
@@ -18,11 +18,24 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.processor;
 
+import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 
-/** DAGProcess plugin, use it can set resource of dag or change other node info. */
-public interface DAGProcessor {
+/** Context for {@link ExecNodeGraphProcessor} to process {@link ExecNodeGraph}. */
+public class ProcessorContext {
 
-    /** Given an {@link ExecNodeGraph}, process it and return the result {@link ExecNodeGraph}. */
-    ExecNodeGraph process(ExecNodeGraph execGraph, DAGProcessContext context);
+    private final PlannerBase planner;
+
+    public ProcessorContext(PlannerBase planner) {
+        this.planner = planner;
+    }
+
+    /**
+     * Gets {@link PlannerBase}, {@link org.apache.flink.table.planner.delegation.BatchPlanner} for
+     * batch job. and {@link org.apache.flink.table.planner.delegation.StreamPlanner} for stream
+     * job.
+     */
+    public PlannerBase getPlanner() {
+        return planner;
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOper
 import org.apache.flink.table.planner.operations.PlannerQueryOperation
 import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
+import org.apache.flink.table.planner.plan.nodes.exec.processor.ExecNodeGraphProcessor
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}
@@ -60,6 +61,8 @@ class StreamPlanner(
   }
 
   override protected def getOptimizer: Optimizer = new StreamCommonSubGraphBasedOptimizer(this)
+
+  override protected def getExecNodeGraphProcessors: Seq[ExecNodeGraphProcessor] = Seq()
 
   override protected def translateToPlan(execGraph: ExecNodeGraph): util.List[Transformation[_]] = {
     val planner = createDummyPlanner()

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -109,7 +109,7 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
         while (!execNode.getInputEdges().isEmpty()) {
             execNode = execNode.getInputEdges().get(0).getSource();
         }
-        DAGProcessContext context = new DAGProcessContext(util.getPlanner());
+        ProcessorContext context = new ProcessorContext(util.getPlanner());
         Assert.assertEquals(
                 expected, MultipleInputNodeCreationProcessor.isChainableSource(execNode, context));
     }


### PR DESCRIPTION


## What is the purpose of the change

*in FLINK-21041, we have introduced ExecNodeGraph to wrap the ExecNode topology. DAGProcessor is used for transforming ExecNodeGraph. Their names do not match. This pr aims to rename DAGProcessor to ExecNodeGraphProcessor.*


## Brief change log

  - *Rename DAGProcessor to ExecNodeGraphProcessor*
  - *Rename DAGProcessContext to ProcessorContext*
  - *Do some minor abstract in PlannerBase*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
