### PR TITLE
[FLINK-21857] StackOverflow for large parallelism jobs when processing EndOfChannelStateEvent

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AbstractStreamTaskNetworkInput.java
@@ -157,7 +157,9 @@ public abstract class AbstractStreamTaskNetworkInput<
             // which is very valuable in case of bounded stream
             releaseDeserializer(bufferOrEvent.getChannelInfo());
         } else if (event.getClass() == EndOfChannelStateEvent.class) {
-            return InputStatus.END_OF_RECOVERY;
+            if (checkpointedInputGate.allChannelsRecovered()) {
+                return InputStatus.END_OF_RECOVERY;
+            }
         }
         return InputStatus.MORE_AVAILABLE;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGate.java
@@ -173,8 +173,7 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
         return next;
     }
 
-    private Optional<BufferOrEvent> handleEvent(BufferOrEvent bufferOrEvent)
-            throws IOException, InterruptedException {
+    private Optional<BufferOrEvent> handleEvent(BufferOrEvent bufferOrEvent) throws IOException {
         Class<? extends AbstractEvent> eventClass = bufferOrEvent.getEvent().getClass();
         if (eventClass == CheckpointBarrier.class) {
             CheckpointBarrier checkpointBarrier = (CheckpointBarrier) bufferOrEvent.getEvent();
@@ -198,9 +197,6 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
                     bufferOrEvent.getChannelInfo());
         } else if (bufferOrEvent.getEvent().getClass() == EndOfChannelStateEvent.class) {
             upstreamRecoveryTracker.handleEndOfRecovery(bufferOrEvent.getChannelInfo());
-            if (!upstreamRecoveryTracker.allChannelsRecovered()) {
-                return pollNext();
-            }
         }
         return Optional.of(bufferOrEvent);
     }
@@ -286,6 +282,10 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 
     public List<InputChannelInfo> getChannelInfos() {
         return inputGate.getChannelInfos();
+    }
+
+    public boolean allChannelsRecovered() {
+        return upstreamRecoveryTracker.allChannelsRecovered();
     }
 
     @VisibleForTesting

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/UpstreamRecoveryTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/UpstreamRecoveryTracker.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.util.Preconditions;
@@ -25,8 +26,10 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 import java.util.HashSet;
 
+/** Tracks status of upstream channels while they recover. */
 @Internal
-interface UpstreamRecoveryTracker {
+@VisibleForTesting
+public interface UpstreamRecoveryTracker {
 
     void handleEndOfRecovery(InputChannelInfo channelInfo) throws IOException;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -93,8 +93,8 @@ public class StreamTaskNetworkInputTest {
     public void testIsAvailableWithBufferedDataInDeserializer() throws Exception {
         List<BufferOrEvent> buffers = Collections.singletonList(createDataBuffer());
 
-        VerifyRecordsDataOutput output = new VerifyRecordsDataOutput<>();
-        StreamTaskNetworkInput input = createStreamTaskNetworkInput(buffers);
+        VerifyRecordsDataOutput<Long> output = new VerifyRecordsDataOutput<>();
+        StreamTaskNetworkInput<Long> input = createStreamTaskNetworkInput(buffers);
 
         assertHasNextElement(input, output);
         assertHasNextElement(input, output);
@@ -115,8 +115,8 @@ public class StreamTaskNetworkInputTest {
         buffers.add(new BufferOrEvent(barrier, new InputChannelInfo(0, 0)));
         buffers.add(createDataBuffer());
 
-        VerifyRecordsDataOutput output = new VerifyRecordsDataOutput<>();
-        StreamTaskNetworkInput input = createStreamTaskNetworkInput(buffers);
+        VerifyRecordsDataOutput<Long> output = new VerifyRecordsDataOutput<>();
+        StreamTaskNetworkInput<Long> input = createStreamTaskNetworkInput(buffers);
 
         assertHasNextElement(input, output);
         assertEquals(0, output.getNumberOfEmittedRecords());
@@ -186,10 +186,10 @@ public class StreamTaskNetworkInputTest {
 
         int numInputChannels = 2;
         LongSerializer inSerializer = LongSerializer.INSTANCE;
-        StreamTestSingleInputGate inputGate =
+        StreamTestSingleInputGate<Long> inputGate =
                 new StreamTestSingleInputGate<>(numInputChannels, 0, inSerializer, 1024);
 
-        DataOutput output = new NoOpDataOutput<>();
+        DataOutput<Long> output = new NoOpDataOutput<>();
         Map<InputChannelInfo, TestRecordDeserializer> deserializers =
                 createDeserializers(inputGate.getInputGate());
         Map<InputChannelInfo, TestRecordDeserializer> copiedDeserializers =
@@ -216,7 +216,7 @@ public class StreamTaskNetworkInputTest {
         return new BufferOrEvent(bufferConsumer.build(), new InputChannelInfo(0, 0));
     }
 
-    private StreamTaskNetworkInput createStreamTaskNetworkInput(List<BufferOrEvent> buffers) {
+    private StreamTaskNetworkInput<Long> createStreamTaskNetworkInput(List<BufferOrEvent> buffers) {
         return new StreamTaskNetworkInput<>(
                 createCheckpointedInputGate(new MockInputGate(1, buffers, false)),
                 LongSerializer.INSTANCE,
@@ -244,7 +244,7 @@ public class StreamTaskNetworkInputTest {
         assertFalse(bufferBuilder.isFull());
     }
 
-    private static void assertHasNextElement(StreamTaskInput input, DataOutput output)
+    private static <T> void assertHasNextElement(StreamTaskInput<T> input, DataOutput<T> output)
             throws Exception {
         assertTrue(input.getAvailableFuture().isDone());
         InputStatus status = input.emitNext(output);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
+import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
@@ -47,6 +48,7 @@ import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierTracker;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.checkpointing.SingleCheckpointBarrierHandler;
+import org.apache.flink.streaming.runtime.io.checkpointing.UpstreamRecoveryTracker;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
@@ -69,6 +71,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -207,6 +210,29 @@ public class StreamTaskNetworkInputTest {
         }
     }
 
+    @Test
+    public void testInputStatusAfterEndOfRecovery() throws Exception {
+        int numInputChannels = 2;
+        LongSerializer inSerializer = LongSerializer.INSTANCE;
+        StreamTestSingleInputGate<Long> inputGate =
+                new StreamTestSingleInputGate<>(numInputChannels, 0, inSerializer, 1024);
+
+        DataOutput<Long> output = new NoOpDataOutput<>();
+        Map<InputChannelInfo, TestRecordDeserializer> deserializers =
+                createDeserializers(inputGate.getInputGate());
+
+        StreamTaskInput<Long> input =
+                new TestStreamTaskNetworkInput(
+                        inputGate, inSerializer, numInputChannels, deserializers);
+
+        inputGate.sendElement(new StreamRecord<>(42L), 0);
+        assertThat(input.emitNext(output), equalTo(InputStatus.MORE_AVAILABLE));
+        inputGate.sendEvent(EndOfChannelStateEvent.INSTANCE, 0);
+        assertThat(input.emitNext(output), equalTo(InputStatus.MORE_AVAILABLE));
+        inputGate.sendEvent(EndOfChannelStateEvent.INSTANCE, 1);
+        assertThat(input.emitNext(output), equalTo(InputStatus.END_OF_RECOVERY));
+    }
+
     private BufferOrEvent createDataBuffer() throws IOException {
         BufferBuilder bufferBuilder = BufferBuilderTestUtils.createEmptyBufferBuilder(PAGE_SIZE);
         BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
@@ -229,7 +255,8 @@ public class StreamTaskNetworkInputTest {
         return new CheckpointedInputGate(
                 inputGate,
                 new CheckpointBarrierTracker(1, new DummyCheckpointInvokable()),
-                new SyncMailboxExecutor());
+                new SyncMailboxExecutor(),
+                UpstreamRecoveryTracker.forInputGate(inputGate));
     }
 
     private void serializeRecord(long value, BufferBuilder bufferBuilder) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -84,7 +84,13 @@ public class CheckpointedInputGateTest {
             assertFalse(gate.pollNext().isPresent());
             for (int channelIndex = 0; channelIndex < numberOfChannels - 1; channelIndex++) {
                 enqueueEndOfState(gate, channelIndex);
-                assertFalse("should align (block all channels)", gate.pollNext().isPresent());
+                Optional<BufferOrEvent> bufferOrEvent = gate.pollNext();
+                while (bufferOrEvent.isPresent()
+                        && bufferOrEvent.get().getEvent() instanceof EndOfChannelStateEvent
+                        && !gate.allChannelsRecovered()) {
+                    bufferOrEvent = gate.pollNext();
+                }
+                assertFalse("should align (block all channels)", bufferOrEvent.isPresent());
             }
 
             enqueueEndOfState(gate, numberOfChannels - 1);


### PR DESCRIPTION
## What is the purpose of the change

This commit moves draining the virtual channels at the end of recovery
out of the CheckpointedInputGate#pollNext method in to the main loop of
StreamTaskNetworkInput so that we do not build up a deeply nested stack.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
