### PR TITLE
[FLINK-21894][hive] Update type of HiveTablePartition#partitionSpec from Map<String, Object> to Map<String, String>

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
@@ -310,13 +310,7 @@ public class HiveLookupTableSource extends HiveTableSource implements LookupTabl
                                     partValues);
                     HiveTablePartition hiveTablePartition =
                             HivePartitionUtils.toHiveTablePartition(
-                                    partitionKeys,
-                                    fieldNames,
-                                    fieldTypes,
-                                    hiveShim,
-                                    tableProps,
-                                    defaultPartitionName,
-                                    partition);
+                                    partitionKeys, tableProps, partition);
                     return Optional.of(hiveTablePartition);
                 } catch (NoSuchObjectException e) {
                     return Optional.empty();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartition.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartition.java
@@ -42,7 +42,7 @@ public class HiveTablePartition implements Serializable {
     private final CachedSerializedValue<StorageDescriptor> storageDescriptor;
 
     /** The map of partition key names and their values. */
-    private final Map<String, Object> partitionSpec;
+    private final Map<String, String> partitionSpec;
 
     // Table properties that should be used to initialize SerDe
     private final Properties tableProps;
@@ -53,7 +53,7 @@ public class HiveTablePartition implements Serializable {
 
     public HiveTablePartition(
             StorageDescriptor storageDescriptor,
-            Map<String, Object> partitionSpec,
+            Map<String, String> partitionSpec,
             Properties tableProps) {
         try {
             this.storageDescriptor =
@@ -74,7 +74,7 @@ public class HiveTablePartition implements Serializable {
         }
     }
 
-    public Map<String, Object> getPartitionSpec() {
+    public Map<String, String> getPartitionSpec() {
         return partitionSpec;
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -419,14 +419,7 @@ public class HiveTableSource
 
         /** Convert partition to HiveTablePartition. */
         public HiveTablePartition toHiveTablePartition(Partition partition) {
-            return HivePartitionUtils.toHiveTablePartition(
-                    partitionKeys,
-                    fieldNames,
-                    fieldTypes,
-                    hiveShim,
-                    tableProps,
-                    defaultPartitionName,
-                    partition);
+            return HivePartitionUtils.toHiveTablePartition(partitionKeys, tableProps, partition);
         }
 
         @Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/JobConfWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/JobConfWrapper.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.java.hadoop.common.HadoopInputFormatCommonBase;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -43,6 +44,12 @@ public class JobConfWrapper implements Serializable {
 
     public JobConf conf() {
         return jobConf;
+    }
+
+    public String getDefaultPartitionName() {
+        return jobConf.get(
+                HiveConf.ConfVars.DEFAULTPARTITIONNAME.varname,
+                HiveConf.ConfVars.DEFAULTPARTITIONNAME.defaultStrVal);
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/JobConfWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/JobConfWrapper.java
@@ -21,7 +21,6 @@ import org.apache.flink.api.java.hadoop.common.HadoopInputFormatCommonBase;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -44,12 +43,6 @@ public class JobConfWrapper implements Serializable {
 
     public JobConf conf() {
         return jobConf;
-    }
-
-    public String getDefaultPartitionName() {
-        return jobConf.get(
-                HiveConf.ConfVars.DEFAULTPARTITIONNAME.varname,
-                HiveConf.ConfVars.DEFAULTPARTITIONNAME.defaultStrVal);
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.file.src.util.ArrayResultIterator;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
 import org.apache.flink.orc.OrcColumnarRowFileInputFormat;
 import org.apache.flink.orc.nohive.OrcNoHiveColumnarRowInputFormat;
@@ -99,7 +100,8 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
         this.producedRowType = producedRowType;
         this.useMapRedReader = useMapRedReader;
         this.partitionFieldExtractor =
-                new PartitionFieldExtractorImpl(hiveShim, jobConfWrapper.getDefaultPartitionName());
+                new PartitionFieldExtractorImpl(
+                        hiveShim, JobConfUtils.getDefaultPartitionName(jobConfWrapper));
     }
 
     @Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveBulkFormatAdapter.java
@@ -24,6 +24,7 @@ import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.ArrayResultIterator;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.connectors.hive.util.HivePartitionUtils;
 import org.apache.flink.formats.parquet.ParquetColumnarRowInputFormat;
 import org.apache.flink.orc.OrcColumnarRowFileInputFormat;
 import org.apache.flink.orc.nohive.OrcNoHiveColumnarRowInputFormat;
@@ -71,10 +72,6 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
     private static final String SCHEMA_EVOLUTION_COLUMNS = "schema.evolution.columns";
     private static final String SCHEMA_EVOLUTION_COLUMNS_TYPES = "schema.evolution.columns.types";
 
-    private static final PartitionFieldExtractor<HiveSourceSplit> PARTITION_FIELD_EXTRACTOR =
-            (split, fieldName, fieldType) ->
-                    split.getHiveTablePartition().getPartitionSpec().get(fieldName);
-
     private final JobConfWrapper jobConfWrapper;
     private final List<String> partitionKeys;
     private final String[] fieldNames;
@@ -83,6 +80,7 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
     private final HiveShim hiveShim;
     private final RowType producedRowType;
     private final boolean useMapRedReader;
+    private final PartitionFieldExtractor<HiveSourceSplit> partitionFieldExtractor;
 
     public HiveBulkFormatAdapter(
             JobConfWrapper jobConfWrapper,
@@ -100,6 +98,8 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
         this.hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
         this.producedRowType = producedRowType;
         this.useMapRedReader = useMapRedReader;
+        this.partitionFieldExtractor =
+                new PartitionFieldExtractorImpl(hiveShim, jobConfWrapper.getDefaultPartitionName());
     }
 
     @Override
@@ -137,7 +137,7 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
                     jobConfWrapper.conf(),
                     producedRowType,
                     partitionKeys,
-                    PARTITION_FIELD_EXTRACTOR,
+                    partitionFieldExtractor,
                     DEFAULT_SIZE,
                     hiveVersion.startsWith("3"),
                     false);
@@ -154,7 +154,7 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
                         jobConfWrapper.conf(),
                         tableRowType(),
                         partitionKeys,
-                        PARTITION_FIELD_EXTRACTOR,
+                        partitionFieldExtractor,
                         computeSelectedFields(),
                         Collections.emptyList(),
                         DEFAULT_SIZE)
@@ -163,7 +163,7 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
                         jobConfWrapper.conf(),
                         tableRowType(),
                         partitionKeys,
-                        PARTITION_FIELD_EXTRACTOR,
+                        partitionFieldExtractor,
                         computeSelectedFields(),
                         Collections.emptyList(),
                         DEFAULT_SIZE);
@@ -388,5 +388,25 @@ public class HiveBulkFormatAdapter implements BulkFormat<RowData, HiveSourceSpli
             selectedFields[i] = index;
         }
         return selectedFields;
+    }
+
+    private static class PartitionFieldExtractorImpl
+            implements PartitionFieldExtractor<HiveSourceSplit> {
+
+        private static final long serialVersionUID = 1L;
+        private final HiveShim hiveShim;
+        private final String defaultPartitionName;
+
+        private PartitionFieldExtractorImpl(HiveShim hiveShim, String defaultPartitionName) {
+            this.hiveShim = hiveShim;
+            this.defaultPartitionName = defaultPartitionName;
+        }
+
+        @Override
+        public Object extract(HiveSourceSplit split, String fieldName, LogicalType fieldType) {
+            String valueString = split.getHiveTablePartition().getPartitionSpec().get(fieldName);
+            return HivePartitionUtils.restorePartitionValueFromType(
+                    hiveShim, valueString, fieldType, defaultPartitionName);
+        }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveCompactReaderFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveCompactReaderFactory.java
@@ -39,13 +39,10 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.mapred.JobConf;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.apache.flink.connectors.hive.util.HivePartitionUtils.restorePartitionValueFromType;
 import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionSpecFromPath;
 
 /** The {@link CompactReader.Factory} to delegate hive bulk format. */
@@ -110,18 +107,7 @@ public class HiveCompactReaderFactory implements CompactReader.Factory<RowData> 
     }
 
     private HiveTablePartition createPartition(Path path) {
-        Map<String, Object> partitionSpec = new LinkedHashMap<>();
-        Map<String, DataType> nameToTypes = new HashMap<>();
-        for (int i = 0; i < fieldNames.length; i++) {
-            nameToTypes.put(fieldNames[i], fieldTypes[i]);
-        }
-        for (Map.Entry<String, String> entry : extractPartitionSpecFromPath(path).entrySet()) {
-            Object partitionValue =
-                    restorePartitionValueFromType(
-                            shim, entry.getValue(), nameToTypes.get(entry.getKey()));
-            partitionSpec.put(entry.getKey(), partitionValue);
-        }
-
+        Map<String, String> partitionSpec = extractPartitionSpecFromPath(path);
         try {
             return new HiveTablePartition(sd.deserializeValue(), partitionSpec, properties);
         } catch (IOException | ClassNotFoundException e) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveMapredSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveMapredSplitReader.java
@@ -21,8 +21,8 @@ package org.apache.flink.connectors.hive.read;
 import org.apache.flink.api.java.hadoop.mapred.wrapper.HadoopDummyReporter;
 import org.apache.flink.connectors.hive.FlinkHiveException;
 import org.apache.flink.connectors.hive.HiveTablePartition;
-import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -145,7 +145,7 @@ public class HiveMapredSplitReader implements SplitReader {
         this.row = new GenericRowData(selectedFields.length);
         // set partition columns
         if (!partitionKeys.isEmpty()) {
-            String defaultPartitionName = new JobConfWrapper(jobConf).getDefaultPartitionName();
+            String defaultPartitionName = JobConfUtils.getDefaultPartitionName(jobConf);
             for (int i = 0; i < selectedFields.length; i++) {
                 if (selectedFields[i] >= structFields.size()) {
                     LogicalType partitionType = fieldTypes[selectedFields[i]].getLogicalType();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveMapredSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveMapredSplitReader.java
@@ -21,12 +21,15 @@ package org.apache.flink.connectors.hive.read;
 import org.apache.flink.api.java.hadoop.mapred.wrapper.HadoopDummyReporter;
 import org.apache.flink.connectors.hive.FlinkHiveException;
 import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.connectors.hive.util.HivePartitionUtils;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -142,13 +145,16 @@ public class HiveMapredSplitReader implements SplitReader {
         this.row = new GenericRowData(selectedFields.length);
         // set partition columns
         if (!partitionKeys.isEmpty()) {
+            String defaultPartitionName = new JobConfWrapper(jobConf).getDefaultPartitionName();
             for (int i = 0; i < selectedFields.length; i++) {
                 if (selectedFields[i] >= structFields.size()) {
+                    LogicalType partitionType = fieldTypes[selectedFields[i]].getLogicalType();
                     String partition = partitionKeys.get(selectedFields[i] - structFields.size());
-                    row.setField(
-                            i,
-                            converters[i].toInternal(
-                                    hiveTablePartition.getPartitionSpec().get(partition)));
+                    String valStr = hiveTablePartition.getPartitionSpec().get(partition);
+                    Object partitionVal =
+                            HivePartitionUtils.restorePartitionValueFromType(
+                                    hiveShim, valStr, partitionType, defaultPartitionName);
+                    row.setField(i, converters[i].toInternal(partitionVal));
                 }
             }
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedOrcSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedOrcSplitReader.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.connectors.hive.read;
 
-import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.orc.OrcColumnarRowSplitReader;
 import org.apache.flink.orc.OrcSplitReaderUtil;
@@ -71,7 +71,7 @@ public class HiveVectorizedOrcSplitReader implements SplitReader {
                         split.getHiveTablePartition().getPartitionSpec(),
                         fieldNames,
                         fieldTypes,
-                        new JobConfWrapper(jobConf).getDefaultPartitionName(),
+                        JobConfUtils.getDefaultPartitionName(jobConf),
                         HiveShimLoader.loadHiveShim(hiveVersion));
         this.reader =
                 hiveVersion.startsWith("1.")

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedOrcSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedOrcSplitReader.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.connectors.hive.read;
 
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.connectors.hive.util.HivePartitionUtils;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.orc.OrcColumnarRowSplitReader;
 import org.apache.flink.orc.OrcSplitReaderUtil;
 import org.apache.flink.orc.nohive.OrcNoHiveSplitReaderUtil;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
@@ -33,6 +36,7 @@ import org.apache.hadoop.mapred.JobConf;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Map;
 
 import static org.apache.flink.table.data.vector.VectorizedColumnBatch.DEFAULT_SIZE;
 
@@ -62,13 +66,20 @@ public class HiveVectorizedOrcSplitReader implements SplitReader {
             throw new IllegalArgumentException("Unknown split type: " + hadoopSplit);
         }
 
+        Map<String, Object> partitionValues =
+                HivePartitionUtils.parsePartitionValues(
+                        split.getHiveTablePartition().getPartitionSpec(),
+                        fieldNames,
+                        fieldTypes,
+                        new JobConfWrapper(jobConf).getDefaultPartitionName(),
+                        HiveShimLoader.loadHiveShim(hiveVersion));
         this.reader =
                 hiveVersion.startsWith("1.")
                         ? OrcNoHiveSplitReaderUtil.genPartColumnarRowReader(
                                 conf,
                                 fieldNames,
                                 fieldTypes,
-                                split.getHiveTablePartition().getPartitionSpec(),
+                                partitionValues,
                                 selectedFields,
                                 new ArrayList<>(),
                                 DEFAULT_SIZE,
@@ -80,7 +91,7 @@ public class HiveVectorizedOrcSplitReader implements SplitReader {
                                 conf,
                                 fieldNames,
                                 fieldTypes,
-                                split.getHiveTablePartition().getPartitionSpec(),
+                                partitionValues,
                                 selectedFields,
                                 new ArrayList<>(),
                                 DEFAULT_SIZE,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.connectors.hive.read;
 
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.connectors.hive.util.HivePartitionUtils;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.vector.ParquetColumnarRowSplitReader;
 import org.apache.flink.formats.parquet.vector.ParquetSplitReaderUtil;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 
@@ -31,6 +34,7 @@ import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.apache.flink.table.data.vector.VectorizedColumnBatch.DEFAULT_SIZE;
 
@@ -60,6 +64,13 @@ public class HiveVectorizedParquetSplitReader implements SplitReader {
             throw new IllegalArgumentException("Unknown split type: " + hadoopSplit);
         }
 
+        Map<String, Object> partitionValues =
+                HivePartitionUtils.parsePartitionValues(
+                        split.getHiveTablePartition().getPartitionSpec(),
+                        fieldNames,
+                        fieldTypes,
+                        new JobConfWrapper(jobConf).getDefaultPartitionName(),
+                        HiveShimLoader.loadHiveShim(hiveVersion));
         this.reader =
                 ParquetSplitReaderUtil.genPartColumnarRowReader(
                         hiveVersion.startsWith("3"),
@@ -67,7 +78,7 @@ public class HiveVectorizedParquetSplitReader implements SplitReader {
                         conf,
                         fieldNames,
                         fieldTypes,
-                        split.getHiveTablePartition().getPartitionSpec(),
+                        partitionValues,
                         selectedFields,
                         DEFAULT_SIZE,
                         new Path(fileSplit.getPath().toString()),

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.connectors.hive.read;
 
-import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.vector.ParquetColumnarRowSplitReader;
 import org.apache.flink.formats.parquet.vector.ParquetSplitReaderUtil;
@@ -69,7 +69,7 @@ public class HiveVectorizedParquetSplitReader implements SplitReader {
                         split.getHiveTablePartition().getPartitionSpec(),
                         fieldNames,
                         fieldTypes,
-                        new JobConfWrapper(jobConf).getDefaultPartitionName(),
+                        JobConfUtils.getDefaultPartitionName(jobConf),
                         HiveShimLoader.loadHiveShim(hiveVersion));
         this.reader =
                 ParquetSplitReaderUtil.genPartColumnarRowReader(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/JobConfUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/JobConfUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.util;
+
+import org.apache.flink.connectors.hive.JobConfWrapper;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.mapred.JobConf;
+
+/** Utilities for {@link JobConf}. */
+public class JobConfUtils {
+
+    /**
+     * Gets the {@link HiveConf.ConfVars#DEFAULTPARTITIONNAME} value from the {@link
+     * JobConfWrapper}.
+     */
+    public static String getDefaultPartitionName(JobConfWrapper confWrapper) {
+        return getDefaultPartitionName(confWrapper.conf());
+    }
+
+    /** Gets the {@link HiveConf.ConfVars#DEFAULTPARTITIONNAME} value from the {@link JobConf}. */
+    public static String getDefaultPartitionName(JobConf jobConf) {
+        return jobConf.get(
+                HiveConf.ConfVars.DEFAULTPARTITIONNAME.varname,
+                HiveConf.ConfVars.DEFAULTPARTITIONNAME.defaultStrVal);
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTypeUtil.java
@@ -84,6 +84,22 @@ public class HiveTypeUtil {
     }
 
     /**
+     * Convert Flink LogicalType to Hive TypeInfo. For types with a precision parameter, e.g.
+     * timestamp, the supported precisions in Hive and Flink can be different. Therefore the
+     * conversion will fail for those types if the precision is not supported by Hive and
+     * checkPrecision is true.
+     *
+     * @param logicalType a Flink LogicalType
+     * @param checkPrecision whether to fail the conversion if the precision of the LogicalType is
+     *     not supported by Hive
+     * @return the corresponding Hive data type
+     */
+    public static TypeInfo toHiveTypeInfo(LogicalType logicalType, boolean checkPrecision) {
+        checkNotNull(logicalType, "type cannot be null");
+        return logicalType.accept(new TypeInfoLogicalTypeVisitor(logicalType, checkPrecision));
+    }
+
+    /**
      * Convert a Hive ObjectInspector to a Flink data type.
      *
      * @param inspector a Hive inspector
@@ -174,12 +190,16 @@ public class HiveTypeUtil {
     }
 
     private static class TypeInfoLogicalTypeVisitor extends LogicalTypeDefaultVisitor<TypeInfo> {
-        private final DataType dataType;
+        private final LogicalType type;
         // whether to check type precision
         private final boolean checkPrecision;
 
         TypeInfoLogicalTypeVisitor(DataType dataType, boolean checkPrecision) {
-            this.dataType = dataType;
+            this(dataType.getLogicalType(), checkPrecision);
+        }
+
+        TypeInfoLogicalTypeVisitor(LogicalType type, boolean checkPrecision) {
+            this.type = type;
             this.checkPrecision = checkPrecision;
         }
 
@@ -344,7 +364,7 @@ public class HiveTypeUtil {
             throw new UnsupportedOperationException(
                     String.format(
                             "Flink doesn't support converting type %s to Hive type yet.",
-                            dataType.toString()));
+                            type.toString()));
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/conversion/HiveInspectors.java
@@ -375,6 +375,11 @@ public class HiveInspectors {
 
     /** Get Hive {@link ObjectInspector} for a Flink {@link DataType}. */
     public static ObjectInspector getObjectInspector(DataType flinkType) {
+        return getObjectInspector(flinkType.getLogicalType());
+    }
+
+    /** Get Hive {@link ObjectInspector} for a Flink {@link LogicalType}. */
+    public static ObjectInspector getObjectInspector(LogicalType flinkType) {
         return getObjectInspector(HiveTypeUtil.toHiveTypeInfo(flinkType, true));
     }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/PartitionMonitorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/PartitionMonitorTest.java
@@ -111,7 +111,7 @@ public class PartitionMonitorTest {
                     @Override
                     public HiveTablePartition toHiveTablePartition(Partition partition) {
                         StorageDescriptor sd = partition.getSd();
-                        Map<String, Object> partitionColValues = new HashMap<>();
+                        Map<String, String> partitionColValues = new HashMap<>();
                         for (String partCol : partition.getValues()) {
                             String[] arr = partCol.split("=");
                             Asserts.check(


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In order to support watermark for Hive connector (FLINK-21871), we need to extract time from the partition string values. However, currently `HiveTablePartition#partitionSpec` uses `Map<String, Object>` type to store the partition spec which is hard convert back to string values. Therefore, I propose to use the raw `Map<String, String>` type instead which is easier to convert into `Map<String, Object>` when needed.


## Brief change log

- Update type of `HiveTablePartition#partitionSpec` from `Map<String, Object>` to `Map<String, String>`


## Verifying this change

This change is a trivial rework which can be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
