### PR TITLE
[FLINK-21331][runtime] Optimize calculating tasks to restart in RestartPipelinedRegionFailoverStrategy

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IterableUtils.java
@@ -60,33 +60,34 @@ public class IterableUtils {
      *     Iterable}
      */
     @Internal
-    public static <K, V, G extends Iterable<K>> Iterator<V> flatMap(
+    public static <K, V, G extends Iterable<K>> Iterable<V> flatMap(
             Iterable<G> itemGroups, Function<K, V> mapper) {
-        return new Iterator<V>() {
-            private final Iterator<G> groupIterator = itemGroups.iterator();
-            private Iterator<K> itemIterator;
+        return () ->
+                new Iterator<V>() {
+                    private final Iterator<G> groupIterator = itemGroups.iterator();
+                    private Iterator<K> itemIterator;
 
-            @Override
-            public boolean hasNext() {
-                while (itemIterator == null || !itemIterator.hasNext()) {
-                    if (!groupIterator.hasNext()) {
-                        return false;
-                    } else {
-                        itemIterator = groupIterator.next().iterator();
+                    @Override
+                    public boolean hasNext() {
+                        while (itemIterator == null || !itemIterator.hasNext()) {
+                            if (!groupIterator.hasNext()) {
+                                return false;
+                            } else {
+                                itemIterator = groupIterator.next().iterator();
+                            }
+                        }
+                        return true;
                     }
-                }
-                return true;
-            }
 
-            @Override
-            public V next() {
-                if (hasNext()) {
-                    return mapper.apply(itemIterator.next());
-                } else {
-                    throw new NoSuchElementException();
-                }
-            }
-        };
+                    @Override
+                    public V next() {
+                        if (hasNext()) {
+                            return mapper.apply(itemIterator.next());
+                        } else {
+                            throw new NoSuchElementException();
+                        }
+                    }
+                };
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionVertex.java
@@ -24,12 +24,12 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.apache.flink.util.IterableUtils.flatMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Default implementation of {@link SchedulingExecutionVertex}. */
@@ -80,7 +80,7 @@ class DefaultExecutionVertex implements SchedulingExecutionVertex {
 
     @Override
     public Iterable<DefaultResultPartition> getConsumedResults() {
-        return () -> flatMap(consumedPartitionGroups, resultPartitionRetriever);
+        return IterableUtils.flatMap(consumedPartitionGroups, resultPartitionRetriever);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartition.java
@@ -26,12 +26,12 @@ import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ResultPartitionState;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.apache.flink.util.IterableUtils.flatMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Default implementation of {@link SchedulingResultPartition}. */
@@ -108,7 +108,7 @@ class DefaultResultPartition implements SchedulingResultPartition {
 
     @Override
     public Iterable<DefaultExecutionVertex> getConsumers() {
-        return () -> flatMap(consumerVertexGroups, executionVertexRetriever);
+        return IterableUtils.flatMap(consumerVertexGroups, executionVertexRetriever);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.strategy;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.util.IterableUtils.flatMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A simple scheduling execution vertex for testing purposes. */
@@ -76,7 +76,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
 
     @Override
     public Iterable<TestingSchedulingResultPartition> getConsumedResults() {
-        return () -> flatMap(consumedPartitionGroups, resultPartitionsById::get);
+        return IterableUtils.flatMap(consumedPartitionGroups, resultPartitionsById::get);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -21,13 +21,13 @@ package org.apache.flink.runtime.scheduler.strategy;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.util.IterableUtils.flatMap;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A simple implementation of {@link SchedulingResultPartition} for testing. */
@@ -84,7 +84,7 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
 
     @Override
     public Iterable<TestingSchedulingExecutionVertex> getConsumers() {
-        return () -> flatMap(consumerVertexGroups, executionVerticesById::get);
+        return IterableUtils.flatMap(consumerVertexGroups, executionVerticesById::get);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces the optimization of calculating tasks to restart in RestartPipelinedRegionFailoverStrategy. The related method is `RestartPipelinedRegionFailoverStrategy#getRegionsToRestart`.*

*RestartPipelinedRegionFailoverStrategy is used to calculate the tasks to restart when a task failure occurs. It contains two parts: firstly calculate the regions to restart; then add all the tasks in these regions to the restarting queue.*

*The bottleneck is mainly in the first part. This part traverses all the upstream and downstream regions of the failed region to determine whether they should be restarted or not.*

*For the current failed region, if its consumed result partition is not available, the owner, i.e., the upstream region should restart. Also, since the failed region needs to restart, its result partition won't be available, all the downstream regions need to restart, too.*

*Based on FLINK-21328 and FLINK-21330, the consumed result partitions of a pipelined region and the consumer vertices of a DefaultResultPartition are already grouped. Here we can use a HashSet to record the visited groups. For vertices connected with all-to-all edges, they will only need to traverse the groups once. This decreases the time complexity from O(N^2) to O(N).*

*For more details, please check FLINK-21331.*

## Brief change log

  - *Optimize RestartPipelinedRegionFailoverStrategy#getRegionsToRestart*

## Verifying this change

*Since this optimization does not change the original logic of calculating tasks to restart in RestartPipelinedRegionFailoverStrategy, we believe that this change is already covered by RestartPipelinedRegionFailoverStrategyTest.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
