### PR TITLE
[FLINK-20533][datadog][release-1.12] Backport flink-metrics-datadog changes from master

### DIFF
--- a/docs/deployment/metric_reporters.md
+++ b/docs/deployment/metric_reporters.md
@@ -230,6 +230,10 @@ metrics.reporter.stsd.interval: 60 SECONDS
 Note any variables in Flink metrics, such as `<host>`, `<job_name>`, `<tm_id>`, `<subtask_index>`, `<task_name>`, and `<operator_name>`,
 will be sent to Datadog as tags. Tags will look like `host:localhost` and `job_name:myjobname`.
 
+<span class="label label-info">Note</span> Histograms are exposed as a series of gauges following the naming convention of Datadog histograms (`<metric_name>.<aggregation>`).
+The `min` aggregation is reported by default, whereas `sum` is not available.
+In contrast to Datadog-provided Histograms the reported aggregations are not computed for a specific reporting interval.
+
 Parameters:
 
 - `apikey` - the Datadog API key

--- a/docs/deployment/metric_reporters.zh.md
+++ b/docs/deployment/metric_reporters.zh.md
@@ -230,6 +230,10 @@ metrics.reporter.stsd.interval: 60 SECONDS
 Note any variables in Flink metrics, such as `<host>`, `<job_name>`, `<tm_id>`, `<subtask_index>`, `<task_name>`, and `<operator_name>`,
 will be sent to Datadog as tags. Tags will look like `host:localhost` and `job_name:myjobname`.
 
+<span class="label label-info">Note</span> Histograms are exposed as a series of gauges following the naming convention of Datadog histograms (`<metric_name>.<aggregation>`).
+The `min` aggregation is reported by default, whereas `sum` is not available.
+In contrast to Datadog-provided Histograms the reported aggregations are not computed for a specific reporting interval.
+
 Parameters:
 
 - `apikey` - the Datadog API key

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DCounter.java
@@ -30,15 +30,12 @@ public class DCounter extends DMetric {
     private long currentReportCount = 0;
 
     public DCounter(Counter c, String metricName, String host, List<String> tags, Clock clock) {
-        super(MetricType.count, metricName, host, tags, clock);
+        super(new MetricMetaData(MetricType.count, metricName, host, tags, clock));
         counter = c;
     }
 
     /**
-     * Visibility of this method must not be changed since we deliberately not map it to json object
-     * in a Datadog-defined format.
-     *
-     * <p>Note: DataDog counters count the number of events during the reporting interval.
+     * Returns the count of events since the last report.
      *
      * @return the number of events since the last retrieval
      */

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DHistogram.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DHistogram.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.datadog;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+
+import java.util.List;
+
+/**
+ * Maps histograms to datadog gauges.
+ *
+ * <p>Note: We cannot map them to datadog histograms because the HTTP API does not support them.
+ */
+public class DHistogram {
+    @VisibleForTesting static final String SUFFIX_AVG = ".avg";
+    @VisibleForTesting static final String SUFFIX_COUNT = ".count";
+    @VisibleForTesting static final String SUFFIX_MEDIAN = ".median";
+    @VisibleForTesting static final String SUFFIX_95_PERCENTILE = ".95percentile";
+    @VisibleForTesting static final String SUFFIX_MIN = ".min";
+    @VisibleForTesting static final String SUFFIX_MAX = ".max";
+
+    private final Histogram histogram;
+
+    private final MetricMetaData metaDataAvg;
+    private final MetricMetaData metaDataCount;
+    private final MetricMetaData metaDataMedian;
+    private final MetricMetaData metaData95Percentile;
+    private final MetricMetaData metaDataMin;
+    private final MetricMetaData metaDataMax;
+
+    public DHistogram(
+            Histogram histogram, String metricName, String host, List<String> tags, Clock clock) {
+        this.histogram = histogram;
+        this.metaDataAvg =
+                new MetricMetaData(MetricType.gauge, metricName + SUFFIX_AVG, host, tags, clock);
+        this.metaDataCount =
+                new MetricMetaData(MetricType.gauge, metricName + SUFFIX_COUNT, host, tags, clock);
+        this.metaDataMedian =
+                new MetricMetaData(MetricType.gauge, metricName + SUFFIX_MEDIAN, host, tags, clock);
+        this.metaData95Percentile =
+                new MetricMetaData(
+                        MetricType.gauge, metricName + SUFFIX_95_PERCENTILE, host, tags, clock);
+        this.metaDataMin =
+                new MetricMetaData(MetricType.gauge, metricName + SUFFIX_MIN, host, tags, clock);
+        this.metaDataMax =
+                new MetricMetaData(MetricType.gauge, metricName + SUFFIX_MAX, host, tags, clock);
+    }
+
+    public void addTo(DSeries series) {
+        final HistogramStatistics statistics = histogram.getStatistics();
+
+        // this selection is based on
+        // https://docs.datadoghq.com/developers/metrics/types/?tab=histogram
+        // we only exclude 'sum' (which is optional), because we cannot compute it
+        // the semantics for count are also slightly different, because we don't reset it after a
+        // report
+        series.add(new StaticDMetric(statistics.getMean(), metaDataAvg));
+        series.add(new StaticDMetric(histogram.getCount(), metaDataCount));
+        series.add(new StaticDMetric(statistics.getQuantile(.5), metaDataMedian));
+        series.add(new StaticDMetric(statistics.getQuantile(.95), metaData95Percentile));
+        series.add(new StaticDMetric(statistics.getMin(), metaDataMin));
+        series.add(new StaticDMetric(statistics.getMax(), metaDataMax));
+    }
+}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMeter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMeter.java
@@ -31,7 +31,7 @@ public class DMeter extends DMetric {
     private final Meter meter;
 
     public DMeter(Meter m, String metricName, String host, List<String> tags, Clock clock) {
-        super(MetricType.gauge, metricName, host, tags, clock);
+        super(new MetricMetaData(MetricType.gauge, metricName, host, tags, clock));
         meter = m;
     }
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DMetric.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -28,46 +31,43 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class DMetric {
 
-    /**
-     * Names of metric/type/tags field and their getters must not be changed since they are mapped
-     * to json objects in a Datadog-defined format.
-     */
-    private final String metric; // Metric name
+    @VisibleForTesting static final String FIELD_NAME_TYPE = "type";
+    @VisibleForTesting static final String FIELD_NAME_METRIC = "metric";
+    @VisibleForTesting static final String FIELD_NAME_HOST = "host";
+    @VisibleForTesting static final String FIELD_NAME_TAGS = "tags";
+    @VisibleForTesting static final String FIELD_NAME_POINTS = "points";
 
-    private final MetricType type;
-    private final String host;
-    private final List<String> tags;
-    private final Clock clock;
+    private final MetricMetaData metaData;
 
-    public DMetric(
-            MetricType metricType, String metric, String host, List<String> tags, Clock clock) {
-        this.type = metricType;
-        this.metric = metric;
-        this.host = host;
-        this.tags = tags;
-        this.clock = clock;
+    public DMetric(MetricMetaData metaData) {
+        this.metaData = metaData;
     }
 
+    @JsonGetter(FIELD_NAME_TYPE)
     public MetricType getType() {
-        return type;
+        return metaData.getType();
     }
 
-    public String getMetric() {
-        return metric;
+    @JsonGetter(FIELD_NAME_METRIC)
+    public String getMetricName() {
+        return metaData.getMetricName();
     }
 
+    @JsonGetter(FIELD_NAME_HOST)
     public String getHost() {
-        return host;
+        return metaData.getHost();
     }
 
+    @JsonGetter(FIELD_NAME_TAGS)
     public List<String> getTags() {
-        return tags;
+        return metaData.getTags();
     }
 
+    @JsonGetter(FIELD_NAME_POINTS)
     public List<List<Number>> getPoints() {
         // One single data point
         List<Number> point = new ArrayList<>();
-        point.add(clock.getUnixEpochTimestamp());
+        point.add(metaData.getClock().getUnixEpochTimestamp());
         point.add(getMetricValue());
 
         List<List<Number>> points = new ArrayList<>();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
@@ -18,15 +18,17 @@
 
 package org.apache.flink.metrics.datadog;
 
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+
 import java.util.ArrayList;
 import java.util.List;
 
 /** Json serialization between Flink and Datadog. */
 public class DSeries {
-    /**
-     * Names of series field and its getters must not be changed since they are mapped to json
-     * objects in a Datadog-defined format.
-     */
+    @VisibleForTesting static final String FIELD_NAME_SERIES = "series";
+
     private final List<DMetric> series;
 
     public DSeries() {
@@ -37,18 +39,11 @@ public class DSeries {
         this.series = series;
     }
 
-    public void addGauge(DGauge gauge) {
-        series.add(gauge);
+    public void add(DMetric metric) {
+        series.add(metric);
     }
 
-    public void addCounter(DCounter counter) {
-        series.add(counter);
-    }
-
-    public void addMeter(DMeter meter) {
-        series.add(meter);
-    }
-
+    @JsonGetter(FIELD_NAME_SERIES)
     public List<DMetric> getSeries() {
         return series;
     }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -54,6 +54,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
     private final Map<Gauge, DGauge> gauges = new ConcurrentHashMap<>();
     private final Map<Counter, DCounter> counters = new ConcurrentHashMap<>();
     private final Map<Meter, DMeter> meters = new ConcurrentHashMap<>();
+    private final Map<Histogram, DHistogram> histograms = new ConcurrentHashMap<>();
 
     private DatadogHttpClient client;
     private List<String> configTags;
@@ -87,8 +88,8 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
             // Only consider rate
             meters.put(m, new DMeter(m, name, host, tags, clock));
         } else if (metric instanceof Histogram) {
-            LOGGER.warn(
-                    "Cannot add {} because Datadog HTTP API doesn't support Histogram", metricName);
+            Histogram h = (Histogram) metric;
+            histograms.put(h, new DHistogram(h, name, host, tags, clock));
         } else {
             LOGGER.warn(
                     "Cannot add unknown metric type {}. This indicates that the reporter "
@@ -106,7 +107,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
         } else if (metric instanceof Meter) {
             meters.remove(metric);
         } else if (metric instanceof Histogram) {
-            // No Histogram is registered
+            histograms.remove(metric);
         } else {
             LOGGER.warn(
                     "Cannot remove unknown metric type {}. This indicates that the reporter "
@@ -149,8 +150,9 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
         DSeries request = new DSeries();
 
         addGaugesAndUnregisterOnException(request);
-        counters.values().forEach(request::addCounter);
-        meters.values().forEach(request::addMeter);
+        counters.values().forEach(request::add);
+        meters.values().forEach(request::add);
+        histograms.values().forEach(histogram -> histogram.addTo(request));
 
         int totalMetrics = request.getSeries().size();
         int fromIndex = 0;
@@ -180,22 +182,22 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
                 // Will throw exception if the Gauge is not of Number type
                 // Flink uses Gauge to store many types other than Number
                 g.getMetricValue();
-                request.addGauge(g);
+                request.add(g);
             } catch (ClassCastException e) {
                 LOGGER.info(
                         "The metric {} will not be reported because only number types are supported by this reporter.",
-                        g.getMetric());
+                        g.getMetricName());
                 gaugesToRemove.add(entry.getKey());
             } catch (Exception e) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug(
                             "The metric {} will not be reported because it threw an exception.",
-                            g.getMetric(),
+                            g.getMetricName(),
                             e);
                 } else {
                     LOGGER.info(
                             "The metric {} will not be reported because it threw an exception.",
-                            g.getMetric());
+                            g.getMetricName());
                 }
                 gaugesToRemove.add(entry.getKey());
             }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/MetricMetaData.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/MetricMetaData.java
@@ -18,21 +18,43 @@
 
 package org.apache.flink.metrics.datadog;
 
-import org.apache.flink.metrics.Gauge;
-
 import java.util.List;
 
-/** Mapping of gauge between Flink and Datadog. */
-public class DGauge extends DMetric {
-    private final Gauge<Number> gauge;
+/** All metadata associated with a given metric. */
+public final class MetricMetaData {
 
-    public DGauge(Gauge<Number> g, String metricName, String host, List<String> tags, Clock clock) {
-        super(new MetricMetaData(MetricType.gauge, metricName, host, tags, clock));
-        gauge = g;
+    private final String metricName;
+    private final MetricType type;
+    private final String host;
+    private final List<String> tags;
+    private final Clock clock;
+
+    public MetricMetaData(
+            MetricType metricType, String metricName, String host, List<String> tags, Clock clock) {
+        this.type = metricType;
+        this.metricName = metricName;
+        this.host = host;
+        this.tags = tags;
+        this.clock = clock;
     }
 
-    @Override
-    public Number getMetricValue() {
-        return gauge.getValue();
+    public MetricType getType() {
+        return type;
+    }
+
+    public String getMetricName() {
+        return metricName;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public Clock getClock() {
+        return clock;
     }
 }

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/StaticDMetric.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/StaticDMetric.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.datadog;
+
+/** A {@link DMetric} that returns a fixed value. */
+public class StaticDMetric extends DMetric {
+    private final Number value;
+
+    public StaticDMetric(Number value, MetricMetaData metaData) {
+        super(metaData);
+        this.value = value;
+    }
+
+    public Number getMetricValue() {
+        return value;
+    }
+}

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.metrics.datadog;
 
-import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.util.TestCounter;
+import org.apache.flink.metrics.util.TestHistogram;
+import org.apache.flink.metrics.util.TestMeter;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.MapperFeature;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
@@ -30,14 +33,29 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the DatadogHttpClient. */
 public class DatadogHttpClientTest {
 
-    private static List<String> tags = Arrays.asList("tag1", "tag2");
+    private static final List<String> tags = Arrays.asList("tag1", "tag2");
+    private static final String TAGS_AS_JSON =
+            tags.stream().collect(Collectors.joining("\",\"", "[\"", "\"]"));
+    private static final String HOST = "localhost";
+    private static final String METRIC = "testMetric";
+
+    private static final ObjectMapper MAPPER;
+
+    static {
+        MAPPER = new ObjectMapper();
+        MAPPER.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+    }
 
     private static final long MOCKED_SYSTEM_MILLIS = 123L;
 
@@ -73,171 +91,130 @@ public class DatadogHttpClientTest {
 
     @Test
     public void serializeGauge() throws JsonProcessingException {
+        DSeries series = new DSeries();
+        series.add(new DGauge(() -> 1, METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-        DGauge g =
-                new DGauge(
-                        new Gauge<Number>() {
-                            @Override
-                            public Number getValue() {
-                                return 1;
-                            }
-                        },
-                        "testCounter",
-                        "localhost",
-                        tags,
-                        () -> MOCKED_SYSTEM_MILLIS);
-
-        assertEquals(
-                "{\"metric\":\"testCounter\",\"type\":\"gauge\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-                DatadogHttpClient.serialize(g));
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.gauge, true, "1"));
     }
 
     @Test
     public void serializeGaugeWithoutHost() throws JsonProcessingException {
+        DSeries series = new DSeries();
+        series.add(new DGauge(() -> 1, METRIC, null, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-        DGauge g =
-                new DGauge(
-                        new Gauge<Number>() {
-                            @Override
-                            public Number getValue() {
-                                return 1;
-                            }
-                        },
-                        "testCounter",
-                        null,
-                        tags,
-                        () -> MOCKED_SYSTEM_MILLIS);
-
-        assertEquals(
-                "{\"metric\":\"testCounter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-                DatadogHttpClient.serialize(g));
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.gauge, false, "1"));
     }
 
     @Test
     public void serializeCounter() throws JsonProcessingException {
-        DCounter c =
-                new DCounter(
-                        new Counter() {
-                            @Override
-                            public void inc() {}
+        DSeries series = new DSeries();
+        series.add(
+                new DCounter(new TestCounter(1), METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-                            @Override
-                            public void inc(long n) {}
-
-                            @Override
-                            public void dec() {}
-
-                            @Override
-                            public void dec(long n) {}
-
-                            @Override
-                            public long getCount() {
-                                return 1;
-                            }
-                        },
-                        "testCounter",
-                        "localhost",
-                        tags,
-                        () -> MOCKED_SYSTEM_MILLIS);
-
-        assertEquals(
-                "{\"metric\":\"testCounter\",\"type\":\"count\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-                DatadogHttpClient.serialize(c));
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.count, true, "1"));
     }
 
     @Test
     public void serializeCounterWithoutHost() throws JsonProcessingException {
-        DCounter c =
-                new DCounter(
-                        new Counter() {
-                            @Override
-                            public void inc() {}
+        DSeries series = new DSeries();
+        series.add(
+                new DCounter(new TestCounter(1), METRIC, null, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-                            @Override
-                            public void inc(long n) {}
-
-                            @Override
-                            public void dec() {}
-
-                            @Override
-                            public void dec(long n) {}
-
-                            @Override
-                            public long getCount() {
-                                return 1;
-                            }
-                        },
-                        "testCounter",
-                        null,
-                        tags,
-                        () -> MOCKED_SYSTEM_MILLIS);
-
-        assertEquals(
-                "{\"metric\":\"testCounter\",\"type\":\"count\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1]]}",
-                DatadogHttpClient.serialize(c));
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.count, false, "1"));
     }
 
     @Test
     public void serializeMeter() throws JsonProcessingException {
+        DSeries series = new DSeries();
+        series.add(new DMeter(new TestMeter(0, 1), METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-        DMeter m =
-                new DMeter(
-                        new Meter() {
-                            @Override
-                            public void markEvent() {}
-
-                            @Override
-                            public void markEvent(long n) {}
-
-                            @Override
-                            public double getRate() {
-                                return 1;
-                            }
-
-                            @Override
-                            public long getCount() {
-                                return 0;
-                            }
-                        },
-                        "testMeter",
-                        "localhost",
-                        tags,
-                        () -> MOCKED_SYSTEM_MILLIS);
-
-        assertEquals(
-                "{\"metric\":\"testMeter\",\"type\":\"gauge\",\"host\":\"localhost\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1.0]]}",
-                DatadogHttpClient.serialize(m));
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.gauge, true, "1.0"));
     }
 
     @Test
     public void serializeMeterWithoutHost() throws JsonProcessingException {
+        DSeries series = new DSeries();
+        series.add(new DMeter(new TestMeter(0, 1), METRIC, null, tags, () -> MOCKED_SYSTEM_MILLIS));
 
-        DMeter m =
-                new DMeter(
-                        new Meter() {
-                            @Override
-                            public void markEvent() {}
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.gauge, false, "1.0"));
+    }
 
-                            @Override
-                            public void markEvent(long n) {}
+    @Test
+    public void serializeHistogram() throws JsonProcessingException {
+        DHistogram h =
+                new DHistogram(new TestHistogram(), METRIC, HOST, tags, () -> MOCKED_SYSTEM_MILLIS);
 
-                            @Override
-                            public double getRate() {
-                                return 1;
-                            }
+        DSeries series = new DSeries();
+        h.addTo(series);
 
-                            @Override
-                            public long getCount() {
-                                return 0;
-                            }
-                        },
-                        "testMeter",
-                        null,
-                        tags,
-                        () -> MOCKED_SYSTEM_MILLIS);
+        assertSerialization(
+                DatadogHttpClient.serialize(series),
+                new MetricAssertion(MetricType.gauge, true, "4.0", DHistogram.SUFFIX_AVG),
+                new MetricAssertion(MetricType.gauge, true, "1", DHistogram.SUFFIX_COUNT),
+                new MetricAssertion(MetricType.gauge, true, "0.5", DHistogram.SUFFIX_MEDIAN),
+                new MetricAssertion(
+                        MetricType.gauge, true, "0.95", DHistogram.SUFFIX_95_PERCENTILE),
+                new MetricAssertion(MetricType.gauge, true, "7", DHistogram.SUFFIX_MIN),
+                new MetricAssertion(MetricType.gauge, true, "6", DHistogram.SUFFIX_MAX));
+    }
 
-        assertEquals(
-                "{\"metric\":\"testMeter\",\"type\":\"gauge\",\"tags\":[\"tag1\",\"tag2\"],\"points\":[[123,1.0]]}",
-                DatadogHttpClient.serialize(m));
+    private static void assertSerialization(String json, MetricAssertion... metricAssertions)
+            throws JsonProcessingException {
+        final JsonNode series = MAPPER.readTree(json).get(DSeries.FIELD_NAME_SERIES);
+
+        for (int i = 0; i < metricAssertions.length; i++) {
+            final JsonNode parsedJson = series.get(i);
+            final MetricAssertion metricAssertion = metricAssertions[i];
+
+            if (metricAssertion.expectHost) {
+                assertThat(parsedJson.get(DMetric.FIELD_NAME_HOST).asText(), is(HOST));
+            } else {
+                assertThat(parsedJson.get(DMetric.FIELD_NAME_HOST), nullValue());
+            }
+            assertThat(
+                    parsedJson.get(DMetric.FIELD_NAME_METRIC).asText(),
+                    is(METRIC + metricAssertion.metricNameSuffix));
+            assertThat(
+                    parsedJson.get(DMetric.FIELD_NAME_TYPE).asText(),
+                    is(metricAssertion.expectedType.name()));
+            assertThat(
+                    parsedJson.get(DMetric.FIELD_NAME_POINTS).toString(),
+                    is(String.format("[[123,%s]]", metricAssertion.expectedValue)));
+            assertThat(parsedJson.get(DMetric.FIELD_NAME_TAGS).toString(), is(TAGS_AS_JSON));
+        }
+    }
+
+    private static final class MetricAssertion {
+        final MetricType expectedType;
+        final boolean expectHost;
+        final String expectedValue;
+        final String metricNameSuffix;
+
+        private MetricAssertion(MetricType expectedType, boolean expectHost, String expectedValue) {
+            this(expectedType, expectHost, expectedValue, "");
+        }
+
+        private MetricAssertion(
+                MetricType expectedType,
+                boolean expectHost,
+                String expectedValue,
+                String metricNameSuffix) {
+            this.expectedType = expectedType;
+            this.expectHost = expectHost;
+            this.expectedValue = expectedValue;
+            this.metricNameSuffix = metricNameSuffix;
+        }
     }
 }


### PR DESCRIPTION
I created this PR by copying the files from master because due to the code reformat it would have been cumbersome to cherry pick individual commits. Changes included:

commit 313e20e8e03953a5e1cec9daa467f561ccfbd599Author: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 16:20:29 2020 +0100
    [FLINK-20533][datadog] Add Histogram support
commit 38e424fd5fa7c4a6e6165921689a232a10e85bddAuthor: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 16:16:02 2020 +0100
    [FLINK-20533][datadog] Encapsulate metric meta data        This allows us to use the 'MetricMetaData' container for histograms later on, which will not directly extend 'DMetric'.
commit ea317c20ac4ab76c9e71fb0c1aa8a104e7173057Author: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 14:55:48 2020 +0100
    [hotfix][datadog] Remove outdated comments
commit f01e1916edf015d3f1b800065eeea4c2ae4af7baAuthor: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 16:14:01 2020 +0100
    [hotfix][datadog][tests] Rework tests        - re-parse JSON to ignore order of serialization    - restrict 'DatadogHttpClient.serialize()' to 'DSeries'    - test series serialization    - refer to constants where possible
commit 7fcb628c0cd6a3daf3f19917ef2414d8743bcc7aAuthor: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 14:40:08 2020 +0100
    [hotfix][datadog] Explicitly mark fields relevant for serialization        It was difficult to tell which fields are relevant for serialization. Adding annotations makes this more obvious, and allows us more freedom in regards to naming.
commit 4d5053067199d46134366abc5c8954c57757a82eAuthor: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 14:40:57 2020 +0100
    [hotfix][datadog] Merge DSeries#add*()        The distinction between metric types adds unnecessary complexity.
commit bf058d68acdcdcb4ea28e6fe3a22904a5f385b8aAuthor: Chesnay Schepler <chesnay@apache.org>Date:   Tue Dec 8 14:38:44 2020 +0100
    [hotfix][datadog][tests] Cleanup code
