### PR TITLE
[FLINK-21916] Allows multiple kinds of ManagedMemoryUseCase for the same operator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtils.java
@@ -155,4 +155,19 @@ public enum ManagedMemoryUtils {
                         BigDecimal.ROUND_DOWN)
                 .doubleValue();
     }
+
+    public static void validateManagedMemoryUseCaseWeights(
+            Map<ManagedMemoryUseCase, Integer> existingOperatorScopeUseCaseWeights,
+            Map<ManagedMemoryUseCase, Integer> newOperatorScopeUseCaseWeights) {
+        for (Map.Entry<ManagedMemoryUseCase, Integer> entry :
+                newOperatorScopeUseCaseWeights.entrySet()) {
+            Integer existingWeight = existingOperatorScopeUseCaseWeights.get(entry.getKey());
+            if (existingWeight != null && !existingWeight.equals(entry.getValue())) {
+                throw new IllegalConfigurationException(
+                        String.format(
+                                "The new value '%d' mismatch with the existing value '%d' for managed memory consumer weight '%s'.",
+                                entry.getValue(), existingWeight, entry.getKey()));
+            }
+        }
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -266,4 +266,43 @@ public class ManagedMemoryUtilsTest extends TestLogger {
         assertEquals(expectedStateFractionOfSlot, stateFractionOfSlot, DELTA);
         assertEquals(expectedPythonFractionOfSlot, pythonFractionOfSlot, DELTA);
     }
+
+    @Test
+    public void testManagedMemoryUseCaseWeightsConfiguredWithConsistentValue() {
+        final Map<ManagedMemoryUseCase, Integer> existingWeights =
+                new HashMap<ManagedMemoryUseCase, Integer>() {
+                    {
+                        put(ManagedMemoryUseCase.OPERATOR, 123);
+                    }
+                };
+
+        final Map<ManagedMemoryUseCase, Integer> newWeights =
+                new HashMap<ManagedMemoryUseCase, Integer>() {
+                    {
+                        put(ManagedMemoryUseCase.OPERATOR, 123);
+                        put(ManagedMemoryUseCase.STATE_BACKEND, 456);
+                    }
+                };
+
+        ManagedMemoryUtils.validateManagedMemoryUseCaseWeights(existingWeights, newWeights);
+    }
+
+    @Test(expected = IllegalConfigurationException.class)
+    public void testManagedMemoryUseCaseWeightsConfiguredWithConflictValue() {
+        final Map<ManagedMemoryUseCase, Integer> existingWeights =
+                new HashMap<ManagedMemoryUseCase, Integer>() {
+                    {
+                        put(ManagedMemoryUseCase.OPERATOR, 123);
+                    }
+                };
+
+        final Map<ManagedMemoryUseCase, Integer> newWeights =
+                new HashMap<ManagedMemoryUseCase, Integer>() {
+                    {
+                        put(ManagedMemoryUseCase.OPERATOR, 456);
+                    }
+                };
+
+        ManagedMemoryUtils.validateManagedMemoryUseCaseWeights(existingWeights, newWeights);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ManagedMemoryUtilsTest.java
@@ -268,7 +268,7 @@ public class ManagedMemoryUtilsTest extends TestLogger {
     }
 
     @Test
-    public void testManagedMemoryUseCaseWeightsConfiguredWithConsistentValue() {
+    public void testUseCaseWeightsConfiguredWithConsistentValue() {
         final Map<ManagedMemoryUseCase, Integer> existingWeights =
                 new HashMap<ManagedMemoryUseCase, Integer>() {
                     {
@@ -284,11 +284,11 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                     }
                 };
 
-        ManagedMemoryUtils.validateManagedMemoryUseCaseWeights(existingWeights, newWeights);
+        ManagedMemoryUtils.validateUseCaseWeightsNoConflict(existingWeights, newWeights);
     }
 
-    @Test(expected = IllegalConfigurationException.class)
-    public void testManagedMemoryUseCaseWeightsConfiguredWithConflictValue() {
+    @Test(expected = IllegalStateException.class)
+    public void testUseCaseWeightsConfiguredWithConflictValue() {
         final Map<ManagedMemoryUseCase, Integer> existingWeights =
                 new HashMap<ManagedMemoryUseCase, Integer>() {
                     {
@@ -303,6 +303,6 @@ public class ManagedMemoryUtilsTest extends TestLogger {
                     }
                 };
 
-        ManagedMemoryUtils.validateManagedMemoryUseCaseWeights(existingWeights, newWeights);
+        ManagedMemoryUtils.validateUseCaseWeightsNoConflict(existingWeights, newWeights);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
@@ -116,9 +116,7 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
         }
 
         final StreamNode streamNode = streamGraph.getStreamNode(transformationId);
-        if (streamNode != null
-                && streamNode.getManagedMemoryOperatorScopeUseCaseWeights().isEmpty()
-                && streamNode.getManagedMemorySlotScopeUseCases().isEmpty()) {
+        if (streamNode != null) {
             streamNode.setManagedMemoryUseCaseWeights(
                     transformation.getManagedMemoryOperatorScopeUseCaseWeights(),
                     transformation.getManagedMemorySlotScopeUseCases());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/SimpleTransformationTranslator.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.util.graph.StreamGraphUtils;
 
 import java.util.Collection;
 
+import static org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils.validateUseCaseWeightsNoConflict;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -117,6 +118,9 @@ public abstract class SimpleTransformationTranslator<OUT, T extends Transformati
 
         final StreamNode streamNode = streamGraph.getStreamNode(transformationId);
         if (streamNode != null) {
+            validateUseCaseWeightsNoConflict(
+                    streamNode.getManagedMemoryOperatorScopeUseCaseWeights(),
+                    transformation.getManagedMemoryOperatorScopeUseCaseWeights());
             streamNode.setManagedMemoryUseCaseWeights(
                     transformation.getManagedMemoryOperatorScopeUseCaseWeights(),
                     transformation.getManagedMemorySlotScopeUseCases());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils.validateManagedMemoryUseCaseWeights;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Class representing the operators in the streaming programs, with all their properties. */
@@ -209,6 +210,8 @@ public class StreamNode {
     public void setManagedMemoryUseCaseWeights(
             Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights,
             Set<ManagedMemoryUseCase> slotScopeUseCases) {
+        validateManagedMemoryUseCaseWeights(
+                managedMemoryOperatorScopeUseCaseWeights, operatorScopeUseCaseWeights);
         managedMemoryOperatorScopeUseCaseWeights.putAll(operatorScopeUseCaseWeights);
         managedMemorySlotScopeUseCases.addAll(slotScopeUseCases);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils.validateManagedMemoryUseCaseWeights;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Class representing the operators in the streaming programs, with all their properties. */
@@ -210,8 +209,6 @@ public class StreamNode {
     public void setManagedMemoryUseCaseWeights(
             Map<ManagedMemoryUseCase, Integer> operatorScopeUseCaseWeights,
             Set<ManagedMemoryUseCase> slotScopeUseCases) {
-        validateManagedMemoryUseCaseWeights(
-                managedMemoryOperatorScopeUseCaseWeights, operatorScopeUseCaseWeights);
         managedMemoryOperatorScopeUseCaseWeights.putAll(operatorScopeUseCaseWeights);
         managedMemorySlotScopeUseCases.addAll(slotScopeUseCases);
     }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request relaxes the restriction that multiple ManagedMemoryUseCase could no be used for the same operator, e.g. PYTHON and OPERATOR.*

## Brief change log

  - *Remove the restriction in SimpleTransformationTranslator*
  - *Add validation to make sure that two sets of weights should be consistent*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests testManagedMemoryUseCaseWeightsConfiguredWithConsistentValue and testManagedMemoryUseCaseWeightsConfiguredWithConflictValue in ManagedMemoryUtilsTest *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
