### PR TITLE
[FLINK-21330][runtime] Optimize the performance of PipelinedRegionSchedulingStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -144,7 +144,9 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                         edgeManager);
 
         IndexedPipelinedRegions indexedPipelinedRegions =
-                computePipelinedRegions(executionGraphIndex.executionVerticesList);
+                computePipelinedRegions(
+                        executionGraphIndex.executionVerticesList,
+                        executionGraphIndex.resultPartitionsById::get);
 
         ensureCoLocatedVerticesInSameRegion(
                 indexedPipelinedRegions.pipelinedRegions, executionGraph);
@@ -240,7 +242,9 @@ public class DefaultExecutionTopology implements SchedulingTopology {
     }
 
     private static IndexedPipelinedRegions computePipelinedRegions(
-            Iterable<DefaultExecutionVertex> topologicallySortedVertexes) {
+            Iterable<DefaultExecutionVertex> topologicallySortedVertexes,
+            Function<IntermediateResultPartitionID, DefaultResultPartition>
+                    resultPartitionRetriever) {
         long buildRegionsStartTime = System.nanoTime();
 
         Set<Set<SchedulingExecutionVertex>> rawPipelinedRegions =
@@ -254,7 +258,8 @@ public class DefaultExecutionTopology implements SchedulingTopology {
             //noinspection unchecked
             final DefaultSchedulingPipelinedRegion pipelinedRegion =
                     new DefaultSchedulingPipelinedRegion(
-                            (Set<DefaultExecutionVertex>) rawPipelinedRegion);
+                            (Set<DefaultExecutionVertex>) rawPipelinedRegion,
+                            resultPartitionRetriever);
             pipelinedRegions.add(pipelinedRegion);
 
             for (SchedulingExecutionVertex executionVertex : rawPipelinedRegion) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
@@ -19,8 +19,11 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingPipelinedRegion;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
@@ -28,21 +31,34 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Default implementation of {@link SchedulingPipelinedRegion}. */
 public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegion {
 
     private final Map<ExecutionVertexID, DefaultExecutionVertex> executionVertices;
 
-    private Set<DefaultResultPartition> consumedResults;
+    private Set<ConsumedPartitionGroup> blockingConsumedPartitionGroups;
 
-    public DefaultSchedulingPipelinedRegion(Set<DefaultExecutionVertex> defaultExecutionVertices) {
+    private final Function<IntermediateResultPartitionID, DefaultResultPartition>
+            resultPartitionRetriever;
+
+    public DefaultSchedulingPipelinedRegion(
+            Set<DefaultExecutionVertex> defaultExecutionVertices,
+            Function<IntermediateResultPartitionID, DefaultResultPartition>
+                    resultPartitionRetriever) {
+
         Preconditions.checkNotNull(defaultExecutionVertices);
 
         this.executionVertices = new HashMap<>();
         for (DefaultExecutionVertex executionVertex : defaultExecutionVertices) {
             this.executionVertices.put(executionVertex.getId(), executionVertex);
         }
+
+        this.resultPartitionRetriever = checkNotNull(resultPartitionRetriever);
     }
 
     @Override
@@ -60,23 +76,38 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
         return executionVertex;
     }
 
-    @Override
-    public Iterable<DefaultResultPartition> getConsumedResults() {
-        if (consumedResults == null) {
-            initializeConsumedResults();
-        }
-        return consumedResults;
-    }
-
-    private void initializeConsumedResults() {
-        final Set<DefaultResultPartition> consumedResults = new HashSet<>();
+    private void initializeAllBlockingConsumedPartitionGroups() {
+        final Set<ConsumedPartitionGroup> consumedPartitionGroupSet = new HashSet<>();
         for (DefaultExecutionVertex executionVertex : executionVertices.values()) {
-            for (DefaultResultPartition resultPartition : executionVertex.getConsumedResults()) {
-                if (!executionVertices.containsKey(resultPartition.getProducer().getId())) {
-                    consumedResults.add(resultPartition);
+            for (ConsumedPartitionGroup consumedPartitionGroup :
+                    executionVertex.getConsumedPartitionGroups()) {
+                SchedulingResultPartition consumedPartition =
+                        resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
+
+                checkState(
+                        consumedPartition.getConsumerVertexGroups().size() <= 1,
+                        "Currently there has to be exactly one consumer for each partition in real jobs.");
+
+                if (consumedPartition.getResultType().isBlocking()) {
+                    consumedPartitionGroupSet.add(consumedPartitionGroup);
                 }
             }
         }
-        this.consumedResults = Collections.unmodifiableSet(consumedResults);
+
+        this.blockingConsumedPartitionGroups =
+                Collections.unmodifiableSet(consumedPartitionGroupSet);
+    }
+
+    @Override
+    public Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups() {
+        if (blockingConsumedPartitionGroups == null) {
+            initializeAllBlockingConsumedPartitionGroups();
+        }
+        return blockingConsumedPartitionGroups;
+    }
+
+    @Override
+    public boolean contains(final ExecutionVertexID vertexId) {
+        return executionVertices.containsKey(vertexId);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.scheduler.SchedulerOperations;
 import org.apache.flink.util.IterableUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -49,15 +50,20 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 
     private final DeploymentOption deploymentOption = new DeploymentOption(false);
 
-    /** Result partitions are correlated if they have the same result id. */
-    private final Map<IntermediateDataSetID, Set<SchedulingResultPartition>>
-            correlatedResultPartitions = new HashMap<>();
+    /** ConsumedPartitionGroups are correlated if they have the same result id. */
+    private final Map<IntermediateDataSetID, Set<ConsumedPartitionGroup>>
+            correlatedResultPartitionGroups = new HashMap<>();
 
-    private final Map<IntermediateResultPartitionID, Set<SchedulingPipelinedRegion>>
-            partitionConsumerRegions = new HashMap<>();
+    /** External consumer regions of each ConsumedPartitionGroup. */
+    private final Map<ConsumedPartitionGroup, Set<SchedulingPipelinedRegion>>
+            partitionGroupConsumerRegions = new IdentityHashMap<>();
 
     private final Map<SchedulingPipelinedRegion, List<ExecutionVertexID>> regionVerticesSorted =
             new IdentityHashMap<>();
+
+    /** The ConsumedPartitionGroups which are produced by multiple regions. */
+    private final Set<ConsumedPartitionGroup> crossRegionConsumedPartitionGroups =
+            Collections.newSetFromMap(new IdentityHashMap<>());
 
     public PipelinedRegionSchedulingStrategy(
             final SchedulerOperations schedulerOperations,
@@ -70,18 +76,12 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     }
 
     private void init() {
-        for (SchedulingPipelinedRegion region : schedulingTopology.getAllPipelinedRegions()) {
-            for (SchedulingResultPartition partition : region.getConsumedResults()) {
-                checkState(partition.getResultType().isBlocking());
 
-                partitionConsumerRegions
-                        .computeIfAbsent(partition.getId(), pid -> new HashSet<>())
-                        .add(region);
-                correlatedResultPartitions
-                        .computeIfAbsent(partition.getResultId(), rid -> new HashSet<>())
-                        .add(partition);
-            }
-        }
+        initCrossRegionConsumedPartitionGroups();
+
+        initPartitionGroupConsumerRegions();
+
+        initCorrelatedResultPartitionGroups();
 
         for (SchedulingExecutionVertex vertex : schedulingTopology.getVertices()) {
             final SchedulingPipelinedRegion region =
@@ -92,13 +92,81 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         }
     }
 
+    private void initCrossRegionConsumedPartitionGroups() {
+        Set<ConsumedPartitionGroup> visitedPartitionGroups =
+                Collections.newSetFromMap(new IdentityHashMap<>());
+
+        for (SchedulingPipelinedRegion pipelinedRegion :
+                schedulingTopology.getAllPipelinedRegions()) {
+            for (ConsumedPartitionGroup consumedPartitionGroup :
+                    pipelinedRegion.getAllBlockingConsumedPartitionGroups()) {
+                if (!visitedPartitionGroups.contains(consumedPartitionGroup)) {
+                    visitedPartitionGroups.add(consumedPartitionGroup);
+
+                    SchedulingPipelinedRegion producerRegion = null;
+                    for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                        SchedulingPipelinedRegion region = getProducerRegion(partitionId);
+                        if (producerRegion == null) {
+                            producerRegion = region;
+                        } else if (producerRegion != region) {
+                            crossRegionConsumedPartitionGroups.add(consumedPartitionGroup);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private SchedulingPipelinedRegion getProducerRegion(IntermediateResultPartitionID partitionId) {
+        return schedulingTopology.getPipelinedRegionOfVertex(
+                schedulingTopology.getResultPartition(partitionId).getProducer().getId());
+    }
+
+    private void initPartitionGroupConsumerRegions() {
+        for (SchedulingPipelinedRegion region : schedulingTopology.getAllPipelinedRegions()) {
+            for (ConsumedPartitionGroup consumedPartitionGroup :
+                    region.getAllBlockingConsumedPartitionGroups()) {
+                if (crossRegionConsumedPartitionGroups.contains(consumedPartitionGroup)
+                        || isExternalConsumedPartitionGroup(consumedPartitionGroup, region)) {
+                    partitionGroupConsumerRegions
+                            .computeIfAbsent(consumedPartitionGroup, group -> new HashSet<>())
+                            .add(region);
+                }
+            }
+        }
+    }
+
+    private void initCorrelatedResultPartitionGroups() {
+        for (ConsumedPartitionGroup consumedPartitionGroup :
+                partitionGroupConsumerRegions.keySet()) {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                correlatedResultPartitionGroups
+                        .computeIfAbsent(
+                                partitionId.getIntermediateDataSetID(), id -> new HashSet<>())
+                        .add(consumedPartitionGroup);
+            }
+        }
+    }
+
     @Override
     public void startScheduling() {
         final Set<SchedulingPipelinedRegion> sourceRegions =
                 IterableUtils.toStream(schedulingTopology.getAllPipelinedRegions())
-                        .filter(region -> !region.getConsumedResults().iterator().hasNext())
+                        .filter(this::isSourceRegion)
                         .collect(Collectors.toSet());
         maybeScheduleRegions(sourceRegions);
+    }
+
+    private boolean isSourceRegion(SchedulingPipelinedRegion region) {
+        for (ConsumedPartitionGroup consumedPartitionGroup :
+                region.getAllBlockingConsumedPartitionGroups()) {
+            if (crossRegionConsumedPartitionGroups.contains(consumedPartitionGroup)
+                    || isExternalConsumedPartitionGroup(consumedPartitionGroup, region)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -114,20 +182,20 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     public void onExecutionStateChange(
             final ExecutionVertexID executionVertexId, final ExecutionState executionState) {
         if (executionState == ExecutionState.FINISHED) {
-            final Set<SchedulingResultPartition> finishedPartitions =
+            final Set<ConsumedPartitionGroup> finishedConsumedPartitionGroups =
                     IterableUtils.toStream(
                                     schedulingTopology
                                             .getVertex(executionVertexId)
                                             .getProducedResults())
                             .filter(
                                     partition ->
-                                            partitionConsumerRegions.containsKey(partition.getId()))
-                            .filter(
-                                    partition ->
                                             partition.getState() == ResultPartitionState.CONSUMABLE)
                             .flatMap(
                                     partition ->
-                                            correlatedResultPartitions.get(partition.getResultId())
+                                            correlatedResultPartitionGroups
+                                                    .getOrDefault(
+                                                            partition.getResultId(),
+                                                            Collections.emptySet())
                                                     .stream())
                             .collect(Collectors.toSet());
 
@@ -135,13 +203,13 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
             // consumers are not affected by the restarting of sibling vertices so they are still in
             // SCHEDULED/DEPLOYING/RUNNING/FINISHED. We should skip rescheduling these vertices.
             final Set<SchedulingPipelinedRegion> consumerRegions =
-                    finishedPartitions.stream()
+                    finishedConsumedPartitionGroups.stream()
                             .flatMap(
-                                    partition ->
-                                            partitionConsumerRegions.get(partition.getId())
+                                    partitionGroup ->
+                                            partitionGroupConsumerRegions.get(partitionGroup)
                                                     .stream())
                             .distinct()
-                            .filter(region -> areRegionVerticesAllInCreatedState(region))
+                            .filter(this::areRegionVerticesAllInCreatedState)
                             .collect(Collectors.toSet());
 
             maybeScheduleRegions(consumerRegions);
@@ -155,13 +223,17 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         final List<SchedulingPipelinedRegion> regionsSorted =
                 SchedulingStrategyUtils.sortPipelinedRegionsInTopologicalOrder(
                         schedulingTopology, regions);
+
+        final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache = new HashMap<>();
         for (SchedulingPipelinedRegion region : regionsSorted) {
-            maybeScheduleRegion(region);
+            maybeScheduleRegion(region, consumableStatusCache);
         }
     }
 
-    private void maybeScheduleRegion(final SchedulingPipelinedRegion region) {
-        if (!areRegionInputsAllConsumable(region)) {
+    private void maybeScheduleRegion(
+            final SchedulingPipelinedRegion region,
+            final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
+        if (!areRegionInputsAllConsumable(region, consumableStatusCache)) {
             return;
         }
 
@@ -175,9 +247,43 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         schedulerOperations.allocateSlotsAndDeploy(vertexDeploymentOptions);
     }
 
-    private boolean areRegionInputsAllConsumable(final SchedulingPipelinedRegion region) {
-        for (SchedulingResultPartition partition : region.getConsumedResults()) {
-            if (partition.getState() != ResultPartitionState.CONSUMABLE) {
+    private boolean areRegionInputsAllConsumable(
+            final SchedulingPipelinedRegion region,
+            final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
+        for (ConsumedPartitionGroup consumedPartitionGroup :
+                region.getAllBlockingConsumedPartitionGroups()) {
+            if (crossRegionConsumedPartitionGroups.contains(consumedPartitionGroup)) {
+                if (!isCrossRegionConsumedPartitionConsumable(consumedPartitionGroup, region)) {
+                    return false;
+                }
+            } else if (isExternalConsumedPartitionGroup(consumedPartitionGroup, region)) {
+                if (!consumableStatusCache.computeIfAbsent(
+                        consumedPartitionGroup, this::isConsumedPartitionGroupConsumable)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean isConsumedPartitionGroupConsumable(
+            final ConsumedPartitionGroup consumedPartitionGroup) {
+        for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+            if (schedulingTopology.getResultPartition(partitionId).getState()
+                    != ResultPartitionState.CONSUMABLE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isCrossRegionConsumedPartitionConsumable(
+            final ConsumedPartitionGroup consumedPartitionGroup,
+            final SchedulingPipelinedRegion pipelinedRegion) {
+        for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+            if (isExternalConsumedPartition(partitionId, pipelinedRegion)
+                    && schedulingTopology.getResultPartition(partitionId).getState()
+                            != ResultPartitionState.CONSUMABLE) {
                 return false;
             }
         }
@@ -191,6 +297,19 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
             }
         }
         return true;
+    }
+
+    private boolean isExternalConsumedPartitionGroup(
+            ConsumedPartitionGroup consumedPartitionGroup,
+            SchedulingPipelinedRegion pipelinedRegion) {
+
+        return isExternalConsumedPartition(consumedPartitionGroup.getFirst(), pipelinedRegion);
+    }
+
+    private boolean isExternalConsumedPartition(
+            IntermediateResultPartitionID partitionId, SchedulingPipelinedRegion pipelinedRegion) {
+        return !pipelinedRegion.contains(
+                schedulingTopology.getResultPartition(partitionId).getProducer().getId());
     }
 
     /** The factory for creating {@link PipelinedRegionSchedulingStrategy}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
@@ -29,4 +29,11 @@ public interface SchedulingPipelinedRegion
                 ExecutionVertexID,
                 IntermediateResultPartitionID,
                 SchedulingExecutionVertex,
-                SchedulingResultPartition> {}
+                SchedulingResultPartition> {
+    /**
+     * Get all distinct blocking {@link ConsumedPartitionGroup}s.
+     *
+     * @return set of {@link ConsumedPartitionGroup}s
+     */
+    Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/PipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/PipelinedRegion.java
@@ -51,9 +51,10 @@ public interface PipelinedRegion<
     V getVertex(VID vertexId);
 
     /**
-     * Returns the results that this pipelined region consumes.
+     * Returns whether the vertex is in this pipelined region or not.
      *
-     * @return Iterable over all consumed results
+     * @param vertexId the vertex id used to look up
+     * @return the vertex is in this pipelined region or not
      */
-    Iterable<? extends R> getConsumedResults();
+    boolean contains(VID vertexId);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -47,12 +47,16 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
 
     private ResultPartitionState state;
 
-    TestingSchedulingResultPartition(
-            IntermediateDataSetID dataSetID, ResultPartitionType type, ResultPartitionState state) {
+    private TestingSchedulingResultPartition(
+            IntermediateDataSetID dataSetID,
+            int partitionNum,
+            ResultPartitionType type,
+            ResultPartitionState state) {
         this.intermediateDataSetID = dataSetID;
         this.partitionType = type;
         this.state = state;
-        this.intermediateResultPartitionID = new IntermediateResultPartitionID();
+        this.intermediateResultPartitionID =
+                new IntermediateResultPartitionID(dataSetID, partitionNum);
         this.consumerVertexGroups = new ArrayList<>();
         this.executionVerticesById = new HashMap<>();
     }
@@ -115,6 +119,7 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
     /** Builder for {@link TestingSchedulingResultPartition}. */
     public static final class Builder {
         private IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
+        private int partitionNum = 0;
         private ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
         private ResultPartitionState resultPartitionState = ResultPartitionState.CONSUMABLE;
 
@@ -133,9 +138,14 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
             return this;
         }
 
+        Builder withPartitionNum(int partitionNum) {
+            this.partitionNum = partitionNum;
+            return this;
+        }
+
         TestingSchedulingResultPartition build() {
             return new TestingSchedulingResultPartition(
-                    intermediateDataSetId, resultPartitionType, resultPartitionState);
+                    intermediateDataSetId, partitionNum, resultPartitionType, resultPartitionState);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -294,6 +294,7 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                         initTestingSchedulingResultPartitionBuilder()
                                 .withIntermediateDataSetID(intermediateDataSetId)
                                 .withResultPartitionState(resultPartitionState)
+                                .withPartitionNum(idx)
                                 .build();
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
@@ -341,10 +342,13 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                     initTestingSchedulingResultPartitionBuilder()
                             .withIntermediateDataSetID(intermediateDataSetId)
                             .withResultPartitionState(resultPartitionState);
+
+            int partitionNum = 0;
+
             for (TestingSchedulingExecutionVertex producer : producers) {
 
                 final TestingSchedulingResultPartition resultPartition =
-                        resultPartitionBuilder.build();
+                        resultPartitionBuilder.withPartitionNum(partitionNum++).build();
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces the optimization of the initialization of PipelinedRegionSchedulingStrategy.*

*PipelinedRegionSchedulingStrategy is used for task scheduling. The bottleneck of initializing PipelinedRegionSchedulingStrategy mainly lies in the procedure of calculating the consumed result partitions of the pipelined region, as well as the consumer pipelined region of the result partitions.*

*For a batch job fulfilled with all-to-all blocking edges, each region consists of one vertex. The time complexity and space complexity both degrades to O(N^2).*

*Based on FLINK-21328, the consumedResults in DefaultSchedulingPipelinedRegion can be replaced with ConsumedPartitionGroup in DefaultExecutionVertex.*

*The complexity of initializing PipelinedRegionSchedulingStrategy decreases from O(N^2) to O(N).*

*For more details, please check FLINK-21330.*


## Brief change log

  - *Add partitionNum for TestingSchedulingResultPartition*
  - *Add getConsumedPartitionGroups for SchedulingPipelinedRegion*
  - *Optimize the initialization of PipelinedRegionSchedulingStrategy*
  - *Optimize PipelinedRegionSchedulingStrategy#maybeScheduleRegion*


## Verifying this change

*Since this optimization does not change the original logic of the initialization of PipelinedRegionSchedulingStrategy, we believe that this change is already covered by existing tests, such as PipelinedRegionSchedulingStrategyTest, DefaultExecutionTopologyTest, and etc.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
