### PR TITLE
[FLINK-21353][state] Add DFS-based StateChangelog (TM-owned state)

### DIFF
--- a/flink-dstl/flink-dstl-dfs/pom.xml
+++ b/flink-dstl/flink-dstl-dfs/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-dstl</artifactId>
+		<version>1.14-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-dstl-dfs_${scala.binary.version}</artifactId>
+	<name>Flink : DSTL : DFS</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-guava</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploader.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.util.ExceptionUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.LongAdder;
+
+import static java.lang.Thread.holdsLock;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.flink.util.ExceptionUtils.findThrowable;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link StateChangeUploader} that waits for some configured amount of time before passing the
+ * accumulated state changes to the actual store.
+ */
+@ThreadSafe
+class BatchingStateChangeUploader implements StateChangeUploader {
+    private static final Logger LOG = LoggerFactory.getLogger(BatchingStateChangeUploader.class);
+
+    private final StateChangeUploader delegate;
+    private final ScheduledExecutorService uploadExecutor;
+    private final long scheduleDelayMs;
+    private final long sizeThresholdBytes;
+
+    @GuardedBy("scheduled")
+    private final Queue<UploadTask> scheduled;
+
+    @GuardedBy("scheduled")
+    private long scheduledBytesCounter;
+
+    /**
+     * There should be at most one scheduled future, so that changes are batched according to
+     * settings.
+     */
+    @Nullable
+    @GuardedBy("scheduled")
+    private ScheduledFuture<?> scheduledFuture;
+
+    @Nullable
+    @GuardedBy("this")
+    private Throwable errorUnsafe;
+
+    private final long maxBytesInFlight;
+    private final LongAdder inFlightBytesCounter = new LongAdder();
+
+    BatchingStateChangeUploader(
+            long persistDelayMs,
+            long sizeThresholdBytes,
+            StateChangeUploader delegate,
+            int numUploadThreads,
+            long maxBytesInFlight) {
+        this(
+                persistDelayMs,
+                sizeThresholdBytes,
+                delegate,
+                SchedulerFactory.create(numUploadThreads, "ChangelogRetryScheduler", LOG),
+                maxBytesInFlight);
+    }
+
+    BatchingStateChangeUploader(
+            long persistDelayMs,
+            long sizeThresholdBytes,
+            StateChangeUploader delegate,
+            ScheduledExecutorService uploadExecutor,
+            long maxBytesInFlight) {
+        this.scheduleDelayMs = persistDelayMs;
+        this.scheduled = new LinkedList<>();
+        this.uploadExecutor = uploadExecutor;
+        this.sizeThresholdBytes = sizeThresholdBytes;
+        this.maxBytesInFlight = maxBytesInFlight;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void upload(UploadTask uploadTask) {
+        Throwable error = getErrorSafe();
+        if (error != null) {
+            LOG.debug("don't persist {} changesets, already failed", uploadTask.changeSets.size());
+            uploadTask.fail(error);
+            return;
+        }
+        LOG.debug("persist {} changeSets", uploadTask.changeSets.size());
+        try {
+            checkState(
+                    inFlightBytesCounter.sum() <= maxBytesInFlight,
+                    "In flight data size threshold exceeded %s > %s",
+                    inFlightBytesCounter.sum(),
+                    maxBytesInFlight);
+            synchronized (scheduled) {
+                long size = uploadTask.getSize();
+                inFlightBytesCounter.add(size);
+                scheduledBytesCounter += size;
+                scheduled.add(wrapWithSizeUpdate(uploadTask, size, inFlightBytesCounter));
+                scheduleUploadIfNeeded();
+            }
+        } catch (Exception e) {
+            uploadTask.fail(e);
+            throw e;
+        }
+    }
+
+    private void scheduleUploadIfNeeded() {
+        checkState(holdsLock(scheduled));
+        if (scheduleDelayMs == 0 || scheduledBytesCounter >= sizeThresholdBytes) {
+            if (scheduledFuture != null) {
+                scheduledFuture.cancel(false);
+                scheduledFuture = null;
+            }
+            uploadExecutor.submit(this::drainAndSave);
+        } else if (scheduledFuture == null) {
+            scheduledFuture =
+                    uploadExecutor.schedule(this::drainAndSave, scheduleDelayMs, MILLISECONDS);
+        }
+    }
+
+    private void drainAndSave() {
+        Collection<UploadTask> tasks;
+        synchronized (scheduled) {
+            tasks = new ArrayList<>(scheduled);
+            scheduled.clear();
+            scheduledBytesCounter = 0;
+            scheduledFuture = null;
+        }
+        try {
+            Throwable error = getErrorSafe();
+            if (error != null) {
+                tasks.forEach(task -> task.fail(error));
+                return;
+            }
+            delegate.upload(tasks);
+        } catch (Throwable t) {
+            tasks.forEach(task -> task.fail(t));
+            if (findThrowable(t, IOException.class).isPresent()) {
+                LOG.warn("Caught IO exception while uploading", t);
+            } else {
+                setErrorSafe(t);
+                ExceptionUtils.rethrow(t);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.debug("close");
+        uploadExecutor.shutdownNow();
+        if (!uploadExecutor.awaitTermination(5, SECONDS)) {
+            LOG.warn("Unable to cleanly shutdown scheduler in 5s");
+        }
+        ArrayList<UploadTask> drained;
+        synchronized (scheduled) {
+            drained = new ArrayList<>(scheduled);
+            scheduled.clear();
+            scheduledBytesCounter = 0;
+        }
+        CancellationException ce = new CancellationException();
+        drained.forEach(task -> task.fail(ce));
+        delegate.close();
+    }
+
+    private synchronized Throwable getErrorSafe() {
+        return errorUnsafe;
+    }
+
+    private synchronized void setErrorSafe(Throwable t) {
+        errorUnsafe = t;
+    }
+
+    private static UploadTask wrapWithSizeUpdate(
+            UploadTask uploadTask, long preComputedTaskSize, LongAdder inflightSize) {
+        return new UploadTask(
+                uploadTask.changeSets,
+                result -> {
+                    inflightSize.add(-preComputedTaskSize);
+                    uploadTask.successCallback.accept(result);
+                },
+                (result, error) -> {
+                    inflightSize.add(-preComputedTaskSize);
+                    uploadTask.failureCallback.accept(result, error);
+                });
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
@@ -24,6 +24,8 @@ import org.apache.flink.configuration.MemorySize;
 
 import java.time.Duration;
 
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_TIMEOUT;
+
 /** {@link ConfigOptions} for {@link FsStateChangelogStorage}. */
 @Experimental
 public class FsStateChangelogOptions {
@@ -92,4 +94,39 @@ public class FsStateChangelogOptions {
                     .withDescription(
                             "Max amount of data allowed to be in-flight. "
                                     + "Upon reaching this limit the task will fail");
+
+    public static final ConfigOption<String> RETRY_POLICY =
+            ConfigOptions.key("dstl.dfs.upload.retry-policy")
+                    .stringType()
+                    .defaultValue("fixed")
+                    .withDescription(
+                            "Retry policy for the failed uploads (in particular, timed out). Valid values: none, fixed.");
+    public static final ConfigOption<Duration> UPLOAD_TIMEOUT =
+            ConfigOptions.key("dstl.dfs.upload.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription(
+                            "Time threshold beyond which an upload is considered timed out. "
+                                    + "If a new attempt is made but this upload succeeds earlier then this upload result will be used. "
+                                    + "May improve upload times if tail latencies of upload requests are significantly high. "
+                                    + "Only takes effect if "
+                                    + RETRY_POLICY.key()
+                                    + " is fixed. "
+                                    + "Please note that timeout * max_attempts should be less than "
+                                    + CHECKPOINTING_TIMEOUT.key());
+    public static final ConfigOption<Integer> RETRY_MAX_ATTEMPTS =
+            ConfigOptions.key("dstl.dfs.upload.max-attempts")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Maximum number of attempts (including the initial one) to peform a particular upload. "
+                                    + "Only takes effect if "
+                                    + RETRY_POLICY.key()
+                                    + " is fixed.");
+    public static final ConfigOption<Duration> RETRY_DELAY_AFTER_FAILURE =
+            ConfigOptions.key("dstl.dfs.upload.next-attempt-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(500))
+                    .withDescription(
+                            "Delay before the next attempt (if the failure was not caused by a timeout).");
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
@@ -22,19 +22,24 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.MemorySize;
 
+import java.time.Duration;
+
 /** {@link ConfigOptions} for {@link FsStateChangelogStorage}. */
 @Experimental
 public class FsStateChangelogOptions {
+
     public static final ConfigOption<String> BASE_PATH =
             ConfigOptions.key("dstl.dfs.base-path")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("Base path to store changelog files.");
+
     public static final ConfigOption<Boolean> COMPRESSION_ENABLED =
             ConfigOptions.key("dstl.dfs.compression.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to enable compression when serializing changelog.");
+
     public static final ConfigOption<MemorySize> PREEMPTIVE_PERSIST_THRESHOLD =
             ConfigOptions.key("dstl.dfs.preemptive-persist-threshold")
                     .memoryType()
@@ -44,9 +49,47 @@ public class FsStateChangelogOptions {
                                     + "beyond which they are persisted pre-emptively without waiting for a checkpoint. "
                                     + " Improves checkpointing time by allowing quasi-continuous uploading of state changes "
                                     + "(as opposed to uploading all accumulated changes on checkpoint).");
+
+    public static final ConfigOption<Duration> PERSIST_DELAY =
+            ConfigOptions.key("dstl.dfs.batch.persist-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(10))
+                    .withDescription(
+                            "Delay before persisting changelog after receiving persist request (on checkpoint). "
+                                    + "Minimizes the number of files and requests "
+                                    + "if multiple operators (backends) or sub-tasks are using the same store. "
+                                    + "Correspondingly increases checkpoint time (async phase).");
+
+    public static final ConfigOption<MemorySize> PERSIST_SIZE_THRESHOLD =
+            ConfigOptions.key("dstl.dfs.batch.persist-size-threshold")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("10Mb"))
+                    .withDescription(
+                            "Size threshold for state changes that were requested to be persisted but are waiting for "
+                                    + PERSIST_DELAY.key()
+                                    + " (from all operators). "
+                                    + ". Once reached, accumulated changes are persisted immediately. "
+                                    + "This is different from "
+                                    + PREEMPTIVE_PERSIST_THRESHOLD.key()
+                                    + " as it happens AFTER the checkpoint and potentially for state changes of multiple operators.");
+
     public static final ConfigOption<MemorySize> UPLOAD_BUFFER_SIZE =
             ConfigOptions.key("dstl.dfs.upload.buffer-size")
                     .memoryType()
                     .defaultValue(MemorySize.parse("1Mb"))
                     .withDescription("Buffer size used when uploading change sets");
+
+    public static final ConfigOption<Integer> NUM_UPLOAD_THREADS =
+            ConfigOptions.key("dstl.dfs.upload.num-threads")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("Number of threads to use for upload.");
+
+    public static final ConfigOption<MemorySize> IN_FLIGHT_DATA_LIMIT =
+            ConfigOptions.key("dstl.dfs.upload.max-in-flight")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("100Mb"))
+                    .withDescription(
+                            "Max amount of data allowed to be in-flight. "
+                                    + "Upon reaching this limit the task will fail");
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.MemorySize;
+
+/** {@link ConfigOptions} for {@link FsStateChangelogStorage}. */
+@Experimental
+public class FsStateChangelogOptions {
+    public static final ConfigOption<String> BASE_PATH =
+            ConfigOptions.key("dstl.dfs.base-path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Base path to store changelog files.");
+    public static final ConfigOption<Boolean> COMPRESSION_ENABLED =
+            ConfigOptions.key("dstl.dfs.compression.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to enable compression when serializing changelog.");
+    public static final ConfigOption<MemorySize> PREEMPTIVE_PERSIST_THRESHOLD =
+            ConfigOptions.key("dstl.dfs.preemptive-persist-threshold")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("5Mb"))
+                    .withDescription(
+                            "Size threshold for state changes of a single operator "
+                                    + "beyond which they are persisted pre-emptively without waiting for a checkpoint. "
+                                    + " Improves checkpointing time by allowing quasi-continuous uploading of state changes "
+                                    + "(as opposed to uploading all accumulated changes on checkpoint).");
+    public static final ConfigOption<MemorySize> UPLOAD_BUFFER_SIZE =
+            ConfigOptions.key("dstl.dfs.upload.buffer-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("1Mb"))
+                    .withDescription("Buffer size used when uploading change sets");
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandleStreamHandleReader;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PREEMPTIVE_PERSIST_THRESHOLD;
+
+/** Filesystem-based implementation of {@link StateChangelogStorage}. */
+@Experimental
+@ThreadSafe
+public class FsStateChangelogStorage
+        implements StateChangelogStorage<ChangelogStateHandleStreamImpl> {
+    private static final Logger LOG = LoggerFactory.getLogger(FsStateChangelogStorage.class);
+
+    private final StateChangeUploader uploader;
+    private final long preEmptivePersistThresholdInBytes;
+
+    /**
+     * The log id is only needed on write to separate changes from different backends (i.e.
+     * operators) in the resulting file.
+     */
+    private final AtomicInteger logIdGenerator = new AtomicInteger(0);
+
+    public FsStateChangelogStorage(Configuration config) throws IOException {
+        this(
+                StateChangeUploader.fromConfig(config),
+                config.get(PREEMPTIVE_PERSIST_THRESHOLD).getBytes());
+    }
+
+    @VisibleForTesting
+    public FsStateChangelogStorage(Path basePath, boolean compression, int bufferSize)
+            throws IOException {
+        this(
+                new StateChangeFsUploader(
+                        basePath, basePath.getFileSystem(), compression, bufferSize),
+                PREEMPTIVE_PERSIST_THRESHOLD.defaultValue().getBytes());
+    }
+
+    private FsStateChangelogStorage(
+            StateChangeUploader uploader, long preEmptivePersistThresholdInBytes) {
+        this.uploader = uploader;
+        this.preEmptivePersistThresholdInBytes = preEmptivePersistThresholdInBytes;
+    }
+
+    @Override
+    public FsStateChangelogWriter createWriter(String operatorID, KeyGroupRange keyGroupRange) {
+        UUID logId = new UUID(0, logIdGenerator.getAndIncrement());
+        LOG.info("createWriter for operator {}/{}: {}", operatorID, keyGroupRange, logId);
+        return new FsStateChangelogWriter(
+                logId, keyGroupRange, uploader, preEmptivePersistThresholdInBytes);
+    }
+
+    @Override
+    public StateChangelogHandleReader<ChangelogStateHandleStreamImpl> createReader() {
+        return new StateChangelogHandleStreamHandleReader(new StateChangeFormat());
+    }
+
+    @Override
+    public void close() throws Exception {
+        uploader.close();
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
+
+import java.io.IOException;
+
+class FsStateChangelogStorageFactory implements StateChangelogStorageFactory {
+
+    @Override
+    public String getIdentifier() {
+        return "filesystem";
+    }
+
+    @Override
+    public StateChangelogStorage<?> createStorage(Configuration configuration) throws IOException {
+        return new FsStateChangelogStorage(configuration);
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -1,0 +1,393 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.changelog.fs.StateChangeUploader.UploadTask;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.changelog.SequenceNumberRange;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.flink.util.IOUtils.closeAllQuietly;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Filesystem-based {@link StateChangelogWriter} implementation. Assumes TM-owned state - so no
+ * re-uploads.
+ *
+ * <p>On {@link #append(int, byte[]) append}, it stores the changes locally in memory (without any
+ * thread synchronization); {@link SequenceNumber} is not changed.
+ *
+ * <p>However, if they exceed {@link #preEmptivePersistThresholdInBytes} then {@link
+ * #persistInternal(SequenceNumber) persist} is called.
+ *
+ * <p>On {@link #persist(SequenceNumber) persist}, accumulated changes are sent to the {@link
+ * StateChangeUploader} as an immutable {@link StateChangeUploader.UploadTask task}. An {@link
+ * FsStateChangelogWriter.UploadCompletionListener upload listener} is also registered. Upon
+ * notification it updates the Writer local state (for future persist calls) and completes the
+ * future returned to the original caller. The uploader notifies all listeners via a callback in a
+ * task.
+ *
+ * <p>If persist() is called for the same state change before the upload completion then the
+ * listener is added but not the upload task (which must already exist).
+ *
+ * <p>Invariants:
+ *
+ * <ol>
+ *   <li>Every change has at most one associated upload (retries are performed at a lower level)
+ *   <li>Every change is present in at most one collection: either {@link #uploaded} OR {@link
+ *       #notUploaded}
+ *   <li>Changes BEING uploaded are NOT referenced locally - they will be added to uploaded upon
+ *       completion
+ *   <li>Failed and truncated changes are NOT stored - only their respective highest sequence
+ *       numbers
+ * </ol>
+ */
+@NotThreadSafe
+class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandleStreamImpl> {
+    private static final Logger LOG = LoggerFactory.getLogger(FsStateChangelogWriter.class);
+    private static final SequenceNumber INITIAL_SQN = SequenceNumber.of(0L);
+
+    private final UUID logId;
+    private final KeyGroupRange keyGroupRange;
+    private final StateChangeUploader uploader;
+    private final long preEmptivePersistThresholdInBytes;
+
+    /** Lock to synchronize handling of upload completion with new upload requests. */
+    // todo: replace with mailbox executor (after FLINK-23204)
+    private final Object lock = new Object();
+
+    /** A list of listener per upload (~ per checkpoint plus pre-emptive uploads). */
+    @GuardedBy("lock")
+    private final List<UploadCompletionListener> uploadCompletionListeners = new ArrayList<>();
+
+    /** Current {@link SequenceNumber}. */
+    private SequenceNumber activeSequenceNumber = INITIAL_SQN;
+
+    /**
+     * {@link SequenceNumber} before which changes will NOT be requested, exclusive. Increased after
+     * materialization.
+     */
+    @GuardedBy("lock")
+    private SequenceNumber lowestSequenceNumber = INITIAL_SQN;
+
+    /**
+     * Active changes, that all share the same {@link #activeSequenceNumber}.
+     *
+     * <p>When the latter is incremented in {@link #rollover()}, those changes are added to {@link
+     * #notUploaded} and {@link #activeChangeSet} is emptied.
+     */
+    private List<StateChange> activeChangeSet = new ArrayList<>();
+
+    /** {@link #activeChangeSet} size in bytes. */
+    private long activeChangeSetSize;
+
+    /** Changes that are not yet uploaded (upload not requested). */
+    private final NavigableMap<SequenceNumber, StateChangeSet> notUploaded = new TreeMap<>();
+
+    /** Uploaded changes, ready for use in snapshots. */
+    @GuardedBy("lock")
+    private final NavigableMap<SequenceNumber, UploadResult> uploaded = new TreeMap<>();
+
+    /**
+     * Highest {@link SequenceNumber} for which upload has failed (won't be restarted), inclusive.
+     */
+    @Nullable
+    @GuardedBy("lock")
+    private Tuple2<SequenceNumber, Throwable> highestFailed;
+
+    @GuardedBy("lock")
+    private boolean closed;
+
+    FsStateChangelogWriter(
+            UUID logId,
+            KeyGroupRange keyGroupRange,
+            StateChangeUploader uploader,
+            long preEmptivePersistThresholdInBytes) {
+        this.logId = logId;
+        this.keyGroupRange = keyGroupRange;
+        this.uploader = uploader;
+        this.preEmptivePersistThresholdInBytes = preEmptivePersistThresholdInBytes;
+    }
+
+    @Override
+    public void append(int keyGroup, byte[] value) throws IOException {
+        LOG.trace("append to {}: keyGroup={} {} bytes", logId, keyGroup, value.length);
+        checkState(!closed, "%s is closed", logId);
+        activeChangeSet.add(new StateChange(keyGroup, value));
+        activeChangeSetSize += value.length;
+        if (activeChangeSetSize >= preEmptivePersistThresholdInBytes) {
+            LOG.debug(
+                    "pre-emptively flush {}Mb of appended changes to the common store",
+                    activeChangeSetSize / 1024 / 1024);
+            persistInternal(notUploaded.isEmpty() ? activeSequenceNumber : notUploaded.firstKey());
+        }
+    }
+
+    @Override
+    public SequenceNumber initialSequenceNumber() {
+        return INITIAL_SQN;
+    }
+
+    @Override
+    public SequenceNumber lastAppendedSequenceNumber() {
+        LOG.trace("query {} sqn: {}", logId, activeSequenceNumber);
+        SequenceNumber tmp = activeSequenceNumber;
+        // the returned current sequence number must be able to distinguish between the changes
+        // appended before and after this call so we need to use the next sequence number
+        // At the same time, we don't want to increment SQN on each append (to avoid too many
+        // objects and segments in the resulting file).
+        rollover();
+        return tmp;
+    }
+
+    @Override
+    public CompletableFuture<ChangelogStateHandleStreamImpl> persist(SequenceNumber from)
+            throws IOException {
+        LOG.debug(
+                "persist {} starting from sqn {} (incl.), active sqn: {}",
+                logId,
+                from,
+                activeSequenceNumber);
+        return persistInternal(from);
+    }
+
+    private CompletableFuture<ChangelogStateHandleStreamImpl> persistInternal(SequenceNumber from)
+            throws IOException {
+        synchronized (lock) {
+            ensureCanPersist(from);
+            rollover();
+            Map<SequenceNumber, StateChangeSet> toUpload = drainTailMap(notUploaded, from);
+            NavigableMap<SequenceNumber, UploadResult> readyToReturn = uploaded.tailMap(from, true);
+            LOG.debug("collected readyToReturn: {}, toUpload: {}", readyToReturn, toUpload);
+
+            SequenceNumberRange range = SequenceNumberRange.generic(from, activeSequenceNumber);
+            if (range.size() == readyToReturn.size()) {
+                checkState(toUpload.isEmpty());
+                return completedFuture(buildHandle(keyGroupRange, readyToReturn));
+            } else {
+                CompletableFuture<ChangelogStateHandleStreamImpl> future =
+                        new CompletableFuture<>();
+                uploadCompletionListeners.add(
+                        new UploadCompletionListener(keyGroupRange, range, readyToReturn, future));
+                if (!toUpload.isEmpty()) {
+                    uploader.upload(
+                            new UploadTask(
+                                    toUpload.values(),
+                                    this::handleUploadSuccess,
+                                    this::handleUploadFailure));
+                }
+                return future;
+            }
+        }
+    }
+
+    private void handleUploadFailure(List<SequenceNumber> failedSqn, Throwable throwable) {
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+            uploadCompletionListeners.removeIf(
+                    listener -> listener.onFailure(failedSqn, throwable));
+            failedSqn.stream()
+                    .max(Comparator.naturalOrder())
+                    .filter(sqn -> sqn.compareTo(lowestSequenceNumber) >= 0)
+                    .filter(sqn -> highestFailed == null || sqn.compareTo(highestFailed.f0) > 0)
+                    .ifPresent(sqn -> highestFailed = Tuple2.of(sqn, throwable));
+        }
+    }
+
+    private void handleUploadSuccess(List<UploadResult> results) {
+        synchronized (lock) {
+            if (closed) {
+                results.forEach(
+                        r -> closeAllQuietly(() -> r.getStreamStateHandle().discardState()));
+            } else {
+                uploadCompletionListeners.removeIf(listener -> listener.onSuccess(results));
+                for (UploadResult result : results) {
+                    if (result.sequenceNumber.compareTo(lowestSequenceNumber) >= 0) {
+                        uploaded.put(result.sequenceNumber, result);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        LOG.debug("close {}", logId);
+        synchronized (lock) {
+            checkState(!closed);
+            closed = true;
+            activeChangeSet.clear();
+            activeChangeSetSize = 0;
+            notUploaded.clear();
+            uploaded.clear();
+        }
+    }
+
+    @Override
+    public void truncate(SequenceNumber to) {
+        LOG.debug("truncate {} to sqn {} (excl.)", logId, to);
+        checkArgument(to.compareTo(activeSequenceNumber) <= 0);
+        synchronized (lock) {
+            lowestSequenceNumber = to;
+            notUploaded.headMap(lowestSequenceNumber, false).clear();
+            uploaded.headMap(lowestSequenceNumber, false).clear();
+        }
+    }
+
+    private void rollover() {
+        if (activeChangeSet.isEmpty()) {
+            return;
+        }
+        notUploaded.put(
+                activeSequenceNumber,
+                new StateChangeSet(logId, activeSequenceNumber, activeChangeSet));
+        activeSequenceNumber = activeSequenceNumber.next();
+        LOG.debug("bump active sqn to {}", activeSequenceNumber);
+        activeChangeSet = new ArrayList<>();
+        activeChangeSetSize = 0;
+    }
+
+    @Override
+    public void confirm(SequenceNumber from, SequenceNumber to) {
+        // do nothing
+    }
+
+    @Override
+    public void reset(SequenceNumber from, SequenceNumber to) {
+        // do nothing
+    }
+
+    private static ChangelogStateHandleStreamImpl buildHandle(
+            KeyGroupRange keyGroupRange, NavigableMap<SequenceNumber, UploadResult> results) {
+        List<Tuple2<StreamStateHandle, Long>> tuples = new ArrayList<>();
+        long size = 0;
+        for (UploadResult uploadResult : results.values()) {
+            tuples.add(Tuple2.of(uploadResult.getStreamStateHandle(), uploadResult.getOffset()));
+            size += uploadResult.getSize();
+        }
+        return new ChangelogStateHandleStreamImpl(tuples, keyGroupRange, size);
+    }
+
+    @VisibleForTesting
+    SequenceNumber lastAppendedSqnUnsafe() {
+        return activeSequenceNumber;
+    }
+
+    private void ensureCanPersist(SequenceNumber from) throws IOException {
+        checkNotNull(from);
+        if (highestFailed != null && highestFailed.f0.compareTo(from) >= 0) {
+            throw new IOException(
+                    "The upload for " + highestFailed.f0 + " has already failed previously",
+                    highestFailed.f1);
+        } else if (lowestSequenceNumber.compareTo(from) > 0) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Requested changes were truncated (requested: %s, truncated: %s)",
+                            from, lowestSequenceNumber));
+        } else if (activeSequenceNumber.compareTo(from) < 0) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Requested changes were not yet appended (requested: %s, appended: %s)",
+                            from, activeSequenceNumber));
+        }
+    }
+
+    private static final class UploadCompletionListener {
+        private final NavigableMap<SequenceNumber, UploadResult> uploaded;
+        private final CompletableFuture<ChangelogStateHandleStreamImpl> completionFuture;
+        private final KeyGroupRange keyGroupRange;
+        private final SequenceNumberRange changeRange;
+
+        private UploadCompletionListener(
+                KeyGroupRange keyGroupRange,
+                SequenceNumberRange changeRange,
+                Map<SequenceNumber, UploadResult> uploaded,
+                CompletableFuture<ChangelogStateHandleStreamImpl> completionFuture) {
+            checkArgument(
+                    !changeRange.isEmpty(), "Empty change range not allowed: %s", changeRange);
+            this.uploaded = new TreeMap<>(uploaded);
+            this.completionFuture = completionFuture;
+            this.keyGroupRange = keyGroupRange;
+            this.changeRange = changeRange;
+        }
+
+        public boolean onSuccess(List<UploadResult> uploadResults) {
+            for (UploadResult uploadResult : uploadResults) {
+                if (changeRange.contains(uploadResult.sequenceNumber)) {
+                    uploaded.put(uploadResult.sequenceNumber, uploadResult);
+                    if (uploaded.size() == changeRange.size()) {
+                        completionFuture.complete(buildHandle(keyGroupRange, uploaded));
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public boolean onFailure(List<SequenceNumber> sequenceNumbers, Throwable throwable) {
+            IOException ioException =
+                    throwable instanceof IOException
+                            ? (IOException) throwable
+                            : new IOException(throwable);
+            for (SequenceNumber sequenceNumber : sequenceNumbers) {
+                if (changeRange.contains(sequenceNumber)) {
+                    completionFuture.completeExceptionally(ioException);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static Map<SequenceNumber, StateChangeSet> drainTailMap(
+            NavigableMap<SequenceNumber, StateChangeSet> src, SequenceNumber fromInclusive) {
+        Map<SequenceNumber, StateChangeSet> tailMap = src.tailMap(fromInclusive, true);
+        Map<SequenceNumber, StateChangeSet> toUpload = new HashMap<>(tailMap);
+        tailMap.clear();
+        return toUpload;
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/OutputStreamWithPos.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/OutputStreamWithPos.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+class OutputStreamWithPos extends OutputStream {
+    private final OutputStream outputStream;
+    private long pos;
+
+    public OutputStreamWithPos(OutputStream outputStream) {
+        this.outputStream = outputStream;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        outputStream.write(b);
+        pos++;
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        outputStream.write(b);
+        pos += b.length;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        outputStream.write(b, off, len);
+        pos += len;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        outputStream.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        outputStream.close();
+    }
+
+    public long getPos() {
+        return pos;
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/RetryPolicy.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/RetryPolicy.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.ReadableConfig;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/** Retry policy to use by {@link RetryingExecutor}. */
+@Internal
+public interface RetryPolicy {
+    static RetryPolicy fromConfig(ReadableConfig config) {
+        switch (config.get(FsStateChangelogOptions.RETRY_POLICY)) {
+            case "fixed":
+                return fixed(
+                        config.get(FsStateChangelogOptions.RETRY_MAX_ATTEMPTS),
+                        config.get(FsStateChangelogOptions.UPLOAD_TIMEOUT).toMillis(),
+                        config.get(FsStateChangelogOptions.RETRY_DELAY_AFTER_FAILURE).toMillis());
+            case "none":
+                return NONE;
+            default:
+                throw new IllegalConfigurationException(
+                        "Unknown retry policy: "
+                                + config.get(FsStateChangelogOptions.RETRY_POLICY));
+        }
+    }
+
+    /** @return timeout in millis. Zero or negative means no timeout. */
+    long timeoutFor(int attempt);
+
+    /**
+     * @return delay in millis before the next attempt. Negative means no retry, zero means no
+     *     delay.
+     */
+    long retryAfter(int failedAttempt, Exception exception);
+
+    RetryPolicy NONE =
+            new RetryPolicy() {
+                @Override
+                public long timeoutFor(int attempt) {
+                    return -1L;
+                }
+
+                @Override
+                public long retryAfter(int failedAttempt, Exception exception) {
+                    return -1L;
+                }
+
+                public String toString() {
+                    return "none";
+                }
+            };
+
+    static RetryPolicy fixed(int maxAttempts, long timeout, long delayAfterFailure) {
+        return new FixedRetryPolicy(maxAttempts, timeout, delayAfterFailure);
+    }
+
+    /** {@link RetryPolicy} with fixed timeout, delay and max attempts. */
+    class FixedRetryPolicy implements RetryPolicy {
+
+        private final long timeout;
+        private final int maxAttempts;
+        private final long delayAfterFailure;
+
+        FixedRetryPolicy(int maxAttempts, long timeout, long delayAfterFailure) {
+            this.maxAttempts = maxAttempts;
+            this.timeout = timeout;
+            this.delayAfterFailure = delayAfterFailure;
+        }
+
+        @Override
+        public long timeoutFor(int attempt) {
+            return timeout;
+        }
+
+        @Override
+        public long retryAfter(int attempt, Exception exception) {
+            if (attempt >= maxAttempts) {
+                return -1L;
+            } else if (exception instanceof TimeoutException) {
+                return 0L;
+            } else if (exception instanceof IOException) {
+                return delayAfterFailure;
+            } else {
+                return -1L;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "timeout="
+                    + timeout
+                    + ", maxAttempts="
+                    + maxAttempts
+                    + ", delay="
+                    + delayAfterFailure;
+        }
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/RetryingExecutor.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/RetryingExecutor.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.util.function.RunnableWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * A {@link RetriableAction} executor that schedules a next attempt upon timeout based on {@link
+ * RetryPolicy}. Aimed to curb tail latencies
+ */
+class RetryingExecutor implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(RetryingExecutor.class);
+
+    private final ScheduledExecutorService scheduler;
+
+    RetryingExecutor(int nThreads) {
+        this(SchedulerFactory.create(nThreads, "ChangelogRetryScheduler", LOG));
+    }
+
+    RetryingExecutor(ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Execute the given action according to the retry policy.
+     *
+     * <p>NOTE: the action must be idempotent because multiple instances of it can be executed
+     * concurrently (if the policy allows retries).
+     */
+    void execute(RetryPolicy retryPolicy, RetriableAction action) {
+        LOG.debug("execute with retryPolicy: {}", retryPolicy);
+        RetriableTask task = new RetriableTask(action, retryPolicy, scheduler);
+        scheduler.submit(task);
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.debug("close");
+        scheduler.shutdownNow();
+        if (!scheduler.awaitTermination(1, TimeUnit.SECONDS)) {
+            LOG.warn("Unable to cleanly shutdown executorService in 1s");
+        }
+    }
+
+    /**
+     * An action to be performed by {@link RetryingExecutor}, potentially with multiple attempts,
+     * potentially concurrently.
+     *
+     * <p>NOTE: the action must be idempotent because of potential concurrent attempts.
+     */
+    interface RetriableAction extends RunnableWithException {}
+
+    private static final class RetriableTask implements Runnable {
+        private final RetriableAction runnable;
+        private final ScheduledExecutorService executorService;
+        private final int current;
+        private final RetryPolicy retryPolicy;
+        /**
+         * The flag shared across all attempts to execute the same {#link #runnable action}
+         * signifying whether it was completed already or not. Used to prevent scheduling a new
+         * attempt or starting it if another attempt has already completed the action.
+         */
+        private final AtomicBoolean actionCompleted;
+
+        /**
+         * The flag private to <b>this</b> attempt signifying whether it has completed or not. Used
+         * to prevent double finalization ({@link #handleError}) by the executing thread and
+         * timeouting thread.
+         */
+        private final AtomicBoolean attemptCompleted = new AtomicBoolean(false);
+
+        RetriableTask(
+                RetriableAction runnable,
+                RetryPolicy retryPolicy,
+                ScheduledExecutorService executorService) {
+            this(1, new AtomicBoolean(false), runnable, retryPolicy, executorService);
+        }
+
+        private RetriableTask(
+                int current,
+                AtomicBoolean actionCompleted,
+                RetriableAction runnable,
+                RetryPolicy retryPolicy,
+                ScheduledExecutorService executorService) {
+            this.current = current;
+            this.runnable = runnable;
+            this.retryPolicy = retryPolicy;
+            this.executorService = executorService;
+            this.actionCompleted = actionCompleted;
+        }
+
+        @Override
+        public void run() {
+            if (!actionCompleted.get()) {
+                Optional<ScheduledFuture<?>> timeoutFuture = scheduleTimeout();
+                try {
+                    runnable.run();
+                    actionCompleted.set(true);
+                    attemptCompleted.set(true);
+                } catch (Exception e) {
+                    handleError(e);
+                } finally {
+                    timeoutFuture.ifPresent(f -> f.cancel(true));
+                }
+            }
+        }
+
+        private void handleError(Exception e) {
+            LOG.info("execution attempt {} failed: {}", current, e.getMessage());
+            // prevent double completion in case of a timeout and another failure
+            boolean attemptTransition = attemptCompleted.compareAndSet(false, true);
+            if (attemptTransition && !actionCompleted.get()) {
+                long nextAttemptDelay = retryPolicy.retryAfter(current, e);
+                if (nextAttemptDelay == 0L) {
+                    executorService.submit(next());
+                } else if (nextAttemptDelay > 0L) {
+                    executorService.schedule(next(), nextAttemptDelay, MILLISECONDS);
+                } else {
+                    actionCompleted.set(true);
+                }
+            }
+        }
+
+        private RetriableTask next() {
+            return new RetriableTask(
+                    current + 1, actionCompleted, runnable, retryPolicy, executorService);
+        }
+
+        private Optional<ScheduledFuture<?>> scheduleTimeout() {
+            long timeout = retryPolicy.timeoutFor(current);
+            return timeout <= 0
+                    ? Optional.empty()
+                    : Optional.of(
+                            executorService.schedule(
+                                    () -> handleError(fmtError(timeout)), timeout, MILLISECONDS));
+        }
+
+        private TimeoutException fmtError(long timeout) {
+            return new TimeoutException(
+                    String.format("Attempt %d timed out after %dms", current, timeout));
+        }
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/SchedulerFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/SchedulerFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.util.FatalExitExceptionHandler.INSTANCE;
+
+class SchedulerFactory {
+    private SchedulerFactory() {}
+
+    /**
+     * Create a {@link ScheduledThreadPoolExecutor} using the provided corePoolSize. The following
+     * behaviour is configured:
+     *
+     * <ul>
+     *   <li>rejected executions are logged if the executor is {@link
+     *       java.util.concurrent.ThreadPoolExecutor#isShutdown shutdown}
+     *   <li>otherwise, {@link RejectedExecutionException} is thrown
+     *   <li>any uncaught exception fails the JVM (using {@link
+     *       org.apache.flink.runtime.util.FatalExitExceptionHandler FatalExitExceptionHandler})
+     * </ul>
+     */
+    public static ScheduledThreadPoolExecutor create(int corePoolSize, String name, Logger log) {
+        AtomicInteger cnt = new AtomicInteger(0);
+        return new ScheduledThreadPoolExecutor(
+                corePoolSize,
+                runnable -> {
+                    Thread thread = new Thread(runnable);
+                    thread.setName(name + "-" + cnt.incrementAndGet());
+                    thread.setUncaughtExceptionHandler(INSTANCE);
+                    return thread;
+                },
+                (ignored, executor) -> {
+                    if (executor.isShutdown()) {
+                        log.debug("Execution rejected because shutdown is in progress");
+                    } else {
+                        throw new RejectedExecutionException();
+                    }
+                });
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFormat.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFormat.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandleStreamHandleReader;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static java.util.Comparator.comparing;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Serialization format for state changes. */
+@Internal
+public class StateChangeFormat
+        implements StateChangelogHandleStreamHandleReader.StateChangeIterator {
+    private static final Logger LOG = LoggerFactory.getLogger(StateChangeFormat.class);
+
+    Map<StateChangeSet, Long> write(OutputStreamWithPos os, Collection<StateChangeSet> changeSets)
+            throws IOException {
+        List<StateChangeSet> sorted = new ArrayList<>(changeSets);
+        // using sorting instead of bucketing for simplicity
+        sorted.sort(
+                comparing(StateChangeSet::getLogId)
+                        .thenComparing(StateChangeSet::getSequenceNumber));
+        DataOutputViewStreamWrapper dataOutput = new DataOutputViewStreamWrapper(os);
+        Map<StateChangeSet, Long> pendingResults = new HashMap<>();
+        for (StateChangeSet changeSet : sorted) {
+            pendingResults.put(changeSet, os.getPos());
+            writeChangeSet(dataOutput, changeSet.getChanges());
+        }
+        return pendingResults;
+    }
+
+    private void writeChangeSet(DataOutputViewStreamWrapper output, List<StateChange> changes)
+            throws IOException {
+        // write in groups to output kg id only once
+        Map<Integer, List<StateChange>> byKeyGroup =
+                changes.stream().collect(Collectors.groupingBy(StateChange::getKeyGroup));
+        // sort groups to output metadata first (see StateChangeLoggerImpl.COMMON_KEY_GROUP)
+        Map<Integer, List<StateChange>> sorted = new TreeMap<>(byKeyGroup);
+        output.writeInt(sorted.size());
+        for (Map.Entry<Integer, List<StateChange>> entry : sorted.entrySet()) {
+            output.writeInt(entry.getValue().size());
+            output.writeInt(entry.getKey());
+            for (StateChange stateChange : entry.getValue()) {
+                output.writeInt(stateChange.getChange().length);
+                output.write(stateChange.getChange());
+            }
+        }
+    }
+
+    @Override
+    public CloseableIterator<StateChange> read(StreamStateHandle handle, long offset)
+            throws IOException {
+        FSDataInputStream stream = handle.openInputStream();
+        DataInputViewStreamWrapper input = wrap(stream);
+        if (stream.getPos() != offset) {
+            LOG.debug("seek from {} to {}", stream.getPos(), offset);
+            input.skipBytesToRead((int) offset);
+        }
+        return new CloseableIterator<StateChange>() {
+            int numUnreadGroups = input.readInt();
+            int numLeftInGroup = numUnreadGroups-- == 0 ? 0 : input.readInt();
+            int keyGroup = numLeftInGroup == 0 ? 0 : input.readInt();
+
+            @Override
+            public boolean hasNext() {
+                advance();
+                return numLeftInGroup > 0;
+            }
+
+            private void advance() {
+                if (numLeftInGroup == 0 && numUnreadGroups > 0) {
+                    numUnreadGroups--;
+                    try {
+                        numLeftInGroup = input.readInt();
+                        keyGroup = input.readInt();
+                    } catch (IOException e) {
+                        ExceptionUtils.rethrow(e);
+                    }
+                }
+            }
+
+            @Override
+            public StateChange next() {
+                advance();
+                if (numLeftInGroup == 0) {
+                    throw new NoSuchElementException();
+                }
+                numLeftInGroup--;
+                try {
+                    return readChange();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            private StateChange readChange() throws IOException {
+                int size = input.readInt();
+                byte[] bytes = new byte[size];
+                checkState(size == input.read(bytes));
+                return new StateChange(keyGroup, bytes);
+            }
+
+            @Override
+            public void close() throws Exception {
+                LOG.trace("close {}", stream);
+                stream.close();
+            }
+        };
+    }
+
+    private DataInputViewStreamWrapper wrap(InputStream stream) throws IOException {
+        stream = new BufferedInputStream(stream);
+        boolean compressed = stream.read() == 1;
+        return new DataInputViewStreamWrapper(
+                compressed
+                        ? SnappyStreamCompressionDecorator.INSTANCE.decorateWithCompression(stream)
+                        : stream);
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.SnappyStreamCompressionDecorator;
+import org.apache.flink.runtime.state.StreamCompressionDecorator;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+
+import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.flink.core.fs.FileSystem.WriteMode.NO_OVERWRITE;
+
+/**
+ * A synchronous {@link StateChangeUploader} implementation that uploads the changes using {@link
+ * FileSystem}.
+ */
+class StateChangeFsUploader implements StateChangeUploader {
+    private static final Logger LOG = LoggerFactory.getLogger(StateChangeFsUploader.class);
+
+    private final Path basePath;
+    private final FileSystem fileSystem;
+    private final StateChangeFormat format;
+    private final boolean compression;
+    private final int bufferSize;
+
+    public StateChangeFsUploader(
+            Path basePath, FileSystem fileSystem, boolean compression, int bufferSize) {
+        this.basePath = basePath;
+        this.fileSystem = fileSystem;
+        this.format = new StateChangeFormat();
+        this.compression = compression;
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public void upload(UploadTask uploadTask) throws IOException {
+        upload(singletonList(uploadTask));
+    }
+
+    public void upload(Collection<UploadTask> tasks) throws IOException {
+        final String fileName = generateFileName();
+        LOG.debug("upload {} tasks to {}", tasks.size(), fileName);
+        Path path = new Path(basePath, fileName);
+
+        try {
+            LocalResult result = upload(path, tasks);
+            result.tasksOffsets.forEach(
+                    (task, offsets) -> task.complete(buildResults(result.handle, offsets)));
+        } catch (IOException e) {
+            try (Closer closer = Closer.create()) {
+                closer.register(
+                        () -> {
+                            throw e;
+                        });
+                tasks.forEach(cs -> closer.register(() -> cs.fail(e)));
+                closer.register(() -> fileSystem.delete(path, true));
+            }
+        }
+    }
+
+    private LocalResult upload(Path path, Collection<UploadTask> tasks) throws IOException {
+        try (FSDataOutputStream fsStream = fileSystem.create(path, NO_OVERWRITE)) {
+            fsStream.write(compression ? 1 : 0);
+            try (OutputStreamWithPos stream = wrap(fsStream); ) {
+                final Map<UploadTask, Map<StateChangeSet, Long>> tasksOffsets = new HashMap<>();
+                for (UploadTask task : tasks) {
+                    tasksOffsets.put(task, format.write(stream, task.changeSets));
+                }
+                FileStateHandle handle = new FileStateHandle(path, stream.getPos());
+                // WARN: streams have to be closed before returning the results
+                // otherwise JM may receive invalid handles
+                return new LocalResult(tasksOffsets, handle);
+            }
+        }
+    }
+
+    private static final class LocalResult {
+        private final Map<UploadTask, Map<StateChangeSet, Long>> tasksOffsets;
+        private final StreamStateHandle handle;
+
+        public LocalResult(
+                Map<UploadTask, Map<StateChangeSet, Long>> tasksOffsets, StreamStateHandle handle) {
+            this.tasksOffsets = tasksOffsets;
+            this.handle = handle;
+        }
+    }
+
+    private OutputStreamWithPos wrap(FSDataOutputStream fsStream) throws IOException {
+        StreamCompressionDecorator instance =
+                compression
+                        ? SnappyStreamCompressionDecorator.INSTANCE
+                        : UncompressedStreamCompressionDecorator.INSTANCE;
+        OutputStream compressed =
+                compression ? instance.decorateWithCompression(fsStream) : fsStream;
+        return new OutputStreamWithPos(new BufferedOutputStream(compressed, bufferSize));
+    }
+
+    private List<UploadResult> buildResults(
+            StreamStateHandle handle, Map<StateChangeSet, Long> offsets) {
+        return offsets.entrySet().stream()
+                .map(e -> UploadResult.of(handle, e.getKey(), e.getValue()))
+                .collect(toList());
+    }
+
+    private String generateFileName() {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void close() {}
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeSet.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeSet.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.changelog.StateChange;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * A set of changes made to some state(s) by a single state backend during a single checkpoint.
+ * There can be zero or more change sets for a single checkpoint. Thread-safe with the assumption
+ * that constructor arguments are not modified outside.
+ */
+@ThreadSafe
+class StateChangeSet {
+    private final UUID logId;
+    private final List<StateChange> changes;
+    private final SequenceNumber sequenceNumber;
+
+    public StateChangeSet(UUID logId, SequenceNumber sequenceNumber, List<StateChange> changes) {
+        this.logId = logId;
+        this.changes = unmodifiableList(changes);
+        this.sequenceNumber = sequenceNumber;
+    }
+
+    public UUID getLogId() {
+        return logId;
+    }
+
+    public SequenceNumber getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public List<StateChange> getChanges() {
+        return changes;
+    }
+
+    public long getSize() {
+        long size = 0;
+        for (StateChange change : changes) {
+            size += change.getChange().length;
+        }
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return "logId=" + logId + ", sequenceNumber=" + sequenceNumber + ", changes=" + changes;
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -82,6 +82,7 @@ interface StateChangeUploader extends AutoCloseable {
                 new BatchingStateChangeUploader(
                         config.get(PERSIST_DELAY).toMillis(),
                         config.get(PERSIST_SIZE_THRESHOLD).getBytes(),
+                        RetryPolicy.fromConfig(config),
                         store,
                         config.get(NUM_UPLOAD_THREADS),
                         config.get(IN_FLIGHT_DATA_LIMIT).getBytes());

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploader.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.COMPRESSION_ENABLED;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_BUFFER_SIZE;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+// todo: consider using CheckpointStreamFactory / CheckpointStorageWorkerView
+//     Considerations:
+//     0. need for checkpointId in the current API to resolve the location
+//       option a: pass checkpointId (race condition?)
+//       option b: pass location (race condition?)
+//       option c: add FsCheckpointStorageAccess.createSharedStateStream
+//     1. different settings for materialized/changelog (e.g. timeouts)
+//     2. re-use closeAndGetHandle
+//     3. re-use in-memory handles (.metadata)
+//     4. handle in-memory handles duplication
+
+/**
+ * The purpose of this interface is to abstract the different implementations of uploading state
+ * changelog parts. It has a single {@link #upload} method with a single {@link UploadTask} argument
+ * which is meant to initiate such an upload.
+ */
+interface StateChangeUploader extends AutoCloseable {
+
+    void upload(UploadTask uploadTask) throws IOException;
+
+    default void upload(Collection<UploadTask> tasks) throws IOException {
+        for (UploadTask task : tasks) {
+            upload(task);
+        }
+    }
+
+    static StateChangeUploader fromConfig(ReadableConfig config) throws IOException {
+        Path basePath = new Path(config.get(BASE_PATH));
+        long bytes = config.get(UPLOAD_BUFFER_SIZE).getBytes();
+        checkArgument(bytes <= Integer.MAX_VALUE);
+        int bufferSize = (int) bytes;
+        return new StateChangeFsUploader(
+                basePath, basePath.getFileSystem(), config.get(COMPRESSION_ENABLED), bufferSize);
+    }
+
+    @ThreadSafe
+    final class UploadTask {
+        final Collection<StateChangeSet> changeSets;
+        final BiConsumer<List<SequenceNumber>, Throwable> failureCallback;
+        final Consumer<List<UploadResult>> successCallback;
+        final AtomicBoolean finished = new AtomicBoolean();
+
+        public UploadTask(
+                Collection<StateChangeSet> changeSets,
+                Consumer<List<UploadResult>> successCallback,
+                BiConsumer<List<SequenceNumber>, Throwable> failureCallback) {
+            this.changeSets = new ArrayList<>(changeSets);
+            this.failureCallback = failureCallback;
+            this.successCallback = successCallback;
+        }
+
+        public void complete(List<UploadResult> results) {
+            if (finished.compareAndSet(false, true)) {
+                successCallback.accept(results);
+            }
+        }
+
+        public void fail(Throwable error) {
+            if (finished.compareAndSet(false, true)) {
+                failureCallback.accept(
+                        changeSets.stream()
+                                .map(StateChangeSet::getSequenceNumber)
+                                .collect(toList()),
+                        error);
+            }
+        }
+
+        public long getSize() {
+            long size = 0;
+            for (StateChangeSet set : changeSets) {
+                size = set.getSize();
+            }
+            return size;
+        }
+
+        @Override
+        public String toString() {
+            return "changeSets=" + changeSets;
+        }
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/UploadResult.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/UploadResult.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+final class UploadResult {
+    public final StreamStateHandle streamStateHandle;
+    public final long offset;
+    public final SequenceNumber sequenceNumber;
+    public final long size;
+
+    public UploadResult(
+            StreamStateHandle streamStateHandle,
+            long offset,
+            SequenceNumber sequenceNumber,
+            long size) {
+        this.streamStateHandle = checkNotNull(streamStateHandle);
+        this.offset = offset;
+        this.sequenceNumber = checkNotNull(sequenceNumber);
+        this.size = size;
+    }
+
+    public static UploadResult of(StreamStateHandle handle, StateChangeSet changeSet, long offset) {
+        return new UploadResult(handle, offset, changeSet.getSequenceNumber(), changeSet.getSize());
+    }
+
+    public StreamStateHandle getStreamStateHandle() {
+        return streamStateHandle;
+    }
+
+    public long getOffset() {
+        return offset;
+    }
+
+    public SequenceNumber getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return "streamStateHandle="
+                + streamStateHandle
+                + ", size="
+                + size
+                + ", offset="
+                + offset
+                + ", sequenceNumber="
+                + sequenceNumber;
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/main/resources/META-INF/services/org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory
+++ b/flink-dstl/flink-dstl-dfs/src/main/resources/META-INF/services/org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.changelog.fs.FsStateChangelogStorageFactory

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploaderTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/BatchingStateChangeUploaderTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.changelog.fs.StateChangeUploader.UploadTask;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** {@link BatchingStateChangeUploader} test. */
+public class BatchingStateChangeUploaderTest {
+
+    private final Random random = new Random();
+
+    @Test
+    public void testNoDelayAndThreshold() throws Exception {
+        withStore(
+                0,
+                0,
+                (store, probe) -> {
+                    List<StateChangeSet> changes1 = getChanges(4);
+                    upload(store, changes1);
+                    assertSaved(probe, changes1);
+                    List<StateChangeSet> changes2 = getChanges(4);
+                    upload(store, changes2);
+                    assertSaved(probe, changes1, changes2);
+                });
+    }
+
+    private void upload(BatchingStateChangeUploader store, List<StateChangeSet> changeSets) {
+        store.upload(new UploadTask(changeSets, unused -> {}, (unused0, unused1) -> {}));
+    }
+
+    @Test
+    public void testSizeThreshold() throws Exception {
+        int numChanges = 7;
+        int changeSize = 11;
+        int threshold = changeSize * numChanges;
+        withStore(
+                Integer.MAX_VALUE,
+                threshold,
+                (store, probe) -> {
+                    List<StateChangeSet> expected = new ArrayList<>();
+                    int runningSize = 0;
+                    for (int i = 0; i < numChanges; i++) {
+                        List<StateChangeSet> changes = getChanges(changeSize);
+                        runningSize += changes.stream().mapToLong(StateChangeSet::getSize).sum();
+                        upload(store, changes);
+                        expected.addAll(changes);
+                        if (runningSize >= threshold) {
+                            assertSaved(probe, expected);
+                        } else {
+                            assertTrue(probe.getUploaded().isEmpty());
+                        }
+                    }
+                });
+    }
+
+    @Test
+    public void testDelay() throws Exception {
+        int delayMs = 50;
+        withStore(
+                delayMs,
+                Integer.MAX_VALUE,
+                (store, probe) -> {
+                    List<StateChangeSet> changeSets = getChanges(4);
+                    upload(store, changeSets);
+                    assertTrue(probe.getUploaded().isEmpty());
+                    Thread.sleep(delayMs * 2);
+                    assertEquals(changeSets, probe.getUploaded());
+                });
+    }
+
+    @Test(expected = RejectedExecutionException.class)
+    public void testErrorHandling() throws Exception {
+        TestingStateChangeUploader probe = new TestingStateChangeUploader();
+        DirectScheduledExecutorService scheduler = new DirectScheduledExecutorService();
+        try (BatchingStateChangeUploader store =
+                new BatchingStateChangeUploader(
+                        Integer.MAX_VALUE, Integer.MAX_VALUE, probe, scheduler, 10_000)) {
+            scheduler.shutdown();
+            upload(store, getChanges(4));
+        }
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        TestingStateChangeUploader probe = new TestingStateChangeUploader();
+        DirectScheduledExecutorService scheduler = new DirectScheduledExecutorService();
+        new BatchingStateChangeUploader(0, 0, probe, scheduler, 10_000).close();
+        assertTrue(probe.isClosed());
+        assertTrue(scheduler.isShutdown());
+    }
+
+    private List<StateChangeSet> getChanges(int size) {
+        byte[] change = new byte[size];
+        random.nextBytes(change);
+        return singletonList(
+                new StateChangeSet(
+                        UUID.randomUUID(),
+                        SequenceNumber.of(0),
+                        singletonList(new StateChange(0, change))));
+    }
+
+    private static void withStore(
+            int delayMs,
+            int sizeThreshold,
+            BiConsumerWithException<
+                            BatchingStateChangeUploader, TestingStateChangeUploader, Exception>
+                    test)
+            throws Exception {
+        TestingStateChangeUploader probe = new TestingStateChangeUploader();
+
+        try (BatchingStateChangeUploader store =
+                new BatchingStateChangeUploader(
+                        delayMs,
+                        sizeThreshold,
+                        probe,
+                        new DirectScheduledExecutorService(),
+                        10_000)) {
+            test.accept(store, probe);
+        }
+    }
+
+    @SafeVarargs
+    private final void assertSaved(
+            TestingStateChangeUploader probe, List<StateChangeSet>... expected) {
+        assertEquals(
+                Arrays.stream(expected).flatMap(Collection::stream).collect(Collectors.toList()),
+                new ArrayList<>(probe.getUploaded()));
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogStorageTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.StateChangelogStorageTest;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+
+/** {@link FsStateChangelogStorage} test. */
+@RunWith(Parameterized.class)
+public class FsStateChangelogStorageTest extends StateChangelogStorageTest {
+    @Parameterized.Parameter public boolean compression;
+
+    @Parameterized.Parameters(name = "use compression = {0}")
+    public static Object[] parameters() {
+        return new Object[] {true, false};
+    }
+
+    @Override
+    protected StateChangelogStorage<?> getFactory() throws IOException {
+        return new FsStateChangelogStorage(
+                Path.fromLocalFile(temporaryFolder.newFolder()), compression, 1024 * 1024 * 10);
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.apache.flink.changelog.fs.FsStateChangelogWriterSqnTest.WriterSqnTestSettings.of;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test of incrementing {@link SequenceNumber sequence numbers} by {@link FsStateChangelogWriter}.
+ */
+@RunWith(Parameterized.class)
+public class FsStateChangelogWriterSqnTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static List<WriterSqnTestSettings> getSettings() {
+        return asList(
+                of(StateChangelogWriter::lastAppendedSequenceNumber, "lastAppendedSequenceNumber")
+                        .withAppendCall(false)
+                        .expectIncrement(false),
+                of(StateChangelogWriter::lastAppendedSequenceNumber, "lastAppendedSequenceNumber")
+                        .withAppendCall(true)
+                        .expectIncrement(true),
+                of(FsStateChangelogWriterSqnTest::persistAll, "persist")
+                        .withAppendCall(false)
+                        .expectIncrement(false),
+                of(FsStateChangelogWriterSqnTest::persistAll, "persist")
+                        .withAppendCall(true)
+                        .expectIncrement(true),
+                of(FsStateChangelogWriterSqnTest::append, "append")
+                        .withAppendCall(true)
+                        .expectIncrement(false),
+                of(FsStateChangelogWriterSqnTest::append, "append")
+                        .withAppendCall(false)
+                        .expectIncrement(false),
+                of(FsStateChangelogWriterSqnTest::truncateAll, "truncate empty")
+                        .withAppendCall(false)
+                        .expectIncrement(false),
+                of(FsStateChangelogWriterSqnTest::truncateAll, "truncate old")
+                        .withAppendCall(true)
+                        .expectIncrement(false),
+                of(FsStateChangelogWriterSqnTest::truncateLast, "truncate last")
+                        .withAppendCall(true)
+                        .expectIncrement(true));
+    }
+
+    private final WriterSqnTestSettings test;
+
+    public FsStateChangelogWriterSqnTest(WriterSqnTestSettings test) {
+        this.test = test;
+    }
+
+    @Test
+    public void runTest() throws IOException {
+        try (FsStateChangelogWriter writer =
+                new FsStateChangelogWriter(
+                        UUID.randomUUID(),
+                        KeyGroupRange.of(0, 0),
+                        new TestingStateChangeUploader(),
+                        Long.MAX_VALUE)) {
+            if (test.withAppend) {
+                append(writer);
+            }
+            test.action.accept(writer);
+            assertEquals(
+                    getMessage(),
+                    test.expectIncrement
+                            ? writer.initialSequenceNumber().next()
+                            : writer.initialSequenceNumber(),
+                    writer.lastAppendedSqnUnsafe());
+        }
+    }
+
+    private String getMessage() {
+        return test.name
+                + " should"
+                + (test.expectIncrement ? " " : " NOT ")
+                + "increment SQN"
+                + (test.expectIncrement ? " after " : " without ")
+                + "appends";
+    }
+
+    static class WriterSqnTestSettings {
+        private final String name;
+        private final ThrowingConsumer<FsStateChangelogWriter, IOException> action;
+        private boolean withAppend;
+        private boolean expectIncrement;
+
+        public WriterSqnTestSettings(
+                String name, ThrowingConsumer<FsStateChangelogWriter, IOException> action) {
+            this.name = name;
+            this.action = action;
+        }
+
+        public static WriterSqnTestSettings of(
+                ThrowingConsumer<FsStateChangelogWriter, IOException> action, String name) {
+            return new WriterSqnTestSettings(name, action);
+        }
+
+        public WriterSqnTestSettings withAppendCall(boolean withAppend) {
+            this.withAppend = withAppend;
+            return this;
+        }
+
+        public WriterSqnTestSettings expectIncrement(boolean expectIncrement) {
+            this.expectIncrement = expectIncrement;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return name + ", withAppend: " + withAppend + ", expectIncrement: " + expectIncrement;
+        }
+    }
+
+    private static void append(FsStateChangelogWriter writer) throws IOException {
+        writer.append(0, new byte[] {1, 2, 3, 4});
+    }
+
+    private static void truncateLast(FsStateChangelogWriter writer) {
+        writer.truncate(writer.lastAppendedSequenceNumber());
+    }
+
+    private static void truncateAll(FsStateChangelogWriter writer) {
+        writer.truncate(writer.initialSequenceNumber());
+    }
+
+    private static void persistAll(FsStateChangelogWriter writer) throws IOException {
+        writer.persist(writer.initialSequenceNumber());
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.shaded.guava30.com.google.common.collect.Iterables.getOnlyElement;
+import static org.apache.flink.util.ExceptionUtils.rethrowIOException;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+/** {@link FsStateChangelogWriter} test. */
+public class FsStateChangelogWriterTest {
+    private static final int KEY_GROUP = 0;
+    private final Random random = new Random();
+
+    @Test
+    public void testAppend() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    writer.append(KEY_GROUP, getBytes());
+                    writer.append(KEY_GROUP, getBytes());
+                    writer.append(KEY_GROUP, getBytes());
+                    assertNoUpload(uploader, "append shouldn't persist");
+                });
+    }
+
+    @Test
+    public void testPreUpload() throws Exception {
+        int threshold = 1000;
+        withWriter(
+                threshold,
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes(threshold);
+                    SequenceNumber sqn = append(writer, bytes);
+                    assertSubmittedOnly(uploader, bytes);
+                    uploader.reset();
+                    writer.persist(sqn);
+                    assertNoUpload(uploader, "changes should have been pre-uploaded");
+                });
+    }
+
+    @Test
+    public void testPersist() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    CompletableFuture<ChangelogStateHandleStreamImpl> future =
+                            writer.persist(append(writer, bytes));
+                    assertSubmittedOnly(uploader, bytes);
+                    uploader.completeUpload();
+                    assertArrayEquals(
+                            bytes,
+                            getOnlyElement(future.get().getHandlesAndOffsets())
+                                    .f0
+                                    .asBytesIfInMemory()
+                                    .get());
+                });
+    }
+
+    @Test
+    public void testPersistAgain() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    SequenceNumber sqn = append(writer, bytes);
+                    writer.persist(sqn);
+                    uploader.reset();
+                    writer.confirm(sqn, writer.lastAppendedSqnUnsafe().next());
+                    writer.persist(sqn);
+                    assertNoUpload(uploader, "confirmed changes shouldn't be re-uploaded");
+                });
+    }
+
+    @Test
+    public void testNoReUploadBeforeCompletion() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    SequenceNumber sqn = append(writer, bytes);
+                    writer.persist(sqn);
+                    uploader.reset();
+                    writer.persist(sqn);
+                    assertNoUpload(uploader, "no re-upload should happen");
+                });
+    }
+
+    @Test
+    public void testPersistNewlyAppended() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    SequenceNumber sqn = append(writer, getBytes());
+                    writer.persist(sqn);
+                    uploader.reset();
+                    byte[] bytes = getBytes();
+                    sqn = append(writer, bytes);
+                    writer.persist(sqn);
+                    assertSubmittedOnly(uploader, bytes);
+                });
+    }
+
+    /** Emulates checkpoint abortion followed by a new checkpoint. */
+    @Test
+    public void testPersistAfterReset() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    SequenceNumber sqn = append(writer, bytes);
+                    writer.reset(sqn, SequenceNumber.of(Long.MAX_VALUE));
+                    uploader.reset();
+                    writer.persist(sqn);
+                    assertSubmittedOnly(uploader, bytes);
+                });
+    }
+
+    @Test(expected = IOException.class)
+    public void testPersistFailure() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    SequenceNumber sqn = append(writer, bytes);
+                    CompletableFuture<ChangelogStateHandleStreamImpl> future = writer.persist(sqn);
+                    uploader.failUpload(new RuntimeException("test"));
+                    try {
+                        future.get();
+                    } catch (ExecutionException e) {
+                        rethrowIOException(e.getCause());
+                    }
+                });
+    }
+
+    @Test(expected = IOException.class)
+    public void testPersistFailedChanges() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    SequenceNumber sqn = append(writer, bytes);
+                    writer.persist(sqn); // future result ignored
+                    uploader.failUpload(new RuntimeException("test"));
+                    writer.persist(sqn); // should fail right away
+                });
+    }
+
+    @Test
+    public void testPersistNonFailedChanges() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    byte[] bytes = getBytes();
+                    SequenceNumber sqn1 = append(writer, bytes);
+                    writer.persist(sqn1); // future result ignored
+                    uploader.failUpload(new RuntimeException("test"));
+                    uploader.reset();
+                    SequenceNumber sqn2 = append(writer, bytes);
+                    CompletableFuture<ChangelogStateHandleStreamImpl> future = writer.persist(sqn2);
+                    uploader.completeUpload();
+                    future.get();
+                });
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTruncate() throws Exception {
+        withWriter(
+                (writer, uploader) -> {
+                    SequenceNumber sqn = append(writer, getBytes());
+                    writer.truncate(sqn.next());
+                    writer.persist(sqn);
+                });
+    }
+
+    private void withWriter(
+            BiConsumerWithException<FsStateChangelogWriter, TestingStateChangeUploader, Exception>
+                    test)
+            throws Exception {
+        withWriter(1000, test);
+    }
+
+    private void withWriter(
+            int appendPersistThreshold,
+            BiConsumerWithException<FsStateChangelogWriter, TestingStateChangeUploader, Exception>
+                    test)
+            throws Exception {
+        TestingStateChangeUploader uploader = new TestingStateChangeUploader();
+        try (FsStateChangelogWriter writer =
+                new FsStateChangelogWriter(
+                        UUID.randomUUID(),
+                        KeyGroupRange.of(KEY_GROUP, KEY_GROUP),
+                        uploader,
+                        appendPersistThreshold)) {
+            test.accept(writer, uploader);
+        }
+    }
+
+    private void assertSubmittedOnly(TestingStateChangeUploader uploader, byte[] bytes) {
+        assertArrayEquals(
+                bytes,
+                getOnlyElement(getOnlyElement(uploader.getUploaded()).getChanges()).getChange());
+    }
+
+    private SequenceNumber append(FsStateChangelogWriter writer, byte[] bytes) throws IOException {
+        writer.append(KEY_GROUP, bytes);
+        return writer.lastAppendedSequenceNumber();
+    }
+
+    private byte[] getBytes() {
+        return getBytes(10);
+    }
+
+    private byte[] getBytes(int size) {
+        byte[] bytes = new byte[size];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    private static void assertNoUpload(TestingStateChangeUploader uploader, String message) {
+        assertTrue(message, uploader.getUploaded().isEmpty());
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.core.testutils.CompletedScheduledFuture;
+import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/** {@link RetryingExecutor} test. */
+public class RetryingExecutorTest {
+
+    private static final ThrowingConsumer<Integer, Exception> FAILING_TASK =
+            attempt -> {
+                throw new IOException();
+            };
+
+    @Test
+    public void testNoRetries() throws Exception {
+        testPolicy(1, RetryPolicy.NONE, FAILING_TASK);
+    }
+
+    @Test
+    public void testFixedRetryLimit() throws Exception {
+        testPolicy(5, RetryPolicy.fixed(5, 0, 0), FAILING_TASK);
+    }
+
+    @Test
+    public void testFixedRetrySuccess() throws Exception {
+        int successfulAttempt = 3;
+        int maxAttempts = successfulAttempt * 2;
+        testPolicy(
+                successfulAttempt,
+                RetryPolicy.fixed(maxAttempts, 0, 0),
+                attempt -> {
+                    if (attempt < successfulAttempt) {
+                        throw new IOException();
+                    }
+                });
+    }
+
+    @Test
+    public void testNonRetryableException() throws Exception {
+        testPolicy(
+                1,
+                RetryPolicy.fixed(Integer.MAX_VALUE, 0, 0),
+                ignored -> {
+                    throw new RuntimeException();
+                });
+    }
+
+    @Test
+    public void testRetryDelay() throws Exception {
+        int delayAfterFailure = 123;
+        int numAttempts = 2;
+        testPolicy(
+                numAttempts,
+                RetryPolicy.fixed(Integer.MAX_VALUE, 0, delayAfterFailure),
+                a -> {
+                    if (a < numAttempts) {
+                        throw new IOException();
+                    }
+                },
+                new DirectScheduledExecutorService() {
+                    @Override
+                    public ScheduledFuture<?> schedule(
+                            Runnable command, long delay, TimeUnit unit) {
+                        assertEquals(delayAfterFailure, delay);
+                        command.run();
+                        return CompletedScheduledFuture.create(null);
+                    }
+                });
+    }
+
+    @Test
+    public void testNoRetryDelayIfTimeout() throws Exception {
+        int delayAfterFailure = 123;
+        int numAttempts = 2;
+        testPolicy(
+                numAttempts,
+                RetryPolicy.fixed(Integer.MAX_VALUE, 0, delayAfterFailure),
+                a -> {
+                    if (a < numAttempts) {
+                        throw new TimeoutException();
+                    }
+                },
+                new DirectScheduledExecutorService() {
+                    @Override
+                    public ScheduledFuture<?> schedule(
+                            Runnable command, long delay, TimeUnit unit) {
+                        fail("task should be executed directly without delay after timeout");
+                        return CompletedScheduledFuture.create(null);
+                    }
+                });
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        int numAttempts = 2;
+        int timeout = 500;
+        CompletableFuture<Long> firstStart = new CompletableFuture<>();
+        CompletableFuture<Long> secondStart = new CompletableFuture<>();
+        testPolicy(
+                numAttempts,
+                RetryPolicy.fixed(Integer.MAX_VALUE, timeout, 0),
+                a -> {
+                    long now = System.nanoTime();
+                    if (a < numAttempts) {
+                        firstStart.complete(now);
+                        secondStart.get(); // cause timeout
+                    } else {
+                        secondStart.complete(now);
+                    }
+                },
+                Executors.newScheduledThreadPool(2));
+        assertEquals(
+                timeout,
+                ((double) secondStart.get() - firstStart.get()) / 1_000_000,
+                timeout
+                        * 0.75d /* future completion can be delayed arbitrarily causing start delta be less than timeout */);
+    }
+
+    private void testPolicy(
+            int expectedAttempts, RetryPolicy policy, ThrowingConsumer<Integer, Exception> task)
+            throws Exception {
+        testPolicy(expectedAttempts, policy, task, new DirectScheduledExecutorService());
+    }
+
+    private void testPolicy(
+            int expectedAttempts,
+            RetryPolicy policy,
+            ThrowingConsumer<Integer, Exception> task,
+            ScheduledExecutorService scheduler)
+            throws Exception {
+        AtomicInteger attemptsMade = new AtomicInteger(0);
+        CountDownLatch firstAttemptCompletedLatch = new CountDownLatch(1);
+        try (RetryingExecutor executor = new RetryingExecutor(scheduler)) {
+            executor.execute(
+                    policy,
+                    () -> {
+                        try {
+                            task.accept(attemptsMade.incrementAndGet());
+                        } finally {
+                            firstAttemptCompletedLatch.countDown();
+                        }
+                    });
+            firstAttemptCompletedLatch.await(); // before closing executor
+        }
+        assertEquals(expectedAttempts, attemptsMade.get());
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
@@ -21,6 +21,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -38,7 +39,7 @@ class TestingStateChangeUploader implements StateChangeUploader {
     }
 
     @Override
-    public void upload(UploadTask uploadTask) {
+    public void upload(UploadTask uploadTask) throws IOException {
         uploaded.addAll(uploadTask.changeSets);
         tasks.add(uploadTask);
     }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingStateChangeUploader.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+class TestingStateChangeUploader implements StateChangeUploader {
+    private final Collection<StateChangeSet> uploaded = new ArrayList<>();
+    private final List<UploadTask> tasks = new ArrayList<>();
+    private boolean closed;
+
+    @Override
+    public void close() {
+        this.closed = true;
+    }
+
+    @Override
+    public void upload(UploadTask uploadTask) {
+        uploaded.addAll(uploadTask.changeSets);
+        tasks.add(uploadTask);
+    }
+
+    public Collection<StateChangeSet> getUploaded() {
+        return uploaded;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    public void reset() {
+        uploaded.clear();
+        tasks.clear();
+    }
+
+    public void failUpload(RuntimeException exception) {
+        tasks.forEach(t -> t.fail(exception));
+    }
+
+    public void completeUpload() {
+        tasks.forEach(
+                t ->
+                        t.complete(
+                                uploaded.stream()
+                                        .map(
+                                                changeSet ->
+                                                        new UploadResult(
+                                                                asBytesHandle(changeSet),
+                                                                0L,
+                                                                changeSet.getSequenceNumber(),
+                                                                changeSet.getSize()))
+                                        .collect(toList())));
+    }
+
+    private StreamStateHandle asBytesHandle(StateChangeSet changeSet) {
+        byte[] bytes = new byte[(int) changeSet.getSize()];
+        int offset = 0;
+        for (StateChange change : changeSet.getChanges()) {
+            for (int i = 0; i < change.getChange().length; i++) {
+                bytes[offset++] = change.getChange()[i];
+            }
+        }
+        return new ByteStreamStateHandle("", bytes);
+    }
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/resources/log4j2.properties
+++ b/flink-dstl/flink-dstl-dfs/src/test/resources/log4j2.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testLogger.name = TestLogger
+appender.testLogger.type = CONSOLE
+appender.testLogger.target = SYSTEM_ERR
+appender.testLogger.layout.type = PatternLayout
+appender.testLogger.layout.pattern = %d %-5p %m [%c{0} %t]%n

--- a/flink-dstl/pom.xml
+++ b/flink-dstl/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.14-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-dstl</artifactId>
+	<name>Flink : DSTL</name>
+
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>flink-dstl-dfs</module>
+	</modules>
+</project>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -67,7 +68,7 @@ public class TaskExecutorStateChangelogStoragesManager {
 
     @Nullable
     public StateChangelogStorage<?> stateChangelogStorageForJob(
-            @Nonnull JobID jobId, Configuration configuration) {
+            @Nonnull JobID jobId, Configuration configuration) throws IOException {
         if (closed) {
             throw new IllegalStateException(
                     "TaskExecutorStateChangelogStoragesManager is already closed and cannot "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -19,7 +19,6 @@ package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
@@ -27,14 +26,11 @@ import org.apache.flink.runtime.state.SharedStateRegistryKey;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
-import org.apache.flink.util.CloseableIterator;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /** {@link ChangelogStateHandle} implementation based on {@link StreamStateHandle}. */
 @Internal
@@ -56,14 +52,6 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
         this.handlesAndOffsets = handlesAndOffsets;
         this.keyGroupRange = keyGroupRange;
         this.size = size;
-    }
-
-    public ChangelogStateHandleStreamImpl(
-            List<Tuple3<StreamStateHandle, Long, Long>> sorted, KeyGroupRange keyGroupRange) {
-        this(
-                sorted.stream().map(t -> Tuple2.of(t.f0, t.f1)).collect(Collectors.toList()),
-                keyGroupRange,
-                sorted.stream().mapToLong(t1 -> t1.f2).sum());
     }
 
     @Override
@@ -115,11 +103,6 @@ public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandl
             return new SharedStateRegistryKey(
                     Integer.toString(System.identityHashCode(stateHandle)));
         }
-    }
-
-    public interface StateChangeStreamReader {
-        CloseableIterator<StateChange> read(StreamStateHandle handle, long offset)
-                throws IOException;
     }
 
     public List<Tuple2<StreamStateHandle, Long>> getHandlesAndOffsets() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/SequenceNumberRange.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/SequenceNumberRange.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state.changelog;
+
+import org.apache.flink.runtime.state.changelog.SequenceNumber.GenericSequenceNumber;
+import org.apache.flink.util.Preconditions;
+
+public interface SequenceNumberRange {
+    /** Inclusive. */
+    SequenceNumber from();
+    /** Exclusive. */
+    SequenceNumber to();
+
+    /** @return the size of this range (positive) or zero if it is empty */
+    long size();
+
+    /**
+     * @return true if {@link #from} &lt; sqn &lt; {@link #to} (this implies that the range is not
+     *     empty, i.e. to &gt; from))
+     */
+    boolean contains(SequenceNumber sqn);
+
+    /** @return true if {@link #from} &ge; {@link #to}, false otherwise. */
+    boolean isEmpty();
+
+    /**
+     * @param from inclusive
+     * @param to exclusive
+     */
+    static SequenceNumberRange generic(SequenceNumber from, SequenceNumber to) {
+        return new GenericSequenceNumberRange(
+                (GenericSequenceNumber) from, (GenericSequenceNumber) to);
+    }
+
+    class GenericSequenceNumberRange implements SequenceNumberRange {
+        private final GenericSequenceNumber from;
+        private final GenericSequenceNumber to;
+        private final long size;
+
+        public GenericSequenceNumberRange(GenericSequenceNumber from, GenericSequenceNumber to) {
+            this.from = from;
+            this.to = to;
+            this.size = to.number - from.number;
+            Preconditions.checkArgument(size >= 0);
+        }
+
+        @Override
+        public SequenceNumber from() {
+            return from;
+        }
+
+        @Override
+        public SequenceNumber to() {
+            return to;
+        }
+
+        @Override
+        public long size() {
+            return size;
+        }
+
+        @Override
+        public boolean contains(SequenceNumber sqn) {
+            return from.compareTo(sqn) <= 0 && sqn.compareTo(to) < 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return size == 0;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("from=%s, to=%s, size=%d", from, to, size);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
@@ -45,8 +45,8 @@ public class StateChangelogHandleStreamHandleReader
 
     /** Reads a stream of state changes starting from a specified offset. */
     public interface StateChangeIterator {
-        // todo: add implementation (FLINK-21353)
-        CloseableIterator<StateChange> read(StreamStateHandle handle, long offset);
+        CloseableIterator<StateChange> read(StreamStateHandle handle, long offset)
+                throws IOException;
     }
 
     private final StateChangeIterator changeIterator;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 
+import java.io.IOException;
+
 /**
  * A factory for {@link StateChangelogStorage}. Please use {@link StateChangelogStorageLoader} to
  * create {@link StateChangelogStorage}.
@@ -31,5 +33,5 @@ public interface StateChangelogStorageFactory {
     String getIdentifier();
 
     /** Create the storage based on a configuration. */
-    StateChangelogStorage<?> createStorage(Configuration configuration);
+    StateChangelogStorage<?> createStorage(Configuration configuration) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ServiceLoader;
@@ -81,7 +82,7 @@ public class StateChangelogStorageLoader {
     }
 
     @Nullable
-    public static StateChangelogStorage<?> load(Configuration configuration) {
+    public static StateChangelogStorage<?> load(Configuration configuration) throws IOException {
         final String identifier =
                 configuration
                         .getString(CheckpointingOptions.STATE_CHANGE_LOG_STORAGE)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -35,7 +35,7 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
     SequenceNumber lastAppendedSequenceNumber();
 
     /** Appends the provided data to this log. No persistency guarantees. */
-    void append(int keyGroup, byte[] value);
+    void append(int keyGroup, byte[] value) throws IOException;
 
     /**
      * Durably persist previously {@link #append(int, byte[]) appended} data starting from the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -678,9 +678,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             tdd.getSubtaskIndex());
 
             // TODO: Pass config value from user program and do overriding here.
-            final StateChangelogStorage<?> changelogStorage =
-                    changelogStoragesManager.stateChangelogStorageForJob(
-                            jobId, taskManagerConfiguration.getConfiguration());
+            final StateChangelogStorage<?> changelogStorage;
+            try {
+                changelogStorage =
+                        changelogStoragesManager.stateChangelogStorageForJob(
+                                jobId, taskManagerConfiguration.getConfiguration());
+            } catch (IOException e) {
+                throw new TaskSubmissionException(e);
+            }
 
             final JobManagerTaskRestore taskRestore = tdd.getTaskRestore();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -96,6 +96,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -156,7 +157,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Rule public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void before() {
+    public void before() throws IOException {
         env = buildMockEnv();
     }
 
@@ -5534,8 +5535,12 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         long value;
     }
 
-    private MockEnvironment buildMockEnv() {
-        return MockEnvironment.builder().build();
+    private MockEnvironment buildMockEnv() throws IOException {
+        return MockEnvironment.builder().setTaskStateManager(getTestTaskStateManager()).build();
+    }
+
+    protected TestTaskStateManager getTestTaskStateManager() throws IOException {
+        return TestTaskStateManager.builder().build();
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Iterator;
 
 import static java.util.Collections.singletonList;
@@ -41,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class TaskExecutorStateChangelogStoragesManagerTest {
 
     @Test
-    public void testDuplicatedAllocation() {
+    public void testDuplicatedAllocation() throws IOException {
         TaskExecutorStateChangelogStoragesManager manager =
                 new TaskExecutorStateChangelogStoragesManager();
         Configuration configuration = new Configuration();
@@ -60,7 +61,7 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
     }
 
     @Test
-    public void testReleaseForJob() {
+    public void testReleaseForJob() throws IOException {
         StateChangelogStorageLoader.initialize(TestStateChangelogStorageFactory.pluginManager);
         TaskExecutorStateChangelogStoragesManager manager =
                 new TaskExecutorStateChangelogStoragesManager();
@@ -85,7 +86,7 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
     }
 
     @Test
-    public void testConsistencyAmongTask() {
+    public void testConsistencyAmongTask() throws IOException {
         TaskExecutorStateChangelogStoragesManager manager =
                 new TaskExecutorStateChangelogStoragesManager();
         Configuration configuration = new Configuration();
@@ -119,7 +120,7 @@ public class TaskExecutorStateChangelogStoragesManagerTest {
     }
 
     @Test
-    public void testShutdown() {
+    public void testShutdown() throws IOException {
         StateChangelogStorageLoader.initialize(TestStateChangelogStorageFactory.pluginManager);
         TaskExecutorStateChangelogStoragesManager manager =
                 new TaskExecutorStateChangelogStoragesManager();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManagerBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
+import org.apache.flink.runtime.taskmanager.CheckpointResponder;
+import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** {@link TestTaskStateManager} builder. */
+public class TestTaskStateManagerBuilder {
+
+    private JobID jobID = new JobID();
+    private ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+    private CheckpointResponder checkpointResponder = new TestCheckpointResponder();
+    private LocalRecoveryConfig localRecoveryConfig = TestLocalRecoveryConfig.disabled();
+    private StateChangelogStorage<?> stateChangelogStorage = new InMemoryStateChangelogStorage();
+    private final Map<Long, TaskStateSnapshot> jobManagerTaskStateSnapshotsByCheckpointId =
+            new HashMap<>();
+    private long reportedCheckpointId = -1L;
+    private OneShotLatch waitForReportLatch = new OneShotLatch();
+
+    public TestTaskStateManagerBuilder setJobID(JobID jobID) {
+        this.jobID = checkNotNull(jobID);
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setExecutionAttemptID(
+            ExecutionAttemptID executionAttemptID) {
+        this.executionAttemptID = checkNotNull(executionAttemptID);
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setCheckpointResponder(
+            CheckpointResponder checkpointResponder) {
+        this.checkpointResponder = checkNotNull(checkpointResponder);
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setLocalRecoveryConfig(
+            LocalRecoveryConfig localRecoveryConfig) {
+        this.localRecoveryConfig = checkNotNull(localRecoveryConfig);
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setStateChangelogStorage(
+            StateChangelogStorage<?> stateChangelogStorage) {
+        Preconditions.checkState(
+                this.stateChangelogStorage == null
+                        || this.stateChangelogStorage instanceof InMemoryStateChangelogStorage,
+                "StateChangelogStorage was already initialized to " + this.stateChangelogStorage);
+        this.stateChangelogStorage = checkNotNull(stateChangelogStorage);
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setJobManagerTaskStateSnapshotsByCheckpointId(
+            Map<Long, TaskStateSnapshot> jobManagerTaskStateSnapshotsByCheckpointId) {
+        this.jobManagerTaskStateSnapshotsByCheckpointId.clear();
+        this.jobManagerTaskStateSnapshotsByCheckpointId.putAll(
+                jobManagerTaskStateSnapshotsByCheckpointId);
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setReportedCheckpointId(long reportedCheckpointId) {
+        this.reportedCheckpointId = reportedCheckpointId;
+        return this;
+    }
+
+    public TestTaskStateManagerBuilder setWaitForReportLatch(OneShotLatch waitForReportLatch) {
+        this.waitForReportLatch = checkNotNull(waitForReportLatch);
+        return this;
+    }
+
+    public TestTaskStateManager build() {
+        return new TestTaskStateManager(
+                jobID,
+                executionAttemptID,
+                checkpointResponder,
+                localRecoveryConfig,
+                stateChangelogStorage,
+                jobManagerTaskStateSnapshotsByCheckpointId,
+                reportedCheckpointId,
+                waitForReportLatch);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Iterator;
 
 import static java.util.Collections.emptyIterator;
@@ -43,13 +44,13 @@ import static org.junit.Assert.assertTrue;
 public class StateChangelogStorageLoaderTest {
 
     @Test
-    public void testLoadSpiImplementation() {
+    public void testLoadSpiImplementation() throws IOException {
         StateChangelogStorageLoader.initialize(getPluginManager(emptyIterator()));
         assertNotNull(StateChangelogStorageLoader.load(new Configuration()));
     }
 
     @Test
-    public void testLoadNotExist() {
+    public void testLoadNotExist() throws IOException {
         StateChangelogStorageLoader.initialize(getPluginManager(emptyIterator()));
         assertNull(
                 StateChangelogStorageLoader.load(
@@ -59,7 +60,7 @@ public class StateChangelogStorageLoaderTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testLoadPluginImplementation() {
+    public void testLoadPluginImplementation() throws IOException {
         StateChangelogStorageFactory factory = new TestStateChangelogStorageFactory();
         PluginManager pluginManager = getPluginManager(singletonList(factory).iterator());
         StateChangelogStorageLoader.initialize(pluginManager);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
@@ -133,7 +133,7 @@ public class StateChangelogStorageTest<T extends ChangelogStateHandle> {
         return bytes;
     }
 
-    protected StateChangelogStorage<T> getFactory() {
+    protected StateChangelogStorage<T> getFactory() throws IOException {
         return (StateChangelogStorage<T>) new InMemoryStateChangelogStorage();
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -66,6 +66,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-dstl-dfs_2.11</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -25,15 +25,25 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.TestTaskStateManager;
 
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 
 /** Tests for {@link ChangelogStateBackend} delegating {@link EmbeddedRocksDBStateBackend}. */
 public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
         extends EmbeddedRocksDBStateBackendTest {
+
+    @Rule public final TemporaryFolder temp = new TemporaryFolder();
+
+    @Override
+    protected TestTaskStateManager getTestTaskStateManager() throws IOException {
+        return ChangelogStateBackendTestUtils.createTaskStateManager(temp.newFolder());
+    }
 
     @Override
     protected boolean snapshotUsesStreamFactory() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -25,11 +25,24 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.FileStateBackendTest;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
 /** Tests for {@link ChangelogStateBackend} delegating {@link FsStateBackend}. */
 public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest {
+
+    @Rule public final TemporaryFolder temp = new TemporaryFolder();
+
+    @Override
+    protected TestTaskStateManager getTestTaskStateManager() throws IOException {
+        return ChangelogStateBackendTestUtils.createTaskStateManager(temp.newFolder());
+    }
 
     @Override
     protected boolean snapshotUsesStreamFactory() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -24,9 +24,21 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.HashMapStateBackendTest;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
 
 /** Tests for {@link ChangelogStateBackend} delegating {@link HashMapStateBackendTest}. */
 public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
+
+    @Rule public final TemporaryFolder temp = new TemporaryFolder();
+
+    protected TestTaskStateManager getTestTaskStateManager() throws IOException {
+        return ChangelogStateBackendTestUtils.createTaskStateManager(temp.newFolder());
+    }
 
     @Override
     protected boolean snapshotUsesStreamFactory() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -25,11 +25,24 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.MemoryStateBackendTest;
+import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
 /** Tests for {@link ChangelogStateBackend} delegating {@link MemoryStateBackend}. */
 public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendTest {
+
+    @Rule public final TemporaryFolder temp = new TemporaryFolder();
+
+    @Override
+    protected TestTaskStateManager getTestTaskStateManager() throws IOException {
+        return ChangelogStateBackendTestUtils.createTaskStateManager(temp.newFolder());
+    }
 
     @Override
     protected boolean snapshotUsesStreamFactory() {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -21,14 +21,19 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.changelog.fs.FsStateChangelogStorage;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 
 /** Test Utilities for Changelog StateBackend. */
@@ -61,5 +66,14 @@ public class ChangelogStateBackendTestUtils {
 
         return createKeyedBackend(
                 stateBackend, IntSerializer.INSTANCE, 10, new KeyGroupRange(0, 9), env);
+    }
+
+    public static TestTaskStateManager createTaskStateManager(File changelogStoragePath)
+            throws IOException {
+        return TestTaskStateManager.builder()
+                .setStateChangelogStorage(
+                        new FsStateChangelogStorage(
+                                Path.fromLocalFile(changelogStoragePath), false, 1024))
+                .build();
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.testutils.BackendForTestStream;
@@ -85,6 +86,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -208,7 +210,11 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
                         jobID,
                         executionAttemptID,
                         checkpointResponderMock,
-                        TestLocalRecoveryConfig.disabled());
+                        TestLocalRecoveryConfig.disabled(),
+                        new InMemoryStateChangelogStorage(),
+                        new HashMap<>(),
+                        -1L,
+                        new OneShotLatch());
 
         StreamMockEnvironment mockEnv =
                 new StreamMockEnvironment(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -558,7 +557,6 @@ public class AsyncWaitOperatorTest extends TestLogger {
         streamConfig.setOperatorID(operatorID);
 
         final TestTaskStateManager taskStateManagerMock = testHarness.getTaskStateManager();
-        taskStateManagerMock.setWaitForReportLatch(new OneShotLatch());
 
         testHarness.invoke();
         testHarness.waitForTaskRunning();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -254,11 +254,14 @@ public class InterruptSensitiveRestoreTest {
                         SourceStreamTask.class.getName(),
                         taskConfig);
 
-        TestTaskStateManager taskStateManager = new TestTaskStateManager();
-        taskStateManager.setReportedCheckpointId(taskRestore.getRestoreCheckpointId());
-        taskStateManager.setJobManagerTaskStateSnapshotsByCheckpointId(
-                Collections.singletonMap(
-                        taskRestore.getRestoreCheckpointId(), taskRestore.getTaskStateSnapshot()));
+        TestTaskStateManager taskStateManager =
+                TestTaskStateManager.builder()
+                        .setReportedCheckpointId(taskRestore.getRestoreCheckpointId())
+                        .setJobManagerTaskStateSnapshotsByCheckpointId(
+                                Collections.singletonMap(
+                                        taskRestore.getRestoreCheckpointId(),
+                                        taskRestore.getTaskStateSnapshot()))
+                        .build();
 
         return new Task(
                 jobInformation,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
@@ -590,9 +589,6 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         configureChainedTestingStreamOperator(streamConfig, numberChainedTasks);
         TestTaskStateManager taskStateManager = testHarness.taskStateManager;
-        OneShotLatch waitForAcknowledgeLatch = new OneShotLatch();
-
-        taskStateManager.setWaitForReportLatch(waitForAcknowledgeLatch);
 
         // reset number of restore calls
         TestingStreamOperator.numberRestoreCalls = 0;
@@ -613,7 +609,7 @@ public class OneInputStreamTaskTest extends TestLogger {
         // since no state was set, there shouldn't be restore calls
         assertEquals(0, TestingStreamOperator.numberRestoreCalls);
 
-        waitForAcknowledgeLatch.await();
+        taskStateManager.getWaitForReportLatch().await();
 
         assertEquals(checkpointId, taskStateManager.getReportedCheckpointId());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
@@ -272,8 +271,6 @@ public class RestoreStreamTaskTest extends TestLogger {
 
         long checkpointId = 1L;
         CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, 1L);
-
-        testHarness.taskStateManager.setWaitForReportLatch(new OneShotLatch());
 
         streamTask.triggerCheckpointAsync(
                 checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -234,8 +233,7 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
             CheckpointOptions checkpointOptions)
             throws Exception {
         // Trigger a checkpoint.
-        OneShotLatch waitForAcknowledgeLatch = new OneShotLatch();
-        testHarness.taskStateManager.setWaitForReportLatch(waitForAcknowledgeLatch);
+        testHarness.taskStateManager.getWaitForReportLatch().reset();
         CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, checkpointId);
         Future<Boolean> checkpointFuture =
                 testHarness
@@ -251,7 +249,7 @@ public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
         Future<Void> checkpointNotified =
                 testHarness.getStreamTask().notifyCheckpointCompleteAsync(checkpointId);
         processUntil(testHarness, checkpointNotified::isDone);
-        waitForAcknowledgeLatch.await();
+        testHarness.taskStateManager.getWaitForReportLatch().await();
     }
 
     private void processUntil(StreamTaskMailboxTestHarness testHarness, Supplier<Boolean> condition)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -77,7 +77,7 @@ public class StreamTaskFinalCheckpointsTest {
         harness.streamTask.operatorChain.finishOperators(harness.streamTask.getActionExecutor());
         assertTrue(FinishingOperator.finished);
 
-        harness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+        harness.getTaskStateManager().getWaitForReportLatch().reset();
         harness.streamTask.triggerCheckpointOnBarrier(
                 new CheckpointMetaData(2, 0),
                 CheckpointOptions.forCheckpointWithDefaultLocation(),
@@ -204,7 +204,7 @@ public class StreamTaskFinalCheckpointsTest {
 
     static Future<Boolean> triggerCheckpoint(
             StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
-        testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+        testHarness.getTaskStateManager().getWaitForReportLatch().reset();
         return testHarness
                 .getStreamTask()
                 .triggerCheckpointAsync(
@@ -315,7 +315,7 @@ public class StreamTaskFinalCheckpointsTest {
             harness.processAll();
 
             // Try trigger a checkpoint.
-            harness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+            harness.getTaskStateManager().getWaitForReportLatch().reset();
             harness.streamTask.triggerCheckpointOnBarrier(
                     new CheckpointMetaData(2, 2),
                     new CheckpointOptions(CheckpointType.CHECKPOINT, getDefault()),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.TestTaskStateManagerBuilder;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -177,13 +178,17 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
     }
 
     public StreamTaskMailboxTestHarness<OUT> buildUnrestored() throws Exception {
-        TestTaskStateManager taskStateManager = new TestTaskStateManager(localRecoveryConfig);
-        taskStateManager.setCheckpointResponder(checkpointResponder);
+        TestTaskStateManagerBuilder taskStateManagerBuilder =
+                TestTaskStateManager.builder()
+                        .setLocalRecoveryConfig(localRecoveryConfig)
+                        .setCheckpointResponder(checkpointResponder);
         if (taskStateSnapshots != null) {
-            taskStateManager.setReportedCheckpointId(taskStateSnapshots.keySet().iterator().next());
-            taskStateManager.setJobManagerTaskStateSnapshotsByCheckpointId(taskStateSnapshots);
+            taskStateManagerBuilder
+                    .setReportedCheckpointId(taskStateSnapshots.keySet().iterator().next())
+                    .setJobManagerTaskStateSnapshotsByCheckpointId(taskStateSnapshots);
         }
 
+        TestTaskStateManager taskStateManager = taskStateManagerBuilder.build();
         StreamMockEnvironment streamMockEnvironment =
                 new StreamMockEnvironment(
                         jobConfig,

--- a/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/StatefulOperatorChainedTaskTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
@@ -179,8 +178,7 @@ public class StatefulOperatorChainedTaskTest {
         long checkpointId = 1L;
         CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, 1L);
 
-        testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
-
+        testHarness.getTaskStateManager().getWaitForReportLatch().reset();
         while (!streamTask
                 .triggerCheckpointAsync(
                         checkpointMetaData, CheckpointOptions.forCheckpointWithDefaultLocation())

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@ under the License.
 		<module>flink-end-to-end-tests</module>
 		<module>flink-test-utils-parent</module>
 		<module>flink-state-backends</module>
+		<module>flink-dstl</module>
 		<module>flink-libraries</module>
 		<module>flink-table</module>
 		<module>flink-quickstart</module>


### PR DESCRIPTION
## What is the purpose of the change

This is an alternative approach to implement FLINK-21353.
In contrast to #14839, it assumes TM-owned state which allows to simplify the code and avoid re-uploading state on abortion.

[Low-level design doc](https://docs.google.com/document/d/1vifa8cqZqirVr6Ke1A0FclLa2aNltOQb25GZon79btM/edit?usp=sharing)
[State ownership design doc](https://docs.google.com/document/d/1NJJQ30P27BmUvD7oa4FChvkYxMEgjRPTVdO1dHLl_9I/edit)

## Verifying this change

Added unit-tests:
- `BatchingStateChangeUploaderTest`
- `FsStateChangelogStorageLoaderTest`
- `FsStateChangelogStorageTest`
- `FsStateChangelogWriterSqnTest`
- `FsStateChangelogWriterTest`
- `RetryingExecutorTest`

Adjusted unit-tests to use DFS DSTL:
- `ChangelogDelegateEmbeddedRocksDBStateBackendTest`
- `ChangelogDelegateFileStateBackendTest`
- `ChangelogDelegateHashMapTest`
- `ChangelogDelegateMemoryStateBackendTest`

Existing integration and e2e tests should start using DFS DSTL after FLINK-21448.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
