### PR TITLE
[FLINK-21751] Eagerly issue release calls from RM if JM disconnects for terminal job 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1131,7 +1131,8 @@ public class JobMaster extends PermanentlyFencedRpcEndpoint<JobMasterId>
 
         ResourceManagerGateway resourceManagerGateway =
                 establishedResourceManagerConnection.getResourceManagerGateway();
-        resourceManagerGateway.disconnectJobManager(jobGraph.getJobID(), cause);
+        resourceManagerGateway.disconnectJobManager(
+                jobGraph.getJobID(), schedulerNG.requestJobStatus(), cause);
         slotPoolService.disconnectResourceManager();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.blob.TransientBlobKey;
@@ -506,7 +507,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     }
 
     @Override
-    public void disconnectJobManager(final JobID jobId, final Exception cause) {
+    public void disconnectJobManager(
+            final JobID jobId, JobStatus jobStatus, final Exception cause) {
         closeJobManagerConnection(jobId, cause);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -869,7 +869,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                         jobManagerAddress);
             } else {
                 // tell old job manager that he is no longer the job leader
-                disconnectJobManager(
+                closeJobManagerConnection(
                         oldJobManagerRegistration.getJobID(),
                         new Exception("New job leader for job " + jobId + " found."));
 
@@ -1083,7 +1083,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
 
         if (jobManagerRegistrations.containsKey(jobId)) {
-            disconnectJobManager(jobId, new Exception("Job " + jobId + "was removed"));
+            closeJobManagerConnection(jobId, new Exception("Job " + jobId + "was removed"));
         }
     }
 
@@ -1092,7 +1092,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             JobManagerRegistration jobManagerRegistration = jobManagerRegistrations.get(jobId);
 
             if (Objects.equals(jobManagerRegistration.getJobMasterId(), oldJobMasterId)) {
-                disconnectJobManager(jobId, new Exception("Job leader lost leadership."));
+                closeJobManagerConnection(jobId, new Exception("Job leader lost leadership."));
             } else {
                 log.debug(
                         "Discarding job leader lost leadership, because a new job leader was found for job {}. ",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -179,9 +180,10 @@ public interface ResourceManagerGateway
      * Disconnects a JobManager specified by the given resourceID from the {@link ResourceManager}.
      *
      * @param jobId JobID for which the JobManager was the leader
+     * @param jobStatus status of the job at the time of disconnection
      * @param cause for the disconnection of the JobManager
      */
-    void disconnectJobManager(JobID jobId, Exception cause);
+    void disconnectJobManager(JobID jobId, JobStatus jobStatus, Exception cause);
 
     /**
      * Requests information about the registered {@link TaskExecutor}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
@@ -185,7 +185,7 @@ public class DefaultSlotTracker implements SlotTracker {
         Preconditions.checkNotNull(slot);
         Preconditions.checkState(
                 jobId.equals(slot.getJobId()),
-                "Job ID from slot status updated (%s) does not match currently assigned job ID (%s) for slot %s.",
+                "Job ID from slot status update (%s) does not match currently assigned job ID (%s) for slot %s.",
                 jobId,
                 slot.getJobId(),
                 slot.getSlotId());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTracker.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.util.Preconditions;
@@ -208,6 +209,19 @@ public class DefaultSlotTracker implements SlotTracker {
     @Override
     public Collection<TaskManagerSlotInformation> getFreeSlots() {
         return Collections.unmodifiableCollection(freeSlots.values());
+    }
+
+    @Override
+    public Collection<TaskExecutorConnection> getTaskExecutorsWithAllocatedSlotsForJob(
+            JobID jobId) {
+        final Map<InstanceID, TaskExecutorConnection> taskExecutorConnections = new HashMap<>();
+        for (DeclarativeTaskManagerSlot value : slots.values()) {
+            if (jobId.equals(value.getJobId())) {
+                taskExecutorConnections.put(
+                        value.getInstanceId(), value.getTaskManagerConnection());
+            }
+        }
+        return taskExecutorConnections.values();
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotTracker.java
@@ -100,4 +100,13 @@ interface SlotTracker {
      * @return free slots
      */
     Collection<TaskManagerSlotInformation> getFreeSlots();
+
+    /**
+     * Returns all task executors that have at least 1 pending/completed allocation for the given
+     * job.
+     *
+     * @param jobId the job for which the task executors must have a slot
+     * @return task executors with at least 1 slot for the job
+     */
+    Collection<TaskExecutorConnection> getTaskExecutorsWithAllocatedSlotsForJob(JobID jobId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -213,6 +213,14 @@ public interface TaskExecutorGateway extends RpcGateway, TaskExecutorOperatorEve
             final AllocationID allocationId, final Throwable cause, @RpcTimeout final Time timeout);
 
     /**
+     * Frees all currently inactive slot allocated for the given job.
+     *
+     * @param jobId job for which all inactive slots should be released
+     * @param timeout for the operation
+     */
+    void freeInactiveSlots(JobID jobId, @RpcTimeout Time timeout);
+
+    /**
      * Requests the file upload of the specified type to the cluster's {@link BlobServer}.
      *
      * @param fileType to upload

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotTrackerTest.java
@@ -266,6 +266,32 @@ public class DefaultSlotTrackerTest extends TestLogger {
         assertThat(tracker.notifySlotStatus(idempotentSlotReport), is(false));
     }
 
+    @Test
+    public void testGetTaskExecutorsWithAllocatedSlotsForJob() {
+        final SlotTracker tracker = new DefaultSlotTracker();
+
+        final JobID jobId = new JobID();
+        final SlotID slotId = new SlotID(TASK_EXECUTOR_CONNECTION.getResourceID(), 0);
+
+        assertThat(tracker.getTaskExecutorsWithAllocatedSlotsForJob(new JobID()), empty());
+
+        tracker.addSlot(slotId, ResourceProfile.ANY, TASK_EXECUTOR_CONNECTION, null);
+        assertThat(tracker.getTaskExecutorsWithAllocatedSlotsForJob(new JobID()), empty());
+
+        tracker.notifyAllocationStart(slotId, jobId);
+        assertThat(
+                tracker.getTaskExecutorsWithAllocatedSlotsForJob(jobId),
+                contains(TASK_EXECUTOR_CONNECTION));
+
+        tracker.notifyAllocationComplete(slotId, jobId);
+        assertThat(
+                tracker.getTaskExecutorsWithAllocatedSlotsForJob(jobId),
+                contains(TASK_EXECUTOR_CONNECTION));
+
+        tracker.notifyFree(slotId);
+        assertThat(tracker.getTaskExecutorsWithAllocatedSlotsForJob(new JobID()), empty());
+    }
+
     private static class SlotStateTransition {
 
         private final SlotID slotId;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.utils;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -86,7 +87,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
                     JobMasterId, ResourceID, String, JobID, CompletableFuture<RegistrationResponse>>
             registerJobManagerFunction;
 
-    private volatile Consumer<Tuple2<JobID, Throwable>> disconnectJobManagerConsumer;
+    private volatile Consumer<Tuple3<JobID, JobStatus, Throwable>> disconnectJobManagerConsumer;
 
     private volatile Function<TaskExecutorRegistration, CompletableFuture<RegistrationResponse>>
             registerTaskExecutorFunction;
@@ -172,7 +173,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     }
 
     public void setDisconnectJobManagerConsumer(
-            Consumer<Tuple2<JobID, Throwable>> disconnectJobManagerConsumer) {
+            Consumer<Tuple3<JobID, JobStatus, Throwable>> disconnectJobManagerConsumer) {
         this.disconnectJobManagerConsumer = disconnectJobManagerConsumer;
     }
 
@@ -381,11 +382,12 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     }
 
     @Override
-    public void disconnectJobManager(JobID jobId, Exception cause) {
-        final Consumer<Tuple2<JobID, Throwable>> currentConsumer = disconnectJobManagerConsumer;
+    public void disconnectJobManager(JobID jobId, JobStatus jobStatus, Exception cause) {
+        final Consumer<Tuple3<JobID, JobStatus, Throwable>> currentConsumer =
+                disconnectJobManagerConsumer;
 
         if (currentConsumer != null) {
-            currentConsumer.accept(Tuple2.of(jobId, cause));
+            currentConsumer.accept(Tuple3.of(jobId, jobStatus, cause));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -78,6 +78,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
     private final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>>
             freeSlotFunction;
 
+    private final Consumer<JobID> freeInactiveSlotsConsumer;
+
     private final Consumer<ResourceID> heartbeatResourceManagerConsumer;
 
     private final Consumer<Exception> disconnectResourceManagerConsumer;
@@ -118,6 +120,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
                             CompletableFuture<Acknowledge>>
                     requestSlotFunction,
             BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction,
+            Consumer<JobID> freeInactiveSlotsConsumer,
             Consumer<ResourceID> heartbeatResourceManagerConsumer,
             Consumer<Exception> disconnectResourceManagerConsumer,
             Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction,
@@ -141,6 +144,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
         this.submitTaskConsumer = Preconditions.checkNotNull(submitTaskConsumer);
         this.requestSlotFunction = Preconditions.checkNotNull(requestSlotFunction);
         this.freeSlotFunction = Preconditions.checkNotNull(freeSlotFunction);
+        this.freeInactiveSlotsConsumer = Preconditions.checkNotNull(freeInactiveSlotsConsumer);
         this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
         this.disconnectResourceManagerConsumer = disconnectResourceManagerConsumer;
         this.cancelTaskFunction = cancelTaskFunction;
@@ -251,6 +255,11 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
     public CompletableFuture<Acknowledge> freeSlot(
             AllocationID allocationId, Throwable cause, Time timeout) {
         return freeSlotFunction.apply(allocationId, cause);
+    }
+
+    @Override
+    public void freeInactiveSlots(JobID jobId, Time timeout) {
+        freeInactiveSlotsConsumer.accept(jobId);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -68,6 +68,7 @@ public class TestingTaskExecutorGatewayBuilder {
     private static final BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>>
             NOOP_FREE_SLOT_FUNCTION =
                     (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
+    private static final Consumer<JobID> NOOP_FREE_INACTIVE_SLOTS_CONSUMER = ignored -> {};
     private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER =
             ignored -> {};
     private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER =
@@ -101,6 +102,7 @@ public class TestingTaskExecutorGatewayBuilder {
             requestSlotFunction = NOOP_REQUEST_SLOT_FUNCTION;
     private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction =
             NOOP_FREE_SLOT_FUNCTION;
+    private Consumer<JobID> freeInactiveSlotsConsumer = NOOP_FREE_INACTIVE_SLOTS_CONSUMER;
     private Consumer<ResourceID> heartbeatResourceManagerConsumer =
             NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
     private Consumer<Exception> disconnectResourceManagerConsumer =
@@ -172,6 +174,12 @@ public class TestingTaskExecutorGatewayBuilder {
         return this;
     }
 
+    public TestingTaskExecutorGatewayBuilder setFreeInactiveSlotsConsumer(
+            Consumer<JobID> freeInactiveSlotsConsumer) {
+        this.freeInactiveSlotsConsumer = freeInactiveSlotsConsumer;
+        return this;
+    }
+
     public TestingTaskExecutorGatewayBuilder setHeartbeatResourceManagerConsumer(
             Consumer<ResourceID> heartbeatResourceManagerConsumer) {
         this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
@@ -234,6 +242,7 @@ public class TestingTaskExecutorGatewayBuilder {
                 submitTaskConsumer,
                 requestSlotFunction,
                 freeSlotFunction,
+                freeInactiveSlotsConsumer,
                 heartbeatResourceManagerConsumer,
                 disconnectResourceManagerConsumer,
                 cancelTaskFunction,


### PR DESCRIPTION
Based on #15288.

With this PR the RM issues a release call for all inactive slots to the TaskExecutor if the resource requirements have been set to 0.
This reset either happens via an explicit call from the JM in case of the default scheduler, or when the JobManager disconnects because the job has terminated globally.

To detect the latter case `RM#disconnectJobManager` now also accepts a job status.

When the requirements are set to 0 the DeclarativeSlotManager asks the SlotTracker for all task executors that have a slot for the job, and tells these TaskManagers via TM#freeInactiveSlots to free all slots not currently in use.
