### PR TITLE
[FLINK-21564][tests] Don't call condition or throw exception after condition met for CommonTestUtils.waitUntil

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/CommonTestUtils.java
@@ -136,20 +136,34 @@ public class CommonTestUtils {
         waitUntilCondition(condition, timeout, RETRY_INTERVAL, errorMsg);
     }
 
+    /**
+     * Wait util the given condition is met or timeout.
+     *
+     * <p>This method guarantees:
+     *
+     * <ul>
+     *   <li>Does not call condition after met.
+     *   <li>Does not throw exception after met.
+     * </ul>
+     *
+     * @throws TimeoutException if the condition is not met before timeout.
+     * @throws InterruptedException if the thread is interrupted.
+     * @throws Exception if condition evaluation throws.
+     */
     public static void waitUntilCondition(
             SupplierWithException<Boolean, Exception> condition,
             Deadline timeout,
             long retryIntervalMillis,
             String errorMsg)
             throws Exception {
-        while (timeout.hasTimeLeft() && !condition.get()) {
+        while (timeout.hasTimeLeft()) {
+            if (condition.get()) {
+                return;
+            }
             final long timeLeft = Math.max(0, timeout.timeLeft().toMillis());
             Thread.sleep(Math.min(retryIntervalMillis, timeLeft));
         }
-
-        if (!timeout.hasTimeLeft()) {
-            throw new TimeoutException(errorMsg);
-        }
+        throw new TimeoutException(errorMsg);
     }
 
     public static void waitForAllTaskRunning(

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -188,6 +188,13 @@ public class CommonTestUtils {
     /**
      * Wait util the given condition is met or timeout.
      *
+     * <p>This method guarantees:
+     *
+     * <ul>
+     *   <li>Does not call condition after met.
+     *   <li>Does not throw exception after met.
+     * </ul>
+     *
      * @param condition the condition to wait for.
      * @param timeout the maximum time to wait for the condition to become true.
      * @param errorMsg the error message to include in the <code>TimeoutException</code> if the
@@ -198,16 +205,17 @@ public class CommonTestUtils {
     @SuppressWarnings("BusyWait")
     public static void waitUtil(Supplier<Boolean> condition, Duration timeout, String errorMsg)
             throws TimeoutException, InterruptedException {
-        long timeoutMs = timeout.toMillis();
-        if (timeoutMs <= 0) {
+        long timeoutNanos = timeout.toNanos();
+        if (timeoutNanos <= 0) {
             throw new IllegalArgumentException("The timeout must be positive.");
         }
-        long startingTime = System.currentTimeMillis();
-        while (!condition.get() && System.currentTimeMillis() - startingTime < timeoutMs) {
+        long startingTime = System.nanoTime();
+        while (System.nanoTime() - startingTime < timeoutNanos) {
+            if (condition.get()) {
+                return;
+            }
             Thread.sleep(1);
         }
-        if (!condition.get()) {
-            throw new TimeoutException(errorMsg);
-        }
+        throw new TimeoutException(errorMsg);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Improve `CommonTestUtils.waitUntil` to provide strong guarantee that there will be no condition call or exception after condition met.

## Brief change log
* Improve `org.apache.flink.runtime.testutils.CommonTestUtils.waitUntilCondition` to provide strong guarantee described above.
* Improve `org.apache.flink.core.testutils.CommonTestUtils.waitUntil` to provide strong guarantee described above.

## Verifying this change
This change is already covered by existing tests which use above two methods.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
