### PR TITLE
Allow users to use fractional values for memory params

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -310,10 +310,10 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
         try {
             result = DoubleMath.roundToLong(fractionalResult, RoundingMode.UP);
         } catch (ArithmeticException e) {
-            if (e.getMessage().contains("not in range")) {
-                // throw the below overflow exception
-                notInRange = true;
-            }
+            // throw the below overflow exception
+            // roundToLong throws if fractionalResult is:
+            // inf, NaN, smaller than Long.MIN_VALUE, or larger than Long.MAX_VALUE
+            notInRange = true;
         }
 
         // check for overflow

--- a/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -88,6 +88,14 @@ public class MemorySizeTest {
     }
 
     @Test
+    public void testFractional() {
+        assertEquals(103, MemorySize.parseBytes("0.1kb"));
+        assertEquals(512, MemorySize.parseBytes("0.5kb"));
+        assertEquals(1, MemorySize.parseBytes("0.00001kb"));
+        assertEquals(1127, MemorySize.parseBytes("1.1kb"));
+    }
+
+    @Test
     public void testParseBytes() {
         assertEquals(1234, MemorySize.parseBytes("1234"));
         assertEquals(1234, MemorySize.parseBytes("1234b"));
@@ -198,6 +206,27 @@ public class MemorySizeTest {
         // negative number
         try {
             MemorySize.parseBytes("-100 bytes");
+            fail("exception expected");
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        // multiple decimal points
+        try {
+            MemorySize.parseBytes("0..1 bytes");
+            fail("exception expected");
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        // multiple decimal points
+        try {
+            MemorySize.parseBytes("0.1.1 bytes");
+            fail("exception expected");
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        // invalid decimal point
+        try {
+            MemorySize.parseBytes("1 .bytes");
             fail("exception expected");
         } catch (IllegalArgumentException ignored) {
         }


### PR DESCRIPTION
## What is the purpose of the change

Allows users to specify memory parameters as fractional values, ex: “0.5gb”.

## Brief change log

  - Changed numeric parsing logic to allow ‘.’ character but only one of such character.
  - Updated range / overflow checks.
  - Rounds value up if necessary.
  - Added tests.


## Verifying this change

This change added tests and can be verified as follows:

  - Added tests to existing parsing logic tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) Yes
  - The serializers: (yes / no / don't know) No
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) No
  - The S3 file system connector: (yes / no / don't know) No

## Documentation

  - Does this pull request introduce a new feature? (yes / no) No
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
