### PR TITLE
[hotfix][build] Add missing antlr3 plugin version

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -873,6 +873,7 @@ under the License.
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr3-maven-plugin</artifactId>
+				<version>3.5.2</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
## What is the purpose of the change

Adds the proper plugin version for `antlr3-maven-plugin` in `flink-connector-hive`.

This avoids build stability issues and clears some warnings.

The version is the latest released plugin version (released 2014) and the one my setup (default settings) picked automatically
in the absence of the proper version. Compilation and tests succeed with that version.
