### PR TITLE
[FLINK-21675][table-planner-blink] Allow Predicate Pushdown with Watermark Assigner Between Filter and Scan

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Calc;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.tools.RelBuilder;
+
+import scala.Tuple2;
+
+/**
+ * Pushes a filter condition from the {@link FlinkLogicalCalc} and into a {@link
+ * FlinkLogicalTableSourceScan}.
+ */
+public class PushFilterInCalcIntoTableSourceScanRule extends PushFilterIntoSourceScanRuleBase {
+    public static final PushFilterInCalcIntoTableSourceScanRule INSTANCE =
+            new PushFilterInCalcIntoTableSourceScanRule();
+
+    public PushFilterInCalcIntoTableSourceScanRule() {
+        super(
+                operand(FlinkLogicalCalc.class, operand(FlinkLogicalTableSourceScan.class, none())),
+                "PushFilterInCalcIntoTableSourceScanRule");
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        if (!super.matches(call)) {
+            return false;
+        }
+
+        FlinkLogicalCalc calc = call.rel(0);
+        RexProgram originProgram = calc.getProgram();
+
+        if (originProgram.getCondition() == null) {
+            return false;
+        }
+
+        FlinkLogicalTableSourceScan scan = call.rel(1);
+        TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
+        // we can not push filter twice
+        return canPushdownFilter(tableSourceTable);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        FlinkLogicalCalc calc = call.rel(0);
+        FlinkLogicalTableSourceScan scan = call.rel(1);
+        TableSourceTable table = scan.getTable().unwrap(TableSourceTable.class);
+        pushFilterIntoScan(call, calc, scan, table);
+    }
+
+    private void pushFilterIntoScan(
+            RelOptRuleCall call,
+            Calc calc,
+            FlinkLogicalTableSourceScan scan,
+            FlinkPreparingTableBase relOptTable) {
+
+        RexProgram originProgram = calc.getProgram();
+
+        RelBuilder relBuilder = call.builder();
+        Tuple2<RexNode[], RexNode[]> extractedPredicates =
+                extractPredicates(
+                        originProgram.getInputRowType().getFieldNames().toArray(new String[0]),
+                        originProgram.expandLocalRef(originProgram.getCondition()),
+                        scan,
+                        relBuilder.getRexBuilder());
+
+        RexNode[] convertiblePredicates = extractedPredicates._1;
+        if (convertiblePredicates.length == 0) {
+            // no condition can be translated to expression
+            return;
+        }
+
+        Tuple2<SupportsFilterPushDown.Result, TableSourceTable> pushdownResultWithScan =
+                resolveFiltersAndCreateTableSourceTable(
+                        convertiblePredicates,
+                        relOptTable.unwrap(TableSourceTable.class),
+                        scan,
+                        relBuilder);
+
+        SupportsFilterPushDown.Result result = pushdownResultWithScan._1;
+        TableSourceTable tableSourceTable = pushdownResultWithScan._2;
+
+        FlinkLogicalTableSourceScan newScan =
+                FlinkLogicalTableSourceScan.create(scan.getCluster(), tableSourceTable);
+
+        // build new calc program
+        RexProgramBuilder programBuilder =
+                RexProgramBuilder.forProgram(originProgram, call.builder().getRexBuilder(), true);
+        programBuilder.clearCondition();
+
+        if (!result.getRemainingFilters().isEmpty() || extractedPredicates._2.length != 0) {
+            RexNode[] unconvertedPredicates = extractedPredicates._2;
+            RexNode remainingCondition =
+                    getRemainingConditions(relBuilder, result, unconvertedPredicates);
+
+            programBuilder.addCondition(remainingCondition);
+        }
+
+        RexProgram program = programBuilder.getProgram();
+        if (program.isTrivial()) {
+            call.transformTo(newScan);
+        } else {
+            FlinkLogicalCalc newCalc = FlinkLogicalCalc.create(newScan, program);
+            call.transformTo(newCalc);
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.expressions.converter.ExpressionConverter;
+import org.apache.flink.table.planner.plan.abilities.source.FilterPushDownSpec;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
+import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
+import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptRuleOperand;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+import scala.Tuple2;
+
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
+
+/** Base class for rules that push down filters into table scan. */
+public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
+    public PushFilterIntoSourceScanRuleBase(RelOptRuleOperand operand, String description) {
+        super(operand, description);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        TableConfig config = ShortcutUtils.unwrapContext(call.getPlanner()).getTableConfig();
+        return config.getConfiguration()
+                .getBoolean(
+                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED);
+    }
+
+    protected List<RexNode> convertExpressionToRexNode(
+            List<ResolvedExpression> expressions, RelBuilder relBuilder) {
+        ExpressionConverter exprConverter = new ExpressionConverter(relBuilder);
+        return expressions.stream().map(e -> e.accept(exprConverter)).collect(Collectors.toList());
+    }
+
+    protected RexNode getRemainingConditions(
+            RelBuilder relBuilder,
+            SupportsFilterPushDown.Result result,
+            RexNode[] unconvertedPredicates) {
+        List<RexNode> remainingPredicates =
+                convertExpressionToRexNode(result.getRemainingFilters(), relBuilder);
+        remainingPredicates.addAll(Arrays.asList(unconvertedPredicates));
+        return relBuilder.and(remainingPredicates);
+    }
+
+    /**
+     * Resolves filters using the underlying sources {@link SupportsFilterPushDown} and creates a
+     * new {@link TableSourceTable} with the supplied predicates.
+     *
+     * @param convertiblePredicates Predicates to resolve
+     * @param oldTableSourceTable TableSourceTable to copy
+     * @param scan Underlying table scan to push to
+     * @param relBuilder Builder to push the scan to
+     * @return A tuple, constituting of the resolved filters and the newly created {@link
+     *     TableSourceTable}
+     */
+    protected Tuple2<SupportsFilterPushDown.Result, TableSourceTable>
+            resolveFiltersAndCreateTableSourceTable(
+                    RexNode[] convertiblePredicates,
+                    TableSourceTable oldTableSourceTable,
+                    TableScan scan,
+                    RelBuilder relBuilder) {
+        // record size before applyFilters for update statistics
+        int originPredicatesSize = convertiblePredicates.length;
+
+        // update DynamicTableSource
+        DynamicTableSource newTableSource = oldTableSourceTable.tableSource().copy();
+
+        SupportsFilterPushDown.Result result =
+                FilterPushDownSpec.apply(
+                        Arrays.asList(convertiblePredicates),
+                        newTableSource,
+                        SourceAbilityContext.from(scan));
+
+        relBuilder.push(scan);
+        List<RexNode> acceptedPredicates =
+                convertExpressionToRexNode(result.getAcceptedFilters(), relBuilder);
+        FilterPushDownSpec filterPushDownSpec = new FilterPushDownSpec(acceptedPredicates);
+
+        // record size after applyFilters for update statistics
+        int updatedPredicatesSize = result.getRemainingFilters().size();
+        // set the newStatistic newTableSource and extraDigests
+        TableSourceTable newTableSourceTable =
+                oldTableSourceTable.copy(
+                        newTableSource,
+                        getNewFlinkStatistic(
+                                oldTableSourceTable, originPredicatesSize, updatedPredicatesSize),
+                        getNewExtraDigests(result.getAcceptedFilters()),
+                        new SourceAbilitySpec[] {filterPushDownSpec});
+
+        return new Tuple2<>(result, newTableSourceTable);
+    }
+
+    protected Tuple2<RexNode[], RexNode[]> extractPredicates(
+            String[] inputNames, RexNode filterExpression, TableScan scan, RexBuilder rexBuilder) {
+        FlinkContext context = ShortcutUtils.unwrapContext(scan);
+        int maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(scan);
+        RexNodeToExpressionConverter converter =
+                new RexNodeToExpressionConverter(
+                        rexBuilder,
+                        inputNames,
+                        context.getFunctionCatalog(),
+                        context.getCatalogManager(),
+                        TimeZone.getTimeZone(context.getTableConfig().getLocalTimeZone()));
+
+        return RexNodeExtractor.extractConjunctiveConditions(
+                filterExpression, maxCnfNodeCount, rexBuilder, converter);
+    }
+
+    /**
+     * Determines wether we can pushdown the filter into the source. we can not push filter twice,
+     * make sure FilterPushDownSpec has not been assigned as a capability.
+     *
+     * @param tableSourceTable Table scan to attempt to push into
+     * @return Whether we can push or not
+     */
+    protected boolean canPushdownFilter(TableSourceTable tableSourceTable) {
+        return tableSourceTable != null
+                && tableSourceTable.tableSource() instanceof SupportsFilterPushDown
+                && Arrays.stream(tableSourceTable.abilitySpecs())
+                        .noneMatch(spec -> spec instanceof FilterPushDownSpec);
+    }
+
+    protected FlinkStatistic getNewFlinkStatistic(
+            TableSourceTable tableSourceTable,
+            int originPredicatesSize,
+            int updatedPredicatesSize) {
+        FlinkStatistic oldStatistic = tableSourceTable.getStatistic();
+        FlinkStatistic newStatistic;
+        if (originPredicatesSize == updatedPredicatesSize) {
+            // Keep all Statistics if no predicates can be pushed down
+            newStatistic = oldStatistic;
+        } else if (oldStatistic == FlinkStatistic.UNKNOWN()) {
+            newStatistic = oldStatistic;
+        } else {
+            // Remove tableStats after predicates pushed down
+            newStatistic =
+                    FlinkStatistic.builder().statistic(oldStatistic).tableStats(null).build();
+        }
+        return newStatistic;
+    }
+
+    protected String[] getNewExtraDigests(List<ResolvedExpression> acceptedFilters) {
+        final String extraDigest;
+        if (!acceptedFilters.isEmpty()) {
+            // push filter successfully
+            String pushedExpr =
+                    acceptedFilters.stream()
+                            .reduce(
+                                    (l, r) ->
+                                            new CallExpression(
+                                                    AND, Arrays.asList(l, r), DataTypes.BOOLEAN()))
+                            .get()
+                            .toString();
+            extraDigest = "filter=[" + pushedExpr + "]";
+        } else {
+            // push filter successfully, but nothing is accepted
+            extraDigest = "filter=[]";
+        }
+        return new String[] {extraDigest};
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -18,48 +18,23 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.api.config.OptimizerConfigOptions;
-import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
-import org.apache.flink.table.expressions.CallExpression;
-import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.planner.calcite.FlinkContext;
-import org.apache.flink.table.planner.expressions.converter.ExpressionConverter;
-import org.apache.flink.table.planner.plan.abilities.source.FilterPushDownSpec;
-import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
-import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
-import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
-import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
-import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
-import org.apache.flink.table.planner.utils.ShortcutUtils;
 
-import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Filter;
-import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
-
 import scala.Tuple2;
-
-import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 
 /**
  * Planner rule that tries to push a filter into a {@link LogicalTableScan}, which table is a {@link
  * TableSourceTable}. And the table source in the table is a {@link SupportsFilterPushDown}.
  */
-public class PushFilterIntoTableSourceScanRule extends RelOptRule {
+public class PushFilterIntoTableSourceScanRule extends PushFilterIntoSourceScanRuleBase {
     public static final PushFilterIntoTableSourceScanRule INSTANCE =
             new PushFilterIntoTableSourceScanRule();
 
@@ -71,10 +46,7 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
 
     @Override
     public boolean matches(RelOptRuleCall call) {
-        TableConfig config = ShortcutUtils.unwrapContext(call.getPlanner()).getTableConfig();
-        if (!config.getConfiguration()
-                .getBoolean(
-                        OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_PREDICATE_PUSHDOWN_ENABLED)) {
+        if (!super.matches(call)) {
             return false;
         }
 
@@ -85,11 +57,8 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
 
         LogicalTableScan scan = call.rel(1);
         TableSourceTable tableSourceTable = scan.getTable().unwrap(TableSourceTable.class);
-        // we can not push filter twice
-        return tableSourceTable != null
-                && tableSourceTable.tableSource() instanceof SupportsFilterPushDown
-                && Arrays.stream(tableSourceTable.abilitySpecs())
-                        .noneMatch(spec -> spec instanceof FilterPushDownSpec);
+
+        return canPushdownFilter(tableSourceTable);
     }
 
     @Override
@@ -107,114 +76,40 @@ public class PushFilterIntoTableSourceScanRule extends RelOptRule {
             FlinkPreparingTableBase relOptTable) {
 
         RelBuilder relBuilder = call.builder();
-        FlinkContext context = ShortcutUtils.unwrapContext(scan);
-        int maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(scan);
-        RexNodeToExpressionConverter converter =
-                new RexNodeToExpressionConverter(
-                        relBuilder.getRexBuilder(),
+        Tuple2<RexNode[], RexNode[]> extractedPredicates =
+                extractPredicates(
                         filter.getInput().getRowType().getFieldNames().toArray(new String[0]),
-                        context.getFunctionCatalog(),
-                        context.getCatalogManager(),
-                        TimeZone.getTimeZone(context.getTableConfig().getLocalTimeZone()));
-
-        Tuple2<RexNode[], RexNode[]> tuple2 =
-                RexNodeExtractor.extractConjunctiveConditions(
                         filter.getCondition(),
-                        maxCnfNodeCount,
-                        relBuilder.getRexBuilder(),
-                        converter);
-        RexNode[] convertiblePredicates = tuple2._1;
-        RexNode[] unconvertedPredicates = tuple2._2;
+                        scan,
+                        relBuilder.getRexBuilder());
+
+        RexNode[] convertiblePredicates = extractedPredicates._1;
         if (convertiblePredicates.length == 0) {
             // no condition can be translated to expression
             return;
         }
 
-        // record size before applyFilters for update statistics
-        int originPredicatesSize = convertiblePredicates.length;
+        Tuple2<SupportsFilterPushDown.Result, TableSourceTable> scanAfterPushdownWithResult =
+                resolveFiltersAndCreateTableSourceTable(
+                        convertiblePredicates,
+                        relOptTable.unwrap(TableSourceTable.class),
+                        scan,
+                        relBuilder);
 
-        // update DynamicTableSource
-        TableSourceTable oldTableSourceTable = relOptTable.unwrap(TableSourceTable.class);
-        DynamicTableSource newTableSource = oldTableSourceTable.tableSource().copy();
+        SupportsFilterPushDown.Result result = scanAfterPushdownWithResult._1;
+        TableSourceTable tableSourceTable = scanAfterPushdownWithResult._2;
 
-        SupportsFilterPushDown.Result result =
-                FilterPushDownSpec.apply(
-                        Arrays.asList(convertiblePredicates),
-                        newTableSource,
-                        SourceAbilityContext.from(scan));
+        LogicalTableScan newScan =
+                LogicalTableScan.create(scan.getCluster(), tableSourceTable, scan.getHints());
 
-        relBuilder.push(scan);
-        List<RexNode> acceptedPredicates =
-                convertExpressionToRexNode(result.getAcceptedFilters(), relBuilder);
-        FilterPushDownSpec filterPushDownSpec = new FilterPushDownSpec(acceptedPredicates);
-
-        // record size after applyFilters for update statistics
-        int updatedPredicatesSize = result.getRemainingFilters().size();
-        // set the newStatistic newTableSource and extraDigests
-        TableSourceTable newTableSourceTable =
-                oldTableSourceTable.copy(
-                        newTableSource,
-                        getNewFlinkStatistic(
-                                oldTableSourceTable, originPredicatesSize, updatedPredicatesSize),
-                        getNewExtraDigests(result.getAcceptedFilters()),
-                        new SourceAbilitySpec[] {filterPushDownSpec});
-        TableScan newScan =
-                LogicalTableScan.create(scan.getCluster(), newTableSourceTable, scan.getHints());
-        // check whether framework still need to do a filter
+        RexNode[] unconvertedPredicates = extractedPredicates._2;
         if (result.getRemainingFilters().isEmpty() && unconvertedPredicates.length == 0) {
             call.transformTo(newScan);
         } else {
-            List<RexNode> remainingPredicates =
-                    convertExpressionToRexNode(result.getRemainingFilters(), relBuilder);
-            remainingPredicates.addAll(Arrays.asList(unconvertedPredicates));
-            RexNode remainingCondition = relBuilder.and(remainingPredicates);
-            Filter newFilter = filter.copy(filter.getTraitSet(), newScan, remainingCondition);
+            RexNode remainingConditions =
+                    getRemainingConditions(relBuilder, result, unconvertedPredicates);
+            Filter newFilter = filter.copy(filter.getTraitSet(), newScan, remainingConditions);
             call.transformTo(newFilter);
         }
-    }
-
-    private List<RexNode> convertExpressionToRexNode(
-            List<ResolvedExpression> expressions, RelBuilder relBuilder) {
-        ExpressionConverter exprConverter = new ExpressionConverter(relBuilder);
-        return expressions.stream().map(e -> e.accept(exprConverter)).collect(Collectors.toList());
-    }
-
-    private FlinkStatistic getNewFlinkStatistic(
-            TableSourceTable tableSourceTable,
-            int originPredicatesSize,
-            int updatedPredicatesSize) {
-        FlinkStatistic oldStatistic = tableSourceTable.getStatistic();
-        FlinkStatistic newStatistic = null;
-        if (originPredicatesSize == updatedPredicatesSize) {
-            // Keep all Statistics if no predicates can be pushed down
-            newStatistic = oldStatistic;
-        } else if (oldStatistic == FlinkStatistic.UNKNOWN()) {
-            newStatistic = oldStatistic;
-        } else {
-            // Remove tableStats after predicates pushed down
-            newStatistic =
-                    FlinkStatistic.builder().statistic(oldStatistic).tableStats(null).build();
-        }
-        return newStatistic;
-    }
-
-    private String[] getNewExtraDigests(List<ResolvedExpression> acceptedFilters) {
-        final String extraDigest;
-        if (!acceptedFilters.isEmpty()) {
-            // push filter successfully
-            String pushedExpr =
-                    acceptedFilters.stream()
-                            .reduce(
-                                    (l, r) ->
-                                            new CallExpression(
-                                                    AND, Arrays.asList(l, r), DataTypes.BOOLEAN()))
-                            .get()
-                            .toString();
-            extraDigest = "filter=[" + pushedExpr + "]";
-        } else {
-            // push filter successfully, but nothing is accepted
-            extraDigest = "filter=[]";
-        }
-        return new String[] {extraDigest};
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -246,7 +246,7 @@ object FlinkStreamRuleSets {
     PushFilterIntoLegacyTableSourceScanRule.INSTANCE,
     PushLimitIntoTableSourceScanRule.INSTANCE,
 
-    // reorder the projecct and watermark assigner
+    // reorder the project and watermark assigner
     ProjectWatermarkAssignerTransposeRule.INSTANCE,
 
     // reorder sort and projection
@@ -378,6 +378,8 @@ object FlinkStreamRuleSets {
     // because [[PushWatermarkIntoTableSourceScanAcrossCalcRule]] will push the rowtime computed
     // column into the source. After FlinkCalcMergeRule applies, it may produces a trivial calc.
     FlinkLogicalCalcRemoveRule.INSTANCE,
+    // filter push down
+    PushFilterInCalcIntoTableSourceScanRule.INSTANCE,
     //Rule that rewrites temporal join with extracted primary key
     TemporalJoinRewriteWithUniqueKeyRule.INSTANCE,
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1102,6 +1102,27 @@ public final class TestValuesTableFactory
                 return TableFunctionProvider.of(new TestValuesLookupFunction(mapping));
             }
         }
+
+        @Override
+        public DynamicTableSource copy() {
+            return new TestValuesScanLookupTableSource(
+                    producedDataType,
+                    changelogMode,
+                    bounded,
+                    runtimeSource,
+                    failingSource,
+                    data,
+                    isAsync,
+                    lookupFunctionClass,
+                    nestedProjectionSupported,
+                    projectedPhysicalFields,
+                    filterPredicates,
+                    filterableFields,
+                    limit,
+                    allPartitions,
+                    readableMetadata,
+                    projectedMetadataFields);
+        }
     }
 
     /** A mocked {@link LookupTableSource} for validation test. */

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWatermarkAssigner;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.FlinkVolcanoProgramBuilder;
+import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
+import org.apache.flink.table.planner.plan.optimize.program.StreamOptimizeContext;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.hep.HepMatchOrder;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.tools.RuleSets;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test for {@link PushFilterInCalcIntoTableSourceRuleTest}. */
+public class PushFilterInCalcIntoTableSourceRuleTest extends PushFilterIntoTableSourceScanRuleTest {
+
+    @Before
+    public void setup() {
+        util_$eq(streamTestUtil(new TableConfig()));
+
+        FlinkChainedProgram<StreamOptimizeContext> program = new FlinkChainedProgram<>();
+        program.addLast(
+                "Converters",
+                FlinkVolcanoProgramBuilder.<StreamOptimizeContext>newBuilder()
+                        .add(
+                                RuleSets.ofList(
+                                        CoreRules.PROJECT_TO_CALC,
+                                        CoreRules.FILTER_TO_CALC,
+                                        FlinkCalcMergeRule$.MODULE$.INSTANCE(),
+                                        FlinkLogicalCalc.CONVERTER(),
+                                        FlinkLogicalTableSourceScan.CONVERTER(),
+                                        FlinkLogicalWatermarkAssigner.CONVERTER()))
+                        .setRequiredOutputTraits(new Convention[] {FlinkConventions.LOGICAL()})
+                        .build());
+        program.addLast(
+                "Filter push in calc down",
+                FlinkHepRuleSetProgramBuilder.<StreamOptimizeContext>newBuilder()
+                        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE())
+                        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+                        .add(RuleSets.ofList(PushFilterInCalcIntoTableSourceScanRule.INSTANCE))
+                        .build());
+        ((StreamTableTestUtil) util()).replaceStreamProgram(program);
+
+        String ddl1 =
+                "CREATE TABLE MyTable (\n"
+                        + "  name STRING,\n"
+                        + "  id bigint,\n"
+                        + "  amount int,\n"
+                        + "  price double\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'filterable-fields' = 'amount',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")";
+        util().tableEnv().executeSql(ddl1);
+
+        String ddl2 =
+                "CREATE TABLE VirtualTable (\n"
+                        + "  name STRING,\n"
+                        + "  id bigint,\n"
+                        + "  amount int,\n"
+                        + "  virtualField as amount + 1,\n"
+                        + "  price double\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'filterable-fields' = 'amount',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")";
+
+        util().tableEnv().executeSql(ddl2);
+
+        String ddl3 =
+                "CREATE TABLE WithWatermark ("
+                        + "  name STRING,\n"
+                        + "  event_time TIMESTAMP(3),\n"
+                        + "  WATERMARK FOR event_time as event_time - INTERVAL '5' SECOND"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'false',\n"
+                        + " 'filterable-fields' = 'name',\n"
+                        + " 'disable-lookup' = 'true'"
+                        + ")";
+
+        util().tableEnv().executeSql(ddl3);
+    }
+
+    @Test
+    public void testFailureToPushFilterIntoSourceWithoutWatermarkPushdown() {
+        util().verifyRelPlan("SELECT * FROM WithWatermark WHERE LOWER(name) = 'foo'");
+    }
+
+    @Override
+    public void testWithInterval() {
+        String ddl =
+                "CREATE TABLE MTable (\n"
+                        + "a TIMESTAMP(3),\n"
+                        + "b TIMESTAMP(3)\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'false',\n"
+                        + " 'filterable-fields' = 'a;b',\n"
+                        + " 'disable-lookup' = 'true'"
+                        + ")";
+
+        util().tableEnv().executeSql(ddl);
+        util().verifyRelPlan(
+                        "SELECT * FROM MTable\n"
+                                + "WHERE TIMESTAMPADD(HOUR, 5, a) >= b\n"
+                                + "OR\n"
+                                + "TIMESTAMPADD(YEAR, 2, b) >= a");
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.plan.optimize.program.BatchOptimizeContext;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram;
 import org.apache.flink.table.planner.plan.optimize.program.FlinkHepRuleSetProgramBuilder;
 import org.apache.flink.table.planner.plan.optimize.program.HEP_RULES_EXECUTION_TYPE;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
 import org.apache.flink.table.planner.utils.TableConfigUtils;
 
 import org.apache.calcite.plan.hep.HepMatchOrder;
@@ -35,7 +37,8 @@ public class PushFilterIntoTableSourceScanRuleTest
 
     @Override
     public void setup() {
-        util().buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE());
+        util_$eq(batchTestUtil(new TableConfig()));
+        ((BatchTableTestUtil) util()).buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE());
         CalciteConfig calciteConfig =
                 TableConfigUtils.getCalciteConfig(util().tableEnv().getConfig());
         calciteConfig
@@ -52,6 +55,7 @@ public class PushFilterIntoTableSourceScanRuleTest
                                                 PushFilterIntoTableSourceScanRule.INSTANCE,
                                                 CoreRules.FILTER_PROJECT_TRANSPOSE))
                                 .build());
+
         // name: STRING, id: LONG, amount: INT, price: DOUBLE
         String ddl1 =
                 "CREATE TABLE MyTable (\n"

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -24,35 +24,13 @@ limitations under the License.
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[>($3, 10)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[>($3, 10)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[]]]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testCannotPushDownWithVirtualColumn">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalFilter(condition=[>($4, 10)])
-   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalFilter(condition=[>($3, 10)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[]]]])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[>(price, 10)])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -64,14 +42,13 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[]]]])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[OR(>(amount, 2), <(amount, 10))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -84,15 +61,52 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
    +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
+FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price], where=[OR(>(amount, 2), <(amount, 10))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[]]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFailureToPushFilterIntoSourceWithoutWatermarkPushdown">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM WithWatermark WHERE LOWER(name) = 'foo']]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], event_time=[$1])
++- LogicalFilter(condition=[=(LOWER($0), _UTF-16LE'foo')])
+   +- LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($1, 5000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, WithWatermark]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[name, event_time], where=[=(LOWER(name), _UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
++- FlinkLogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($1, 5000:INTERVAL SECOND)])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, WithWatermark]], fields=[name, event_time])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCannotPushDownWithVirtualColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalFilter(condition=[OR(>($2, 2), <($2, 10))])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[]]]])
++- LogicalFilter(condition=[>($4, 10)])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price], where=[>(price, 10)])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -104,13 +118,12 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[>($2, 2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -123,14 +136,13 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalFilter(condition=[>($2, 2)])
    +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -142,13 +154,12 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[AND(>($2, 2), <($2, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]]])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -161,14 +172,13 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalFilter(condition=[AND(>($2, 2), <($2, 10))])
    +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]]])
+FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[and(greaterThan(amount, 2), lessThan(amount, 10))]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -180,13 +190,12 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[AND(=(LOWER($0), _UTF-16LE'foo'), =(UPPER($1), _UTF-16LE'bar'))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[and(equals(lower(a), 'foo'), equals(upper(b), 'bar'))]]]])
+FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, filter=[and(equals(lower(a), 'foo'), equals(upper(b), 'bar'))]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -198,39 +207,34 @@ LogicalProject(a=[$0], b=[$1])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[AND(>($2, 2), >($3, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[>($3, 10)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[>(price, 10)])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testWithInterval">
     <Resource name="sql">
-      <![CDATA[
-SELECT * FROM MTable
-WHERE
-  TIMESTAMPADD(HOUR, 5, a) >= b
-  OR
-  TIMESTAMPADD(YEAR, 2, b) >= a
-]]>
+      <![CDATA[SELECT * FROM MTable
+WHERE TIMESTAMPADD(HOUR, 5, a) >= b
+OR
+TIMESTAMPADD(YEAR, 2, b) >= a]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1])
-+- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL DAY TO SECOND, 5)), $1), >=(+($1, *(12:INTERVAL YEAR TO MONTH, 2)), $0))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[]]]])
+FlinkLogicalCalc(select=[a, b], where=[OR(>=(+(a, *(3600000:INTERVAL DAY TO SECOND, 5)), b), >=(+(b, *(12:INTERVAL YEAR TO MONTH, 2)), a))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MTable, filter=[]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -242,14 +246,13 @@ LogicalProject(a=[$0], b=[$1])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[OR(>($2, 2), >($3, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[OR(>($2, 2), >($3, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[]]]])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[OR(>(amount, 2), >(price, 10))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -262,15 +265,13 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalFilter(condition=[AND(>($2, 2), >($4, 10))])
    +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalFilter(condition=[>($3, 10)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price], where=[>(price, 10)])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -285,14 +286,13 @@ SELECT * FROM MyTable WHERE
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[AND(>($2, 2), <($1, 100), >(CAST($2):BIGINT, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[AND(<($1, 100), >(CAST($2):BIGINT, 10))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[AND(<(id, 100), >(CAST(amount), 10))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -305,15 +305,13 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 +- LogicalFilter(condition=[OR(>($2, 2), >($4, 10))])
    +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[false], filter=[]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalFilter(condition=[OR(>($2, 2), >($3, 10))])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, source: [filterPushedDown=[true], filter=[]]]])
+FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price], where=[OR(>(amount, 2), >(price, 10))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, VirtualTable, filter=[]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>
@@ -325,14 +323,13 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[AND(>($2, 2), <(myUdf($2), 32))])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[<(org$apache$flink$table$planner$expressions$utils$Func1$$879c8537562dbe74f3349fa0e6502755($2), 32)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[<(Func1$(amount), 32)])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -253,6 +253,27 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPartialPushDownWithVirtualColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 AND price > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalFilter(condition=[AND(>($2, 2), >($4, 10))])
+   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
++- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
+   +- LogicalFilter(condition=[>($3, 10)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testUnconvertedExpression">
     <Resource name="sql">
       <![CDATA[
@@ -312,27 +333,6 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 +- LogicalFilter(condition=[<(org$apache$flink$table$planner$expressions$utils$Func1$$879c8537562dbe74f3349fa0e6502755($2), 32)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testPartialPushDownWithVirtualColumn">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM VirtualTable WHERE amount > 2 AND price > 10]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalFilter(condition=[AND(>($2, 2), >($4, 10))])
-   +- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
-+- LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[+($2, 1)], price=[$3])
-   +- LogicalFilter(condition=[>($3, 10)])
-      +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable, filter=[greaterThan(amount, 2)]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testFullFilterMatchWithWatermark">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE LOWER(d) = 'hello']]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[=(LOWER($3), _UTF-16LE'hello')])
+   +- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'hello')]]], fields=[a, b, c, d])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialFilterMatchWithWatermark">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE LOWER(d) = 'h' AND d IS NOT NULL]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[AND(=(LOWER($3), _UTF-16LE'h'), IS NOT NULL($3))])
+   +- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a, b, c, d], where=[d IS NOT NULL])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'h')]]], fields=[a, b, c, d])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialFilterMatchWithWatermark">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE LOWER(d) = 'h' AND d IS NOT NULL]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[AND(=(LOWER($3), _UTF-16LE'h'), IS NOT NULL($3))])
+   +- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a, b, c, d], where=[d IS NOT NULL])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[equals(lower(d), 'h')]]], fields=[a, b, c, d])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testNoFilterMatchWithWatermark">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM MyTable WHERE b > 5]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[>($1, 5)])
+   +- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a, b, c, d], where=[(b > 5)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, watermark=[$2], filter=[]]], fields=[a, b, c, d])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testComputedColumnPushdownAcrossWatermark">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM WithWatermark WHERE lowercase_name = 'foo']]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(event_time=[$0], name=[$1], lowercase_name=[$2])
++- LogicalFilter(condition=[=($2, _UTF-16LE'foo')])
+   +- LogicalWatermarkAssigner(rowtime=[event_time], watermark=[$0])
+      +- LogicalProject(event_time=[$0], name=[$1], lowercase_name=[LOWER($1)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, WithWatermark]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[Reinterpret(event_time) AS event_time, name, CAST(_UTF-16LE'foo':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS lowercase_name])
++- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, watermark=[$0], filter=[equals(lower(name), 'foo')]]], fields=[event_time, name])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testFullPushdownWithoutWatermarkAssigner">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM NoWatermark WHERE LOWER(name) = 'foo' AND UPPER(name) = 'FOO']]>
+		</Resource>
+		<Resource name="ast" >
+			<![CDATA[
+LogicalProject(name=[$0], event_time=[$1])
++- LogicalFilter(condition=[AND(=(LOWER($0), _UTF-16LE'foo'), =(UPPER($0), _UTF-16LE'FOO'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, NoWatermark]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[and(equals(lower(name), 'foo'), equals(upper(name), 'FOO'))]]], fields=[name, event_time])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testFilterPushdownWithUdf">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM UdfTable WHERE UPPER(f) = 'welcome']]>
+		</Resource>
+		<Resource name="ast" >
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
++- LogicalFilter(condition=[=(UPPER($4), _UTF-16LE'welcome')])
+   +- LogicalWatermarkAssigner(rowtime=[c], watermark=[func(func($3, $0), $0)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[func($2, $0)], f=[$3])
+         +- LogicalTableScan(table=[[default_catalog, default_database, UdfTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testFilterPushdownWithUdf">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM UdfTable WHERE UPPER(f) = 'welcome']]>
+		</Resource>
+		<Resource name="ast" >
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], f=[$4])
++- LogicalFilter(condition=[=(UPPER($4), _UTF-16LE'welcome')])
+   +- LogicalWatermarkAssigner(rowtime=[c], watermark=[func(func($3, $0), $0)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[func($2, $0)], f=[$3])
+         +- LogicalTableScan(table=[[default_catalog, default_database, UdfTable]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a, b, Reinterpret(c) AS c, func(c, a) AS d, f])
++- TableSourceScan(table=[[default_catalog, default_database, UdfTable, watermark=[func(func(func($2, $0), $0), $0)], filter=[equals(upper(f), 'welcome')]]], fields=[a, b, c, f])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testPartialPushdownWithoutWatermarkAssigner">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM NoWatermark WHERE LOWER(name) = 'foo' AND name IS NOT NULL]]>
+		</Resource>
+		<Resource name="ast" >
+			<![CDATA[
+LogicalProject(name=[$0], event_time=[$1])
++- LogicalFilter(condition=[AND(=(LOWER($0), _UTF-16LE'foo'), IS NOT NULL($0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, NoWatermark]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[name, event_time], where=[name IS NOT NULL])
++- TableSourceScan(table=[[default_catalog, default_database, NoWatermark, filter=[equals(lower(name), 'foo')]]], fields=[name, event_time])
+]]>
+		</Resource>
+	</TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/SourceWatermarkTest.xml
@@ -87,7 +87,7 @@ LogicalProject(a=[$0], b=[$1])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[a, b], where=[(b > 10)])
-+- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)]]], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, VirtualTable, watermark=[-(+($2, 5000:INTERVAL SECOND), 5000:INTERVAL SECOND)], filter=[]]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -462,7 +462,7 @@ Calc(select=[currency, currency0, rate1])
    :           +- TableSourceScan(table=[[default_catalog, default_database, Orders]], fields=[amount, currency, rowtime])
    +- Exchange(distribution=[hash[currency]])
       +- Calc(select=[currency, (rate + 1) AS rate1], where=[(rate < 100)])
-         +- TableSourceScan(table=[[default_catalog, default_database, RatesBinlogWithoutWatermark]], fields=[currency, rate, rowtime])
+         +- TableSourceScan(table=[[default_catalog, default_database, RatesBinlogWithoutWatermark, filter=[]]], fields=[currency, rate, rowtime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
@@ -17,27 +17,27 @@
  */
 package org.apache.flink.table.planner.plan.rules.logical
 
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.rules.CoreRules
+import org.apache.calcite.tools.RuleSets
 import org.apache.flink.table.api.{DataTypes, TableSchema}
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
-import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestLegacyFilterableTableSource}
+import org.apache.flink.table.planner.utils.{BatchTableTestUtil, TableConfigUtils, TableTestBase, TableTestUtil, TestLegacyFilterableTableSource}
 import org.apache.flink.types.Row
-
-import org.apache.calcite.plan.hep.HepMatchOrder
-import org.apache.calcite.rel.rules.CoreRules
-import org.apache.calcite.tools.RuleSets
 import org.junit.{Before, Test}
 
 /**
-  * Test for [[PushFilterIntoLegacyTableSourceScanRule]].
-  */
+ * Test for [[PushFilterIntoLegacyTableSourceScanRule]].
+ */
 class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
-  protected val util = batchTestUtil()
+  var util: TableTestUtil = _
 
   @Before
   def setup(): Unit = {
-    util.buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE)
+    util = batchTestUtil()
+    util.asInstanceOf[BatchTableTestUtil].buildBatchProgram(FlinkBatchProgram.DEFAULT_REWRITE)
     val calciteConfig = TableConfigUtils.getCalciteConfig(util.tableEnv.getConfig)
     calciteConfig.getBatchProgram.get.addLast(
       "rules",
@@ -56,17 +56,17 @@ class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
       "MyTable",
       isBounded = true)
     val ddl =
-      s"""
-         |CREATE TABLE VirtualTable (
-         |  name STRING,
-         |  id bigint,
-         |  amount int,
-         |  virtualField as amount + 1,
-         |  price double
-         |) with (
-         |  'connector.type' = 'TestFilterableSource',
-         |  'is-bounded' = 'true'
-         |)
+      """
+        |CREATE TABLE VirtualTable (
+        |  name STRING,
+        |  id bigint,
+        |  amount int,
+        |  virtualField as amount + 1,
+        |  price double
+        |) with (
+        |  'connector.type' = 'TestFilterableSource',
+        |  'is-bounded' = 'true'
+        |)
        """.stripMargin
     util.tableEnv.executeSql(ddl)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/FilterableSourceTest.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql
+
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc5
+import org.apache.flink.table.planner.utils.TableTestBase
+import org.junit.{Before, Test}
+
+/**
+ * Tests for pushing filter into table scan
+ */
+class FilterableSourceTest extends TableTestBase {
+  private val util = streamTestUtil()
+
+  @Before
+  def setup(): Unit = {
+    val ddl =
+      """
+        | CREATE TABLE MyTable(
+        |   a INT,
+        |   b BIGINT,
+        |   c TIMESTAMP(3),
+        |   d STRING,
+        |   WATERMARK FOR c AS c
+        | ) WITH (
+        |   'connector' = 'values',
+        |   'enable-watermark-push-down' = 'true',
+        |   'filterable-fields' = 'a;d',
+        |   'bounded' = 'false',
+        |   'disable-lookup' = 'true'
+        | )
+        |""".stripMargin
+
+    util.tableEnv.executeSql(ddl)
+  }
+
+  @Test
+  def testFullFilterMatchWithWatermark(): Unit = {
+    util.verifyExecPlan("SELECT * FROM MyTable WHERE LOWER(d) = 'hello'")
+  }
+
+  @Test
+  def testPartialFilterMatchWithWatermark(): Unit = {
+    util.verifyExecPlan("SELECT * FROM MyTable WHERE LOWER(d) = 'h' AND d IS NOT NULL")
+  }
+
+  @Test
+  def testNoFilterMatchWithWatermark(): Unit = {
+    util.verifyExecPlan("SELECT * FROM MyTable WHERE b > 5")
+  }
+
+  @Test def testFullPushdownWithoutWatermarkAssigner(): Unit = {
+    val ddl =
+      """
+        |CREATE TABLE NoWatermark (
+        |  name STRING,
+        |  event_time TIMESTAMP(3)
+        |) WITH (
+        |  'connector' = 'values',
+        |  'filterable-fields' = 'name',
+        |  'bounded' = 'false',
+        |  'disable-lookup' = 'true'
+        |)
+        |""".stripMargin
+
+    util.tableEnv.executeSql(ddl)
+    util.verifyExecPlan(
+      "SELECT * FROM NoWatermark WHERE LOWER(name) = 'foo' AND UPPER(name) = 'FOO'"
+    )
+  }
+
+  @Test
+  def testPartialPushdownWithoutWatermarkAssigner(): Unit = {
+    val ddl =
+      """
+        |CREATE TABLE NoWatermark (
+        |  name STRING,
+        |  event_time TIMESTAMP(3)
+        |) WITH (
+        |  'connector' = 'values',
+        |  'filterable-fields' = 'name',
+        |  'bounded' = 'false',
+        |  'disable-lookup' = 'true'
+        |)
+        |""".stripMargin
+
+    util.tableEnv.executeSql(ddl)
+    util.verifyExecPlan("SELECT * FROM NoWatermark WHERE LOWER(name) = 'foo' AND name IS NOT NULL")
+  }
+
+  @Test
+  def testComputedColumnPushdownAcrossWatermark() {
+    val ddl =
+      """
+        |CREATE TABLE WithWatermark (
+        |  event_time TIMESTAMP(3),
+        |  name STRING,
+        |  lowercase_name AS LOWER(name),
+        |  WATERMARK FOR event_time AS event_time
+        |) WITH (
+        |  'connector' = 'values',
+        |  'bounded' = 'false',
+        |  'enable-watermark-push-down' = 'true',
+        |  'filterable-fields' = 'name',
+        |  'disable-lookup' = 'true'
+        |)
+        |""".stripMargin
+
+    util.tableEnv.executeSql(ddl)
+    util.verifyExecPlan(
+      "SELECT * FROM WithWatermark WHERE lowercase_name = 'foo'")
+  }
+
+  @Test
+  def testFilterPushdownWithUdf(): Unit = {
+    JavaFunc5.closeCalled = false
+    JavaFunc5.openCalled = false
+    util.tableEnv.createTemporarySystemFunction("func", new JavaFunc5)
+    val ddl =
+      """
+         | CREATE Table UdfTable (
+         |   a INT,
+         |   b BIGINT,
+         |   c timestamp(3),
+         |   d as func(c, a),
+         |   f STRING,
+         |   WATERMARK FOR c as func(func(d, a), a)
+         | ) with (
+         |   'connector' = 'values',
+         |   'bounded' = 'false',
+         |   'filterable-fields' = 'f',
+         |   'enable-watermark-push-down' = 'true',
+         |   'disable-lookup' = 'true'
+         | )
+         |""".stripMargin
+    util.tableEnv.executeSql(ddl)
+    util.verifyExecPlan("SELECT * FROM UdfTable WHERE UPPER(f) = 'welcome'")
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FilterableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FilterableSourceITCase.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.api.scala.createTypeInformation
+import org.apache.flink.table.api.bridge.scala.tableConversions
+import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestData, TestingAppendSink}
+import org.apache.flink.table.utils.LegacyRowResource
+import org.apache.flink.types.Row
+import org.junit.Assert.assertEquals
+import org.junit.{Rule, Test}
+
+import java.time.LocalDateTime
+
+/**
+ * Tests for pushing filters into a table scan
+ */
+class FilterableSourceITCase extends StreamingTestBase {
+
+  @Rule
+  def usesLegacyRows: LegacyRowResource = LegacyRowResource.INSTANCE
+
+  @Test
+  def testFilterPushdown(): Unit = {
+    val data = Seq(
+      row(1, 2L, LocalDateTime.parse("2020-11-21T19:00:05.23")),
+      row(2, 3L, LocalDateTime.parse("2020-11-21T21:00:05.23"))
+    )
+
+    val dataId = TestValuesTableFactory.registerData(data)
+    val ddl =
+      s"""
+         | CREATE TABLE MyTable(
+         |   a INT,
+         |   b BIGINT,
+         |   c TIMESTAMP(3),
+         |   WATERMARK FOR c AS c
+         | ) WITH (
+         |   'connector' = 'values',
+         |   'enable-watermark-push-down' = 'true',
+         |   'filterable-fields' = 'a;c;d',
+         |   'bounded' = 'false',
+         |   'disable-lookup' = 'true',
+         |   'data-id' = '$dataId'
+         | )
+         |""".stripMargin
+
+    tEnv.executeSql(ddl)
+
+    val query = "SELECT * FROM MyTable WHERE a > 1"
+    val expectedData = Seq("2,3,2020-11-21T21:00:05.230")
+
+    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val sink = new TestingAppendSink()
+    result.addSink(sink)
+
+    env.execute()
+    assertEquals(expectedData.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testWithRejectedFilter(): Unit = {
+    val data = Seq(
+      row(1, 2L, LocalDateTime.parse("2020-11-21T19:00:05.23")),
+      row(2, 3L, LocalDateTime.parse("2020-11-21T21:00:05.23"))
+    )
+
+    val dataId = TestValuesTableFactory.registerData(data)
+
+    // Reject the filter by leaving out 'a' from 'filterable-fields'
+    val ddl =
+      s"""
+         | CREATE TABLE MyTable(
+         |   a INT,
+         |   b BIGINT,
+         |   c TIMESTAMP(3),
+         |   WATERMARK FOR c AS c
+         | ) WITH (
+         |   'connector' = 'values',
+         |   'enable-watermark-push-down' = 'true',
+         |   'filterable-fields' = 'c;d',
+         |   'bounded' = 'false',
+         |   'disable-lookup' = 'true',
+         |   'data-id' = '$dataId'
+         | )
+         |""".stripMargin
+
+    tEnv.executeSql(ddl)
+
+    val query = "SELECT * FROM MyTable WHERE a > 1"
+    val expectedData = Seq("2,3,2020-11-21T21:00:05.230")
+
+    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val sink = new TestingAppendSink()
+    result.addSink(sink)
+
+    env.execute()
+    assertEquals(expectedData.sorted, sink.getAppendResults.sorted)
+  }
+
+  @Test
+  def testProjectWithWatermarkFilterPushdown(): Unit = {
+    val data = Seq(
+      row(1, 2L, "Hello", LocalDateTime.parse("2020-11-21T19:00:05.23")),
+      row(2, 3L, "World", LocalDateTime.parse("2020-11-21T21:00:05.23"))
+    )
+
+    val dataId = TestValuesTableFactory.registerData(data)
+    val ddl =
+      s"""
+         |CREATE TABLE TableWithWatermark (
+         |  a int,
+         |  b bigint,
+         |  c string,
+         |  d timestamp(3),
+         |  WATERMARK FOR d as d
+         |) WITH (
+         |  'connector' = 'values',
+         |  'filterable-fields' = 'c',
+         |  'enable-watermark-push-down' = 'true',
+         |  'data-id' = '$dataId',
+         |  'bounded' = 'false',
+         |  'disable-lookup' = 'true'
+         |)
+       """.stripMargin
+    tEnv.executeSql(ddl)
+
+    val result =
+      tEnv.sqlQuery   (
+        "select a,b from TableWithWatermark WHERE LOWER(c) = 'world'"
+      ).toAppendStream[Row]
+
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = List("2,3")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Purpose of the change is to fix https://issues.apache.org/jira/browse/FLINK-21675 which allows predicates to be pushed down even though a `LogicalWatermarkAssigner` is present between the `LogicalFilter` and `LogicalTableScan`.

This means, that, for example, the following table plan:

```
LogicalProject(name=[$0], event_time=[$1])
+- LogicalFilter(condition=[AND(=(LOWER($0), _UTF-16LE'foo'), IS NOT NULL($0))])
   +- LogicalWatermarkAssigner(rowtime=[event_time], watermark=[-($1, 5000:INTERVAL SECOND)])
      +- LogicalTableScan(table=[[default_catalog, default_database, WithWatermark]])
```

When PP is enabled, and given that there's support for `LOWER` pushdown, can be re-written to:

```
Calc(select=[name, event_time], where=[IS NOT NULL(name)])
+- WatermarkAssigner(rowtime=[event_time], watermark=[-(event_time, 5000:INTERVAL SECOND)])
   +- TableSourceScan(table=[[default_catalog, default_database, WithWatermark, filter=[equals(lower(name), 'foo')]]], fields=[name, event_time])
```

## Brief change log

- Implement `PushFilterIntoTableSourceScanAcrossWatermarkRule`
- Refactor `PushFilterIntoTableSourceScanRule` to inherit a common base class `PushFilterIntoSourceScanRuleBase`
- Add new rule to `FlinkStreamRuleSets` under `FILTER_TABLESCAN_PUSHDOWN_RULES` and `LOGICAL_RULES`
- Implement tests

## Verifying this change

This change added tests and can be verified as follows:

- Added `testPushdownAcrossWatermarkFullPredicateMatch` for testing full match of predicates (all predicates in query) and with `SupportsWatermarkPushdown` support
- Added `testPushdownAcrossWatermarkPartialPredicateMatch` for testing that a partial match generates the correct plan (LogicalFilter with the remaining predicates to be filtered).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
