### PR TITLE
[FLINK-21933][kinesis] EFO consumer treats interrupts as retryable ex…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -800,6 +800,12 @@ public class KinesisDataFetcher<T> {
      * executed and all shard consuming threads will be interrupted.
      */
     public void shutdownFetcher() {
+        if (LOG.isInfoEnabled()) {
+            LOG.info(
+                    "Starting shutdown of shard consumer threads and AWS SDK resources of subtask {} ...",
+                    indexOfThisConsumerSubtask);
+        }
+
         running = false;
 
         StreamConsumerRegistrarUtil.deregisterStreamConsumers(configProps, streams);
@@ -822,6 +828,15 @@ public class KinesisDataFetcher<T> {
                     "Shutting down the shard consumer threads of subtask {} ...",
                     indexOfThisConsumerSubtask);
         }
+    }
+
+    /**
+     * Returns a flag indicating if this fetcher is running.
+     *
+     * @return true if the fetch is running, false if it has been shutdown
+     */
+    boolean isRunning() {
+        return running;
     }
 
     /**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisher.java
@@ -45,7 +45,10 @@ public interface RecordPublisher {
         COMPLETE,
 
         /** There are more records to consume from this shard. */
-        INCOMPLETE
+        INCOMPLETE,
+
+        /** The record publisher has been cancelled. */
+        CANCELLED
     }
 
     /**

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
@@ -58,6 +58,21 @@ public class ShardConsumerTestUtils {
             final SequenceNumber startingSequenceNumber,
             final Properties consumerProperties)
             throws InterruptedException {
+        return assertNumberOfMessagesReceivedFromKinesis(
+                expectedNumberOfMessages,
+                recordPublisherFactory,
+                startingSequenceNumber,
+                consumerProperties,
+                SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get());
+    }
+
+    public static <T> ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+            final int expectedNumberOfMessages,
+            final RecordPublisherFactory recordPublisherFactory,
+            final SequenceNumber startingSequenceNumber,
+            final Properties consumerProperties,
+            final SequenceNumber expectedLastProcessedSequenceNum)
+            throws InterruptedException {
         ShardConsumerMetricsReporter shardMetricsReporter =
                 new ShardConsumerMetricsReporter(mock(MetricGroup.class));
 
@@ -118,7 +133,7 @@ public class ShardConsumerTestUtils {
 
         assertEquals(expectedNumberOfMessages, sourceContext.getCollectedOutputs().size());
         assertEquals(
-                SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+                expectedLastProcessedSequenceNum,
                 subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
 
         return shardMetricsReporter;


### PR DESCRIPTION
## What is the purpose of the change

Gracefully handle Interrupted exceptions in Kinesis EFO source consumer.

## Brief change log

- Update error handling to treat Interrupted exceptions as non-recoverable
- Introduced a `CANCELLED` result for record publisher to cause `ShardConsumer` to terminate
- Do not retry when KinesisDataFetcher is not running (shutdown started) and Thread not yet interrupted

## Verifying this change

- Unit tests
- Kinesis e2e test
- Running locally with 400 shard stream and 25 parallelism
- Deployed to test bed of continuously running applications in AWS KDA

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
