### PR TITLE
[FLINK-21387][tests] Remove test timeout from DispatcherTest.testNonBlockingJobSubmission and .testInvalidCallDuringInitialization

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -79,6 +79,7 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.hamcrest.Matchers;
@@ -391,7 +392,7 @@ public class DispatcherTest extends TestLogger {
         }
     }
 
-    @Test(timeout = 5_000L)
+    @Test
     public void testNonBlockingJobSubmission() throws Exception {
         final OneShotLatch latch = new OneShotLatch();
         dispatcher =
@@ -423,11 +424,11 @@ public class DispatcherTest extends TestLogger {
         // ensure job is running
         CommonTestUtils.waitUntilCondition(
                 () -> dispatcherGateway.requestJobStatus(jobID, TIMEOUT).get() == JobStatus.RUNNING,
-                Deadline.fromNow(Duration.of(10, ChronoUnit.SECONDS)),
+                Deadline.fromNow(TimeUtils.toDuration(TIMEOUT)),
                 5L);
     }
 
-    @Test(timeout = 5_000L)
+    @Test
     public void testInvalidCallDuringInitialization() throws Exception {
         final OneShotLatch latch = new OneShotLatch();
         dispatcher =
@@ -465,7 +466,7 @@ public class DispatcherTest extends TestLogger {
                 () ->
                         dispatcherGateway.requestJobStatus(jobGraph.getJobID(), TIMEOUT).get()
                                 == JobStatus.RUNNING,
-                Deadline.fromNow(Duration.of(10, ChronoUnit.SECONDS)),
+                Deadline.fromNow(TimeUtils.toDuration(TIMEOUT)),
                 5L);
     }
 


### PR DESCRIPTION
The 5s test timeout for the DispatcherTest.testNonBlockingJobSubmission and .testInvalidCallDuringInitialization failed on the CI infrastructure. Therefore, this commit removes these timeouts in order to harden the mentioned tests.