### PR TITLE
[FLINK-21868][table-planner-blink]Support StreamExecLookupJoin json serialization/deserialization

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.planner.plan.utils.LookupJoinUtil;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -42,10 +41,8 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
             @Nullable RexNode joinCondition,
             TemporalTableSourceSpec temporalTableSourceSpec,
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
-            boolean existCalcOnTemporalTable,
-            @Nullable RelDataType calcOnTemporalTableOutputRowType,
-            @Nullable List<RexNode> calcOnTemporalTableProjections,
-            @Nullable RexNode calcOnTemporalTableCondition,
+            @Nullable List<RexNode> projectionOnTemporalTable,
+            @Nullable RexNode filterOnTemporalTable,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
@@ -54,10 +51,8 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
                 joinCondition,
                 temporalTableSourceSpec,
                 lookupKeys,
-                existCalcOnTemporalTable,
-                calcOnTemporalTableOutputRowType,
-                calcOnTemporalTableProjections,
-                calcOnTemporalTableCondition,
+                projectionOnTemporalTable,
+                filterOnTemporalTable,
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),
                 outputType,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -21,16 +21,18 @@ package org.apache.flink.table.planner.plan.nodes.exec.batch;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLookupJoin;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.TemporalTableSourceSpec;
 import org.apache.flink.table.planner.plan.utils.LookupJoinUtil;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexProgram;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /** {@link BatchExecNode} for temporal table join that implemented by lookup. */
@@ -38,19 +40,26 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
     public BatchExecLookupJoin(
             FlinkJoinType joinType,
             @Nullable RexNode joinCondition,
-            RelOptTable temporalTable,
-            @Nullable RexProgram calcOnTemporalTable,
+            TemporalTableSourceSpec temporalTableSourceSpec,
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
+            boolean existCalcOnTemporalTable,
+            @Nullable RelDataType calcOnTemporalTableOutputRowType,
+            @Nullable List<RexNode> calcOnTemporalTableProjections,
+            @Nullable RexNode calcOnTemporalTableCondition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
         super(
                 joinType,
                 joinCondition,
-                temporalTable,
-                calcOnTemporalTable,
+                temporalTableSourceSpec,
                 lookupKeys,
-                inputProperty,
+                existCalcOnTemporalTable,
+                calcOnTemporalTableOutputRowType,
+                calcOnTemporalTableProjections,
+                calcOnTemporalTableCondition,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
                 outputType,
                 description);
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecTableSour
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin;
-import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitorImpl;
@@ -240,26 +239,22 @@ public class ExecNodeGraphJsonPlanGenerator {
                             ((CommonExecSink) execNode).getTableSinkSpec();
                     tableSinkSpec.setReadableConfig(serdeCtx.getConfiguration());
                     tableSinkSpec.setClassLoader(serdeCtx.getClassLoader());
+                } else if (execNode instanceof StreamExecLookupJoin) {
+                    StreamExecLookupJoin streamExecLookupJoin = (StreamExecLookupJoin) execNode;
+                    if (null == streamExecLookupJoin.getTemporalTableSourceSpec()) {
+                        throw new TableException(
+                                "temporalTable can't be null, please check corresponding node.");
+                    }
+                    streamExecLookupJoin
+                            .getTemporalTableSourceSpec()
+                            .getTableSourceSpec()
+                            .setReadableConfig(serdeCtx.getConfiguration());
+                    streamExecLookupJoin
+                            .getTemporalTableSourceSpec()
+                            .getTableSourceSpec()
+                            .setClassLoader(serdeCtx.getClassLoader());
                 }
                 idToExecNodes.put(id, execNode);
-                if (execNode instanceof StreamExecTableSourceScan) {
-                    ((StreamExecTableSourceScan) execNode)
-                            .getTableSourceSpec()
-                            .setReadableConfig(serdeCtx.getConfiguration());
-                    ((StreamExecTableSourceScan) execNode)
-                            .getTableSourceSpec()
-                            .setClassLoader(serdeCtx.getClassLoader());
-                }
-                if (execNode instanceof StreamExecLookupJoin) {
-                    ((StreamExecLookupJoin) execNode)
-                            .getTemporalTableSourceSpec()
-                            .getTableSourceSpec()
-                            .setReadableConfig(serdeCtx.getConfiguration());
-                    ((StreamExecLookupJoin) execNode)
-                            .getTemporalTableSourceSpec()
-                            .getTableSourceSpec()
-                            .setClassLoader(serdeCtx.getClassLoader());
-                }
             }
             Map<Integer, List<ExecEdge>> idToInputEdges = new HashMap<>();
             Map<Integer, List<ExecEdge>> idToOutputEdges = new HashMap<>();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecSink;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecTableSourceScan;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
@@ -246,6 +247,16 @@ public class ExecNodeGraphJsonPlanGenerator {
                             .getTableSourceSpec()
                             .setReadableConfig(serdeCtx.getConfiguration());
                     ((StreamExecTableSourceScan) execNode)
+                            .getTableSourceSpec()
+                            .setClassLoader(serdeCtx.getClassLoader());
+                }
+                if (execNode instanceof StreamExecLookupJoin) {
+                    ((StreamExecLookupJoin) execNode)
+                            .getTemporalTableSourceSpec()
+                            .getTableSourceSpec()
+                            .setReadableConfig(serdeCtx.getConfiguration());
+                    ((StreamExecLookupJoin) execNode)
+                            .getTemporalTableSourceSpec()
                             .getTableSourceSpec()
                             .setClassLoader(serdeCtx.getClassLoader());
                 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -130,4 +130,10 @@ public class DynamicTableSourceSpec extends CatalogTableSpecBase {
     public void setTableSource(DynamicTableSource tableSource) {
         this.tableSource = tableSource;
     }
+
+    @JsonIgnore
+    @Nullable
+    public List<SourceAbilitySpec> getSourceAbilitySpecs() {
+        return sourceAbilitySpecs;
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.spec;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -48,16 +47,16 @@ import java.util.Arrays;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TemporalTableSourceSpec {
-    public static final String FIELD_NAME_SCAN_TABLE_SOURCE = "scanTableSource";
-    public static final String FIELD_NAME_ROW_TYPE = "rowType";
+    public static final String FIELD_NAME_LOOK_UP_TABLE_SOURCE = "lookupTableSource";
+    public static final String FIELD_NAME_OUTPUT_TYPE = "outputType";
 
-    @JsonProperty(FIELD_NAME_SCAN_TABLE_SOURCE)
+    @JsonProperty(FIELD_NAME_LOOK_UP_TABLE_SOURCE)
     @Nullable
     private DynamicTableSourceSpec tableSourceSpec;
 
-    @JsonProperty(FIELD_NAME_ROW_TYPE)
+    @JsonProperty(FIELD_NAME_OUTPUT_TYPE)
     @Nullable
-    private RelDataType rowType;
+    private RelDataType outputType;
 
     @JsonIgnore private RelOptTable temporalTable;
 
@@ -65,7 +64,7 @@ public class TemporalTableSourceSpec {
         this.temporalTable = temporalTable;
         if (temporalTable instanceof TableSourceTable) {
             TableSourceTable tableSourceTable = (TableSourceTable) temporalTable;
-            rowType = tableSourceTable.getRowType();
+            outputType = tableSourceTable.getRowType();
             this.tableSourceSpec =
                     new DynamicTableSourceSpec(
                             tableSourceTable.tableIdentifier(),
@@ -78,11 +77,11 @@ public class TemporalTableSourceSpec {
 
     @JsonCreator
     public TemporalTableSourceSpec(
-            @JsonProperty(FIELD_NAME_SCAN_TABLE_SOURCE) @Nullable
+            @JsonProperty(FIELD_NAME_LOOK_UP_TABLE_SOURCE) @Nullable
                     DynamicTableSourceSpec dynamicTableSourceSpec,
-            @JsonProperty(FIELD_NAME_ROW_TYPE) @Nullable RelDataType rowType) {
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) @Nullable RelDataType outputType) {
         this.tableSourceSpec = dynamicTableSourceSpec;
-        this.rowType = rowType;
+        this.outputType = outputType;
     }
 
     @JsonIgnore
@@ -90,7 +89,7 @@ public class TemporalTableSourceSpec {
         if (null != temporalTable) {
             return temporalTable;
         }
-        if (null != tableSourceSpec && null != rowType) {
+        if (null != tableSourceSpec && null != outputType) {
             LookupTableSource lookupTableSource = tableSourceSpec.getLookupTableSource(planner);
             ObjectIdentifier objectIdentifier = tableSourceSpec.getObjectIdentifier();
             ResolvedCatalogTable catalogTable = tableSourceSpec.getCatalogTable();
@@ -102,7 +101,7 @@ public class TemporalTableSourceSpec {
             return new TableSourceTable(
                     null,
                     objectIdentifier,
-                    rowType,
+                    outputType,
                     FlinkStatistic.UNKNOWN(),
                     lookupTableSource,
                     true,
@@ -114,14 +113,14 @@ public class TemporalTableSourceSpec {
     }
 
     @JsonIgnore
-    @VisibleForTesting
+    @Nullable
     public DynamicTableSourceSpec getTableSourceSpec() {
         return tableSourceSpec;
     }
 
     @JsonIgnore
-    @VisibleForTesting
-    public RelDataType getRowType() {
-        return rowType;
+    @Nullable
+    public RelDataType getOutputType() {
+        return outputType;
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.spec;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.type.RelDataType;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * TemporalTableSpec describes how the right tale of lookupJoin ser/des.
+ *
+ * <p>This class corresponds to {@link org.apache.calcite.plan.RelOptTable} rel node.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TemporalTableSourceSpec {
+    public static final String FIELD_NAME_SCAN_TABLE_SOURCE = "scanTableSource";
+    public static final String FIELD_NAME_ROW_TYPE = "rowType";
+
+    @JsonProperty(FIELD_NAME_SCAN_TABLE_SOURCE)
+    @Nullable
+    private DynamicTableSourceSpec tableSourceSpec;
+
+    @JsonProperty(FIELD_NAME_ROW_TYPE)
+    @Nullable
+    private RelDataType rowType;
+
+    @JsonIgnore private RelOptTable temporalTable;
+
+    public TemporalTableSourceSpec(RelOptTable temporalTable, TableConfig tableConfig) {
+        this.temporalTable = temporalTable;
+        if (temporalTable instanceof TableSourceTable) {
+            TableSourceTable tableSourceTable = (TableSourceTable) temporalTable;
+            rowType = tableSourceTable.getRowType();
+            this.tableSourceSpec =
+                    new DynamicTableSourceSpec(
+                            tableSourceTable.tableIdentifier(),
+                            tableSourceTable.catalogTable(),
+                            Arrays.asList(tableSourceTable.abilitySpecs()));
+            tableSourceSpec.setTableSource(tableSourceTable.tableSource());
+            tableSourceSpec.setReadableConfig(tableConfig.getConfiguration());
+        }
+    }
+
+    @JsonCreator
+    public TemporalTableSourceSpec(
+            @JsonProperty(FIELD_NAME_SCAN_TABLE_SOURCE) @Nullable
+                    DynamicTableSourceSpec dynamicTableSourceSpec,
+            @JsonProperty(FIELD_NAME_ROW_TYPE) @Nullable RelDataType rowType) {
+        this.tableSourceSpec = dynamicTableSourceSpec;
+        this.rowType = rowType;
+    }
+
+    @JsonIgnore
+    public RelOptTable getTemporalTable(PlannerBase planner) {
+        if (null != temporalTable) {
+            return temporalTable;
+        }
+        if (null != tableSourceSpec && null != rowType) {
+            LookupTableSource lookupTableSource = tableSourceSpec.getLookupTableSource(planner);
+            ObjectIdentifier objectIdentifier = tableSourceSpec.getObjectIdentifier();
+            ResolvedCatalogTable catalogTable = tableSourceSpec.getCatalogTable();
+            SourceAbilitySpec[] sourceAbilitySpecs = null;
+            if (null != tableSourceSpec.getSourceAbilitySpecs()) {
+                sourceAbilitySpecs =
+                        tableSourceSpec.getSourceAbilitySpecs().toArray(new SourceAbilitySpec[0]);
+            }
+            return new TableSourceTable(
+                    null,
+                    objectIdentifier,
+                    rowType,
+                    FlinkStatistic.UNKNOWN(),
+                    lookupTableSource,
+                    true,
+                    catalogTable,
+                    new String[] {},
+                    sourceAbilitySpecs);
+        }
+        throw new TableException("Can not obtain temporalTable correctly!");
+    }
+
+    @JsonIgnore
+    @VisibleForTesting
+    public DynamicTableSourceSpec getTableSourceSpec() {
+        return tableSourceSpec;
+    }
+
+    @JsonIgnore
+    @VisibleForTesting
+    public RelDataType getRowType() {
+        return rowType;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -30,7 +30,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 
 import javax.annotation.Nullable;
@@ -47,10 +46,8 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
             @Nullable RexNode joinCondition,
             TemporalTableSourceSpec temporalTableSourceSpec,
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
-            boolean existCalcOnTemporalTable,
-            @Nullable RelDataType calcOnTemporalTableOutputRowType,
-            @Nullable List<RexNode> calcOnTemporalTableProjections,
-            @Nullable RexNode calcOnTemporalTableCondition,
+            @Nullable List<RexNode> projectionOnTemporalTable,
+            @Nullable RexNode filterOnTemporalTable,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
@@ -59,10 +56,8 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 joinCondition,
                 temporalTableSourceSpec,
                 lookupKeys,
-                existCalcOnTemporalTable,
-                calcOnTemporalTableOutputRowType,
-                calcOnTemporalTableProjections,
-                calcOnTemporalTableCondition,
+                projectionOnTemporalTable,
+                filterOnTemporalTable,
                 getNewNodeId(),
                 Collections.singletonList(inputProperty),
                 outputType,
@@ -76,13 +71,10 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
             @JsonProperty(FIELD_NAME_TEMPORAL_TABLE)
                     TemporalTableSourceSpec temporalTableSourceSpec,
             @JsonProperty(FIELD_NAME_LOOKUP_KEYS) Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
-            @JsonProperty(FIELD_NAME_EXIST_CALC_ON_TEMPORAL_TABLE) boolean existCalcOnTemporalTable,
-            @JsonProperty(FIELD_NAME_CALC_ON_TEMPORAL_TABLE_OUTPUT_TYPE) @Nullable
-                    RelDataType calcOnTemporalTableOutputRowType,
-            @JsonProperty(FIELD_NAME_CALC_ON_TEMPORAL_TABLE_PROJECTIONS) @Nullable
-                    List<RexNode> calcOnTemporalTableProjections,
-            @JsonProperty(FIELD_NAME_CALC_ON_TEMPORAL_TABLE_CONDITION) @Nullable
-                    RexNode calcOnTemporalTableCondition,
+            @JsonProperty(FIELD_NAME_PROJECTION_ON_TEMPORAL_TABLE) @Nullable
+                    List<RexNode> projectionOnTemporalTable,
+            @JsonProperty(FIELD_NAME_FILTER_ON_TEMPORAL_TABLE) @Nullable
+                    RexNode filterOnTemporalTable,
             @JsonProperty(FIELD_NAME_ID) int id,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
@@ -92,10 +84,8 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 joinCondition,
                 temporalTableSourceSpec,
                 lookupKeys,
-                existCalcOnTemporalTable,
-                calcOnTemporalTableOutputRowType,
-                calcOnTemporalTableProjections,
-                calcOnTemporalTableCondition,
+                projectionOnTemporalTable,
+                filterOnTemporalTable,
                 id,
                 inputProperties,
                 outputType,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -21,36 +21,83 @@ package org.apache.flink.table.planner.plan.nodes.exec.stream;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLookupJoin;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.TemporalTableSourceSpec;
 import org.apache.flink.table.planner.plan.utils.LookupJoinUtil;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.calcite.plan.RelOptTable;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexProgram;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /** {@link StreamExecNode} for temporal table join that implemented by lookup. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecLookupJoin extends CommonExecLookupJoin implements StreamExecNode<RowData> {
     public StreamExecLookupJoin(
             FlinkJoinType joinType,
             @Nullable RexNode joinCondition,
-            RelOptTable temporalTable,
-            @Nullable RexProgram calcOnTemporalTable,
+            TemporalTableSourceSpec temporalTableSourceSpec,
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
+            boolean existCalcOnTemporalTable,
+            @Nullable RelDataType calcOnTemporalTableOutputRowType,
+            @Nullable List<RexNode> calcOnTemporalTableProjections,
+            @Nullable RexNode calcOnTemporalTableCondition,
             InputProperty inputProperty,
             RowType outputType,
             String description) {
+        this(
+                joinType,
+                joinCondition,
+                temporalTableSourceSpec,
+                lookupKeys,
+                existCalcOnTemporalTable,
+                calcOnTemporalTableOutputRowType,
+                calcOnTemporalTableProjections,
+                calcOnTemporalTableCondition,
+                getNewNodeId(),
+                Collections.singletonList(inputProperty),
+                outputType,
+                description);
+    }
+
+    @JsonCreator
+    public StreamExecLookupJoin(
+            @JsonProperty(FIELD_NAME_JOIN_TYPE) FlinkJoinType joinType,
+            @JsonProperty(FIELD_NAME_JOIN_CONDITION) @Nullable RexNode joinCondition,
+            @JsonProperty(FIELD_NAME_TEMPORAL_TABLE)
+                    TemporalTableSourceSpec temporalTableSourceSpec,
+            @JsonProperty(FIELD_NAME_LOOKUP_KEYS) Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
+            @JsonProperty(FIELD_NAME_EXIST_CALC_ON_TEMPORAL_TABLE) boolean existCalcOnTemporalTable,
+            @JsonProperty(FIELD_NAME_CALC_ON_TEMPORAL_TABLE_OUTPUT_TYPE) @Nullable
+                    RelDataType calcOnTemporalTableOutputRowType,
+            @JsonProperty(FIELD_NAME_CALC_ON_TEMPORAL_TABLE_PROJECTIONS) @Nullable
+                    List<RexNode> calcOnTemporalTableProjections,
+            @JsonProperty(FIELD_NAME_CALC_ON_TEMPORAL_TABLE_CONDITION) @Nullable
+                    RexNode calcOnTemporalTableCondition,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
                 joinType,
                 joinCondition,
-                temporalTable,
-                calcOnTemporalTable,
+                temporalTableSourceSpec,
                 lookupKeys,
-                inputProperty,
+                existCalcOnTemporalTable,
+                calcOnTemporalTableOutputRowType,
+                calcOnTemporalTableProjections,
+                calcOnTemporalTableCondition,
+                id,
+                inputProperties,
                 outputType,
                 description);
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLookupJoin.scala
@@ -69,17 +69,15 @@ class BatchPhysicalLookupJoin(
 
   override def translateToExecNode(): ExecNode[_] = {
     val existCalcOnTemporalTable = calcOnTemporalTable.nonEmpty
-    var calcOnTemporalTableOutputRowType: RelDataType = null
-    var calcOnTemporalTableProjections: java.util.List[RexNode] = null
-    var calcOnTemporalTableCondition: RexNode = null
+    var projectionOnTemporalTable: java.util.List[RexNode] = null
+    var filterOnTemporalTable: RexNode = null
     if (existCalcOnTemporalTable) {
-      calcOnTemporalTableOutputRowType = calcOnTemporalTable.get.getOutputRowType
       val projections = JavaScalaConversionUtil
         .toScala(calcOnTemporalTable.get.getProjectList)
         .map(calcOnTemporalTable.get.expandLocalRef)
-      calcOnTemporalTableProjections = JavaScalaConversionUtil.toJava(projections)
+      projectionOnTemporalTable = JavaScalaConversionUtil.toJava(projections)
       if (calcOnTemporalTable.get.getCondition != null) {
-        calcOnTemporalTableCondition = calcOnTemporalTable.get
+        filterOnTemporalTable = calcOnTemporalTable.get
           .expandLocalRef(calcOnTemporalTable.get.getCondition)
       }
     }
@@ -89,10 +87,8 @@ class BatchPhysicalLookupJoin(
       new TemporalTableSourceSpec(temporalTable,
                                   FlinkRelOptUtil.getTableConfigFromContext(this)),
       allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
-      existCalcOnTemporalTable,
-      calcOnTemporalTableOutputRowType,
-      calcOnTemporalTableProjections,
-      calcOnTemporalTableCondition,
+      projectionOnTemporalTable,
+      filterOnTemporalTable,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       getRelDetailedDescription)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
@@ -18,18 +18,19 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.plan.nodes.exec.{InputProperty, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalLookupJoin
-import org.apache.flink.table.planner.plan.utils.JoinTypeUtil
-
+import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, JoinTypeUtil}
 import org.apache.calcite.plan.{RelOptCluster, RelOptTable, RelTraitSet}
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
-import org.apache.calcite.rex.RexProgram
+import org.apache.calcite.rex.{RexNode, RexProgram}
+import org.apache.flink.table.planner.plan.nodes.exec.spec.TemporalTableSourceSpec
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil
 
 import java.util
-
 import scala.collection.JavaConverters._
 
 /**
@@ -67,15 +68,34 @@ class StreamPhysicalLookupJoin(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
+    val existCalcOnTemporalTable = calcOnTemporalTable.nonEmpty
+    var calcOnTemporalTableOutputRowType: RelDataType = null
+    var calcOnTemporalTableProjections: java.util.List[RexNode] = null
+    var calcOnTemporalTableCondition: RexNode = null
+    if (existCalcOnTemporalTable) {
+      calcOnTemporalTableOutputRowType = calcOnTemporalTable.get.getOutputRowType
+      val projections = JavaScalaConversionUtil
+        .toScala(calcOnTemporalTable.get.getProjectList)
+        .map(calcOnTemporalTable.get.expandLocalRef)
+      calcOnTemporalTableProjections = JavaScalaConversionUtil.toJava(projections)
+      if (calcOnTemporalTable.get.getCondition != null) {
+        calcOnTemporalTableCondition = calcOnTemporalTable.get
+          .expandLocalRef(calcOnTemporalTable.get.getCondition)
+      }
+    }
     new StreamExecLookupJoin(
-        JoinTypeUtil.getFlinkJoinType(joinType),
-        remainingCondition.orNull,
-        temporalTable,
-        calcOnTemporalTable.orNull,
-        allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
-        InputProperty.DEFAULT,
-        FlinkTypeFactory.toLogicalRowType(getRowType),
-        getRelDetailedDescription)
+      JoinTypeUtil.getFlinkJoinType(joinType),
+      remainingCondition.orNull,
+      new TemporalTableSourceSpec(temporalTable,
+                                  FlinkRelOptUtil.getTableConfigFromContext(this)),
+      allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
+      existCalcOnTemporalTable,
+      calcOnTemporalTableOutputRowType,
+      calcOnTemporalTableProjections,
+      calcOnTemporalTableCondition,
+      InputProperty.DEFAULT,
+      FlinkTypeFactory.toLogicalRowType(getRowType),
+      getRelDetailedDescription)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LookupKeySerdeTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.planner.plan.utils.LookupJoinUtil;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test LookupKey json ser/de. */
+public class LookupKeySerdeTest {
+
+    @Test
+    public void testLookupKey() throws JsonProcessingException {
+        TableConfig tableConfig = TableConfig.getDefault();
+        CatalogManager catalogManager =
+                CatalogManager.newBuilder()
+                        .classLoader(Thread.currentThread().getContextClassLoader())
+                        .config(tableConfig.getConfiguration())
+                        .defaultCatalog("default_catalog", new GenericInMemoryCatalog("default_db"))
+                        .build();
+        FlinkContext flinkContext =
+                new FlinkContextImpl(
+                        tableConfig,
+                        new FunctionCatalog(tableConfig, catalogManager, new ModuleManager()),
+                        catalogManager,
+                        null);
+        SerdeContext serdeCtx =
+                new SerdeContext(
+                        flinkContext,
+                        Thread.currentThread().getContextClassLoader(),
+                        FlinkTypeFactory.INSTANCE(),
+                        FlinkSqlOperatorTable.instance());
+        ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(new LogicalTypeJsonSerializer());
+        module.addDeserializer(LogicalType.class, new LogicalTypeJsonDeserializer());
+        module.addSerializer(new RexNodeJsonSerializer());
+        module.addSerializer(new RelDataTypeJsonSerializer());
+        module.addDeserializer(RexNode.class, new RexNodeJsonDeserializer());
+        module.addDeserializer(RelDataType.class, new RelDataTypeJsonDeserializer());
+        mapper.registerModule(module);
+
+        LookupJoinUtil.LookupKey[] lookupKeys =
+                new LookupJoinUtil.LookupKey[] {
+                    new LookupJoinUtil.ConstantLookupKey(
+                            new BigIntType(),
+                            new RexBuilder(FlinkTypeFactory.INSTANCE()).makeLiteral("a")),
+                    new LookupJoinUtil.FieldRefLookupKey(3)
+                };
+        for (LookupJoinUtil.LookupKey lookupKey : lookupKeys) {
+            LookupJoinUtil.LookupKey result =
+                    mapper.readValue(
+                            mapper.writeValueAsString(lookupKey), LookupJoinUtil.LookupKey.class);
+            assertEquals(lookupKey, result);
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.serde;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.planner.calcite.FlinkContextImpl;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.TemporalTableSourceSpec;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.utils.CatalogManagerMocks;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link TemporalTableSourceSpec} serialization and deserialization. */
+public class TemporalTableSourceSpecSerdeTest {
+    private static final FlinkTypeFactory FACTORY = FlinkTypeFactory.INSTANCE();
+
+    @Test
+    public void testTemporalTableSourceSpecSerde() throws IOException {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        SerdeContext serdeCtx =
+                new SerdeContext(
+                        new FlinkContextImpl(
+                                TableConfig.getDefault(),
+                                null,
+                                CatalogManagerMocks.createEmptyCatalogManager(),
+                                null),
+                        classLoader,
+                        FlinkTypeFactory.INSTANCE(),
+                        FlinkSqlOperatorTable.instance());
+        ObjectMapper mapper = JsonSerdeUtil.createObjectMapper(serdeCtx);
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(new RexNodeJsonSerializer());
+        module.addSerializer(new RelDataTypeJsonSerializer());
+        module.addDeserializer(RexNode.class, new RexNodeJsonDeserializer());
+        module.addDeserializer(RelDataType.class, new RelDataTypeJsonDeserializer());
+        mapper.registerModule(module);
+        StringWriter writer = new StringWriter(100);
+        List<TemporalTableSourceSpec> specs = testData();
+        for (TemporalTableSourceSpec spec : specs) {
+            try (JsonGenerator gen = mapper.getFactory().createGenerator(writer)) {
+                gen.writeObject(spec);
+            }
+            String json = writer.toString();
+            TemporalTableSourceSpec actual = mapper.readValue(json, TemporalTableSourceSpec.class);
+            assertEquals(spec.getTableSourceSpec(), actual.getTableSourceSpec());
+            assertEquals(spec.getRowType(), actual.getRowType());
+        }
+    }
+
+    public static List<TemporalTableSourceSpec> testData() {
+        Map<String, String> properties1 = new HashMap<>();
+        properties1.put("connector", "filesystem");
+        properties1.put("format", "testcsv");
+        properties1.put("path", "/tmp");
+        properties1.put("schema.0.name", "a");
+        properties1.put("schema.0.data-type", "BIGINT");
+
+        final CatalogTable catalogTable1 = CatalogTable.fromProperties(properties1);
+
+        final ResolvedSchema resolvedSchema1 =
+                new ResolvedSchema(
+                        Collections.singletonList(Column.physical("a", DataTypes.BIGINT())),
+                        Collections.emptyList(),
+                        null);
+        ResolvedCatalogTable resolvedCatalogTable =
+                new ResolvedCatalogTable(catalogTable1, resolvedSchema1);
+
+        RelDataType relDataType1 = FACTORY.createSqlType(SqlTypeName.BIGINT);
+        LookupTableSource lookupTableSource = new TestValuesTableFactory.MockedLookupTableSource();
+        TableSourceTable tableSourceTable1 =
+                new TableSourceTable(
+                        null,
+                        ObjectIdentifier.of("default_catalog", "default_db", "MyTable"),
+                        relDataType1,
+                        FlinkStatistic.UNKNOWN(),
+                        lookupTableSource,
+                        true,
+                        resolvedCatalogTable,
+                        new String[] {},
+                        new SourceAbilitySpec[] {});
+        TemporalTableSourceSpec temporalTableSourceSpec1 =
+                new TemporalTableSourceSpec(tableSourceTable1, new TableConfig());
+        return Arrays.asList(temporalTableSourceSpec1);
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -89,7 +89,7 @@ public class TemporalTableSourceSpecSerdeTest {
             String json = writer.toString();
             TemporalTableSourceSpec actual = mapper.readValue(json, TemporalTableSourceSpec.class);
             assertEquals(spec.getTableSourceSpec(), actual.getTableSourceSpec());
-            assertEquals(spec.getRowType(), actual.getRowType());
+            assertEquals(spec.getOutputType(), actual.getOutputType());
         }
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -42,7 +42,6 @@ public class JsonSerdeCoverageTest {
                     "StreamExecDataStreamScan",
                     "StreamExecLegacyTableSourceScan",
                     "StreamExecLegacySink",
-                    "StreamExecLookupJoin",
                     "StreamExecPythonGroupAggregate",
                     "StreamExecWindowTableFunction",
                     "StreamExecPythonGroupWindowAggregate",

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization/deserialization for LookupJoin. */
+public class LookupJoinJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+
+        String srcTableA =
+                "CREATE TABLE MyTable (\n"
+                        + "  a int,\n"
+                        + "  b varchar,\n"
+                        + "  c bigint,\n"
+                        + "  proctime as PROCTIME(),\n"
+                        + "  rowtime as TO_TIMESTAMP(FROM_UNIXTIME(c)),\n"
+                        + "  watermark for rowtime as rowtime - INTERVAL '1' second \n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        String srcTableB =
+                "CREATE TABLE LookupTable (\n"
+                        + "  id int,\n"
+                        + "  name varchar,\n"
+                        + "  age int \n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false')";
+        tEnv.executeSql(srcTableA);
+        tEnv.executeSql(srcTableB);
+    }
+
+    @Test
+    public void testJoinTemporalTable() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a int,\n"
+                        + "  b varchar,"
+                        + "  c bigint,"
+                        + "  proctime timestamp(3),"
+                        + "  rowtime timestamp(3),"
+                        + "  id int,"
+                        + "  name varchar,"
+                        + "  age int"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan(
+                "INSERT INTO MySink SELECT * FROM MyTable AS T JOIN LookupTable "
+                        + "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id");
+    }
+
+    @Test
+    public void testJoinTemporalTableWithProjectionPushDown() {
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a int,\n"
+                        + "  b varchar,"
+                        + "  c bigint,"
+                        + "  proctime timestamp(3),"
+                        + "  rowtime timestamp(3),"
+                        + "  id int"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+        util.verifyJsonPlan(
+                "INSERT INTO MySink \n"
+                        + "SELECT T.*, D.id \n"
+                        + "FROM MyTable AS T \n"
+                        + "JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D \n"
+                        + "ON T.a = D.id\n");
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LookupJoinJsonPlanITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LookupJoinJsonPlanITCase.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/** Test for LookupJoin json plan. */
+public class LookupJoinJsonPlanITCase extends JsonPlanTestBase {
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        List<Row> rowT1 =
+                Arrays.asList(
+                        Row.of(1L, 12, "Julian"),
+                        Row.of(2L, 15, "Hello"),
+                        Row.of(3L, 15, "Fabian"),
+                        Row.of(8L, 11, "Hello world"),
+                        Row.of(9L, 12, "Hello world!"));
+
+        List<Row> rowT2 =
+                Arrays.asList(
+                        Row.of(11, 1L, "Julian"),
+                        Row.of(22, 2L, "Jark"),
+                        Row.of(33, 3L, "Fabian"),
+                        Row.of(11, 4L, "Hello world"),
+                        Row.of(11, 5L, "Hello world"));
+        createTestValuesSourceTable(
+                "src", rowT1, "id bigint", "len int", "content varchar", "proctime as PROCTIME()");
+        createTestValuesSourceTable(
+                "user_table",
+                rowT2,
+                new String[] {"age int", "id bigint", "name varchar"},
+                new HashMap<String, String>() {
+                    {
+                        put("disable-lookup", "false");
+                    }
+                });
+        createTestValuesSinkTable(
+                "MySink", "id bigint", "len int", "content varchar", "name varchar");
+    }
+
+    /** test join temporal table. * */
+    @Test
+    public void testJoinLookupTable() throws Exception {
+        String jsonPlan =
+                tableEnv.getJsonPlan(
+                        "insert into MySink "
+                                + "SELECT T.id, T.len, T.content, D.name FROM src AS T JOIN user_table \n"
+                                + "for system_time as of T.proctime AS D ON T.id = D.id \n");
+        tableEnv.executeJsonPlan(jsonPlan).await();
+        List<String> expected =
+                Arrays.asList(
+                        "+I[1, 12, Julian, Julian]",
+                        "+I[2, 15, Hello, Jark]",
+                        "+I[3, 15, Fabian, Fabian]");
+        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+    }
+
+    @Test
+    public void testJoinLookupTableWithPushDown() throws Exception {
+        String jsonPlan =
+                tableEnv.getJsonPlan(
+                        "insert into MySink \n"
+                                + "SELECT T.id, T.len, T.content, D.name FROM src AS T JOIN user_table \n "
+                                + "for system_time as of T.proctime AS D ON T.id = D.id AND D.age > 20");
+        tableEnv.executeJsonPlan(jsonPlan).await();
+        List<String> expected =
+                Arrays.asList("+I[2, 15, Hello, Jark]", "+I[3, 15, Fabian, Fabian]");
+        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
@@ -220,7 +220,7 @@
     "joinType" : "INNER",
     "joinCondition" : null,
     "temporalTable" : {
-      "scanTableSource" : {
+      "lookupTableSource" : {
         "identifier" : {
           "catalogName" : "default_catalog",
           "databaseName" : "default_database",
@@ -237,7 +237,7 @@
           "schema.1.data-type" : "VARCHAR(2147483647)"
         }
       },
-      "rowType" : {
+      "outputType" : {
         "structKind" : "FULLY_QUALIFIED",
         "nullable" : false,
         "fields" : [ {
@@ -262,10 +262,8 @@
         "index" : 0
       }
     },
-    "existCalcOnTemporalTable" : false,
-    "calcOnTemporalTableOutputRowType" : null,
-    "calcOnTemporalTableProjections" : null,
-    "calcOnTemporalTableCondition" : null,
+    "projectionOnTemporalTable" : null,
+    "filterOnTemporalTable" : null,
     "id" : 10,
     "inputProperties" : [ {
       "requiredDistribution" : {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
@@ -1,0 +1,531 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.watermark.0.strategy.expr" : "`rowtime` - INTERVAL '1' SECOND",
+        "schema.4.expr" : "TO_TIMESTAMP(FROM_UNIXTIME(`c`))",
+        "schema.0.data-type" : "INT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.4.name" : "rowtime",
+        "schema.1.data-type" : "VARCHAR(2147483647)",
+        "schema.3.data-type" : "TIMESTAMP(3) NOT NULL",
+        "schema.2.data-type" : "BIGINT",
+        "schema.3.name" : "proctime",
+        "connector" : "values",
+        "schema.watermark.0.rowtime" : "rowtime",
+        "schema.watermark.0.strategy.data-type" : "TIMESTAMP(3)",
+        "schema.3.expr" : "PROCTIME()",
+        "schema.4.data-type" : "TIMESTAMP(3)",
+        "schema.0.name" : "a"
+      }
+    },
+    "id" : 7,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      } ]
+    },
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ ],
+      "type" : {
+        "timestampKind" : "PROCTIME",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "TO_TIMESTAMP",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ {
+        "kind" : "REX_CALL",
+        "operator" : {
+          "name" : "FROM_UNIXTIME",
+          "kind" : "OTHER_FUNCTION",
+          "syntax" : "FUNCTION"
+        },
+        "operands" : [ {
+          "kind" : "INPUT_REF",
+          "inputIndex" : 2,
+          "type" : {
+            "typeName" : "BIGINT",
+            "nullable" : true
+          }
+        } ],
+        "type" : {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2000
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    } ],
+    "condition" : null,
+    "id" : 8,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[a, b, c, PROCTIME() AS proctime, TO_TIMESTAMP(FROM_UNIXTIME(c)) AS rowtime])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
+    "watermarkExpr" : {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "-",
+        "kind" : "MINUS",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 4,
+        "type" : {
+          "typeName" : "TIMESTAMP",
+          "nullable" : true,
+          "precision" : 3
+        }
+      }, {
+        "kind" : "LITERAL",
+        "value" : 1000,
+        "type" : {
+          "typeName" : "INTERVAL_SECOND",
+          "nullable" : false,
+          "precision" : 2,
+          "scale" : 6
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    },
+    "rowtimeFieldIndex" : 4,
+    "id" : 9,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin",
+    "joinType" : "INNER",
+    "joinCondition" : null,
+    "temporalTable" : {
+      "scanTableSource" : {
+        "identifier" : {
+          "catalogName" : "default_catalog",
+          "databaseName" : "default_database",
+          "tableName" : "LookupTable"
+        },
+        "catalogTable" : {
+          "schema.2.data-type" : "INT",
+          "connector" : "values",
+          "schema.0.data-type" : "INT",
+          "schema.2.name" : "age",
+          "schema.1.name" : "name",
+          "bounded" : "false",
+          "schema.0.name" : "id",
+          "schema.1.data-type" : "VARCHAR(2147483647)"
+        }
+      },
+      "rowType" : {
+        "structKind" : "FULLY_QUALIFIED",
+        "nullable" : false,
+        "fields" : [ {
+          "typeName" : "INTEGER",
+          "nullable" : true,
+          "fieldName" : "id"
+        }, {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2147483647,
+          "fieldName" : "name"
+        }, {
+          "typeName" : "INTEGER",
+          "nullable" : true,
+          "fieldName" : "age"
+        } ]
+      }
+    },
+    "lookupKeys" : {
+      "0" : {
+        "type" : "FieldRef",
+        "index" : 0
+      }
+    },
+    "existCalcOnTemporalTable" : false,
+    "calcOnTemporalTableOutputRowType" : null,
+    "calcOnTemporalTableProjections" : null,
+    "calcOnTemporalTableCondition" : null,
+    "id" : 10,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "id" : "INT"
+      }, {
+        "name" : "VARCHAR(2147483647)"
+      }, {
+        "age" : "INT"
+      } ]
+    },
+    "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME_MATERIALIZE",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 3,
+        "type" : {
+          "timestampKind" : "PROCTIME",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : false,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 4,
+      "type" : {
+        "timestampKind" : "ROWTIME",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 6,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 7,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    } ],
+    "condition" : null,
+    "id" : 11,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "id" : "INT"
+      }, {
+        "name" : "VARCHAR(2147483647)"
+      }, {
+        "age" : "INT"
+      } ]
+    },
+    "description" : "Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "schema.5.name" : "id",
+        "schema.7.data-type" : "INT",
+        "schema.0.data-type" : "INT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.6.data-type" : "VARCHAR(2147483647)",
+        "schema.4.name" : "rowtime",
+        "schema.1.data-type" : "VARCHAR(2147483647)",
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "BIGINT",
+        "schema.3.name" : "proctime",
+        "schema.7.name" : "age",
+        "connector" : "values",
+        "schema.6.name" : "name",
+        "schema.5.data-type" : "INT",
+        "schema.4.data-type" : "TIMESTAMP(3)",
+        "schema.0.name" : "a"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 12,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "id" : "INT"
+      }, {
+        "name" : "VARCHAR(2147483647)"
+      }, {
+        "age" : "INT"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c, proctime, rowtime, id, name, age])"
+  } ],
+  "edges" : [ {
+    "source" : 7,
+    "target" : 8,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 8,
+    "target" : 9,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 9,
+    "target" : 10,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 10,
+    "target" : 11,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 11,
+    "target" : 12,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
@@ -1,0 +1,515 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan",
+    "scanTableSource" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MyTable"
+      },
+      "catalogTable" : {
+        "schema.watermark.0.strategy.expr" : "`rowtime` - INTERVAL '1' SECOND",
+        "schema.4.expr" : "TO_TIMESTAMP(FROM_UNIXTIME(`c`))",
+        "schema.0.data-type" : "INT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "bounded" : "false",
+        "schema.4.name" : "rowtime",
+        "schema.1.data-type" : "VARCHAR(2147483647)",
+        "schema.3.data-type" : "TIMESTAMP(3) NOT NULL",
+        "schema.2.data-type" : "BIGINT",
+        "schema.3.name" : "proctime",
+        "connector" : "values",
+        "schema.watermark.0.rowtime" : "rowtime",
+        "schema.watermark.0.strategy.data-type" : "TIMESTAMP(3)",
+        "schema.3.expr" : "PROCTIME()",
+        "schema.4.data-type" : "TIMESTAMP(3)",
+        "schema.0.name" : "a"
+      }
+    },
+    "id" : 1,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      } ]
+    },
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ ],
+      "type" : {
+        "timestampKind" : "PROCTIME",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "TO_TIMESTAMP",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ {
+        "kind" : "REX_CALL",
+        "operator" : {
+          "name" : "FROM_UNIXTIME",
+          "kind" : "OTHER_FUNCTION",
+          "syntax" : "FUNCTION"
+        },
+        "operands" : [ {
+          "kind" : "INPUT_REF",
+          "inputIndex" : 2,
+          "type" : {
+            "typeName" : "BIGINT",
+            "nullable" : true
+          }
+        } ],
+        "type" : {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2000
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    } ],
+    "condition" : null,
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      } ]
+    },
+    "description" : "Calc(select=[a, b, c, PROCTIME() AS proctime, TO_TIMESTAMP(FROM_UNIXTIME(c)) AS rowtime])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecWatermarkAssigner",
+    "watermarkExpr" : {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "-",
+        "kind" : "MINUS",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 4,
+        "type" : {
+          "typeName" : "TIMESTAMP",
+          "nullable" : true,
+          "precision" : 3
+        }
+      }, {
+        "kind" : "LITERAL",
+        "value" : 1000,
+        "type" : {
+          "typeName" : "INTERVAL_SECOND",
+          "nullable" : false,
+          "precision" : 2,
+          "scale" : 6
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : true,
+        "precision" : 3
+      }
+    },
+    "rowtimeFieldIndex" : 4,
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      } ]
+    },
+    "description" : "WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin",
+    "joinType" : "INNER",
+    "joinCondition" : null,
+    "temporalTable" : {
+      "scanTableSource" : {
+        "identifier" : {
+          "catalogName" : "default_catalog",
+          "databaseName" : "default_database",
+          "tableName" : "LookupTable"
+        },
+        "catalogTable" : {
+          "schema.2.data-type" : "INT",
+          "connector" : "values",
+          "schema.0.data-type" : "INT",
+          "schema.2.name" : "age",
+          "schema.1.name" : "name",
+          "bounded" : "false",
+          "schema.0.name" : "id",
+          "schema.1.data-type" : "VARCHAR(2147483647)"
+        }
+      },
+      "rowType" : {
+        "structKind" : "FULLY_QUALIFIED",
+        "nullable" : false,
+        "fields" : [ {
+          "typeName" : "INTEGER",
+          "nullable" : true,
+          "fieldName" : "id"
+        }, {
+          "typeName" : "VARCHAR",
+          "nullable" : true,
+          "precision" : 2147483647,
+          "fieldName" : "name"
+        }, {
+          "typeName" : "INTEGER",
+          "nullable" : true,
+          "fieldName" : "age"
+        } ]
+      }
+    },
+    "lookupKeys" : {
+      "0" : {
+        "type" : "FieldRef",
+        "index" : 0
+      }
+    },
+    "existCalcOnTemporalTable" : true,
+    "calcOnTemporalTableOutputRowType" : {
+      "structKind" : "FULLY_QUALIFIED",
+      "nullable" : false,
+      "fields" : [ {
+        "typeName" : "INTEGER",
+        "nullable" : true,
+        "fieldName" : "id"
+      } ]
+    },
+    "calcOnTemporalTableProjections" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    } ],
+    "calcOnTemporalTableCondition" : null,
+    "id" : 4,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "PROCTIME"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "id" : "INT"
+      } ]
+    },
+    "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 1,
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "PROCTIME_MATERIALIZE",
+        "kind" : "OTHER_FUNCTION",
+        "syntax" : "FUNCTION"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 3,
+        "type" : {
+          "timestampKind" : "PROCTIME",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "TIMESTAMP",
+        "nullable" : false,
+        "precision" : 3
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 4,
+      "type" : {
+        "timestampKind" : "ROWTIME",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 5,
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : true
+      }
+    } ],
+    "condition" : null,
+    "id" : 5,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "id" : "INT"
+      } ]
+    },
+    "description" : "Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "schema.5.name" : "id",
+        "schema.0.data-type" : "INT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.4.name" : "rowtime",
+        "schema.1.data-type" : "VARCHAR(2147483647)",
+        "schema.3.data-type" : "TIMESTAMP(3)",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "BIGINT",
+        "schema.3.name" : "proctime",
+        "connector" : "values",
+        "schema.5.data-type" : "INT",
+        "schema.4.data-type" : "TIMESTAMP(3)",
+        "schema.0.name" : "a"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 6,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "INT"
+      }, {
+        "b" : "VARCHAR(2147483647)"
+      }, {
+        "c" : "BIGINT"
+      }, {
+        "proctime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : false,
+          "precision" : 3,
+          "kind" : "REGULAR"
+        }
+      }, {
+        "rowtime" : {
+          "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
+          "nullable" : true,
+          "precision" : 3,
+          "kind" : "ROWTIME"
+        }
+      }, {
+        "id" : "INT"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c, proctime, rowtime, id])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 3,
+    "target" : 4,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 4,
+    "target" : 5,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 5,
+    "target" : 6,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
@@ -220,7 +220,7 @@
     "joinType" : "INNER",
     "joinCondition" : null,
     "temporalTable" : {
-      "scanTableSource" : {
+      "lookupTableSource" : {
         "identifier" : {
           "catalogName" : "default_catalog",
           "databaseName" : "default_database",
@@ -237,7 +237,7 @@
           "schema.1.data-type" : "VARCHAR(2147483647)"
         }
       },
-      "rowType" : {
+      "outputType" : {
         "structKind" : "FULLY_QUALIFIED",
         "nullable" : false,
         "fields" : [ {
@@ -262,17 +262,7 @@
         "index" : 0
       }
     },
-    "existCalcOnTemporalTable" : true,
-    "calcOnTemporalTableOutputRowType" : {
-      "structKind" : "FULLY_QUALIFIED",
-      "nullable" : false,
-      "fields" : [ {
-        "typeName" : "INTEGER",
-        "nullable" : true,
-        "fieldName" : "id"
-      } ]
-    },
-    "calcOnTemporalTableProjections" : [ {
+    "projectionOnTemporalTable" : [ {
       "kind" : "INPUT_REF",
       "inputIndex" : 0,
       "type" : {
@@ -280,7 +270,7 @@
         "nullable" : true
       }
     } ],
-    "calcOnTemporalTableCondition" : null,
+    "filterOnTemporalTable" : null,
     "id" : 4,
     "inputProperties" : [ {
       "requiredDistribution" : {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
@@ -281,6 +281,9 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
 
   @Test
   def testJoinTemporalTableWithTrueCondition(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Temporal table join requires an equality condition on fields of " +
+                           "table [default_catalog.default_database.LookupTable]")
     val sql =
       """
         |SELECT * FROM MyTable AS T
@@ -288,7 +291,7 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
         |ON true
         |WHERE T.c > 1000
       """.stripMargin
-    testUtil.verifyExecPlan(sql)
+    testUtil.verifyExplain(sql)
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/LookupJoinTest.scala
@@ -281,9 +281,6 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase {
 
   @Test
   def testJoinTemporalTableWithTrueCondition(): Unit = {
-    thrown.expect(classOf[TableException])
-    thrown.expectMessage("Temporal table join requires an equality condition on fields of " +
-      "table [default_catalog.default_database.LookupTable]")
     val sql =
       """
         |SELECT * FROM MyTable AS T

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -369,9 +369,6 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
 
   @Test
   def testJoinTemporalTableWithTrueCondition(): Unit = {
-    thrown.expect(classOf[TableException])
-    thrown.expectMessage("Temporal table join requires an equality condition on fields of " +
-        "table [default_catalog.default_database.LookupTable]")
     val sql =
       """
         |SELECT * FROM MyTable AS T

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -369,6 +369,9 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
 
   @Test
   def testJoinTemporalTableWithTrueCondition(): Unit = {
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Temporal table join requires an equality condition on fields of " +
+                           "table [default_catalog.default_database.LookupTable]")
     val sql =
       """
         |SELECT * FROM MyTable AS T
@@ -377,7 +380,7 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
         |WHERE T.c > 1000
       """.stripMargin
 
-    util.verifyExecPlan(sql)
+    util.verifyExplain(sql)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

*Support StreamExecLookupJoin json serialization/deserialization*

## Brief change log

  - 481ee3c Support StreamExecLookupJoin json serialization/deserialization


## Verifying this change
This change added tests and can be verified as follows:
  - *Add `LookupJoinJsonPlanITCase` integration test to verify lookup join json plan can e2e work normally*
  - *Added test `LookupJoinJsonPlanTest` that validates that exec plan is as expected*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
