### PR TITLE
[FLINK-21626][core] Make RuntimeContext.jobID non-optional

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/SemanticXidGenerator.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/SemanticXidGenerator.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.jdbc.xa;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.util.AbstractID;
 
 import javax.transaction.xa.Xid;
 
@@ -63,12 +62,8 @@ class SemanticXidGenerator implements XidGenerator {
 
     @Override
     public Xid generateXid(RuntimeContext runtimeContext, long checkpointId) {
-        byte[] jobIdOrRandomBytes =
-                runtimeContext
-                        .getJobId()
-                        .map(AbstractID::getBytes)
-                        .orElse(getRandomBytes(JobID.SIZE));
-        System.arraycopy(jobIdOrRandomBytes, 0, gtridBuffer, 0, JobID.SIZE);
+        byte[] jobIdBytes = runtimeContext.getJobId().getBytes();
+        System.arraycopy(jobIdBytes, 0, gtridBuffer, 0, JobID.SIZE);
 
         writeNumber(runtimeContext.getIndexOfThisSubtask(), Integer.BYTES, gtridBuffer, JobID.SIZE);
         writeNumber(checkpointId, Long.BYTES, gtridBuffer, JobID.SIZE + Integer.BYTES);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
@@ -63,7 +63,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -168,8 +167,8 @@ public abstract class JdbcXaSinkTestBase extends JdbcTestBase {
     static final RuntimeContext TEST_RUNTIME_CONTEXT =
             new RuntimeContext() {
                 @Override
-                public Optional<JobID> getJobId() {
-                    return Optional.of(new JobID());
+                public JobID getJobId() {
+                    return new JobID();
                 }
 
                 @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -43,7 +43,6 @@ import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -59,11 +58,10 @@ import java.util.Set;
 public interface RuntimeContext {
 
     /**
-     * The ID of the current job. Empty if the execution happens outside of any job context (e.g.
-     * standalone collection executor). Note that Job ID can change in particular upon manual
-     * restart. The returned ID should NOT be used for any job management tasks.
+     * The ID of the current job. Note that Job ID can change in particular upon manual restart. The
+     * returned ID should NOT be used for any job management tasks.
      */
-    Optional<JobID> getJobId();
+    JobID getJobId();
 
     /**
      * Returns the name of the task in which the UDF runs, as assigned during plan construction.

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/CollectionExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/CollectionExecutor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.accumulators.Accumulator;
@@ -106,11 +107,12 @@ public class CollectionExecutor {
 
     public JobExecutionResult execute(Plan program) throws Exception {
         long startTime = System.currentTimeMillis();
+        JobID jobID = program.getJobId() == null ? new JobID() : program.getJobId();
 
         initCache(program.getCachedFiles());
         Collection<? extends GenericDataSinkBase<?>> sinks = program.getDataSinks();
         for (Operator<?> sink : sinks) {
-            execute(sink);
+            execute(sink, jobID);
         }
 
         long endTime = System.currentTimeMillis();
@@ -126,11 +128,11 @@ public class CollectionExecutor {
         }
     };
 
-    private List<?> execute(Operator<?> operator) throws Exception {
-        return execute(operator, 0);
+    private List<?> execute(Operator<?> operator, JobID jobID) throws Exception {
+        return execute(operator, 0, jobID);
     }
 
-    private List<?> execute(Operator<?> operator, int superStep) throws Exception {
+    private List<?> execute(Operator<?> operator, int superStep, JobID jobID) throws Exception {
         List<?> result = this.intermediateResults.get(operator);
 
         // if it has already been computed, use the cached variant
@@ -139,17 +141,20 @@ public class CollectionExecutor {
         }
 
         if (operator instanceof BulkIterationBase) {
-            result = executeBulkIteration((BulkIterationBase<?>) operator);
+            result = executeBulkIteration((BulkIterationBase<?>) operator, jobID);
         } else if (operator instanceof DeltaIterationBase) {
-            result = executeDeltaIteration((DeltaIterationBase<?, ?>) operator);
+            result = executeDeltaIteration((DeltaIterationBase<?, ?>) operator, jobID);
         } else if (operator instanceof SingleInputOperator) {
-            result = executeUnaryOperator((SingleInputOperator<?, ?, ?>) operator, superStep);
+            result =
+                    executeUnaryOperator((SingleInputOperator<?, ?, ?>) operator, superStep, jobID);
         } else if (operator instanceof DualInputOperator) {
-            result = executeBinaryOperator((DualInputOperator<?, ?, ?, ?>) operator, superStep);
+            result =
+                    executeBinaryOperator(
+                            (DualInputOperator<?, ?, ?, ?>) operator, superStep, jobID);
         } else if (operator instanceof GenericDataSourceBase) {
-            result = executeDataSource((GenericDataSourceBase<?, ?>) operator, superStep);
+            result = executeDataSource((GenericDataSourceBase<?, ?>) operator, superStep, jobID);
         } else if (operator instanceof GenericDataSinkBase) {
-            executeDataSink((GenericDataSinkBase<?>) operator, superStep);
+            executeDataSink((GenericDataSinkBase<?>) operator, superStep, jobID);
             result = Collections.emptyList();
         } else {
             throw new RuntimeException("Cannot execute operator " + operator.getClass().getName());
@@ -164,14 +169,15 @@ public class CollectionExecutor {
     //  Operator class specific execution methods
     // --------------------------------------------------------------------------------------------
 
-    private <IN> void executeDataSink(GenericDataSinkBase<?> sink, int superStep) throws Exception {
+    private <IN> void executeDataSink(GenericDataSinkBase<?> sink, int superStep, JobID jobID)
+            throws Exception {
         Operator<?> inputOp = sink.getInput();
         if (inputOp == null) {
             throw new InvalidProgramException("The data sink " + sink.getName() + " has no input.");
         }
 
         @SuppressWarnings("unchecked")
-        List<IN> input = (List<IN>) execute(inputOp);
+        List<IN> input = (List<IN>) execute(inputOp, jobID);
 
         @SuppressWarnings("unchecked")
         GenericDataSinkBase<IN> typedSink = (GenericDataSinkBase<IN>) sink;
@@ -192,14 +198,16 @@ public class CollectionExecutor {
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics)
+                                    metrics,
+                                    jobID)
                             : new IterationRuntimeUDFContext(
                                     taskInfo,
                                     userCodeClassLoader,
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics);
+                                    metrics,
+                                    jobID);
         } else {
             ctx = null;
         }
@@ -207,8 +215,8 @@ public class CollectionExecutor {
         typedSink.executeOnCollections(input, ctx, executionConfig);
     }
 
-    private <OUT> List<OUT> executeDataSource(GenericDataSourceBase<?, ?> source, int superStep)
-            throws Exception {
+    private <OUT> List<OUT> executeDataSource(
+            GenericDataSourceBase<?, ?> source, int superStep, JobID jobID) throws Exception {
         @SuppressWarnings("unchecked")
         GenericDataSourceBase<OUT, ?> typedSource = (GenericDataSourceBase<OUT, ?>) source;
         // build the runtime context and compute broadcast variables, if necessary
@@ -227,14 +235,16 @@ public class CollectionExecutor {
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics)
+                                    metrics,
+                                    jobID)
                             : new IterationRuntimeUDFContext(
                                     taskInfo,
                                     userCodeClassLoader,
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics);
+                                    metrics,
+                                    jobID);
         } else {
             ctx = null;
         }
@@ -242,7 +252,7 @@ public class CollectionExecutor {
     }
 
     private <IN, OUT> List<OUT> executeUnaryOperator(
-            SingleInputOperator<?, ?, ?> operator, int superStep) throws Exception {
+            SingleInputOperator<?, ?, ?> operator, int superStep, JobID jobID) throws Exception {
         Operator<?> inputOp = operator.getInput();
         if (inputOp == null) {
             throw new InvalidProgramException(
@@ -250,7 +260,7 @@ public class CollectionExecutor {
         }
 
         @SuppressWarnings("unchecked")
-        List<IN> inputData = (List<IN>) execute(inputOp, superStep);
+        List<IN> inputData = (List<IN>) execute(inputOp, superStep, jobID);
 
         @SuppressWarnings("unchecked")
         SingleInputOperator<IN, OUT, ?> typedOp = (SingleInputOperator<IN, OUT, ?>) operator;
@@ -269,18 +279,20 @@ public class CollectionExecutor {
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics)
+                                    metrics,
+                                    jobID)
                             : new IterationRuntimeUDFContext(
                                     taskInfo,
                                     userCodeClassLoader,
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics);
+                                    metrics,
+                                    jobID);
 
             for (Map.Entry<String, Operator<?>> bcInputs :
                     operator.getBroadcastInputs().entrySet()) {
-                List<?> bcData = execute(bcInputs.getValue());
+                List<?> bcData = execute(bcInputs.getValue(), jobID);
                 ctx.setBroadcastVariable(bcInputs.getKey(), bcData);
             }
         } else {
@@ -291,7 +303,7 @@ public class CollectionExecutor {
     }
 
     private <IN1, IN2, OUT> List<OUT> executeBinaryOperator(
-            DualInputOperator<?, ?, ?, ?> operator, int superStep) throws Exception {
+            DualInputOperator<?, ?, ?, ?> operator, int superStep, JobID jobID) throws Exception {
         Operator<?> inputOp1 = operator.getFirstInput();
         Operator<?> inputOp2 = operator.getSecondInput();
 
@@ -306,9 +318,9 @@ public class CollectionExecutor {
 
         // compute inputs
         @SuppressWarnings("unchecked")
-        List<IN1> inputData1 = (List<IN1>) execute(inputOp1, superStep);
+        List<IN1> inputData1 = (List<IN1>) execute(inputOp1, superStep, jobID);
         @SuppressWarnings("unchecked")
-        List<IN2> inputData2 = (List<IN2>) execute(inputOp2, superStep);
+        List<IN2> inputData2 = (List<IN2>) execute(inputOp2, superStep, jobID);
 
         @SuppressWarnings("unchecked")
         DualInputOperator<IN1, IN2, OUT, ?> typedOp =
@@ -329,18 +341,20 @@ public class CollectionExecutor {
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics)
+                                    metrics,
+                                    jobID)
                             : new IterationRuntimeUDFContext(
                                     taskInfo,
                                     userCodeClassLoader,
                                     executionConfig,
                                     cachedFiles,
                                     accumulators,
-                                    metrics);
+                                    metrics,
+                                    jobID);
 
             for (Map.Entry<String, Operator<?>> bcInputs :
                     operator.getBroadcastInputs().entrySet()) {
-                List<?> bcData = execute(bcInputs.getValue());
+                List<?> bcData = execute(bcInputs.getValue(), jobID);
                 ctx.setBroadcastVariable(bcInputs.getKey(), bcData);
             }
         } else {
@@ -351,7 +365,8 @@ public class CollectionExecutor {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> List<T> executeBulkIteration(BulkIterationBase<?> iteration) throws Exception {
+    private <T> List<T> executeBulkIteration(BulkIterationBase<?> iteration, JobID jobID)
+            throws Exception {
         Operator<?> inputOp = iteration.getInput();
         if (inputOp == null) {
             throw new InvalidProgramException(
@@ -366,7 +381,7 @@ public class CollectionExecutor {
                             + " has no next partial solution defined (is not closed).");
         }
 
-        List<T> inputData = (List<T>) execute(inputOp);
+        List<T> inputData = (List<T>) execute(inputOp, jobID);
 
         // get the operators that are iterative
         Set<Operator<?>> dynamics = new LinkedHashSet<Operator<?>>();
@@ -399,11 +414,11 @@ public class CollectionExecutor {
             iterationSuperstep = superstep;
 
             // grab the current iteration result
-            currentResult = (List<T>) execute(iteration.getNextPartialSolution(), superstep);
+            currentResult = (List<T>) execute(iteration.getNextPartialSolution(), superstep, jobID);
 
             // evaluate the termination criterion
             if (iteration.getTerminationCriterion() != null) {
-                execute(iteration.getTerminationCriterion(), superstep);
+                execute(iteration.getTerminationCriterion(), superstep, jobID);
             }
 
             // evaluate the aggregator convergence criterion
@@ -433,7 +448,8 @@ public class CollectionExecutor {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> List<T> executeDeltaIteration(DeltaIterationBase<?, ?> iteration) throws Exception {
+    private <T> List<T> executeDeltaIteration(DeltaIterationBase<?, ?> iteration, JobID jobID)
+            throws Exception {
         Operator<?> solutionInput = iteration.getInitialSolutionSet();
         Operator<?> worksetInput = iteration.getInitialWorkset();
         if (solutionInput == null) {
@@ -457,8 +473,8 @@ public class CollectionExecutor {
                             + " has no workset defined (is not closed).");
         }
 
-        List<T> solutionInputData = (List<T>) execute(solutionInput);
-        List<T> worksetInputData = (List<T>) execute(worksetInput);
+        List<T> solutionInputData = (List<T>) execute(solutionInput, jobID);
+        List<T> worksetInputData = (List<T>) execute(worksetInput, jobID);
 
         // get the operators that are iterative
         Set<Operator<?>> dynamics = new LinkedHashSet<Operator<?>>();
@@ -511,7 +527,7 @@ public class CollectionExecutor {
 
             // grab the current iteration result
             List<T> solutionSetDelta =
-                    (List<T>) execute(iteration.getSolutionSetDelta(), superstep);
+                    (List<T>) execute(iteration.getSolutionSetDelta(), superstep, jobID);
             this.intermediateResults.put(iteration.getSolutionSetDelta(), solutionSetDelta);
 
             // update the solution
@@ -520,7 +536,7 @@ public class CollectionExecutor {
                 solutionMap.put(wrapper, delta);
             }
 
-            currentWorkset = execute(iteration.getNextWorkset(), superstep);
+            currentWorkset = execute(iteration.getNextWorkset(), superstep, jobID);
 
             if (currentWorkset.isEmpty()) {
                 break;
@@ -625,8 +641,9 @@ public class CollectionExecutor {
                 ExecutionConfig executionConfig,
                 Map<String, Future<Path>> cpTasks,
                 Map<String, Accumulator<?, ?>> accumulators,
-                MetricGroup metrics) {
-            super(taskInfo, classloader, executionConfig, cpTasks, accumulators, metrics);
+                MetricGroup metrics,
+                JobID jobID) {
+            super(taskInfo, classloader, executionConfig, cpTasks, accumulators, metrics, jobID);
         }
 
         @Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
@@ -44,7 +44,6 @@ import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -66,7 +65,7 @@ class CepRuntimeContext implements RuntimeContext {
     }
 
     @Override
-    public Optional<JobID> getJobId() {
+    public JobID getJobId() {
         return runtimeContext.getJobId();
     }
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
@@ -49,7 +49,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -81,7 +80,7 @@ public final class SavepointRuntimeContext implements RuntimeContext {
     }
 
     @Override
-    public Optional<JobID> getJobId() {
+    public JobID getJobId() {
         return ctx.getJobId();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -62,7 +62,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Future;
 
 /** The abstract base class for all tasks able to participate in an iteration. */
@@ -432,7 +431,7 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
         }
 
         @Override
-        public Optional<JobID> getJobId() {
+        public JobID getJobId() {
             return runtimeUdfContext.getJobId();
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
@@ -37,7 +37,6 @@ import org.apache.flink.util.UserCodeClassLoader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 
@@ -115,8 +114,8 @@ public class DistributedRuntimeUDFContext extends AbstractRuntimeUDFContext {
     }
 
     @Override
-    public Optional<JobID> getJobId() {
-        return Optional.of(jobID);
+    public JobID getJobId() {
+        return jobID;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -50,7 +50,6 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -107,7 +106,7 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
         }
 
         @Override
-        public Optional<JobID> getJobId() {
+        public JobID getJobId() {
             return runtimeContext.getJobId();
         }
 
@@ -299,7 +298,7 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
         }
 
         @Override
-        public Optional<JobID> getJobId() {
+        public JobID getJobId() {
             return iterationRuntimeContext.getJobId();
         }
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -52,7 +52,6 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -161,8 +160,8 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
     }
 
     @Override
-    public Optional<JobID> getJobId() {
-        return Optional.of(taskEnvironment.getJobID());
+    public JobID getJobId() {
+        return taskEnvironment.getJobID();
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -19,14 +19,13 @@
 package org.apache.flink.table.planner.expressions.utils
 
 import java.util.Collections
-
 import org.apache.calcite.plan.hep.{HepPlanner, HepProgramBuilder}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.logical.LogicalCalc
 import org.apache.calcite.rel.rules._
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.`type`.SqlTypeName.VARCHAR
-import org.apache.flink.api.common.TaskInfo
+import org.apache.flink.api.common.{JobID, TaskInfo}
 import org.apache.flink.api.common.functions.util.RuntimeUDFContext
 import org.apache.flink.api.common.functions.{MapFunction, RichFunction, RichMapFunction}
 import org.apache.flink.api.java.typeutils.RowTypeInfo

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
@@ -25,7 +25,7 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.`type`.SqlTypeName._
 import org.apache.calcite.tools.Programs
-import org.apache.flink.api.common.TaskInfo
+import org.apache.flink.api.common.{JobID, TaskInfo}
 import org.apache.flink.api.common.accumulators.Accumulator
 import org.apache.flink.api.common.functions._
 import org.apache.flink.api.common.functions.util.RuntimeUDFContext


### PR DESCRIPTION
## What is the purpose of the change

Make RuntimeContext.jobID non-optional.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
