### PR TITLE
[FLINK-21696][docs] Add output parameter in WatermarkGenerator scala sections

### DIFF
--- a/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
@@ -325,11 +325,11 @@ class BoundedOutOfOrdernessGenerator extends WatermarkGenerator[MyEvent] {
 
     var currentMaxTimestamp: Long = _
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long): Unit = {
+    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         currentMaxTimestamp = max(eventTimestamp, currentMaxTimestamp)
     }
 
-    override def onPeriodicEmit(): Unit = {
+    override def onPeriodicEmit(output: WatermarkOutput): Unit = {
         // emit the watermark as current highest timestamp minus the out-of-orderness bound
         output.emitWatermark(new Watermark(currentMaxTimestamp - maxOutOfOrderness - 1));
     }
@@ -344,11 +344,11 @@ class TimeLagWatermarkGenerator extends WatermarkGenerator[MyEvent] {
 
     val maxTimeLag = 5000L // 5 seconds
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long): Unit = {
+    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         // don't need to do anything because we work on processing time
     }
 
-    override def onPeriodicEmit(): Unit = {
+    override def onPeriodicEmit(output: WatermarkOutput): Unit = {
         output.emitWatermark(new Watermark(System.currentTimeMillis() - maxTimeLag));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request completes the changes in docs started by https://github.com/apache/flink/pull/15142 by adding the `output` parameter to the `onEvent` and `onPeriodicEmit` signatures


## Brief change log

 - Update Scala examples in 'Generating Watermarks' documentation page

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

