### PR TITLE
[FLINK-21913][table][connectors] Update DynamicTableFactory.Context to use ResolvedCatalogTable

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/TestContext.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/TestContext.java
@@ -18,61 +18,54 @@
 
 package org.apache.flink.streaming.connectors.elasticsearch.table;
 
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 /** A utility class for mocking {@link DynamicTableFactory.Context}. */
 class TestContext {
-    private TableSchema schema;
-    private Map<String, String> properties = new HashMap<>();
+
+    private ResolvedSchema schema = ResolvedSchema.of(Column.physical("a", DataTypes.TIME()));
+
+    private final Map<String, String> options = new HashMap<>();
 
     public static TestContext context() {
         return new TestContext();
     }
 
-    public TestContext withSchema(TableSchema schema) {
+    public TestContext withSchema(ResolvedSchema schema) {
         this.schema = schema;
         return this;
     }
 
     DynamicTableFactory.Context build() {
-        return new DynamicTableFactory.Context() {
-            @Override
-            public ObjectIdentifier getObjectIdentifier() {
-                return null;
-            }
-
-            @Override
-            public CatalogTable getCatalogTable() {
-                return new CatalogTableImpl(schema, properties, "");
-            }
-
-            @Override
-            public ReadableConfig getConfiguration() {
-                return null;
-            }
-
-            @Override
-            public ClassLoader getClassLoader() {
-                return TestContext.class.getClassLoader();
-            }
-
-            @Override
-            public boolean isTemporary() {
-                return false;
-            }
-        };
+        return new FactoryUtil.DefaultDynamicTableContext(
+                ObjectIdentifier.of("default", "default", "t1"),
+                new ResolvedCatalogTable(
+                        CatalogTable.of(
+                                Schema.newBuilder().fromResolvedSchema(schema).build(),
+                                "mock context",
+                                Collections.emptyList(),
+                                options),
+                        schema),
+                new Configuration(),
+                TestContext.class.getClassLoader(),
+                false);
     }
 
     public TestContext withOption(String key, String value) {
-        properties.put(key, value);
+        options.put(key, value);
         return this;
     }
 }

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkFactoryTest.java
@@ -20,12 +20,17 @@ package org.apache.flink.streaming.connectors.elasticsearch.table;
 
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.apache.flink.streaming.connectors.elasticsearch.table.TestContext.context;
 
@@ -46,10 +51,7 @@ public class Elasticsearch6DynamicSinkFactoryTest {
                         + "document-type\n"
                         + "hosts\n"
                         + "index");
-        sinkFactory.createDynamicTableSink(
-                context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
-                        .build());
+        sinkFactory.createDynamicTableSink(context().build());
     }
 
     @Test
@@ -60,7 +62,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
         thrown.expectMessage("'index' must not be empty");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption("index", "")
                         .withOption("document-type", "MyType")
                         .withOption("hosts", "http://localhost:12345")
@@ -76,7 +77,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
                 "Could not parse host 'wrong-host' in option 'hosts'. It should follow the format 'http://host_name:port'.");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption("index", "MyIndex")
                         .withOption("document-type", "MyType")
                         .withOption("hosts", "wrong-host")
@@ -92,7 +92,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
                 "'sink.bulk-flush.max-size' must be in MB granularity. Got: 1024 bytes");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(ElasticsearchOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
@@ -109,7 +108,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
         thrown.expectMessage("'sink.bulk-flush.backoff.max-retries' must be at least 1. Got: 0");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(ElasticsearchOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
@@ -128,7 +126,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
         thrown.expectMessage("'sink.bulk-flush.max-actions' must be at least 1. Got: -2");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(ElasticsearchOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
@@ -145,7 +142,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
         thrown.expectMessage("Invalid value for option 'sink.bulk-flush.backoff.delay'.");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(ElasticsearchOptions.DOCUMENT_TYPE_OPTION.key(), "MyType")
                         .withOption(
@@ -168,35 +164,45 @@ public class Elasticsearch6DynamicSinkFactoryTest {
         sinkFactory.createDynamicTableSink(
                 context()
                         .withSchema(
-                                TableSchema.builder()
-                                        .field("a", DataTypes.BIGINT().notNull())
-                                        .field(
-                                                "b",
-                                                DataTypes.ARRAY(DataTypes.BIGINT().notNull())
-                                                        .notNull())
-                                        .field(
-                                                "c",
-                                                DataTypes.MAP(
-                                                                DataTypes.BIGINT(),
-                                                                DataTypes.STRING())
-                                                        .notNull())
-                                        .field(
-                                                "d",
-                                                DataTypes.MULTISET(DataTypes.BIGINT().notNull())
-                                                        .notNull())
-                                        .field(
-                                                "e",
-                                                DataTypes.ROW(
-                                                                DataTypes.FIELD(
-                                                                        "a", DataTypes.BIGINT()))
-                                                        .notNull())
-                                        .field(
-                                                "f",
-                                                DataTypes.RAW(Void.class, VoidSerializer.INSTANCE)
-                                                        .notNull())
-                                        .field("g", DataTypes.BYTES().notNull())
-                                        .primaryKey("a", "b", "c", "d", "e", "f", "g")
-                                        .build())
+                                new ResolvedSchema(
+                                        Arrays.asList(
+                                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                                Column.physical(
+                                                        "b",
+                                                        DataTypes.ARRAY(
+                                                                        DataTypes.BIGINT()
+                                                                                .notNull())
+                                                                .notNull()),
+                                                Column.physical(
+                                                        "c",
+                                                        DataTypes.MAP(
+                                                                        DataTypes.BIGINT(),
+                                                                        DataTypes.STRING())
+                                                                .notNull()),
+                                                Column.physical(
+                                                        "d",
+                                                        DataTypes.MULTISET(
+                                                                        DataTypes.BIGINT()
+                                                                                .notNull())
+                                                                .notNull()),
+                                                Column.physical(
+                                                        "e",
+                                                        DataTypes.ROW(
+                                                                        DataTypes.FIELD(
+                                                                                "a",
+                                                                                DataTypes.BIGINT()))
+                                                                .notNull()),
+                                                Column.physical(
+                                                        "f",
+                                                        DataTypes.RAW(
+                                                                        Void.class,
+                                                                        VoidSerializer.INSTANCE)
+                                                                .notNull()),
+                                                Column.physical("g", DataTypes.BYTES().notNull())),
+                                        Collections.emptyList(),
+                                        UniqueConstraint.primaryKey(
+                                                "name",
+                                                Arrays.asList("a", "b", "c", "d", "e", "f", "g"))))
                         .withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(
                                 ElasticsearchOptions.HOSTS_OPTION.key(), "http://localhost:1234")
@@ -214,7 +220,6 @@ public class Elasticsearch6DynamicSinkFactoryTest {
                 "'username' and 'password' must be set at the same time. Got: username 'username' and password ''");
         sinkFactory.createDynamicTableSink(
                 context()
-                        .withSchema(TableSchema.builder().field("a", DataTypes.TIME()).build())
                         .withOption(ElasticsearchOptions.INDEX_OPTION.key(), "MyIndex")
                         .withOption(
                                 ElasticsearchOptions.HOSTS_OPTION.key(), "http://localhost:1234")

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -25,7 +25,9 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.GenericRowData;
@@ -50,6 +52,8 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -79,17 +83,18 @@ public class Elasticsearch6DynamicSinkITCase {
 
     @Test
     public void testWritingDocuments() throws Exception {
-        TableSchema schema =
-                TableSchema.builder()
-                        .field("a", DataTypes.BIGINT().notNull())
-                        .field("b", DataTypes.TIME())
-                        .field("c", DataTypes.STRING().notNull())
-                        .field("d", DataTypes.FLOAT())
-                        .field("e", DataTypes.TINYINT().notNull())
-                        .field("f", DataTypes.DATE())
-                        .field("g", DataTypes.TIMESTAMP().notNull())
-                        .primaryKey("a", "g")
-                        .build();
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.TIME()),
+                                Column.physical("c", DataTypes.STRING().notNull()),
+                                Column.physical("d", DataTypes.FLOAT()),
+                                Column.physical("e", DataTypes.TINYINT().notNull()),
+                                Column.physical("f", DataTypes.DATE()),
+                                Column.physical("g", DataTypes.TIMESTAMP().notNull())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("name", Arrays.asList("a", "g")));
         GenericRowData rowData =
                 GenericRowData.of(
                         1L,

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -25,7 +25,9 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.GenericRowData;
@@ -50,6 +52,8 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -79,17 +83,19 @@ public class Elasticsearch7DynamicSinkITCase {
 
     @Test
     public void testWritingDocuments() throws Exception {
-        TableSchema schema =
-                TableSchema.builder()
-                        .field("a", DataTypes.BIGINT().notNull())
-                        .field("b", DataTypes.TIME())
-                        .field("c", DataTypes.STRING().notNull())
-                        .field("d", DataTypes.FLOAT())
-                        .field("e", DataTypes.TINYINT().notNull())
-                        .field("f", DataTypes.DATE())
-                        .field("g", DataTypes.TIMESTAMP().notNull())
-                        .primaryKey("a", "g")
-                        .build();
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.TIME()),
+                                Column.physical("c", DataTypes.STRING().notNull()),
+                                Column.physical("d", DataTypes.FLOAT()),
+                                Column.physical("e", DataTypes.TINYINT().notNull()),
+                                Column.physical("f", DataTypes.DATE()),
+                                Column.physical("g", DataTypes.TIMESTAMP().notNull())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("name", Arrays.asList("a", "g")));
+
         GenericRowData rowData =
                 GenericRowData.of(
                         1L,

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseDynamicTableFactoryTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.hbase2;
 
 import org.apache.flink.api.common.typeinfo.Types;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.hbase.options.HBaseLookupOptions;
 import org.apache.flink.connector.hbase.options.HBaseWriteOptions;
 import org.apache.flink.connector.hbase.source.HBaseRowDataLookupFunction;
@@ -28,16 +27,14 @@ import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.connector.hbase2.sink.HBaseDynamicTableSink;
 import org.apache.flink.connector.hbase2.source.HBaseDynamicTableSource;
 import org.apache.flink.connector.hbase2.source.HBaseRowDataAsyncLookupFunction;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.connector.source.AsyncTableFunctionProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.TableFunctionProvider;
-import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.functions.AsyncTableFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
@@ -66,6 +63,8 @@ import static org.apache.flink.table.api.DataTypes.ROW;
 import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.api.DataTypes.TIME;
 import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -89,25 +88,24 @@ public class HBaseDynamicTableFactoryTest {
     @SuppressWarnings("rawtypes")
     @Test
     public void testTableSourceFactory() {
-        TableSchema schema =
-                TableSchema.builder()
-                        .field(FAMILY1, ROW(FIELD(COL1, INT())))
-                        .field(FAMILY2, ROW(FIELD(COL1, INT()), FIELD(COL2, BIGINT())))
-                        .field(ROWKEY, BIGINT())
-                        .field(
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical(FAMILY1, ROW(FIELD(COL1, INT()))),
+                        Column.physical(FAMILY2, ROW(FIELD(COL1, INT()), FIELD(COL2, BIGINT()))),
+                        Column.physical(ROWKEY, BIGINT()),
+                        Column.physical(
                                 FAMILY3,
                                 ROW(
                                         FIELD(COL1, DOUBLE()),
                                         FIELD(COL2, BOOLEAN()),
-                                        FIELD(COL3, STRING())))
-                        .field(
+                                        FIELD(COL3, STRING()))),
+                        Column.physical(
                                 FAMILY4,
                                 ROW(
                                         FIELD(COL1, DECIMAL(10, 3)),
                                         FIELD(COL2, TIMESTAMP(3)),
                                         FIELD(COL3, DATE()),
-                                        FIELD(COL4, TIME())))
-                        .build();
+                                        FIELD(COL4, TIME()))));
 
         DynamicTableSource source = createTableSource(schema, getAllOptions());
         assertTrue(source instanceof HBaseDynamicTableSource);
@@ -148,20 +146,20 @@ public class HBaseDynamicTableFactoryTest {
 
     @Test
     public void testTableSinkFactory() {
-        TableSchema schema =
-                TableSchema.builder()
-                        .field(ROWKEY, STRING())
-                        .field(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT())))
-                        .field(FAMILY2, ROW(FIELD(COL1, INT()), FIELD(COL3, BIGINT())))
-                        .field(FAMILY3, ROW(FIELD(COL2, BOOLEAN()), FIELD(COL3, STRING())))
-                        .field(
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical(ROWKEY, STRING()),
+                        Column.physical(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT()))),
+                        Column.physical(FAMILY2, ROW(FIELD(COL1, INT()), FIELD(COL3, BIGINT()))),
+                        Column.physical(
+                                FAMILY3, ROW(FIELD(COL2, BOOLEAN()), FIELD(COL3, STRING()))),
+                        Column.physical(
                                 FAMILY4,
                                 ROW(
                                         FIELD(COL1, DECIMAL(10, 3)),
                                         FIELD(COL2, TIMESTAMP(3)),
                                         FIELD(COL3, DATE()),
-                                        FIELD(COL4, TIME())))
-                        .build();
+                                        FIELD(COL4, TIME()))));
 
         DynamicTableSink sink = createTableSink(schema, getAllOptions());
         assertTrue(sink instanceof HBaseDynamicTableSink);
@@ -221,7 +219,7 @@ public class HBaseDynamicTableFactoryTest {
         options.put("sink.buffer-flush.max-rows", "100");
         options.put("sink.buffer-flush.interval", "10s");
 
-        TableSchema schema = TableSchema.builder().field(ROWKEY, STRING()).build();
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
 
         DynamicTableSink sink = createTableSink(schema, options);
         HBaseWriteOptions expected =
@@ -239,7 +237,7 @@ public class HBaseDynamicTableFactoryTest {
         Map<String, String> options = getAllOptions();
         options.put("sink.parallelism", "2");
 
-        TableSchema schema = TableSchema.builder().field(ROWKEY, STRING()).build();
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
 
         DynamicTableSink sink = createTableSink(schema, options);
         assertTrue(sink instanceof HBaseDynamicTableSink);
@@ -256,11 +254,10 @@ public class HBaseDynamicTableFactoryTest {
         options.put("lookup.cache.max-rows", "1000");
         options.put("lookup.cache.ttl", "10s");
         options.put("lookup.max-retries", "10");
-        TableSchema schema =
-                TableSchema.builder()
-                        .field(ROWKEY, STRING())
-                        .field(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT())))
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical(ROWKEY, STRING()),
+                        Column.physical(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT()))));
         DynamicTableSource source = createTableSource(schema, options);
         HBaseLookupOptions actual = ((HBaseDynamicTableSource) source).getLookupOptions();
         HBaseLookupOptions expected =
@@ -276,11 +273,10 @@ public class HBaseDynamicTableFactoryTest {
     public void testLookupAsync() {
         Map<String, String> options = getAllOptions();
         options.put("lookup.async", "true");
-        TableSchema schema =
-                TableSchema.builder()
-                        .field(ROWKEY, STRING())
-                        .field(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT())))
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical(ROWKEY, STRING()),
+                        Column.physical(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT()))));
         DynamicTableSource source = createTableSource(schema, options);
         assertTrue(source instanceof HBaseDynamicTableSource);
         HBaseDynamicTableSource hbaseSource = (HBaseDynamicTableSource) source;
@@ -305,7 +301,7 @@ public class HBaseDynamicTableFactoryTest {
         options.put("sink.buffer-flush.max-rows", "0");
         options.put("sink.buffer-flush.interval", "0");
 
-        TableSchema schema = TableSchema.builder().field(ROWKEY, STRING()).build();
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical(ROWKEY, STRING()));
 
         DynamicTableSink sink = createTableSink(schema, options);
         HBaseWriteOptions expected =
@@ -322,11 +318,10 @@ public class HBaseDynamicTableFactoryTest {
     public void testUnknownOption() {
         Map<String, String> options = getAllOptions();
         options.put("sink.unknown.key", "unknown-value");
-        TableSchema schema =
-                TableSchema.builder()
-                        .field(ROWKEY, STRING())
-                        .field(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT())))
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical(ROWKEY, STRING()),
+                        Column.physical(FAMILY1, ROW(FIELD(COL1, DOUBLE()), FIELD(COL2, INT()))));
 
         try {
             createTableSource(schema, options);
@@ -353,11 +348,11 @@ public class HBaseDynamicTableFactoryTest {
     public void testTypeWithUnsupportedPrecision() {
         Map<String, String> options = getAllOptions();
         // test unsupported timestamp precision
-        TableSchema schema =
-                TableSchema.builder()
-                        .field(ROWKEY, STRING())
-                        .field(FAMILY1, ROW(FIELD(COL1, TIMESTAMP(6)), FIELD(COL2, INT())))
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical(ROWKEY, STRING()),
+                        Column.physical(
+                                FAMILY1, ROW(FIELD(COL1, TIMESTAMP(6)), FIELD(COL2, INT()))));
         try {
             createTableSource(schema, options);
             fail("Should fail");
@@ -383,10 +378,9 @@ public class HBaseDynamicTableFactoryTest {
         }
         // test unsupported time precision
         schema =
-                TableSchema.builder()
-                        .field(ROWKEY, STRING())
-                        .field(FAMILY1, ROW(FIELD(COL1, TIME(6)), FIELD(COL2, INT())))
-                        .build();
+                ResolvedSchema.of(
+                        Column.physical(ROWKEY, STRING()),
+                        Column.physical(FAMILY1, ROW(FIELD(COL1, TIME(6)), FIELD(COL2, INT()))));
 
         try {
             createTableSource(schema, options);
@@ -421,27 +415,5 @@ public class HBaseDynamicTableFactoryTest {
         options.put("zookeeper.znode.parent", "/flink");
         options.put("properties.hbase.security.authentication", "kerberos");
         return options;
-    }
-
-    private static DynamicTableSource createTableSource(
-            TableSchema schema, Map<String, String> options) {
-        return FactoryUtil.createTableSource(
-                null,
-                ObjectIdentifier.of("default", "default", "t1"),
-                new CatalogTableImpl(schema, options, "mock source"),
-                new Configuration(),
-                HBase2DynamicTableFactory.class.getClassLoader(),
-                false);
-    }
-
-    private static DynamicTableSink createTableSink(
-            TableSchema schema, Map<String, String> options) {
-        return FactoryUtil.createTableSink(
-                null,
-                ObjectIdentifier.of("default", "default", "t1"),
-                new CatalogTableImpl(schema, options, "mock sink"),
-                new Configuration(),
-                HBase2DynamicTableFactory.class.getClassLoader(),
-                false);
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
@@ -66,7 +67,7 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         throw new UnsupportedOperationException("Hive factory is only work for catalog.");
     }
 
-    private static CatalogTable removeIsGenericFlag(Context context) {
+    private static ResolvedCatalogTable removeIsGenericFlag(Context context) {
         Map<String, String> newOptions = new HashMap<>(context.getCatalogTable().getOptions());
         boolean isGeneric = Boolean.parseBoolean(newOptions.remove(IS_GENERIC));
         // temporary table doesn't have the IS_GENERIC flag but we still consider it generic

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
@@ -230,6 +231,7 @@ public class HiveDynamicTableFactoryTest {
     }
 
     private DynamicTableSource getTableSource(String tableName) throws Exception {
+        TableEnvironmentInternal tableEnvInternal = (TableEnvironmentInternal) tableEnv;
         ObjectIdentifier tableIdentifier =
                 ObjectIdentifier.of(hiveCatalog.getName(), "default", tableName);
         CatalogTable catalogTable =
@@ -237,7 +239,7 @@ public class HiveDynamicTableFactoryTest {
         return FactoryUtil.createTableSource(
                 hiveCatalog,
                 tableIdentifier,
-                catalogTable,
+                tableEnvInternal.getCatalogManager().resolveCatalogTable(catalogTable),
                 tableEnv.getConfig().getConfiguration(),
                 Thread.currentThread().getContextClassLoader(),
                 false);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.api.internal.TableImpl;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -359,6 +360,7 @@ public class HiveLookupJoinITCase {
 
     private FileSystemLookupFunction<HiveTablePartition> getLookupFunction(String tableName)
             throws Exception {
+        TableEnvironmentInternal tableEnvInternal = (TableEnvironmentInternal) tableEnv;
         ObjectIdentifier tableIdentifier =
                 ObjectIdentifier.of(hiveCatalog.getName(), "default", tableName);
         CatalogTable catalogTable =
@@ -368,7 +370,9 @@ public class HiveLookupJoinITCase {
                         FactoryUtil.createTableSource(
                                 hiveCatalog,
                                 tableIdentifier,
-                                catalogTable,
+                                tableEnvInternal
+                                        .getCatalogManager()
+                                        .resolveCatalogTable(catalogTable),
                                 tableEnv.getConfig().getConfiguration(),
                                 Thread.currentThread().getContextClassLoader(),
                                 false);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -25,8 +25,11 @@ import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -105,25 +108,26 @@ public class HiveTableFactoryTest {
 
     @Test
     public void testHiveTable() throws Exception {
-        TableSchema schema =
-                TableSchema.builder()
-                        .field("name", DataTypes.STRING())
-                        .field("age", DataTypes.INT())
-                        .build();
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical("name", DataTypes.STRING()),
+                        Column.physical("age", DataTypes.INT()));
 
         Map<String, String> properties = new HashMap<>();
         properties.put(CatalogPropertiesUtil.IS_GENERIC, String.valueOf(false));
 
         catalog.createDatabase("mydb", new CatalogDatabaseImpl(new HashMap<>(), ""), true);
         ObjectPath path = new ObjectPath("mydb", "mytable");
-        CatalogTable table = new CatalogTableImpl(schema, properties, "hive table");
+        CatalogTable table =
+                new CatalogTableImpl(
+                        TableSchema.fromResolvedSchema(schema), properties, "hive table");
         catalog.createTable(path, table, true);
 
         DynamicTableSource tableSource =
                 FactoryUtil.createTableSource(
                         catalog,
                         ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
-                        table,
+                        new ResolvedCatalogTable(table, schema),
                         new Configuration(),
                         Thread.currentThread().getContextClassLoader(),
                         false);
@@ -133,7 +137,7 @@ public class HiveTableFactoryTest {
                 FactoryUtil.createTableSink(
                         catalog,
                         ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
-                        table,
+                        new ResolvedCatalogTable(table, schema),
                         new Configuration(),
                         Thread.currentThread().getContextClassLoader(),
                         false);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
@@ -33,15 +33,13 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.planner.runtime.utils.TestData;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
@@ -67,6 +65,7 @@ import java.util.Map;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.DERBY_EBOOKSHOP_DB;
 import static org.apache.flink.connector.jdbc.internal.JdbcTableOutputFormatTest.check;
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 
 /** The ITCase for {@link JdbcDynamicTableSink}. */
 public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
@@ -433,17 +432,10 @@ public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
         options.put("table-name", OUTPUT_TABLE5);
         options.put("sink.buffer-flush.interval", "0");
 
-        TableSchema sinkTableSchema =
-                TableSchema.builder().field("id", DataTypes.BIGINT().notNull()).build();
+        ResolvedSchema schema =
+                ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT().notNull()));
 
-        DynamicTableSink tableSink =
-                FactoryUtil.createTableSink(
-                        null,
-                        ObjectIdentifier.of("default", "default", "checkpoint_sink"),
-                        new CatalogTableImpl(sinkTableSchema, options, "mock sink"),
-                        new Configuration(),
-                        this.getClass().getClassLoader(),
-                        false);
+        DynamicTableSink tableSink = createTableSink(schema, options);
 
         SinkRuntimeProviderContext context = new SinkRuntimeProviderContext(false);
         SinkFunctionProvider sinkProvider =

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.connectors.kafka.table;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.avro.AvroRowDataSerializationSchema;
 import org.apache.flink.formats.avro.RowDataToAvroConverters;
 import org.apache.flink.formats.avro.registry.confluent.ConfluentRegistryAvroSerializationSchema;
@@ -35,12 +34,11 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.catalog.WatermarkSpec;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
@@ -50,6 +48,7 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.factories.TestFormatFactory.DecodingFormatMock;
@@ -80,6 +79,8 @@ import java.util.regex.Pattern;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.AVRO_CONFLUENT;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.DEBEZIUM_AVRO_CONFLUENT;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -148,26 +149,33 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
                     "partition:%d,offset:%d;partition:%d,offset:%d",
                     PARTITION_0, OFFSET_0, PARTITION_1, OFFSET_1);
 
-    private static final TableSchema SCHEMA =
-            TableSchema.builder()
-                    .add(TableColumn.physical(NAME, DataTypes.STRING()))
-                    .add(TableColumn.physical(COUNT, DataTypes.DECIMAL(38, 18)))
-                    .add(TableColumn.physical(TIME, DataTypes.TIMESTAMP(3)))
-                    .add(
-                            TableColumn.computed(
+    private static final ResolvedSchema SCHEMA =
+            new ResolvedSchema(
+                    Arrays.asList(
+                            Column.physical(NAME, DataTypes.STRING().notNull()),
+                            Column.physical(COUNT, DataTypes.DECIMAL(38, 18)),
+                            Column.physical(TIME, DataTypes.TIMESTAMP(3)),
+                            Column.computed(
                                     COMPUTED_COLUMN_NAME,
-                                    COMPUTED_COLUMN_DATATYPE,
-                                    COMPUTED_COLUMN_EXPRESSION))
-                    .watermark(TIME, WATERMARK_EXPRESSION, WATERMARK_DATATYPE)
-                    .build();
+                                    ResolvedExpressionMock.of(
+                                            COMPUTED_COLUMN_DATATYPE, COMPUTED_COLUMN_EXPRESSION))),
+                    Collections.singletonList(
+                            WatermarkSpec.of(
+                                    TIME,
+                                    ResolvedExpressionMock.of(
+                                            WATERMARK_DATATYPE, WATERMARK_EXPRESSION))),
+                    null);
 
-    private static final TableSchema SCHEMA_WITH_METADATA =
-            TableSchema.builder()
-                    .add(TableColumn.physical(NAME, DataTypes.STRING()))
-                    .add(TableColumn.physical(COUNT, DataTypes.DECIMAL(38, 18)))
-                    .add(TableColumn.metadata(TIME, DataTypes.TIMESTAMP(3), "timestamp"))
-                    .add(TableColumn.metadata(METADATA, DataTypes.STRING(), "value.metadata_2"))
-                    .build();
+    private static final ResolvedSchema SCHEMA_WITH_METADATA =
+            new ResolvedSchema(
+                    Arrays.asList(
+                            Column.physical(NAME, DataTypes.STRING()),
+                            Column.physical(COUNT, DataTypes.DECIMAL(38, 18)),
+                            Column.metadata(TIME, DataTypes.TIMESTAMP(3), "timestamp", false),
+                            Column.metadata(
+                                    METADATA, DataTypes.STRING(), "value.metadata_2", false)),
+                    Collections.emptyList(),
+                    null);
 
     private static final DataType SCHEMA_DATA_TYPE = SCHEMA.toPhysicalRowDataType();
 
@@ -290,7 +298,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
         final DecodingFormatMock keyDecodingFormat = new DecodingFormatMock("#", false);
         keyDecodingFormat.producedDataType =
-                DataTypes.ROW(DataTypes.FIELD(NAME, DataTypes.STRING())).notNull();
+                DataTypes.ROW(DataTypes.FIELD(NAME, DataTypes.STRING().notNull())).notNull();
 
         final DecodingFormatMock valueDecodingFormat = new DecodingFormatMock("|", false);
         valueDecodingFormat.producedDataType =
@@ -327,7 +335,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
         // initialize stateful testing formats
         actualKafkaSource.applyReadableMetadata(
                 Arrays.asList("timestamp", "value.metadata_2"),
-                SCHEMA_WITH_METADATA.toRowDataType());
+                SCHEMA_WITH_METADATA.toSourceRowDataType());
         actualKafkaSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
 
         final DecodingFormatMock expectedKeyFormat =
@@ -364,7 +372,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
                         StartupMode.GROUP_OFFSETS,
                         Collections.emptyMap(),
                         0);
-        expectedKafkaSource.producedDataType = SCHEMA_WITH_METADATA.toRowDataType();
+        expectedKafkaSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedKafkaSource.metadataKeys = Collections.singletonList("timestamp");
 
         assertEquals(actualSource, expectedKafkaSource);
@@ -411,7 +419,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
         final EncodingFormatMock keyEncodingFormat = new EncodingFormatMock("#");
         keyEncodingFormat.consumedDataType =
-                DataTypes.ROW(DataTypes.FIELD(NAME, DataTypes.STRING())).notNull();
+                DataTypes.ROW(DataTypes.FIELD(NAME, DataTypes.STRING().notNull())).notNull();
 
         final EncodingFormatMock valueEncodingFormat = new EncodingFormatMock("|");
         valueEncodingFormat.consumedDataType =
@@ -776,18 +784,11 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testPrimaryKeyValidation() {
-        final TableSchema pkSchema =
-                TableSchema.builder()
-                        .field(NAME, DataTypes.STRING().notNull())
-                        .field(COUNT, DataTypes.DECIMAL(38, 18))
-                        .field(TIME, DataTypes.TIMESTAMP(3))
-                        .field(
-                                COMPUTED_COLUMN_NAME,
-                                COMPUTED_COLUMN_DATATYPE,
-                                COMPUTED_COLUMN_EXPRESSION)
-                        .watermark(TIME, WATERMARK_EXPRESSION, WATERMARK_DATATYPE)
-                        .primaryKey(NAME)
-                        .build();
+        final ResolvedSchema pkSchema =
+                new ResolvedSchema(
+                        SCHEMA.getColumns(),
+                        SCHEMA.getWatermarkSpecs(),
+                        UniqueConstraint.primaryKey(NAME, Collections.singletonList(NAME)));
 
         Map<String, String> sinkOptions =
                 getModifiedOptions(
@@ -807,7 +808,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
             fail();
         } catch (Throwable t) {
             String error =
-                    "The Kafka table 'default.default.sinkTable' with 'test-format' format"
+                    "The Kafka table 'default.default.t1' with 'test-format' format"
                             + " doesn't support defining PRIMARY KEY constraint on the table, because it can't"
                             + " guarantee the semantic of primary key.";
             assertEquals(error, t.getCause().getMessage());
@@ -831,7 +832,7 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
             fail();
         } catch (Throwable t) {
             String error =
-                    "The Kafka table 'default.default.scanTable' with 'test-format' format"
+                    "The Kafka table 'default.default.t1' with 'test-format' format"
                             + " doesn't support defining PRIMARY KEY constraint on the table, because it can't"
                             + " guarantee the semantic of primary key.";
             assertEquals(error, t.getCause().getMessage());
@@ -896,34 +897,6 @@ public class KafkaDynamicTableFactoryTest extends TestLogger {
                 semantic,
                 false,
                 parallelism);
-    }
-
-    private static DynamicTableSource createTableSource(
-            TableSchema schema, Map<String, String> options) {
-        final ObjectIdentifier objectIdentifier =
-                ObjectIdentifier.of("default", "default", "scanTable");
-        final CatalogTable catalogTable = new CatalogTableImpl(schema, options, "scanTable");
-        return FactoryUtil.createTableSource(
-                null,
-                objectIdentifier,
-                catalogTable,
-                new Configuration(),
-                Thread.currentThread().getContextClassLoader(),
-                false);
-    }
-
-    private static DynamicTableSink createTableSink(
-            TableSchema schema, Map<String, String> options) {
-        final ObjectIdentifier objectIdentifier =
-                ObjectIdentifier.of("default", "default", "sinkTable");
-        final CatalogTable catalogTable = new CatalogTableImpl(schema, options, "sinkTable");
-        return FactoryUtil.createTableSink(
-                null,
-                objectIdentifier,
-                catalogTable,
-                new Configuration(),
-                Thread.currentThread().getContextClassLoader(),
-                false);
     }
 
     /**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisOptions.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisOptions.java
@@ -26,14 +26,15 @@ import org.apache.flink.streaming.connectors.kinesis.FixedKinesisPartitioner;
 import org.apache.flink.streaming.connectors.kinesis.KinesisPartitioner;
 import org.apache.flink.streaming.connectors.kinesis.RandomKinesisPartitioner;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -222,15 +223,19 @@ public class KinesisOptions {
      * </ul>
      *
      * @param tableOptions A read-only set of config options that determines the partitioner type.
-     * @param targetTable A catalog version of the table backing the partitioner.
+     * @param physicalType Physical type for partitioning.
+     * @param partitionKeys Partitioning keys in physical type.
      * @param classLoader A {@link ClassLoader} to use for loading user-defined partitioner classes.
      */
     public static KinesisPartitioner<RowData> getKinesisPartitioner(
-            ReadableConfig tableOptions, CatalogTable targetTable, ClassLoader classLoader) {
+            ReadableConfig tableOptions,
+            RowType physicalType,
+            List<String> partitionKeys,
+            ClassLoader classLoader) {
 
-        if (targetTable.isPartitioned()) {
+        if (!partitionKeys.isEmpty()) {
             String delimiter = tableOptions.get(SINK_PARTITIONER_FIELD_DELIMITER);
-            return new RowDataFieldsKinesisPartitioner(targetTable, delimiter);
+            return new RowDataFieldsKinesisPartitioner(physicalType, partitionKeys, delimiter);
         } else if (!tableOptions.getOptional(SINK_PARTITIONER).isPresent()) {
             return new RandomKinesisPartitioner<>();
         } else {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/table/KinesisDynamicTableFactoryTest.java
@@ -18,30 +18,28 @@
 
 package org.apache.flink.streaming.connectors.kinesis.table;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisConsumer;
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisProducer;
 import org.apache.flink.streaming.connectors.kinesis.RandomKinesisPartitioner;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.WatermarkSpec;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
 import org.apache.flink.table.factories.TableOptionsBuilder;
 import org.apache.flink.table.factories.TestFormatFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
@@ -60,6 +58,8 @@ import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.streaming.connectors.kinesis.table.RowDataKinesisDeserializationSchema.Metadata;
 import static org.apache.flink.streaming.connectors.kinesis.table.RowDataKinesisDeserializationSchema.Metadata.ShardId;
 import static org.apache.flink.streaming.connectors.kinesis.table.RowDataKinesisDeserializationSchema.Metadata.Timestamp;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -72,8 +72,6 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     private static final String STREAM_NAME = "myStream";
 
-    private static final String TABLE_NAME = "myTable";
-
     @Rule public ExpectedException thrown = ExpectedException.none();
 
     // --------------------------------------------------------------------------------------------
@@ -82,12 +80,12 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testGoodTableSource() {
-        TableSchema sourceSchema = defaultSourceSchema().build();
+        ResolvedSchema sourceSchema = defaultSourceSchema();
         Map<String, String> sourceOptions = defaultTableOptions().build();
-        CatalogTable catalogTable = createSourceTable(sourceSchema, sourceOptions);
 
         // Construct actual DynamicTableSource using FactoryUtil
-        KinesisDynamicSource actualSource = actualDynamicSource(catalogTable);
+        KinesisDynamicSource actualSource =
+                (KinesisDynamicSource) createTableSource(sourceSchema, sourceOptions);
 
         // Construct expected DynamicTableSink using factory under test
         KinesisDynamicSource expectedSource =
@@ -113,16 +111,16 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testGoodTableSourceWithMetadataFields() {
-        TableSchema sourceSchema = defaultSourceSchema().build();
+        ResolvedSchema sourceSchema = defaultSourceSchema();
         Map<String, String> sourceOptions = defaultTableOptions().build();
-        CatalogTable sourceTable = createSourceTable(sourceSchema, sourceOptions);
 
         Metadata[] requestedMetadata = new Metadata[] {ShardId, Timestamp};
         List<String> metadataKeys = Arrays.asList(ShardId.getFieldName(), Timestamp.getFieldName());
         DataType producedDataType = getProducedType(sourceSchema, requestedMetadata);
 
         // Construct actual DynamicTableSource using FactoryUtil
-        KinesisDynamicSource actualSource = actualDynamicSource(sourceTable);
+        KinesisDynamicSource actualSource =
+                (KinesisDynamicSource) createTableSource(sourceSchema, sourceOptions);
         actualSource.applyReadableMetadata(metadataKeys, producedDataType);
 
         // Construct expected DynamicTableSink using factory under test
@@ -144,22 +142,24 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testGoodTableSinkForPartitionedTable() {
-        TableSchema sinkSchema = defaultSinkSchema().build();
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
         Map<String, String> sinkOptions = defaultTableOptions().build();
         List<String> sinkPartitionKeys = Arrays.asList("name", "curr_id");
-        CatalogTable sinkTable = createSinkTable(sinkSchema, sinkOptions, sinkPartitionKeys);
 
         // Construct actual DynamicTableSink using FactoryUtil
-        KinesisDynamicSink actualSink = actualDynamicSink(sinkTable);
+        KinesisDynamicSink actualSink =
+                (KinesisDynamicSink) createTableSink(sinkSchema, sinkPartitionKeys, sinkOptions);
 
         // Construct expected DynamicTableSink using factory under test
         KinesisDynamicSink expectedSink =
                 new KinesisDynamicSink(
-                        sinkSchema.toPhysicalRowDataType(),
+                        physicalDataType,
                         STREAM_NAME,
                         defaultProducerProperties(),
                         new TestFormatFactory.EncodingFormatMock(","),
-                        new RowDataFieldsKinesisPartitioner(sinkTable));
+                        new RowDataFieldsKinesisPartitioner(
+                                (RowType) physicalDataType.getLogicalType(), sinkPartitionKeys));
 
         // verify that the constructed DynamicTableSink is as expected
         assertEquals(expectedSink, actualSink);
@@ -177,12 +177,12 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testGoodTableSinkForNonPartitionedTable() {
-        TableSchema sinkSchema = defaultSinkSchema().build();
+        ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions = defaultTableOptions().build();
-        CatalogTable sinkTable = createSinkTable(sinkSchema, sinkOptions);
 
         // Construct actual DynamicTableSink using FactoryUtil
-        KinesisDynamicSink actualSink = actualDynamicSink(sinkTable);
+        KinesisDynamicSink actualSink =
+                (KinesisDynamicSink) createTableSink(sinkSchema, sinkOptions);
 
         // Construct expected DynamicTableSink using factory under test
         KinesisDynamicSink expectedSink =
@@ -213,7 +213,7 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testBadTableSinkForCustomPartitionerForPartitionedTable() {
-        TableSchema sinkSchema = defaultSinkSchema().build();
+        ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions =
                 defaultTableOptions()
                         .withTableOption(KinesisOptions.SINK_PARTITIONER, "random")
@@ -228,13 +228,7 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
                                         KinesisOptions.SINK_PARTITIONER.key()))));
 
         try {
-            FactoryUtil.createTableSink(
-                    null,
-                    ObjectIdentifier.of("default", "default", TABLE_NAME),
-                    createSinkTable(sinkSchema, sinkOptions, Arrays.asList("name", "curr_id")),
-                    new Configuration(),
-                    Thread.currentThread().getContextClassLoader(),
-                    false);
+            createTableSink(sinkSchema, Arrays.asList("name", "curr_id"), sinkOptions);
         } catch (ValidationException e) {
             throw (ValidationException) e.getCause(); // unpack the causing exception
         }
@@ -242,7 +236,7 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
 
     @Test
     public void testBadTableSinkForNonExistingPartitionerClass() {
-        TableSchema sinkSchema = defaultSinkSchema().build();
+        ResolvedSchema sinkSchema = defaultSinkSchema();
         Map<String, String> sinkOptions =
                 defaultTableOptions()
                         .withTableOption(KinesisOptions.SINK_PARTITIONER, "abc")
@@ -254,54 +248,35 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
                         new ValidationException(
                                 "Could not find and instantiate partitioner class 'abc'")));
 
-        FactoryUtil.createTableSink(
-                null,
-                ObjectIdentifier.of("default", "default", TABLE_NAME),
-                createSinkTable(sinkSchema, sinkOptions, Collections.emptyList()),
-                new Configuration(),
-                Thread.currentThread().getContextClassLoader(),
-                false);
+        createTableSink(sinkSchema, sinkOptions);
     }
 
     // --------------------------------------------------------------------------------------------
     // Utilities
     // --------------------------------------------------------------------------------------------
 
-    private CatalogTable createSourceTable(
-            TableSchema sourceSchema, Map<String, String> sourceOptions) {
-        return createSourceTable(sourceSchema, sourceOptions, Collections.emptyList());
+    private ResolvedSchema defaultSourceSchema() {
+        return new ResolvedSchema(
+                Arrays.asList(
+                        Column.physical("name", DataTypes.STRING()),
+                        Column.physical("curr_id", DataTypes.BIGINT()),
+                        Column.physical("time", DataTypes.TIMESTAMP(3)),
+                        Column.computed(
+                                "next_id",
+                                ResolvedExpressionMock.of(DataTypes.BIGINT(), "curr_id + 1"))),
+                Collections.singletonList(
+                        WatermarkSpec.of(
+                                "time",
+                                ResolvedExpressionMock.of(
+                                        DataTypes.TIMESTAMP(3), "time - INTERVAL '5' SECOND"))),
+                null);
     }
 
-    private CatalogTable createSourceTable(
-            TableSchema sourceSchema,
-            Map<String, String> sourceOptions,
-            List<String> partitionKeys) {
-        return new CatalogTableImpl(sourceSchema, partitionKeys, sourceOptions, TABLE_NAME);
-    }
-
-    private CatalogTable createSinkTable(TableSchema sinkSchema, Map<String, String> sinkOptions) {
-        return createSinkTable(sinkSchema, sinkOptions, Collections.emptyList());
-    }
-
-    private CatalogTable createSinkTable(
-            TableSchema sinkSchema, Map<String, String> sinkOptions, List<String> partitionKeys) {
-        return new CatalogTableImpl(sinkSchema, partitionKeys, sinkOptions, TABLE_NAME);
-    }
-
-    private TableSchema.Builder defaultSourceSchema() {
-        return TableSchema.builder()
-                .add(TableColumn.physical("name", DataTypes.STRING()))
-                .add(TableColumn.physical("curr_id", DataTypes.BIGINT()))
-                .add(TableColumn.physical("time", DataTypes.TIMESTAMP(3)))
-                .add(TableColumn.computed("next_id", DataTypes.BIGINT(), "curr_id + 1"))
-                .watermark("time", "time" + " - INTERVAL '5' SECOND", DataTypes.TIMESTAMP(3));
-    }
-
-    private TableSchema.Builder defaultSinkSchema() {
-        return TableSchema.builder()
-                .add(TableColumn.physical("name", DataTypes.STRING()))
-                .add(TableColumn.physical("curr_id", DataTypes.BIGINT()))
-                .add(TableColumn.physical("time", DataTypes.TIMESTAMP(3)));
+    private ResolvedSchema defaultSinkSchema() {
+        return ResolvedSchema.of(
+                Column.physical("name", DataTypes.STRING()),
+                Column.physical("curr_id", DataTypes.BIGINT()),
+                Column.physical("time", DataTypes.TIMESTAMP(3)));
     }
 
     private TableOptionsBuilder defaultTableOptions() {
@@ -351,38 +326,14 @@ public class KinesisDynamicTableFactoryTest extends TestLogger {
         };
     }
 
-    private KinesisDynamicSource actualDynamicSource(CatalogTable catalogTable) {
-        return (KinesisDynamicSource)
-                FactoryUtil.createTableSource(
-                        null,
-                        ObjectIdentifier.of("default", "default", TABLE_NAME),
-                        catalogTable,
-                        new Configuration(),
-                        Thread.currentThread().getContextClassLoader(),
-                        false);
-    }
-
-    private KinesisDynamicSink actualDynamicSink(CatalogTable catalogTable) {
-        return (KinesisDynamicSink)
-                FactoryUtil.createTableSink(
-                        null,
-                        ObjectIdentifier.of("default", "default", TABLE_NAME),
-                        catalogTable,
-                        new Configuration(),
-                        Thread.currentThread().getContextClassLoader(),
-                        false);
-    }
-
-    private DataType getProducedType(TableSchema schema, Metadata... requestedMetadata) {
+    private DataType getProducedType(ResolvedSchema schema, Metadata... requestedMetadata) {
         Stream<DataTypes.Field> physicalFields =
-                IntStream.range(0, schema.getFieldCount())
+                IntStream.range(0, schema.getColumnCount())
                         .mapToObj(
                                 i ->
                                         DataTypes.FIELD(
-                                                schema.getFieldName(i)
-                                                        .orElseThrow(RuntimeException::new),
-                                                schema.getFieldDataType(i)
-                                                        .orElseThrow(RuntimeException::new)));
+                                                schema.getColumnNames().get(i),
+                                                schema.getColumnDataTypes().get(i)));
         Stream<DataTypes.Field> metadataFields =
                 Arrays.stream(requestedMetadata)
                         .map(m -> DataTypes.FIELD(m.name(), m.getDataType()));

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/table/RowDataFieldsKinesisPartitionerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/table/RowDataFieldsKinesisPartitionerTest.java
@@ -19,15 +19,13 @@
 package org.apache.flink.streaming.connectors.kinesis.table;
 
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.factories.TableOptionsBuilder;
 import org.apache.flink.table.factories.TestFormatFactory;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Rule;
@@ -54,17 +52,18 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
     /** Table name to use for the tests. */
     private static final String TABLE_NAME = "click_stream";
 
-    /** Table schema to use for the tests. */
-    private static final TableSchema TABLE_SCHEMA =
-            TableSchema.builder()
-                    .field("time", DataTypes.TIMESTAMP(3))
-                    .field("ip", DataTypes.VARCHAR(16))
-                    .field("route", DataTypes.STRING())
-                    .field("date", DataTypes.STRING(), "CAST(DATE(`time`) AS STRING)")
-                    .field("year", DataTypes.STRING(), "CAST(YEAR(`time`) AS STRING)")
-                    .field("month", DataTypes.STRING(), "CAST(MONTH(`time`) AS STRING)")
-                    .field("day", DataTypes.STRING(), "CAST(DAYOFMONTH(`time`) AS STRING)")
-                    .build();
+    /** Row type to use for the tests. */
+    private static final RowType ROW_TYPE =
+            (RowType)
+                    DataTypes.ROW(
+                                    DataTypes.FIELD("time", DataTypes.TIMESTAMP(3)),
+                                    DataTypes.FIELD("ip", DataTypes.VARCHAR(16)),
+                                    DataTypes.FIELD("route", DataTypes.STRING()),
+                                    DataTypes.FIELD("date", DataTypes.STRING()),
+                                    DataTypes.FIELD("year", DataTypes.STRING()),
+                                    DataTypes.FIELD("month", DataTypes.STRING()),
+                                    DataTypes.FIELD("day", DataTypes.STRING()))
+                            .getLogicalType();
 
     /** A list of field delimiters to use in the tests. */
     private static final List<String> FIELD_DELIMITERS = Arrays.asList("", "|", ",", "--");
@@ -100,11 +99,10 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
 
     @Test
     public void testGoodPartitioner() {
-        CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE_AND_IP);
-
         for (String delimiter : FIELD_DELIMITERS) {
             RowDataFieldsKinesisPartitioner partitioner =
-                    new RowDataFieldsKinesisPartitioner(table, delimiter);
+                    new RowDataFieldsKinesisPartitioner(
+                            ROW_TYPE, PARTITION_BY_DATE_AND_IP, delimiter);
 
             for (LocalDateTime time : DATE_TIMES) {
                 String expectedKey = String.join(delimiter, String.valueOf(days(time)), IP);
@@ -117,8 +115,8 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
 
     @Test
     public void testGoodPartitionerExceedingMaxLength() {
-        CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_ROUTE);
-        RowDataFieldsKinesisPartitioner partitioner = new RowDataFieldsKinesisPartitioner(table);
+        RowDataFieldsKinesisPartitioner partitioner =
+                new RowDataFieldsKinesisPartitioner(ROW_TYPE, PARTITION_BY_ROUTE);
 
         String ip = "255.255.255.255";
         String route = "http://www.very-" + repeat("long-", 50) + "address.com/home";
@@ -132,15 +130,13 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
 
     @Test
     public void testGoodPartitionerWithStaticPrefix() {
-        CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE);
-
         // fixed prefix
         String year = String.valueOf(year(DATE_TIMES.get(0)));
         String month = String.valueOf(monthOfYear(DATE_TIMES.get(0)));
 
         for (String delimiter : FIELD_DELIMITERS) {
             RowDataFieldsKinesisPartitioner partitioner =
-                    new RowDataFieldsKinesisPartitioner(table, delimiter);
+                    new RowDataFieldsKinesisPartitioner(ROW_TYPE, PARTITION_BY_DATE, delimiter);
 
             partitioner.setStaticFields(
                     new HashMap<String, String>() {
@@ -162,15 +158,13 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
 
     @Test
     public void testGoodPartitionerWithStaticSuffix() {
-        CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE);
-
         // fixed suffix
         String month = String.valueOf(monthOfYear(DATE_TIMES.get(0)));
         String day = String.valueOf(dayOfMonth(DATE_TIMES.get(0)));
 
         for (String delimiter : FIELD_DELIMITERS) {
             RowDataFieldsKinesisPartitioner partitioner =
-                    new RowDataFieldsKinesisPartitioner(table, delimiter);
+                    new RowDataFieldsKinesisPartitioner(ROW_TYPE, PARTITION_BY_DATE, delimiter);
 
             partitioner.setStaticFields(
                     new HashMap<String, String>() {
@@ -192,14 +186,12 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
 
     @Test
     public void testGoodPartitionerWithStaticInfix() {
-        CatalogTable table = createTable(defaultTableOptions(), PARTITION_BY_DATE);
-
         // fixed infix
         String month = String.valueOf(monthOfYear(DATE_TIMES.get(0)));
 
         for (String delimiter : FIELD_DELIMITERS) {
             RowDataFieldsKinesisPartitioner partitioner =
-                    new RowDataFieldsKinesisPartitioner(table, delimiter);
+                    new RowDataFieldsKinesisPartitioner(ROW_TYPE, PARTITION_BY_DATE, delimiter);
 
             partitioner.setStaticFields(
                     new HashMap<String, String>() {
@@ -231,8 +223,7 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
                         new IllegalArgumentException(
                                 "Cannot create a RowDataFieldsKinesisPartitioner for a non-partitioned table")));
 
-        CatalogTable table = createTable(defaultTableOptions(), Collections.emptyList());
-        new RowDataFieldsKinesisPartitioner(table);
+        new RowDataFieldsKinesisPartitioner(ROW_TYPE, Collections.emptyList());
     }
 
     @Test
@@ -243,8 +234,7 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
                         new IllegalArgumentException(
                                 "The sequence of partition keys cannot contain duplicates")));
 
-        CatalogTable table = createTable(defaultTableOptions(), Arrays.asList("ip", "ip"));
-        new RowDataFieldsKinesisPartitioner(table);
+        new RowDataFieldsKinesisPartitioner(ROW_TYPE, Arrays.asList("ip", "ip"));
     }
 
     @Test
@@ -255,8 +245,7 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
                         new IllegalArgumentException(
                                 "The following partition keys are not present in the table: abc")));
 
-        CatalogTable table = createTable(defaultTableOptions(), Arrays.asList("ip", "abc"));
-        new RowDataFieldsKinesisPartitioner(table);
+        new RowDataFieldsKinesisPartitioner(ROW_TYPE, Arrays.asList("ip", "abc"));
     }
 
     @Test
@@ -267,8 +256,7 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
                         new IllegalArgumentException(
                                 "The following partition keys have types that are not supported by Kinesis: time")));
 
-        CatalogTable table = createTable(defaultTableOptions(), Arrays.asList("time", "ip"));
-        new RowDataFieldsKinesisPartitioner(table);
+        new RowDataFieldsKinesisPartitioner(ROW_TYPE, Arrays.asList("time", "ip"));
     }
 
     // --------------------------------------------------------------------------------------------
@@ -280,7 +268,7 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
     }
 
     private RowData createElement(LocalDateTime time, String ip, String route) {
-        GenericRowData element = new GenericRowData(TABLE_SCHEMA.getFieldCount());
+        GenericRowData element = new GenericRowData(ROW_TYPE.getFieldCount());
         element.setField(0, TimestampData.fromLocalDateTime(time));
         element.setField(1, StringData.fromString(ip));
         element.setField(2, StringData.fromString(route));
@@ -305,10 +293,6 @@ public class RowDataFieldsKinesisPartitionerTest extends TestLogger {
 
     private int dayOfMonth(LocalDateTime time) {
         return time.get(ChronoField.DAY_OF_MONTH);
-    }
-
-    private CatalogTable createTable(TableOptionsBuilder options, List<String> partitionKeys) {
-        return new CatalogTableImpl(TABLE_SCHEMA, partitionKeys, options.build(), TABLE_NAME);
     }
 
     private TableOptionsBuilder defaultTableOptions() {

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -20,15 +20,12 @@ package org.apache.flink.formats.avro.registry.confluent.debezium;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.TestDynamicTableFactory;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
@@ -45,6 +42,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
@@ -52,14 +51,14 @@ import static org.junit.Assert.assertThat;
 public class DebeziumAvroFormatFactoryTest extends TestLogger {
     @Rule public ExpectedException thrown = ExpectedException.none();
 
-    private static final TableSchema SCHEMA =
-            TableSchema.builder()
-                    .field("a", DataTypes.STRING())
-                    .field("b", DataTypes.INT())
-                    .field("c", DataTypes.BOOLEAN())
-                    .build();
+    private static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("a", DataTypes.STRING()),
+                    Column.physical("b", DataTypes.INT()),
+                    Column.physical("c", DataTypes.BOOLEAN()));
 
-    private static final RowType ROW_TYPE = (RowType) SCHEMA.toRowDataType().getLogicalType();
+    private static final RowType ROW_TYPE =
+            (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
 
     private static final String SUBJECT = "test-debezium-avro";
     private static final String REGISTRY_URL = "http://localhost:8081";
@@ -94,43 +93,23 @@ public class DebeziumAvroFormatFactoryTest extends TestLogger {
 
     private static DeserializationSchema<RowData> createDeserializationSchema(
             Map<String, String> options) {
-        final DynamicTableSource actualSource = createTableSource(options);
+        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
         assertThat(actualSource, instanceOf(TestDynamicTableFactory.DynamicTableSourceMock.class));
         TestDynamicTableFactory.DynamicTableSourceMock scanSourceMock =
                 (TestDynamicTableFactory.DynamicTableSourceMock) actualSource;
 
         return scanSourceMock.valueFormat.createRuntimeDecoder(
-                ScanRuntimeProviderContext.INSTANCE, SCHEMA.toRowDataType());
+                ScanRuntimeProviderContext.INSTANCE, SCHEMA.toPhysicalRowDataType());
     }
 
     private static SerializationSchema<RowData> createSerializationSchema(
             Map<String, String> options) {
-        final DynamicTableSink actualSink = createTableSink(options);
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
         assertThat(actualSink, instanceOf(TestDynamicTableFactory.DynamicTableSinkMock.class));
         TestDynamicTableFactory.DynamicTableSinkMock sinkMock =
                 (TestDynamicTableFactory.DynamicTableSinkMock) actualSink;
 
         return sinkMock.valueFormat.createRuntimeEncoder(
-                new SinkRuntimeProviderContext(false), SCHEMA.toRowDataType());
-    }
-
-    private static DynamicTableSource createTableSource(Map<String, String> options) {
-        return FactoryUtil.createTableSource(
-                null,
-                ObjectIdentifier.of("default", "default", "t1"),
-                new CatalogTableImpl(SCHEMA, options, "mock source"),
-                new Configuration(),
-                DebeziumAvroFormatFactoryTest.class.getClassLoader(),
-                false);
-    }
-
-    private static DynamicTableSink createTableSink(Map<String, String> options) {
-        return FactoryUtil.createTableSink(
-                null,
-                ObjectIdentifier.of("default", "default", "t1"),
-                new CatalogTableImpl(SCHEMA, options, "mock sink"),
-                new Configuration(),
-                DebeziumAvroFormatFactoryTest.class.getClassLoader(),
-                false);
+                new SinkRuntimeProviderContext(false), SCHEMA.toPhysicalRowDataType());
     }
 }

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/BlackHoleSinkFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/BlackHoleSinkFactoryTest.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.table.factories;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 import org.junit.Assert;
@@ -32,36 +30,26 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link BlackHoleTableSinkFactory}. */
 public class BlackHoleSinkFactoryTest {
 
-    private static final TableSchema TEST_SCHEMA =
-            TableSchema.builder()
-                    .field("f0", DataTypes.STRING())
-                    .field("f1", DataTypes.BIGINT())
-                    .field("f2", DataTypes.BIGINT())
-                    .build();
+    private static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("f0", DataTypes.STRING()),
+                    Column.physical("f1", DataTypes.BIGINT()),
+                    Column.physical("f2", DataTypes.BIGINT()));
 
     @Test
     public void testBlackHole() {
         Map<String, String> properties = new HashMap<>();
         properties.put("connector", "blackhole");
 
-        DynamicTableSink sink = createSink(properties);
+        DynamicTableSink sink = createTableSink(SCHEMA, properties);
 
         assertEquals("BlackHole", sink.asSummaryString());
-    }
-
-    private DynamicTableSink createSink(Map<String, String> properties) {
-        return FactoryUtil.createTableSink(
-                null,
-                ObjectIdentifier.of("", "", ""),
-                new CatalogTableImpl(TEST_SCHEMA, properties, ""),
-                new Configuration(),
-                Thread.currentThread().getContextClassLoader(),
-                false);
     }
 
     @Test
@@ -70,7 +58,7 @@ public class BlackHoleSinkFactoryTest {
             Map<String, String> properties = new HashMap<>();
             properties.put("connector", "blackhole");
             properties.put("unknown-key", "1");
-            createSink(properties);
+            createTableSink(SCHEMA, properties);
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
             Assert.assertTrue(cause.toString(), cause instanceof ValidationException);

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.factories;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSourceTest;
@@ -26,10 +25,9 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -44,7 +42,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.flink.table.factories.DataGenTableSourceFactory.END;
@@ -58,43 +55,43 @@ import static org.apache.flink.table.factories.DataGenTableSourceFactory.RANDOM;
 import static org.apache.flink.table.factories.DataGenTableSourceFactory.ROWS_PER_SECOND;
 import static org.apache.flink.table.factories.DataGenTableSourceFactory.SEQUENCE;
 import static org.apache.flink.table.factories.DataGenTableSourceFactory.START;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link DataGenTableSourceFactory}. */
 public class DataGenTableSourceFactoryTest {
 
-    private static final TableSchema TEST_SCHEMA =
-            TableSchema.builder()
-                    .field("f0", DataTypes.STRING())
-                    .field("f1", DataTypes.BIGINT())
-                    .field("f2", DataTypes.BIGINT())
-                    .build();
+    private static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("f0", DataTypes.STRING()),
+                    Column.physical("f1", DataTypes.BIGINT()),
+                    Column.physical("f2", DataTypes.BIGINT()));
 
     @Test
     public void testDataTypeCoverage() throws Exception {
-        TableSchema schema =
-                TableSchema.builder()
-                        .field("f0", DataTypes.CHAR(1))
-                        .field("f1", DataTypes.VARCHAR(10))
-                        .field("f2", DataTypes.STRING())
-                        .field("f3", DataTypes.BOOLEAN())
-                        .field("f4", DataTypes.DECIMAL(32, 2))
-                        .field("f5", DataTypes.TINYINT())
-                        .field("f6", DataTypes.SMALLINT())
-                        .field("f7", DataTypes.INT())
-                        .field("f8", DataTypes.BIGINT())
-                        .field("f9", DataTypes.FLOAT())
-                        .field("f10", DataTypes.DOUBLE())
-                        .field("f11", DataTypes.DATE())
-                        .field("f12", DataTypes.TIME())
-                        .field("f13", DataTypes.TIMESTAMP())
-                        .field("f14", DataTypes.TIMESTAMP_WITH_TIME_ZONE())
-                        .field("f15", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
-                        .field("f16", DataTypes.INTERVAL(DataTypes.DAY()))
-                        .field("f17", DataTypes.ARRAY(DataTypes.INT()))
-                        .field("f18", DataTypes.MAP(DataTypes.STRING(), DataTypes.DATE()))
-                        .field("f19", DataTypes.MULTISET(DataTypes.DECIMAL(32, 2)))
-                        .field(
+        ResolvedSchema schema =
+                ResolvedSchema.of(
+                        Column.physical("f0", DataTypes.CHAR(1)),
+                        Column.physical("f1", DataTypes.VARCHAR(10)),
+                        Column.physical("f2", DataTypes.STRING()),
+                        Column.physical("f3", DataTypes.BOOLEAN()),
+                        Column.physical("f4", DataTypes.DECIMAL(32, 2)),
+                        Column.physical("f5", DataTypes.TINYINT()),
+                        Column.physical("f6", DataTypes.SMALLINT()),
+                        Column.physical("f7", DataTypes.INT()),
+                        Column.physical("f8", DataTypes.BIGINT()),
+                        Column.physical("f9", DataTypes.FLOAT()),
+                        Column.physical("f10", DataTypes.DOUBLE()),
+                        Column.physical("f11", DataTypes.DATE()),
+                        Column.physical("f12", DataTypes.TIME()),
+                        Column.physical("f13", DataTypes.TIMESTAMP()),
+                        Column.physical("f14", DataTypes.TIMESTAMP_WITH_TIME_ZONE()),
+                        Column.physical("f15", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()),
+                        Column.physical("f16", DataTypes.INTERVAL(DataTypes.DAY())),
+                        Column.physical("f17", DataTypes.ARRAY(DataTypes.INT())),
+                        Column.physical("f18", DataTypes.MAP(DataTypes.STRING(), DataTypes.DATE())),
+                        Column.physical("f19", DataTypes.MULTISET(DataTypes.DECIMAL(32, 2))),
+                        Column.physical(
                                 "f20",
                                 DataTypes.ROW(
                                         DataTypes.FIELD("a", DataTypes.BIGINT()),
@@ -103,8 +100,7 @@ public class DataGenTableSourceFactoryTest {
                                                 "c",
                                                 DataTypes.ROW(
                                                         DataTypes.FIELD(
-                                                                "d", DataTypes.TIMESTAMP())))))
-                        .build();
+                                                                "d", DataTypes.TIMESTAMP()))))));
 
         DescriptorProperties descriptor = new DescriptorProperties();
         descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
@@ -116,7 +112,7 @@ public class DataGenTableSourceFactoryTest {
         for (RowData row : results) {
             for (int i = 0; i < row.getArity(); i++) {
                 Assert.assertFalse(
-                        "Column " + schema.getFieldNames()[i] + " should not be null",
+                        "Column " + schema.getColumnNames().get(i) + " should not be null",
                         row.isNullAt(i));
             }
         }
@@ -139,7 +135,7 @@ public class DataGenTableSourceFactoryTest {
         descriptor.putLong(FIELDS + ".f2." + START, 50);
         descriptor.putLong(FIELDS + ".f2." + END, 60);
 
-        List<RowData> results = runGenerator(TEST_SCHEMA, descriptor);
+        List<RowData> results = runGenerator(SCHEMA, descriptor);
 
         Assert.assertEquals(11, results.size());
         for (int i = 0; i < results.size(); i++) {
@@ -151,9 +147,9 @@ public class DataGenTableSourceFactoryTest {
         }
     }
 
-    private List<RowData> runGenerator(TableSchema schema, DescriptorProperties descriptor)
+    private List<RowData> runGenerator(ResolvedSchema schema, DescriptorProperties descriptor)
             throws Exception {
-        DynamicTableSource source = createSource(schema, descriptor.asMap());
+        DynamicTableSource source = createTableSource(schema, descriptor.asMap());
 
         assertTrue(source instanceof DataGenTableSource);
 
@@ -184,8 +180,8 @@ public class DataGenTableSourceFactoryTest {
         descriptor.putLong(FIELDS + ".f0." + END, 100);
 
         DynamicTableSource dynamicTableSource =
-                createSource(
-                        TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+                createTableSource(
+                        ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                         descriptor.asMap());
 
         DataGenTableSource dataGenTableSource = (DataGenTableSource) dynamicTableSource;
@@ -216,8 +212,8 @@ public class DataGenTableSourceFactoryTest {
             descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
             descriptor.putLong(FIELDS + ".f0." + END, 100);
 
-            createSource(
-                    TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+            createTableSource(
+                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                     descriptor.asMap());
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
@@ -240,8 +236,8 @@ public class DataGenTableSourceFactoryTest {
             descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
             descriptor.putLong(FIELDS + ".f0." + START, 0);
 
-            createSource(
-                    TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+            createTableSource(
+                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                     descriptor.asMap());
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
@@ -263,8 +259,8 @@ public class DataGenTableSourceFactoryTest {
             descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
             descriptor.putLong("wrong-rows-per-second", 1);
 
-            createSource(
-                    TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+            createTableSource(
+                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                     descriptor.asMap());
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
@@ -285,8 +281,8 @@ public class DataGenTableSourceFactoryTest {
             descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
             descriptor.putLong(FIELDS + ".f0." + START, 0);
 
-            createSource(
-                    TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+            createTableSource(
+                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                     descriptor.asMap());
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
@@ -307,8 +303,8 @@ public class DataGenTableSourceFactoryTest {
             descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
             descriptor.putInt(FIELDS + ".f0." + LENGTH, 100);
 
-            createSource(
-                    TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+            createTableSource(
+                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                     descriptor.asMap());
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
@@ -330,8 +326,8 @@ public class DataGenTableSourceFactoryTest {
             descriptor.putString(FIELDS + ".f0." + START, "Wrong");
             descriptor.putString(FIELDS + ".f0." + END, "Wrong");
 
-            createSource(
-                    TableSchema.builder().field("f0", DataTypes.BIGINT()).build(),
+            createTableSource(
+                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
                     descriptor.asMap());
         } catch (ValidationException e) {
             Throwable cause = e.getCause();
@@ -343,17 +339,6 @@ public class DataGenTableSourceFactoryTest {
             return;
         }
         Assert.fail("Should fail by ValidationException.");
-    }
-
-    private static DynamicTableSource createSource(
-            TableSchema schema, Map<String, String> options) {
-        return FactoryUtil.createTableSource(
-                null,
-                ObjectIdentifier.of("", "", ""),
-                new CatalogTableImpl(schema, options, ""),
-                new Configuration(),
-                Thread.currentThread().getContextClassLoader(),
-                false);
     }
 
     private static class TestContext implements SourceFunction.SourceContext<RowData> {

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/PrintSinkFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/PrintSinkFactoryTest.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.table.factories;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 import org.junit.Assert;
@@ -33,16 +31,16 @@ import java.util.Map;
 
 import static org.apache.flink.table.factories.PrintTableSinkFactory.PRINT_IDENTIFIER;
 import static org.apache.flink.table.factories.PrintTableSinkFactory.STANDARD_ERROR;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 
 /** Tests for {@link PrintTableSinkFactory}. */
 public class PrintSinkFactoryTest {
 
-    private static final TableSchema TEST_SCHEMA =
-            TableSchema.builder()
-                    .field("f0", DataTypes.STRING())
-                    .field("f1", DataTypes.BIGINT())
-                    .field("f2", DataTypes.BIGINT())
-                    .build();
+    private static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("f0", DataTypes.STRING()),
+                    Column.physical("f1", DataTypes.BIGINT()),
+                    Column.physical("f2", DataTypes.BIGINT()));
 
     @Test
     public void testPrint() {
@@ -51,14 +49,7 @@ public class PrintSinkFactoryTest {
         properties.put(PRINT_IDENTIFIER.key(), "my_print");
         properties.put(STANDARD_ERROR.key(), "true");
 
-        DynamicTableSink sink =
-                FactoryUtil.createTableSink(
-                        null,
-                        ObjectIdentifier.of("", "", ""),
-                        new CatalogTableImpl(TEST_SCHEMA, properties, ""),
-                        new Configuration(),
-                        Thread.currentThread().getContextClassLoader(),
-                        false);
+        DynamicTableSink sink = createTableSink(SCHEMA, properties);
         Assert.assertEquals("Print to System.err", sink.asSummaryString());
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -866,7 +866,9 @@ public final class CatalogManager {
                 "Unknown kind of catalog base table: " + baseTable.getClass());
     }
 
-    private ResolvedCatalogTable resolveCatalogTable(CatalogTable table) {
+    /** Resolves a {@link CatalogTable} to a validated {@link ResolvedCatalogTable}. */
+    public ResolvedCatalogTable resolveCatalogTable(CatalogTable table) {
+        Preconditions.checkState(schemaResolver != null, "Schema resolver is not initialized.");
         if (table instanceof ResolvedCatalogTable) {
             return (ResolvedCatalogTable) table;
         }
@@ -874,7 +876,9 @@ public final class CatalogManager {
         return new ResolvedCatalogTable(table, resolvedSchema);
     }
 
-    private ResolvedCatalogView resolveCatalogView(CatalogView view) {
+    /** Resolves a {@link CatalogView} to a validated {@link ResolvedCatalogView}. */
+    public ResolvedCatalogView resolveCatalogView(CatalogView view) {
+        Preconditions.checkState(schemaResolver != null, "Schema resolver is not initialized.");
         if (view instanceof ResolvedCatalogView) {
             return (ResolvedCatalogView) view;
         }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/DefaultSchemaResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/DefaultSchemaResolver.java
@@ -221,7 +221,7 @@ class DefaultSchemaResolver implements SchemaResolver {
         validateWatermarkExpression(watermarkExpression.getOutputDataType().getLogicalType());
 
         return Collections.singletonList(
-                new WatermarkSpec(watermarkSpec.getColumnName(), watermarkExpression));
+                WatermarkSpec.of(watermarkSpec.getColumnName(), watermarkExpression));
     }
 
     private void validateTimeColumn(String columnName, List<Column> columns) {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -105,7 +105,7 @@ public class CatalogBaseTableResolutionTest {
                             Column.metadata("topic", DataTypes.VARCHAR(200), null, true),
                             Column.metadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp", false),
                             Column.computed("ts", COMPUTED_COLUMN_RESOLVED)),
-                    Collections.singletonList(new WatermarkSpec("ts", WATERMARK_RESOLVED)),
+                    Collections.singletonList(WatermarkSpec.of("ts", WATERMARK_RESOLVED)),
                     UniqueConstraint.primaryKey(
                             "primary_constraint", Collections.singletonList("id")));
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/SchemaResolutionTest.java
@@ -98,7 +98,7 @@ public class SchemaResolutionTest {
                                 Column.metadata(
                                         "orig_ts", DataTypes.TIMESTAMP(3), "timestamp", false),
                                 Column.computed("proctime", PROCTIME_RESOLVED)),
-                        Collections.singletonList(new WatermarkSpec("ts", WATERMARK_RESOLVED)),
+                        Collections.singletonList(WatermarkSpec.of("ts", WATERMARK_RESOLVED)),
                         UniqueConstraint.primaryKey(
                                 "primary_constraint", Collections.singletonList("id")));
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
@@ -53,6 +53,9 @@ import static org.apache.flink.table.types.utils.DataTypeUtils.removeTimeAttribu
  *   <li>{@link Expression}s have been translated to {@link ResolvedExpression}.
  *   <li>{@link AbstractDataType}s have been translated to {@link DataType}.
  * </ul>
+ *
+ * <p>This class should not be passed into a connector. It is therefore also not serializable.
+ * Instead, the {@link #toPhysicalRowDataType()} can be passed around where necessary.
  */
 @PublicEvolving
 public final class ResolvedSchema {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/WatermarkSpec.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/WatermarkSpec.java
@@ -39,11 +39,16 @@ public final class WatermarkSpec {
 
     private final ResolvedExpression watermarkExpression;
 
-    public WatermarkSpec(String rowtimeAttribute, ResolvedExpression watermarkExpression) {
+    private WatermarkSpec(String rowtimeAttribute, ResolvedExpression watermarkExpression) {
         this.rowtimeAttribute =
                 checkNotNull(rowtimeAttribute, "Rowtime attribute must not be null.");
         this.watermarkExpression =
                 checkNotNull(watermarkExpression, "Watermark expression must not be null.");
+    }
+
+    public static WatermarkSpec of(
+            String rowtimeAttribute, ResolvedExpression watermarkExpression) {
+        return new WatermarkSpec(rowtimeAttribute, watermarkExpression);
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/DynamicTableFactory.java
@@ -21,8 +21,9 @@ package org.apache.flink.table.factories;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 
@@ -49,8 +50,28 @@ public interface DynamicTableFactory extends Factory {
         /** Returns the identifier of the table in the {@link Catalog}. */
         ObjectIdentifier getObjectIdentifier();
 
-        /** Returns table information received from the {@link Catalog}. */
-        CatalogTable getCatalogTable();
+        /**
+         * Returns the resolved table information received from the {@link Catalog}.
+         *
+         * <p>The {@link ResolvedCatalogTable} forwards the metadata from the catalog but offers a
+         * validated {@link ResolvedSchema}. The original metadata object is available via {@link
+         * ResolvedCatalogTable#getOrigin()}.
+         *
+         * <p>In most cases, a factory is interested in the following two characteristics:
+         *
+         * <pre>{@code
+         * // get the physical data type to initialize the connector
+         * context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType()
+         *
+         * // get primary key information if the connector supports upserts
+         * context.getCatalogTable().getResolvedSchema().getPrimaryKey()
+         * }</pre>
+         *
+         * <p>Other characteristics such as metadata columns or watermarks will be pushed down into
+         * the created {@link DynamicTableSource} or {@link DynamicTableSink} during planning
+         * depending on the implemented ability interfaces.
+         */
+        ResolvedCatalogTable getCatalogTable();
 
         /** Gives read-only access to the configuration of the current session. */
         ReadableConfig getConfiguration();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -106,7 +107,7 @@ public final class FactoryUtil {
     public static DynamicTableSource createTableSource(
             @Nullable Catalog catalog,
             ObjectIdentifier objectIdentifier,
-            CatalogTable catalogTable,
+            ResolvedCatalogTable catalogTable,
             ReadableConfig configuration,
             ClassLoader classLoader,
             boolean isTemporary) {
@@ -140,7 +141,7 @@ public final class FactoryUtil {
     public static DynamicTableSink createTableSink(
             @Nullable Catalog catalog,
             ObjectIdentifier objectIdentifier,
-            CatalogTable catalogTable,
+            ResolvedCatalogTable catalogTable,
             ReadableConfig configuration,
             ClassLoader classLoader,
             boolean isTemporary) {
@@ -205,8 +206,9 @@ public final class FactoryUtil {
      *
      * <p>This method is meant for cases where {@link #createTableFactoryHelper(DynamicTableFactory,
      * DynamicTableFactory.Context)} {@link #createTableSource(Catalog, ObjectIdentifier,
-     * CatalogTable, ReadableConfig, ClassLoader, boolean)}, and {@link #createTableSink(Catalog,
-     * ObjectIdentifier, CatalogTable, ReadableConfig, ClassLoader, boolean)} are not applicable.
+     * ResolvedCatalogTable, ReadableConfig, ClassLoader, boolean)}, and {@link
+     * #createTableSink(Catalog, ObjectIdentifier, ResolvedCatalogTable, ReadableConfig,
+     * ClassLoader, boolean)} are not applicable.
      */
     @SuppressWarnings("unchecked")
     public static <T extends Factory> T discoverFactory(
@@ -630,14 +632,14 @@ public final class FactoryUtil {
     public static class DefaultDynamicTableContext implements DynamicTableFactory.Context {
 
         private final ObjectIdentifier objectIdentifier;
-        private final CatalogTable catalogTable;
+        private final ResolvedCatalogTable catalogTable;
         private final ReadableConfig configuration;
         private final ClassLoader classLoader;
         private final boolean isTemporary;
 
         public DefaultDynamicTableContext(
                 ObjectIdentifier objectIdentifier,
-                CatalogTable catalogTable,
+                ResolvedCatalogTable catalogTable,
                 ReadableConfig configuration,
                 ClassLoader classLoader,
                 boolean isTemporary) {
@@ -654,7 +656,7 @@ public final class FactoryUtil {
         }
 
         @Override
-        public CatalogTable getCatalogTable() {
+        public ResolvedCatalogTable getCatalogTable() {
             return catalogTable;
         }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/utils/ResolvedExpressionMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/utils/ResolvedExpressionMock.java
@@ -39,6 +39,10 @@ public class ResolvedExpressionMock implements ResolvedExpression {
         this.stringRepresentation = stringRepresentation;
     }
 
+    public static ResolvedExpression of(DataType outputDataType, String stringRepresentation) {
+        return new ResolvedExpressionMock(outputDataType, () -> stringRepresentation);
+    }
+
     @Override
     public String asSummaryString() {
         return stringRepresentation.get();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.table.factories;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSinkMock;
@@ -43,6 +41,9 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
+import static org.apache.flink.table.factories.utils.FactoryMocks.SCHEMA;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -168,14 +169,14 @@ public class FactoryUtilTest {
     @Test
     public void testAllOptions() {
         final Map<String, String> options = createAllOptions();
-        final DynamicTableSource actualSource = createTableSource(options);
+        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
         final DynamicTableSource expectedSource =
                 new DynamicTableSourceMock(
                         "MyTarget",
                         new DecodingFormatMock(",", false),
                         new DecodingFormatMock("|", true));
         assertEquals(expectedSource, actualSource);
-        final DynamicTableSink actualSink = createTableSink(options);
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
         final DynamicTableSink expectedSink =
                 new DynamicTableSinkMock(
                         "MyTarget",
@@ -192,7 +193,7 @@ public class FactoryUtilTest {
         // see TestDynamicTableSinkFactory and TestDynamicTableSourceFactory
         options.put("connector", "test");
 
-        final DynamicTableSource actualSource = createTableSource(options);
+        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
         final DynamicTableSource expectedSource =
                 new DynamicTableSourceMock(
                         "MyTarget",
@@ -200,7 +201,7 @@ public class FactoryUtilTest {
                         new DecodingFormatMock("|", true));
         assertEquals(expectedSource, actualSource);
 
-        final DynamicTableSink actualSink = createTableSink(options);
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
         final DynamicTableSink expectedSink =
                 new DynamicTableSinkMock(
                         "MyTarget",
@@ -215,11 +216,11 @@ public class FactoryUtilTest {
         final Map<String, String> options = createAllOptions();
         options.remove("key.format");
         options.remove("key.test-format.delimiter");
-        final DynamicTableSource actualSource = createTableSource(options);
+        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
         final DynamicTableSource expectedSource =
                 new DynamicTableSourceMock("MyTarget", null, new DecodingFormatMock("|", true));
         assertEquals(expectedSource, actualSource);
-        final DynamicTableSink actualSink = createTableSink(options);
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
         final DynamicTableSink expectedSink =
                 new DynamicTableSinkMock("MyTarget", 1000L, null, new EncodingFormatMock("|"));
         assertEquals(expectedSink, actualSink);
@@ -234,14 +235,14 @@ public class FactoryUtilTest {
         options.put("format", "test-format");
         options.put("test-format.delimiter", ";");
         options.put("test-format.fail-on-missing", "true");
-        final DynamicTableSource actualSource = createTableSource(options);
+        final DynamicTableSource actualSource = createTableSource(SCHEMA, options);
         final DynamicTableSource expectedSource =
                 new DynamicTableSourceMock(
                         "MyTarget",
                         new DecodingFormatMock(",", false),
                         new DecodingFormatMock(";", true));
         assertEquals(expectedSource, actualSource);
-        final DynamicTableSink actualSink = createTableSink(options);
+        final DynamicTableSink actualSink = createTableSink(SCHEMA, options);
         final DynamicTableSink expectedSink =
                 new DynamicTableSinkMock(
                         "MyTarget",
@@ -254,7 +255,7 @@ public class FactoryUtilTest {
     @Test
     public void testConnectorErrorHint() {
         try {
-            createTableSource(Collections.singletonMap("connector", "sink-only"));
+            createTableSource(SCHEMA, Collections.singletonMap("connector", "sink-only"));
             fail();
         } catch (Exception e) {
             String errorMsg =
@@ -263,7 +264,7 @@ public class FactoryUtilTest {
         }
 
         try {
-            createTableSink(Collections.singletonMap("connector", "source-only"));
+            createTableSink(SCHEMA, Collections.singletonMap("connector", "source-only"));
             fail();
         } catch (Exception e) {
             String errorMsg =
@@ -282,7 +283,7 @@ public class FactoryUtilTest {
     private static void testError(Consumer<Map<String, String>> optionModifier) {
         final Map<String, String> options = createAllOptions();
         optionModifier.accept(options);
-        createTableSource(options);
+        createTableSource(SCHEMA, options);
     }
 
     private static Map<String, String> createAllOptions() {
@@ -298,26 +299,6 @@ public class FactoryUtilTest {
         options.put("value.test-format.delimiter", "|");
         options.put("value.test-format.fail-on-missing", "true");
         return options;
-    }
-
-    private static DynamicTableSource createTableSource(Map<String, String> options) {
-        return FactoryUtil.createTableSource(
-                null,
-                ObjectIdentifier.of("cat", "db", "table"),
-                new CatalogTableMock(options),
-                new Configuration(),
-                FactoryUtilTest.class.getClassLoader(),
-                false);
-    }
-
-    private static DynamicTableSink createTableSink(Map<String, String> options) {
-        return FactoryUtil.createTableSink(
-                null,
-                ObjectIdentifier.of("cat", "db", "table"),
-                new CatalogTableMock(options),
-                new Configuration(),
-                FactoryUtilTest.class.getClassLoader(),
-                false);
     }
 
     private static class CatalogTableMock implements CatalogTable {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/utils/FactoryMocks.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Utilities for testing instances usually created by {@link FactoryUtil}. */
+public final class FactoryMocks {
+
+    public static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("a", DataTypes.STRING()),
+                    Column.physical("b", DataTypes.INT()),
+                    Column.physical("c", DataTypes.BOOLEAN()));
+
+    public static final DataType PHYSICAL_DATA_TYPE = SCHEMA.toPhysicalRowDataType();
+
+    public static final RowType PHYSICAL_TYPE = (RowType) PHYSICAL_DATA_TYPE.getLogicalType();
+
+    public static final ObjectIdentifier IDENTIFIER =
+            ObjectIdentifier.of("default", "default", "t1");
+
+    public static DynamicTableSource createTableSource(
+            ResolvedSchema schema, Map<String, String> options) {
+        return FactoryUtil.createTableSource(
+                null,
+                IDENTIFIER,
+                new ResolvedCatalogTable(
+                        CatalogTable.of(
+                                Schema.newBuilder().fromResolvedSchema(schema).build(),
+                                "mock source",
+                                Collections.emptyList(),
+                                options),
+                        schema),
+                new Configuration(),
+                FactoryMocks.class.getClassLoader(),
+                false);
+    }
+
+    public static DynamicTableSink createTableSink(
+            ResolvedSchema schema, Map<String, String> options) {
+        return createTableSink(schema, Collections.emptyList(), options);
+    }
+
+    public static DynamicTableSink createTableSink(
+            ResolvedSchema schema, List<String> partitionKeys, Map<String, String> options) {
+        return FactoryUtil.createTableSink(
+                null,
+                IDENTIFIER,
+                new ResolvedCatalogTable(
+                        CatalogTable.of(
+                                Schema.newBuilder().fromResolvedSchema(schema).build(),
+                                "mock sink",
+                                partitionKeys,
+                                options),
+                        schema),
+                new Configuration(),
+                FactoryMocks.class.getClassLoader(),
+                false);
+    }
+
+    public static DynamicTableFactory.Context createTableContext(
+            ResolvedSchema schema, Map<String, String> options) {
+        return new FactoryUtil.DefaultDynamicTableContext(
+                IDENTIFIER,
+                new ResolvedCatalogTable(
+                        CatalogTable.of(
+                                Schema.newBuilder().fromResolvedSchema(schema).build(),
+                                "mock context",
+                                Collections.emptyList(),
+                                options),
+                        schema),
+                new Configuration(),
+                FactoryMocks.class.getClassLoader(),
+                false);
+    }
+
+    private FactoryMocks() {
+        // no instantiation
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/CatalogTableJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/CatalogTableJsonDeserializer.java
@@ -54,6 +54,6 @@ public class CatalogTableJsonDeserializer extends StdDeserializer<ResolvedCatalo
 
         final CatalogTable unresolvedTable = CatalogTable.fromProperties(catalogProperties);
 
-        return (ResolvedCatalogTable) catalogManager.resolveCatalogBaseTable(unresolvedTable);
+        return catalogManager.resolveCatalogTable(unresolvedTable);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
@@ -246,7 +246,7 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
     }
 
     private DynamicTableSource createDynamicTableSource(
-            FlinkContext context, CatalogTable catalogTable) {
+            FlinkContext context, ResolvedCatalogTable catalogTable) {
         final ReadableConfig config = context.getTableConfig().getConfiguration();
         return FactoryUtil.createTableSource(
                 schemaTable.getCatalog(),


### PR DESCRIPTION
## What is the purpose of the change

This complete FLIP-164 by updating `DynamicTableFactory.Context`. The change mostly impacts tests. It should not have a big impact on API users.

## Brief change log

- Introduce `FactoryMocks` as a utility for tests
- Update `FactoryUtil` and `DynamicTableFactory.Context` with `ResolvedCatalogTable`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
