### PR TITLE
[FLINK-21879][tests] Harden ActiveResourceManagerTest.testWorkerRegistrationTimeoutNotCountingAllocationTime

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -778,10 +778,11 @@ public class ActiveResourceManagerTest extends TestLogger {
                             // resource allocation takes longer than worker registration timeout
                             try {
                                 Thread.sleep(TESTING_START_WORKER_TIMEOUT_MS * 2);
-                                requestResourceFuture.complete(tmResourceId);
                             } catch (InterruptedException e) {
                                 fail();
                             }
+
+                            runInMainThread(() -> requestResourceFuture.complete(tmResourceId));
 
                             // worker registered, verify not released due to timeout
                             CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =


### PR DESCRIPTION
The requestResourceFuture needs to be completed within the main thread of the ResourceManager.
Otherwise, we risk to not see the caused state changes.

cc @xintongsong
