### PR TITLE
[FLINK-21701][sql-client] Improve support "RESET key" statement in the SQL Client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -77,7 +77,7 @@ public final class CliStrings {
                     .append(
                             formatCommand(
                                     SqlCommand.RESET,
-                                    "Resets all session configuration properties."))
+                                    "Resets a session configuration property. Syntax: 'RESET <key>;'. Use 'RESET;' for reset all session properties."))
                     .append(
                             formatCommand(
                                     SqlCommand.SELECT,
@@ -177,6 +177,8 @@ public final class CliStrings {
 
     public static final String MESSAGE_RESET =
             "All session properties have been set to their default values.";
+
+    public static final String MESSAGE_RESET_KEY = "Session property has been reset.";
 
     public static final String MESSAGE_SET = "Session property has been set.";
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -339,7 +339,16 @@ public final class SqlCommandParser {
                     return Optional.of(new String[] {operands[1], operands[2]});
                 }),
 
-        RESET("RESET", NO_OPERANDS),
+        RESET(
+                "RESET(\\s+(\\S+)\\s*)?",
+                (operands) -> {
+                    if (operands.length < 2) {
+                        return Optional.empty();
+                    } else if (operands[0] == null) {
+                        return Optional.of(new String[0]);
+                    }
+                    return Optional.of(new String[] {operands[1]});
+                }),
 
         SOURCE("SOURCE\\s+(.*)", SINGLE_OPERAND);
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/YamlConfigUtils.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/YamlConfigUtils.java
@@ -170,6 +170,14 @@ public class YamlConfigUtils {
         return ENTRY_TO_OPTION.get(key);
     }
 
+    public static boolean isOptionKey(String key) {
+        return OPTION_TO_ENTRY.containsKey(key);
+    }
+
+    public static String getDeprecatedNameWithOptionKey(String key) {
+        return OPTION_TO_ENTRY.get(key);
+    }
+
     // --------------------------------------------------------------------------------------------
 
     public static void setKeyToConfiguration(

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -62,6 +62,16 @@ public interface Executor {
     void resetSessionProperties(String sessionId) throws SqlExecutionException;
 
     /**
+     * Reset given key's the session property for default value, if key is not defined in config
+     * file, then remove it.
+     *
+     * @param sessionId to identifier the session
+     * @param key of need to reset the session property
+     * @throws SqlExecutionException if any error happen.
+     */
+    void resetSessionProperty(String sessionId, String key) throws SqlExecutionException;
+
+    /**
      * Set given key's session property to the specific value.
      *
      * @param key of the session property

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/SessionContext.java
@@ -114,6 +114,35 @@ public class SessionContext {
         this.executionContext = new ExecutionContext(executionContext);
     }
 
+    /**
+     * Reset key's property to default. It will rebuild a new {@link ExecutionContext}.
+     *
+     * <p>If key is not defined in default config file, remove it from session configuration.
+     */
+    public void reset(String key) {
+        Configuration configuration = defaultContext.getFlinkConfig();
+        // If the key exist in default yaml , reset to default
+        if (configuration.containsKey(key)) {
+            String defaultValue =
+                    configuration.get(ConfigOptions.key(key).stringType().noDefaultValue());
+            this.set(key, defaultValue);
+        } else {
+            ConfigOption<String> keyToDelete = ConfigOptions.key(key).stringType().noDefaultValue();
+            sessionConfiguration.removeConfig(keyToDelete);
+            // need to remove compatible key
+            if (YamlConfigUtils.isDeprecatedKey(key)) {
+                String optionKey = YamlConfigUtils.getOptionNameWithDeprecatedKey(key);
+                sessionConfiguration.removeConfig(
+                        ConfigOptions.key(optionKey).stringType().noDefaultValue());
+            } else if (YamlConfigUtils.isOptionKey(key)) {
+                String deprecatedKey = YamlConfigUtils.getDeprecatedNameWithOptionKey(key);
+                sessionConfiguration.removeConfig(
+                        ConfigOptions.key(deprecatedKey).stringType().noDefaultValue());
+            }
+            this.executionContext = new ExecutionContext(executionContext);
+        }
+    }
+
     /** Set properties. It will rebuild a new {@link ExecutionContext} */
     public void set(String key, String value) {
         Configuration originConfiguration = sessionConfiguration.clone();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -147,6 +147,12 @@ public class LocalExecutor implements Executor {
     }
 
     @Override
+    public void resetSessionProperty(String sessionId, String key) throws SqlExecutionException {
+        SessionContext context = getSessionContext(sessionId);
+        context.reset(key);
+    }
+
+    @Override
     public void setSessionProperty(String sessionId, String key, String value)
             throws SqlExecutionException {
         SessionContext context = getSessionContext(sessionId);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -100,7 +100,7 @@ public class CliClientTest extends TestLogger {
     @Test
     public void testSqlCompletion() throws IOException {
         verifySqlCompletion(
-                "", 0, Arrays.asList("SOURCE", "QUIT;", "RESET;"), Collections.emptyList());
+                "", 0, Arrays.asList("SOURCE", "QUIT;", "RESET"), Collections.emptyList());
         verifySqlCompletion(
                 "SELE", 5, Collections.singletonList("HintA"), Collections.singletonList("QUIT;"));
         verifySqlCompletion(
@@ -281,6 +281,10 @@ public class CliClientTest extends TestLogger {
 
         @Override
         public void resetSessionProperties(String sessionId) throws SqlExecutionException {}
+
+        @Override
+        public void resetSessionProperty(String sessionId, String key)
+                throws SqlExecutionException {}
 
         @Override
         public void setSessionProperty(String sessionId, String key, String value)

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -153,6 +153,10 @@ public class CliResultViewTest {
         public void resetSessionProperties(String sessionId) throws SqlExecutionException {}
 
         @Override
+        public void resetSessionProperty(String sessionId, String key)
+                throws SqlExecutionException {}
+
+        @Override
         public void setSessionProperty(String sessionId, String key, String value)
                 throws SqlExecutionException {}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -167,6 +167,9 @@ public class SqlCommandParserTest {
                                 .cannotParseComment(),
                         // reset
                         TestItem.validSql("reset;", SqlCommand.RESET).cannotParseComment(),
+                        // reset xx
+                        TestItem.validSql("reset xx.yy;", SqlCommand.RESET, "xx.yy")
+                                .cannotParseComment(),
                         // source xx
                         TestItem.validSql("source /my/file;", SqlCommand.SOURCE, "/my/file")
                                 .cannotParseComment(),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -63,6 +63,10 @@ class TestingExecutor implements Executor {
     private final FunctionWithException<String, Void, SqlExecutionException>
             resetSessionPropertiesFunction;
 
+    private int numResetOneSessionPropertyCalls = 0;
+    private final BiFunctionWithException<String, String, Void, SqlExecutionException>
+            resetOneSessionPropertyFunction;
+
     private final SqlParserHelper helper;
 
     TestingExecutor(
@@ -76,13 +80,16 @@ class TestingExecutor implements Executor {
             TriFunctionWithException<String, String, String, Void, SqlExecutionException>
                     setSessionPropertyFunction,
             FunctionWithException<String, Void, SqlExecutionException>
-                    resetSessionPropertiesFunction) {
+                    resetSessionPropertiesFunction,
+            BiFunctionWithException<String, String, Void, SqlExecutionException>
+                    resetOneSessionPropertiesFunction) {
         this.resultChanges = resultChanges;
         this.snapshotResults = snapshotResults;
         this.resultPages = resultPages;
         this.executeSqlConsumer = executeSqlConsumer;
         this.setSessionPropertyFunction = setSessionPropertyFunction;
         this.resetSessionPropertiesFunction = resetSessionPropertiesFunction;
+        this.resetOneSessionPropertyFunction = resetOneSessionPropertiesFunction;
         helper = new SqlParserHelper();
         helper.registerTables();
     }
@@ -135,6 +142,12 @@ class TestingExecutor implements Executor {
     public void resetSessionProperties(String sessionId) throws SqlExecutionException {
         numResetSessionPropertiesCalls++;
         resetSessionPropertiesFunction.apply(sessionId);
+    }
+
+    @Override
+    public void resetSessionProperty(String sessionId, String key) throws SqlExecutionException {
+        numResetOneSessionPropertyCalls++;
+        resetOneSessionPropertyFunction.apply(sessionId, key);
     }
 
     @Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
@@ -45,6 +45,8 @@ class TestingExecutorBuilder {
             setSessionPropertyFunction = (ignoredA, ignoredB, ignoredC) -> null;
     private FunctionWithException<String, Void, SqlExecutionException>
             resetSessionPropertiesFunction = (ignoredA) -> null;
+    private BiFunctionWithException<String, String, Void, SqlExecutionException>
+            resetOneSessionPropertiesFunction = (ignoredA, ignoredB) -> null;
 
     @SafeVarargs
     public final TestingExecutorBuilder setResultChangesSupplier(
@@ -97,6 +99,7 @@ class TestingExecutorBuilder {
                 resultPagesSupplier,
                 setExecuteSqlConsumer,
                 setSessionPropertyFunction,
-                resetSessionPropertiesFunction);
+                resetSessionPropertiesFunction,
+                resetOneSessionPropertiesFunction);
     }
 }

--- a/flink-table/flink-sql-client/src/test/resources/sql/misc.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/misc.q
@@ -30,7 +30,7 @@ HELP		Prints the available commands.
 INSERT INTO		Inserts the results of a SQL SELECT query into a declared table sink.
 INSERT OVERWRITE		Inserts the results of a SQL SELECT query into a declared table sink and overwrite existing data.
 QUIT		Quits the SQL CLI client.
-RESET		Resets all session configuration properties.
+RESET		Resets a session configuration property. Syntax: 'RESET <key>;'. Use 'RESET;' for reset all session properties.
 SELECT		Executes a SQL SELECT query on the Flink cluster.
 SET		Sets a session configuration property. Syntax: 'SET <key>=<value>;'. Use 'SET;' for listing all properties.
 SHOW FUNCTIONS		Shows all user-defined and built-in functions or only user-defined functions. Syntax: 'SHOW [USER] FUNCTIONS;'

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -104,3 +104,70 @@ Was expecting one of:
     "," ...
 
 !error
+
+# test reset remove key
+reset execution.max-idle-state-retention;
+[WARNING] The specified key is not supported anymore.
+!warning
+
+set execution.max-table-result-rows=100;
+[WARNING] The specified key 'execution.max-table-result-rows' is deprecated. Please use 'sql-client.execution.max-table-result.rows' instead.
+[INFO] Session property has been set.
+!warning
+
+# test reset the deprecated key
+reset execution.max-table-result-rows;
+[WARNING] The specified key 'execution.max-table-result-rows' is deprecated. Please use 'sql-client.execution.max-table-result.rows' instead.
+[INFO] Session property has been reset.
+!warning
+
+set;
+execution.attached=true
+execution.savepoint.ignore-unclaimed-state=false
+execution.shutdown-on-attached-exit=false
+execution.target=remote
+jobmanager.rpc.address=$VAR_JOBMANAGER_RPC_ADDRESS
+pipeline.classpaths=
+pipeline.jars=$VAR_PIPELINE_JARS
+rest.port=$VAR_REST_PORT
+!ok
+
+
+set parallelism.default=3;
+[INFO] Session property has been set.
+!info
+
+# test reset option key
+reset parallelism.default;
+[INFO] Session property has been reset.
+!info
+
+set;
+execution.attached=true
+execution.savepoint.ignore-unclaimed-state=false
+execution.shutdown-on-attached-exit=false
+execution.target=remote
+jobmanager.rpc.address=$VAR_JOBMANAGER_RPC_ADDRESS
+pipeline.classpaths=
+pipeline.jars=$VAR_PIPELINE_JARS
+rest.port=$VAR_REST_PORT
+!ok
+
+set execution.attached=false;
+[INFO] Session property has been set.
+!info
+
+reset execution.attached;
+[INFO] Session property has been reset.
+!info
+
+set;
+execution.attached=true
+execution.savepoint.ignore-unclaimed-state=false
+execution.shutdown-on-attached-exit=false
+execution.target=remote
+jobmanager.rpc.address=$VAR_JOBMANAGER_RPC_ADDRESS
+pipeline.classpaths=
+pipeline.jars=$VAR_PIPELINE_JARS
+rest.port=$VAR_REST_PORT
+!ok


### PR DESCRIPTION
## What is the purpose of the change

this change is to Improve support "RESET key" statement in the SQL Client

## Brief change log

  - *Add a method resetSessionProperty(String sessionId, String key) in Executor*
  - *Add a method reset(String key) in SessionContext*
  - *`RESET` command pattern change to RESET(\s+(\S+)\s*)?  *

## Verifying this change

This change added tests and can be verified as follows:

  - *Added grammar test in *
  - *Add single statement test in SessionContextTest*
  - *Added integration tests for reset statement in  resources/sql/set.q*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)