### PR TITLE
[FLINK-20547][network] Fix inconsistent availability issue of LocalBufferPool

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -29,6 +30,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -515,6 +518,22 @@ public class LocalBufferPoolTest extends TestLogger {
         assertTrue(availableFuture2.isDone());
     }
 
+    /** For FLINK-20547: https://issues.apache.org/jira/browse/FLINK-20547. */
+    @Test
+    public void testConsistentAvailability() throws Exception {
+        NetworkBufferPool globalPool = new TestNetworkBufferPool(numBuffers, memorySegmentSize);
+        try {
+            BufferPool localPool = new LocalBufferPool(globalPool, 1);
+            MemorySegment segment = localPool.requestBufferBuilderBlocking().getMemorySegment();
+            localPool.setNumBuffers(2);
+
+            localPool.recycle(segment);
+            localPool.lazyDestroy();
+        } finally {
+            globalPool.destroy();
+        }
+    }
+
     // ------------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------------
@@ -568,6 +587,24 @@ public class LocalBufferPoolTest extends TestLogger {
             }
 
             return true;
+        }
+    }
+
+    private static class TestNetworkBufferPool extends NetworkBufferPool {
+
+        private int requestCounter;
+
+        public TestNetworkBufferPool(int numberOfSegmentsToAllocate, int segmentSize) {
+            super(numberOfSegmentsToAllocate, segmentSize);
+        }
+
+        @Nullable
+        @Override
+        public MemorySegment requestMemorySegment() {
+            if (requestCounter++ == 1) {
+                return null;
+            }
+            return super.requestMemorySegment();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

LocalBufferPool#checkAvailability may return wrong availability state of LocalBufferPool which may lead to the set of inconsistent availability state when LocalBufferPool#setNumBuffers is called. This patch fixes the issue.


## Brief change log

  - Fix wrong return value of LocalBufferPool#checkAvailability.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
