### PR TITLE
[FLINK-21332][runtime] Optimize releasing result partitions in RegionPartitionReleaseStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -297,7 +297,7 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
         for (int i = 0; i < prevJobEdges.size(); ++i) {
             if (prevJobEdges.get(i).getDistributionPattern() == DistributionPattern.POINTWISE) {
                 for (IntermediateResultPartitionID consumedPartitionId :
-                        vertex.getConsumedPartitions(i)) {
+                        vertex.getConsumedPartitionGroup(i)) {
                     ExecutionVertex precedentTask =
                             executionGraphAccessor
                                     .getResultPartitionOrThrow(consumedPartitionId)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -111,7 +111,7 @@ public class TaskDeploymentDescriptorFactory {
             // TODO Refactor after removing the consumers from the intermediate result partitions
             IntermediateResultPartition resultPartition = partitions.get(0);
 
-            int numConsumers = resultPartition.getConsumers().get(0).size();
+            int numConsumers = resultPartition.getConsumerVertexGroups().get(0).size();
 
             int queueToRequest = subtaskIndex % numConsumers;
             IntermediateResult consumedIntermediateResult = resultPartition.getIntermediateResult();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -473,11 +473,11 @@ public class Execution
     private static int getPartitionMaxParallelism(
             IntermediateResultPartition partition,
             Function<ExecutionVertexID, ExecutionVertex> getVertexById) {
-        final List<ConsumerVertexGroup> consumers = partition.getConsumers();
+        final List<ConsumerVertexGroup> consumerVertexGroups = partition.getConsumerVertexGroups();
         Preconditions.checkArgument(
-                consumers.size() == 1,
+                consumerVertexGroups.size() == 1,
                 "Currently there has to be exactly one consumer in real jobs");
-        final ConsumerVertexGroup consumerVertexGroup = consumers.get(0);
+        final ConsumerVertexGroup consumerVertexGroup = consumerVertexGroups.get(0);
         return getVertexById
                 .apply(consumerVertexGroup.getFirst())
                 .getJobVertex()
@@ -696,19 +696,19 @@ public class Execution
 
     private void updatePartitionConsumers(final IntermediateResultPartition partition) {
 
-        final List<ConsumerVertexGroup> allConsumers = partition.getConsumers();
+        final List<ConsumerVertexGroup> consumerVertexGroups = partition.getConsumerVertexGroups();
 
-        if (allConsumers.size() == 0) {
+        if (consumerVertexGroups.size() == 0) {
             return;
         }
-        if (allConsumers.size() > 1) {
+        if (consumerVertexGroups.size() > 1) {
             fail(
                     new IllegalStateException(
                             "Currently, only a single consumer group per partition is supported."));
             return;
         }
 
-        for (ExecutionVertexID consumerVertexId : allConsumers.get(0)) {
+        for (ExecutionVertexID consumerVertexId : consumerVertexGroups.get(0)) {
             final ExecutionVertex consumerVertex =
                     vertex.getExecutionGraphAccessor().getExecutionVertexOrThrow(consumerVertexId);
             final Execution consumer = consumerVertex.getCurrentExecutionAttempt();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -213,7 +213,7 @@ public class ExecutionVertex
                 .getConsumedPartitionGroupsForVertex(executionVertexId);
     }
 
-    public ConsumedPartitionGroup getConsumedPartitions(int input) {
+    public ConsumedPartitionGroup getConsumedPartitionGroup(int input) {
         final List<ConsumedPartitionGroup> allConsumedPartitions = getAllConsumedPartitionGroups();
 
         if (input < 0 || input >= allConsumedPartitions.size()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -68,7 +68,7 @@ public class IntermediateResultPartition {
         return totalResult.getResultType();
     }
 
-    public List<ConsumerVertexGroup> getConsumers() {
+    public List<ConsumerVertexGroup> getConsumerVertexGroups() {
         return getEdgeManager().getConsumerVertexGroupsForPartition(partitionId);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionView.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease;
+
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingPipelinedRegion;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * This view maintains the finished progress of consumer {@link SchedulingPipelinedRegion}s for each
+ * {@link ConsumedPartitionGroup}.
+ */
+public class ConsumerRegionGroupExecutionView implements Iterable<SchedulingPipelinedRegion> {
+
+    private final Set<SchedulingPipelinedRegion> unfinishedConsumerRegions;
+
+    public ConsumerRegionGroupExecutionView() {
+        this.unfinishedConsumerRegions = new HashSet<>();
+    }
+
+    @Override
+    public Iterator<SchedulingPipelinedRegion> iterator() {
+        return unfinishedConsumerRegions.iterator();
+    }
+
+    void add(SchedulingPipelinedRegion region) {
+        unfinishedConsumerRegions.add(region);
+    }
+
+    void regionFinished(SchedulingPipelinedRegion region) {
+        unfinishedConsumerRegions.remove(region);
+    }
+
+    void regionUnfinished(SchedulingPipelinedRegion region) {
+        unfinishedConsumerRegions.add(region);
+    }
+
+    boolean isFinished() {
+        return unfinishedConsumerRegions.isEmpty();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease;
+
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingPipelinedRegion;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Track the finished progress of {@link ConsumerRegionGroupExecutionView}s.
+ *
+ * <p>NOTE: It only contains {@link SchedulingPipelinedRegion}s that have {@link
+ * ConsumedPartitionGroup}s.
+ */
+class ConsumerRegionGroupExecutionViewMaintainer {
+
+    /**
+     * The set of {@link ConsumerRegionGroupExecutionView}s that a SchedulingPipelinedRegion belongs
+     * to.
+     */
+    private final Map<SchedulingPipelinedRegion, Set<ConsumerRegionGroupExecutionView>>
+            executionViewByRegion = new HashMap<>();
+
+    ConsumerRegionGroupExecutionViewMaintainer(
+            Iterable<ConsumerRegionGroupExecutionView> executionViews) {
+
+        for (ConsumerRegionGroupExecutionView executionView : executionViews) {
+            for (SchedulingPipelinedRegion region : executionView) {
+                executionViewByRegion
+                        .computeIfAbsent(
+                                region, r -> Collections.newSetFromMap(new IdentityHashMap<>()))
+                        .add(executionView);
+            }
+        }
+    }
+
+    void regionFinished(SchedulingPipelinedRegion region) {
+        for (ConsumerRegionGroupExecutionView executionView :
+                executionViewByRegion.getOrDefault(region, Collections.emptySet())) {
+            executionView.regionFinished(region);
+        }
+    }
+
+    void regionUnfinished(SchedulingPipelinedRegion region) {
+        for (ConsumerRegionGroupExecutionView executionView :
+                executionViewByRegion.getOrDefault(region, Collections.emptySet())) {
+            executionView.regionUnfinished(region);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
@@ -113,13 +113,13 @@ public class PartitionDescriptor implements Serializable {
         // If no consumers are known at this point, we use a single subpartition, otherwise we have
         // one for each consuming sub task.
         int numberOfSubpartitions = 1;
-        List<ConsumerVertexGroup> consumers = partition.getConsumers();
-        if (!consumers.isEmpty() && !consumers.get(0).isEmpty()) {
-            if (consumers.size() > 1) {
+        List<ConsumerVertexGroup> consumerVertexGroups = partition.getConsumerVertexGroups();
+        if (!consumerVertexGroups.isEmpty() && !consumerVertexGroups.get(0).isEmpty()) {
+            if (consumerVertexGroups.size() > 1) {
                 throw new IllegalStateException(
                         "Currently, only a single consumer group per partition is supported.");
             }
-            numberOfSubpartitions = consumers.get(0).size();
+            numberOfSubpartitions = consumerVertexGroups.get(0).size();
         }
         IntermediateResult result = partition.getIntermediateResult();
         return new PartitionDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -501,12 +501,14 @@ public class ExecutionGraphTestUtils {
                 assertEquals(inputJobVertices.size(), ev.getNumberOfInputs());
 
                 for (int i = 0; i < inputJobVertices.size(); i++) {
-                    ConsumedPartitionGroup consumedPartitions = ev.getConsumedPartitions(i);
+                    ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(i);
                     assertEquals(
-                            inputJobVertices.get(i).getParallelism(), consumedPartitions.size());
+                            inputJobVertices.get(i).getParallelism(),
+                            consumedPartitionGroup.size());
 
                     int expectedPartitionNum = 0;
-                    for (IntermediateResultPartitionID consumedPartitionId : consumedPartitions) {
+                    for (IntermediateResultPartitionID consumedPartitionId :
+                            consumedPartitionGroup) {
                         assertEquals(
                                 expectedPartitionNum, consumedPartitionId.getPartitionNumber());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -51,7 +51,7 @@ public class PointwisePatternTest {
         for (ExecutionVertex ev : target.getTaskVertices()) {
             assertEquals(1, ev.getNumberOfInputs());
 
-            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitions(0);
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
             assertEquals(1, consumedPartitionGroup.size());
 
             assertEquals(
@@ -69,7 +69,7 @@ public class PointwisePatternTest {
         for (ExecutionVertex ev : target.getTaskVertices()) {
             assertEquals(1, ev.getNumberOfInputs());
 
-            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitions(0);
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
             assertEquals(2, consumedPartitionGroup.size());
 
             int idx = 0;
@@ -90,7 +90,7 @@ public class PointwisePatternTest {
         for (ExecutionVertex ev : target.getTaskVertices()) {
             assertEquals(1, ev.getNumberOfInputs());
 
-            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitions(0);
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
             assertEquals(3, consumedPartitionGroup.size());
 
             int idx = 0;
@@ -111,12 +111,12 @@ public class PointwisePatternTest {
         for (ExecutionVertex ev : target.getTaskVertices()) {
             assertEquals(1, ev.getNumberOfInputs());
 
-            ConsumedPartitionGroup consumedPartitions = ev.getConsumedPartitions(0);
-            assertEquals(1, consumedPartitions.size());
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
+            assertEquals(1, consumedPartitionGroup.size());
 
             assertEquals(
                     ev.getParallelSubtaskIndex() / 2,
-                    consumedPartitions.getFirst().getPartitionNumber());
+                    consumedPartitionGroup.getFirst().getPartitionNumber());
         }
     }
 
@@ -129,12 +129,12 @@ public class PointwisePatternTest {
         for (ExecutionVertex ev : target.getTaskVertices()) {
             assertEquals(1, ev.getNumberOfInputs());
 
-            ConsumedPartitionGroup consumedPartitions = ev.getConsumedPartitions(0);
-            assertEquals(1, consumedPartitions.size());
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
+            assertEquals(1, consumedPartitionGroup.size());
 
             assertEquals(
                     ev.getParallelSubtaskIndex() / 7,
-                    consumedPartitions.getFirst().getPartitionNumber());
+                    consumedPartitionGroup.getFirst().getPartitionNumber());
         }
     }
 
@@ -192,10 +192,10 @@ public class PointwisePatternTest {
         for (ExecutionVertex ev : target.getTaskVertices()) {
             assertEquals(1, ev.getNumberOfInputs());
 
-            ConsumedPartitionGroup consumedPartitions = ev.getConsumedPartitions(0);
-            assertEquals(1, consumedPartitions.size());
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
+            assertEquals(1, consumedPartitionGroup.size());
 
-            timesUsed[consumedPartitions.getFirst().getPartitionNumber()]++;
+            timesUsed[consumedPartitionGroup.getFirst().getPartitionNumber()]++;
         }
 
         for (int used : timesUsed) {
@@ -276,12 +276,14 @@ public class PointwisePatternTest {
         for (int vertexIndex = 0; vertexIndex < target.getTaskVertices().length; vertexIndex++) {
 
             ExecutionVertex ev = target.getTaskVertices()[vertexIndex];
-            ConsumedPartitionGroup partitionIds = ev.getConsumedPartitions(0);
+            ConsumedPartitionGroup consumedPartitionGroup = ev.getConsumedPartitionGroup(0);
 
-            assertEquals(expectedConsumedPartitionNumber[vertexIndex].length, partitionIds.size());
+            assertEquals(
+                    expectedConsumedPartitionNumber[vertexIndex].length,
+                    consumedPartitionGroup.size());
 
             int partitionIndex = 0;
-            for (IntermediateResultPartitionID partitionId : partitionIds) {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
                 assertEquals(
                         expectedConsumedPartitionNumber[vertexIndex][partitionIndex++],
                         partitionId.getPartitionNumber());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/ConsumerRegionGroupExecutionViewMaintainerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease;
+
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingExecutionVertex;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingPipelinedRegion;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ConsumerRegionGroupExecutionView} and {@link
+ * ConsumerRegionGroupExecutionViewMaintainer}.
+ */
+public class ConsumerRegionGroupExecutionViewMaintainerTest extends TestLogger {
+
+    private TestingSchedulingPipelinedRegion producerRegion;
+    private TestingSchedulingPipelinedRegion consumerRegion;
+
+    private ConsumerRegionGroupExecutionView consumerRegionGroupExecutionView;
+    private ConsumerRegionGroupExecutionViewMaintainer consumerRegionGroupExecutionViewMaintainer;
+
+    @Before
+    public void setup() {
+        createProducerAndConsumer();
+        createConsumerRegionGroupExecutionViewMaintainer();
+    }
+
+    @Test
+    public void testRegionFinished() throws Exception {
+        consumerRegionGroupExecutionViewMaintainer.regionFinished(consumerRegion);
+        assertTrue(consumerRegionGroupExecutionView.isFinished());
+    }
+
+    @Test
+    public void testRegionUnfinished() throws Exception {
+        consumerRegionGroupExecutionViewMaintainer.regionFinished(consumerRegion);
+        consumerRegionGroupExecutionViewMaintainer.regionUnfinished(consumerRegion);
+
+        assertFalse(consumerRegionGroupExecutionView.isFinished());
+    }
+
+    @Test
+    public void testRegionFinishedMultipleTimes() throws Exception {
+        consumerRegionGroupExecutionViewMaintainer.regionFinished(consumerRegion);
+        consumerRegionGroupExecutionViewMaintainer.regionFinished(consumerRegion);
+
+        assertTrue(consumerRegionGroupExecutionView.isFinished());
+    }
+
+    @Test
+    public void testRegionUnfinishedMultipleTimes() throws Exception {
+        consumerRegionGroupExecutionViewMaintainer.regionUnfinished(consumerRegion);
+        consumerRegionGroupExecutionViewMaintainer.regionUnfinished(consumerRegion);
+
+        assertFalse(consumerRegionGroupExecutionView.isFinished());
+
+        consumerRegionGroupExecutionViewMaintainer.regionFinished(consumerRegion);
+        assertTrue(consumerRegionGroupExecutionView.isFinished());
+    }
+
+    @Test
+    public void testFinishWrongRegion() {
+        consumerRegionGroupExecutionViewMaintainer.regionFinished(producerRegion);
+        assertFalse(consumerRegionGroupExecutionView.isFinished());
+    }
+
+    @Test
+    public void testUnfinishedWrongRegion() {
+        consumerRegionGroupExecutionViewMaintainer.regionUnfinished(producerRegion);
+        assertFalse(consumerRegionGroupExecutionView.isFinished());
+    }
+
+    private void createProducerAndConsumer() {
+        TestingSchedulingExecutionVertex producer =
+                TestingSchedulingExecutionVertex.newBuilder().build();
+        TestingSchedulingExecutionVertex consumer =
+                TestingSchedulingExecutionVertex.newBuilder().build();
+
+        producerRegion = new TestingSchedulingPipelinedRegion(Collections.singleton(producer));
+        consumerRegion = new TestingSchedulingPipelinedRegion(Collections.singleton(consumer));
+    }
+
+    private void createConsumerRegionGroupExecutionViewMaintainer() {
+        consumerRegionGroupExecutionView = new ConsumerRegionGroupExecutionView();
+        consumerRegionGroupExecutionView.add(consumerRegion);
+
+        consumerRegionGroupExecutionViewMaintainer =
+                new ConsumerRegionGroupExecutionViewMaintainer(
+                        Collections.singletonList(consumerRegionGroupExecutionView));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -233,7 +233,8 @@ public class DefaultExecutionTopologyTest extends TestLogger {
             assertPartitionEquals(originalPartition, adaptedPartition);
 
             List<ExecutionVertexID> originalConsumerIds = new ArrayList<>();
-            for (ConsumerVertexGroup consumerVertexGroup : originalPartition.getConsumers()) {
+            for (ConsumerVertexGroup consumerVertexGroup :
+                    originalPartition.getConsumerVertexGroups()) {
                 for (ExecutionVertexID executionVertexId : consumerVertexGroup) {
                     originalConsumerIds.add(executionVertexId);
                 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -140,9 +140,9 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
         Map<Integer, Integer> mapInputPartitionCounts = new HashMap<>();
         for (ExecutionVertex mapTaskVertex : mapTaskVertices) {
             assertEquals(1, mapTaskVertex.getNumberOfInputs());
-            assertEquals(1, mapTaskVertex.getConsumedPartitions(0).size());
+            assertEquals(1, mapTaskVertex.getConsumedPartitionGroup(0).size());
             IntermediateResultPartitionID consumedPartitionId =
-                    mapTaskVertex.getConsumedPartitions(0).getFirst();
+                    mapTaskVertex.getConsumedPartitionGroup(0).getFirst();
             assertEquals(
                     sourceVertex.getID(),
                     mapTaskVertex
@@ -174,9 +174,9 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
         Set<Integer> mapSubpartitions = new HashSet<>();
         for (ExecutionVertex sinkTaskVertex : sinkTaskVertices) {
             assertEquals(1, sinkTaskVertex.getNumberOfInputs());
-            assertEquals(2, sinkTaskVertex.getConsumedPartitions(0).size());
+            assertEquals(2, sinkTaskVertex.getConsumedPartitionGroup(0).size());
             for (IntermediateResultPartitionID consumedPartitionId :
-                    sinkTaskVertex.getConsumedPartitions(0)) {
+                    sinkTaskVertex.getConsumedPartitionGroup(0)) {
                 IntermediateResultPartition consumedPartition =
                         executionGraphAccessor.getResultPartitionOrThrow(consumedPartitionId);
                 assertEquals(mapVertex.getID(), consumedPartition.getProducer().getJobvertexId());


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduce the optimization of releasing result partitions in RegionPartitionReleaseStrategy.*
*RegionPartitionReleaseStrategy is responsible for releasing result partitions when all the downstream tasks finish.*

*The current implementation is:*
```
for each consumed SchedulingResultPartition of current finished SchedulingPipelinedRegion:
  for each consumer SchedulingPipelinedRegion of the SchedulingResultPartition:
    if all the regions are finished:
      release the partitions
```

*The time complexity of releasing a result partition is O(N^2). However, considering that during the entire stage, all the result partitions need to be released, the time complexity is actually O(N^3).*

*Based on FLINK-21228, the consumed result partitions of a pipelined region are grouped. Since the result partitions in one group are isomorphic, we can just cache the finished status of the pipeline regions and the fully consumed status of result partition groups.*

*The optimized implementation is:*
```
for each ConsumedPartitionGroup of current finished SchedulingPipelinedRegion:
  if all consumer SchedulingPipelinedRegion of the ConsumedPartitionGroup are finished:
    set the ConsumePartitionGroup to be fully consumed
    for result partition in the ConsumePartitionGroup:
      if all the ConsumePartitionGroups it belongs to are fully consumed:
        release the result partition
```

*After the optimization, the complexity decreases from O(N^3) to O(N).*

*For more details, please check FLINK-21332.*

## Brief change log

  - *Optimize RegionPartitionReleaseStrategy#filterReleasablePartitions*

## Verifying this change

*Since this optimization does not change the original logic of releasing result partitions in RegionPartitionReleaseStrategy, we believe that this change is already covered by RegionPartitionReleaseStrategyTest.*

*For newly added class `ConsumerRegionGroupExecutionViewTracker` and `ConsumerRegionGroupExecutionView`, we added the test case `ConsumerRegionGroupExecutionViewTrackerTest`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
