### PR TITLE
[FLINK-21922][python] Fix partition_by in Over which doesn't work for expression DSL

### DIFF
--- a/flink-python/pyflink/table/tests/test_window.py
+++ b/flink-python/pyflink/table/tests/test_window.py
@@ -31,8 +31,8 @@ class StreamTableWindowTests(PyFlinkBlinkStreamTableTestCase):
         t = t_env.from_elements([(1, 1, "Hello")], ['a', 'b', 'c'])
 
         result = t.over_window(
-            Over.partition_by("c")
-                .order_by("a")
+            Over.partition_by(t.c)
+                .order_by(t.a)
                 .preceding(expr.row_interval(2))
                 .following(expr.CURRENT_ROW)
                 .alias("w"))

--- a/flink-python/pyflink/table/window.py
+++ b/flink-python/pyflink/table/window.py
@@ -31,6 +31,8 @@ __all__ = [
     'OverWindow'
 ]
 
+from pyflink.table.utils import to_expression_jarray
+
 
 class GroupWindow(object):
     """
@@ -355,7 +357,7 @@ class Over(object):
             _get_java_expression(order_by)))
 
     @classmethod
-    def partition_by(cls, partition_by: Union[str, Expression]) -> 'OverWindowPartitioned':
+    def partition_by(cls, *partition_by: Union[str, Expression]) -> 'OverWindowPartitioned':
         """
         Partitions the elements on some partition keys.
 
@@ -365,8 +367,13 @@ class Over(object):
         :param partition_by: List of field references.
         :return: An over window with defined partitioning.
         """
-        return OverWindowPartitioned(get_gateway().jvm.Over.partitionBy(
-            _get_java_expression(partition_by)))
+        if all(isinstance(f, Expression) for f in partition_by):
+            return OverWindowPartitioned(get_gateway().jvm.Over.partitionBy(
+                to_expression_jarray(partition_by)))
+        else:
+            assert len(partition_by) == 1
+            assert isinstance(partition_by[0], str)
+            return OverWindowPartitioned(get_gateway().jvm.Over.partitionBy(partition_by[0]))
 
 
 class OverWindowPartitionedOrdered(object):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes partition_by in Over which doesn't work*


## Verifying this change

This change added tests and can be verified as follows:

  - *Updated tests test_over_window*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
