### PR TITLE
[FLINK-21918][python] Add execution.runtime-mode setter in StreamExecutionEnvironment

### DIFF
--- a/flink-python/pyflink/datastream/execution_mode.py
+++ b/flink-python/pyflink/datastream/execution_mode.py
@@ -1,0 +1,62 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from enum import Enum
+
+from pyflink.java_gateway import get_gateway
+
+__all__ = ['RuntimeExecutionMode']
+
+
+class RuntimeExecutionMode(Enum):
+    """
+    Runtime execution mode of DataStream programs. Among other things, this controls task
+    scheduling, network shuffle behavior, and time semantics. Some operations will also change
+    their record emission behaviour based on the configured execution mode.
+
+    :data:`STREAMING`:
+
+    The Pipeline will be executed with Streaming Semantics. All tasks will be deployed before
+    execution starts, checkpoints will be enabled, and both processing and event time will be
+    fully supported.
+
+    :data:`BATCH`:
+
+    The Pipeline will be executed with Batch Semantics. Tasks will be scheduled gradually based
+    on the scheduling region they belong, shuffles between regions will be blocking, watermarks
+    are assumed to be "perfect" i.e. no late data, and processing time is assumed to not advance
+    during execution.
+
+    :data:`AUTOMATIC`:
+
+    Flink will set the execution mode to BATCH if all sources are bounded, or STREAMING if there
+    is at least one source which is unbounded.
+    """
+    STREAMING = 0
+    BATCH = 1
+    AUTOMATIC = 2
+
+    @staticmethod
+    def _from_j_execution_mode(j_execution_mode) -> 'RuntimeExecutionMode':
+        return RuntimeExecutionMode[j_execution_mode.name()]
+
+    def _to_j_execution_mode(self):
+        gateway = get_gateway()
+        JRuntimeExecutionMode = \
+            gateway.jvm.org.apache.flink.api.common.RuntimeExecutionMode
+        return getattr(JRuntimeExecutionMode, self.name)

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -30,6 +30,7 @@ from pyflink.common.typeinfo import TypeInformation, Types
 from pyflink.datastream.checkpoint_config import CheckpointConfig
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.data_stream import DataStream
+from pyflink.datastream.execution_mode import RuntimeExecutionMode
 from pyflink.datastream.functions import SourceFunction
 from pyflink.datastream.state_backend import _from_j_state_backend, StateBackend
 from pyflink.datastream.time_characteristic import TimeCharacteristic
@@ -117,6 +118,26 @@ class StreamExecutionEnvironment(object):
         :return: Maximum degree of parallelism.
         """
         return self._j_stream_execution_environment.getMaxParallelism()
+
+    def set_runtime_mode(self, execution_mode: RuntimeExecutionMode):
+        """
+        Sets the runtime execution mode for the application
+        :class:`~pyflink.datastream.execution_mode.RuntimeExecutionMode`. This
+        is equivalent to setting the `execution.runtime-mode` in your application's
+        configuration file.
+
+        We recommend users to NOT use this method but set the `execution.runtime-mode` using
+        the command-line when submitting the application. Keeping the application code
+        configuration-free allows for more flexibility as the same application will be able to be
+        executed in any execution mode.
+
+        :param execution_mode: The desired execution mode.
+        :return: The execution environment of your application.
+
+        .. versionadded:: 1.13.0
+        """
+        return self._j_stream_execution_environment.setRuntimeMode(
+            execution_mode._to_j_execution_mode())
 
     def set_buffer_timeout(self, timeout_millis: int) -> 'StreamExecutionEnvironment':
         """

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -49,7 +49,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
                 'clearJobListeners', 'getJobListeners', "fromSource", "fromSequence",
-                'setRuntimeMode', 'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory'}
+                'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory'}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds execution.runtime-mode setter in StreamExecutionEnvironment.*

## Brief change log

  - *Introduce set_runtime_mode in StreamExecutionEnvironment*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_set_runtime_mode*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
