### PR TITLE
[FLINK-21701][sql-client] Extend the "RESET" syntax in the SQL Client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -77,7 +77,7 @@ public final class CliStrings {
                     .append(
                             formatCommand(
                                     SqlCommand.RESET,
-                                    "Resets all session configuration properties."))
+                                    "Resets a session configuration property. Syntax: 'RESET <key>;'. Use 'RESET;' for reset all session properties."))
                     .append(
                             formatCommand(
                                     SqlCommand.SELECT,
@@ -178,12 +178,13 @@ public final class CliStrings {
     public static final String MESSAGE_RESET =
             "All session properties have been set to their default values.";
 
+    public static final String MESSAGE_RESET_KEY = "Session property has been reset.";
+
     public static final String MESSAGE_SET = "Session property has been set.";
 
-    public static final String MESSAGE_SET_REMOVED_KEY =
-            "The specified key is not supported anymore.";
+    public static final String MESSAGE_REMOVED_KEY = "The specified key is not supported anymore.";
 
-    public static final String MESSAGE_SET_DEPRECATED_KEY =
+    public static final String MESSAGE_DEPRECATED_KEY =
             "The specified key '%s' is deprecated. Please use '%s' instead.";
 
     public static final String MESSAGE_EMPTY = "Result was empty.";

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/SqlCommandParser.java
@@ -337,7 +337,16 @@ public final class SqlCommandParser {
                     return Optional.of(new String[] {operands[1], operands[2]});
                 }),
 
-        RESET("RESET", NO_OPERANDS),
+        RESET(
+                "RESET(\\s+(\\S+)\\s*)?",
+                (operands) -> {
+                    if (operands.length < 2) {
+                        return Optional.empty();
+                    } else if (operands[0] == null) {
+                        return Optional.of(new String[0]);
+                    }
+                    return Optional.of(new String[] {operands[1]});
+                }),
 
         SOURCE("SOURCE\\s+(.*)", SINGLE_OPERAND);
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/YamlConfigUtils.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/YamlConfigUtils.java
@@ -170,6 +170,14 @@ public class YamlConfigUtils {
         return ENTRY_TO_OPTION.get(key);
     }
 
+    public static boolean isOptionHasDeprecatedKey(String key) {
+        return OPTION_TO_ENTRY.containsKey(key);
+    }
+
+    public static String getDeprecatedNameWithOptionKey(String key) {
+        return OPTION_TO_ENTRY.get(key);
+    }
+
     // --------------------------------------------------------------------------------------------
 
     public static void setKeyToConfiguration(

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -62,6 +62,16 @@ public interface Executor {
     void resetSessionProperties(String sessionId) throws SqlExecutionException;
 
     /**
+     * Reset given key's the session property for default value, if key is not defined in config
+     * file, then remove it.
+     *
+     * @param sessionId to identifier the session
+     * @param key of need to reset the session property
+     * @throws SqlExecutionException if any error happen.
+     */
+    void resetSessionProperty(String sessionId, String key) throws SqlExecutionException;
+
+    /**
      * Set given key's session property to the specific value.
      *
      * @param key of the session property

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -147,6 +147,12 @@ public class LocalExecutor implements Executor {
     }
 
     @Override
+    public void resetSessionProperty(String sessionId, String key) throws SqlExecutionException {
+        SessionContext context = getSessionContext(sessionId);
+        context.reset(key);
+    }
+
+    @Override
     public void setSessionProperty(String sessionId, String key, String value)
             throws SqlExecutionException {
         SessionContext context = getSessionContext(sessionId);

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -97,7 +97,7 @@ public class CliClientTest extends TestLogger {
     @Test
     public void testSqlCompletion() throws IOException {
         verifySqlCompletion(
-                "", 0, Arrays.asList("SOURCE", "QUIT;", "RESET;"), Collections.emptyList());
+                "", 0, Arrays.asList("SOURCE", "QUIT;", "RESET"), Collections.emptyList());
         verifySqlCompletion(
                 "SELE", 5, Collections.singletonList("HintA"), Collections.singletonList("QUIT;"));
         verifySqlCompletion(
@@ -239,6 +239,10 @@ public class CliClientTest extends TestLogger {
 
         @Override
         public void resetSessionProperties(String sessionId) throws SqlExecutionException {}
+
+        @Override
+        public void resetSessionProperty(String sessionId, String key)
+                throws SqlExecutionException {}
 
         @Override
         public void setSessionProperty(String sessionId, String key, String value)

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -153,6 +153,10 @@ public class CliResultViewTest {
         public void resetSessionProperties(String sessionId) throws SqlExecutionException {}
 
         @Override
+        public void resetSessionProperty(String sessionId, String key)
+                throws SqlExecutionException {}
+
+        @Override
         public void setSessionProperty(String sessionId, String key, String value)
                 throws SqlExecutionException {}
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/SqlCommandParserTest.java
@@ -173,6 +173,12 @@ public class SqlCommandParserTest {
                                 .cannotParseComment(),
                         // reset
                         TestItem.validSql("reset;", SqlCommand.RESET).cannotParseComment(),
+                        // reset xx.yy
+                        TestItem.validSql("reset xx.yy;", SqlCommand.RESET, "xx.yy")
+                                .cannotParseComment(),
+                        // reset xx-yy
+                        TestItem.validSql("reset xx-yy;", SqlCommand.RESET, "xx-yy")
+                                .cannotParseComment(),
                         // source xx
                         TestItem.validSql("source /my/file;", SqlCommand.SOURCE, "/my/file")
                                 .cannotParseComment(),

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -104,6 +104,11 @@ class TestingExecutor implements Executor {
     }
 
     @Override
+    public void resetSessionProperty(String sessionId, String key) throws SqlExecutionException {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
     public void setSessionProperty(String sessionId, String key, String value)
             throws SqlExecutionException {
         throw new UnsupportedOperationException("Not implemented.");

--- a/flink-table/flink-sql-client/src/test/resources/sql/misc.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/misc.q
@@ -30,7 +30,7 @@ HELP		Prints the available commands.
 INSERT INTO		Inserts the results of a SQL SELECT query into a declared table sink.
 INSERT OVERWRITE		Inserts the results of a SQL SELECT query into a declared table sink and overwrite existing data.
 QUIT		Quits the SQL CLI client.
-RESET		Resets all session configuration properties.
+RESET		Resets a session configuration property. Syntax: 'RESET <key>;'. Use 'RESET;' for reset all session properties.
 SELECT		Executes a SQL SELECT query on the Flink cluster.
 SET		Sets a session configuration property. Syntax: 'SET <key>=<value>;'. Use 'SET;' for listing all properties.
 SHOW FUNCTIONS		Shows all user-defined and built-in functions or only user-defined functions. Syntax: 'SHOW [USER] FUNCTIONS;'

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -104,3 +104,69 @@ Was expecting one of:
     "," ...
 
 !error
+
+# test reset remove key
+reset execution.max-idle-state-retention;
+[WARNING] The specified key is not supported anymore.
+!warning
+
+# test reset the deprecated key
+set execution.max-table-result-rows=200;
+[WARNING] The specified key 'execution.max-table-result-rows' is deprecated. Please use 'sql-client.execution.max-table-result.rows' instead.
+[INFO] Session property has been set.
+!warning
+
+reset sql-client.execution.max-table-result.rows;
+[INFO] Session property has been reset.
+!info
+
+set;
+execution.attached=true
+execution.savepoint.ignore-unclaimed-state=false
+execution.shutdown-on-attached-exit=false
+execution.target=remote
+jobmanager.rpc.address=$VAR_JOBMANAGER_RPC_ADDRESS
+pipeline.classpaths=
+pipeline.jars=$VAR_PIPELINE_JARS
+rest.port=$VAR_REST_PORT
+!ok
+
+set parallelism.default=3;
+[INFO] Session property has been set.
+!info
+
+# test reset deprecated key
+reset execution.parallelism;
+[WARNING] The specified key 'execution.parallelism' is deprecated. Please use 'parallelism.default' instead.
+[INFO] Session property has been reset.
+!warning
+
+set;
+execution.attached=true
+execution.savepoint.ignore-unclaimed-state=false
+execution.shutdown-on-attached-exit=false
+execution.target=remote
+jobmanager.rpc.address=$VAR_JOBMANAGER_RPC_ADDRESS
+pipeline.classpaths=
+pipeline.jars=$VAR_PIPELINE_JARS
+rest.port=$VAR_REST_PORT
+!ok
+
+set execution.attached=false;
+[INFO] Session property has been set.
+!info
+
+reset execution.attached;
+[INFO] Session property has been reset.
+!info
+
+set;
+execution.attached=true
+execution.savepoint.ignore-unclaimed-state=false
+execution.shutdown-on-attached-exit=false
+execution.target=remote
+jobmanager.rpc.address=$VAR_JOBMANAGER_RPC_ADDRESS
+pipeline.classpaths=
+pipeline.jars=$VAR_PIPELINE_JARS
+rest.port=$VAR_REST_PORT
+!ok


### PR DESCRIPTION
## What is the purpose of the change

this change is to Improve support "RESET key" statement in the SQL Client

## Brief change log

  - *Add a method resetSessionProperty(String sessionId, String key) in Executor*
  - *Add a method reset(String key) in SessionContext*
  - *`RESET` command pattern change to RESET(\s+(\S+)\s*)?  *

## Verifying this change

This change added tests and can be verified as follows:

  - *Added grammar test in *
  - *Add single statement test in SessionContextTest*
  - *Added integration tests for reset statement in  resources/sql/set.q*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
