### PR TITLE
[FLINK-21937][python] Support batch mode in Python DataStream API for basic operations

### DIFF
--- a/flink-python/pyflink/common/configuration.py
+++ b/flink-python/pyflink/common/configuration.py
@@ -20,7 +20,7 @@ from typing import Set, Dict
 from py4j.java_gateway import JavaObject
 
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import add_jars_to_context_class_loader
+from pyflink.util.java_utils import add_jars_to_context_class_loader
 
 
 class Configuration:

--- a/flink-python/pyflink/common/execution_config.py
+++ b/flink-python/pyflink/common/execution_config.py
@@ -23,7 +23,7 @@ from pyflink.common.execution_mode import ExecutionMode
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import load_java_class
+from pyflink.util.java_utils import load_java_class
 
 __all__ = ['ExecutionConfig']
 

--- a/flink-python/pyflink/common/restart_strategy.py
+++ b/flink-python/pyflink/common/restart_strategy.py
@@ -22,7 +22,7 @@ from typing import Optional
 from py4j.java_gateway import get_java_class
 
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import to_j_flink_time, from_j_flink_time
+from pyflink.util.java_utils import to_j_flink_time, from_j_flink_time
 
 __all__ = ['RestartStrategies', 'RestartStrategyConfiguration']
 

--- a/flink-python/pyflink/common/serialization.py
+++ b/flink-python/pyflink/common/serialization.py
@@ -19,7 +19,7 @@ from py4j.java_gateway import java_import, JavaObject
 from pyflink.common import typeinfo
 from pyflink.common.typeinfo import TypeInformation
 
-from pyflink.util.utils import load_java_class
+from pyflink.util.java_utils import load_java_class
 
 from pyflink.java_gateway import get_gateway
 from typing import Union

--- a/flink-python/pyflink/dataset/execution_environment.py
+++ b/flink-python/pyflink/dataset/execution_environment.py
@@ -19,7 +19,7 @@ from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import load_java_class
+from pyflink.util.java_utils import load_java_class
 
 
 class ExecutionEnvironment(object):

--- a/flink-python/pyflink/datastream/connectors.py
+++ b/flink-python/pyflink/datastream/connectors.py
@@ -24,7 +24,7 @@ from pyflink.common.serialization import DeserializationSchema, Encoder, Seriali
 from pyflink.common.typeinfo import RowTypeInfo, TypeInformation
 from pyflink.datastream.functions import SourceFunction, SinkFunction
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import load_java_class, to_jarray
+from pyflink.util.java_utils import load_java_class, to_jarray
 
 from py4j.java_gateway import java_import
 

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -23,7 +23,7 @@ from py4j.java_gateway import get_java_class
 from typing import List, Optional
 
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import load_java_class
+from pyflink.util.java_utils import load_java_class
 
 __all__ = [
     'StateBackend',

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -36,7 +36,7 @@ from pyflink.datastream.state_backend import _from_j_state_backend, StateBackend
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.java_gateway import get_gateway
 from pyflink.serializers import PickleSerializer
-from pyflink.util.utils import load_java_class, add_jars_to_context_class_loader
+from pyflink.util.java_utils import load_java_class, add_jars_to_context_class_loader, invoke_method
 
 __all__ = ['StreamExecutionEnvironment']
 
@@ -768,10 +768,22 @@ class StreamExecutionEnvironment(object):
                 execution_config
             )
 
-            j_data_stream_source = self._j_stream_execution_environment.createInput(
-                j_input_format,
-                out_put_type_info.get_java_type_info()
-            )
+            JInputFormatSourceFunction = gateway.jvm.org.apache.flink.streaming.api.functions.\
+                source.InputFormatSourceFunction
+            JBoundedness = gateway.jvm.org.apache.flink.api.connector.source.Boundedness
+
+            j_data_stream_source = invoke_method(
+                self._j_stream_execution_environment,
+                "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment",
+                "addSource",
+                [JInputFormatSourceFunction(j_input_format, out_put_type_info.get_java_type_info()),
+                 "Collection Source",
+                 out_put_type_info.get_java_type_info(),
+                 JBoundedness.BOUNDED],
+                ["org.apache.flink.streaming.api.functions.source.SourceFunction",
+                 "java.lang.String",
+                 "org.apache.flink.api.common.typeinfo.TypeInformation",
+                 "org.apache.flink.api.connector.source.Boundedness"])
             j_data_stream_source.forceNonParallel()
             return DataStream(j_data_stream=j_data_stream_source)
         finally:

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -23,7 +23,7 @@ import uuid
 from pyflink.common import Row
 from pyflink.common.typeinfo import Types
 from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
-from pyflink.datastream import StreamExecutionEnvironment, TimeCharacteristic, RuntimeContext
+from pyflink.datastream import TimeCharacteristic, RuntimeContext
 from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import CoMapFunction, CoFlatMapFunction, AggregateFunction, \
     ReduceFunction
@@ -35,46 +35,21 @@ from pyflink.datastream.state import ValueStateDescriptor, ListStateDescriptor, 
     AggregatingStateDescriptor
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
-from pyflink.testing.test_case_utils import PyFlinkTestCase, invoke_java_object_method
+from pyflink.testing.test_case_utils import invoke_java_object_method, \
+    PyFlinkBatchTestCase, PyFlinkStreamingTestCase
 
 
-class DataStreamTests(PyFlinkTestCase):
+class DataStreamTests(object):
 
     def setUp(self) -> None:
-        self.env = StreamExecutionEnvironment.get_execution_environment()
-        self.env.set_parallelism(2)
-        getConfigurationMethod = invoke_java_object_method(
+        super(DataStreamTests, self).setUp()
+        config = invoke_java_object_method(
             self.env._j_stream_execution_environment, "getConfiguration")
-        getConfigurationMethod.setString("akka.ask.timeout", "20 s")
+        config.setString("akka.ask.timeout", "20 s")
         self.test_sink = DataStreamTestSinkFunction()
 
-    def test_data_stream_name(self):
-        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')])
-        test_name = 'test_name'
-        ds.name(test_name)
-        self.assertEqual(test_name, ds.get_name())
-
-    def test_set_parallelism(self):
-        parallelism = 3
-        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')]).map(lambda x: x)
-        ds.set_parallelism(parallelism).add_sink(self.test_sink)
-        plan = eval(str(self.env.get_execution_plan()))
-        self.assertEqual(parallelism, plan['nodes'][1]['parallelism'])
-
-    def test_set_max_parallelism(self):
-        max_parallelism = 4
-        self.env.set_parallelism(8)
-        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')]).map(lambda x: x)
-        ds.set_parallelism(max_parallelism).add_sink(self.test_sink)
-        plan = eval(str(self.env.get_execution_plan()))
-        self.assertEqual(max_parallelism, plan['nodes'][1]['parallelism'])
-
-    def test_force_non_parallel(self):
-        self.env.set_parallelism(8)
-        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')])
-        ds.force_non_parallel().add_sink(self.test_sink)
-        plan = eval(str(self.env.get_execution_plan()))
-        self.assertEqual(1, plan['nodes'][0]['parallelism'])
+    def tearDown(self) -> None:
+        self.test_sink.clear()
 
     def test_reduce_function_without_data_types(self):
         ds = self.env.from_collection([(1, 'a'), (2, 'a'), (3, 'a'), (4, 'b')],
@@ -575,191 +550,6 @@ class DataStreamTests(PyFlinkTestCase):
         self.assertEqual(3, len(plan['nodes']))
         self.assertEqual("Sink: Print to Std. Out", plan['nodes'][2]['type'])
 
-    def test_union_stream(self):
-        ds_1 = self.env.from_collection([1, 2, 3])
-        ds_2 = self.env.from_collection([4, 5, 6])
-        ds_3 = self.env.from_collection([7, 8, 9])
-
-        united_stream = ds_3.union(ds_1, ds_2)
-
-        united_stream.map(lambda x: x + 1).add_sink(self.test_sink)
-        exec_plan = eval(self.env.get_execution_plan())
-        source_ids = []
-        union_node_pre_ids = []
-        for node in exec_plan['nodes']:
-            if node['pact'] == 'Data Source':
-                source_ids.append(node['id'])
-            if node['pact'] == 'Operator':
-                for pre in node['predecessors']:
-                    union_node_pre_ids.append(pre['id'])
-
-        source_ids.sort()
-        union_node_pre_ids.sort()
-        self.assertEqual(source_ids, union_node_pre_ids)
-
-    def test_project(self):
-        ds = self.env.from_collection([[1, 2, 3, 4], [5, 6, 7, 8]],
-                                      type_info=Types.TUPLE(
-                                          [Types.INT(), Types.INT(), Types.INT(), Types.INT()]))
-        ds.project(1, 3).map(lambda x: (x[0], x[1] + 1)).add_sink(self.test_sink)
-        exec_plan = eval(self.env.get_execution_plan())
-        self.assertEqual(exec_plan['nodes'][1]['type'], 'Projection')
-
-    def test_broadcast(self):
-        ds_1 = self.env.from_collection([1, 2, 3])
-        ds_1.broadcast().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
-        exec_plan = eval(self.env.get_execution_plan())
-        broadcast_node = exec_plan['nodes'][1]
-        pre_ship_strategy = broadcast_node['predecessors'][0]['ship_strategy']
-        self.assertEqual(pre_ship_strategy, 'BROADCAST')
-
-    def test_rebalance(self):
-        ds_1 = self.env.from_collection([1, 2, 3])
-        ds_1.rebalance().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
-        exec_plan = eval(self.env.get_execution_plan())
-        rebalance_node = exec_plan['nodes'][1]
-        pre_ship_strategy = rebalance_node['predecessors'][0]['ship_strategy']
-        self.assertEqual(pre_ship_strategy, 'REBALANCE')
-
-    def test_rescale(self):
-        ds_1 = self.env.from_collection([1, 2, 3])
-        ds_1.rescale().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
-        exec_plan = eval(self.env.get_execution_plan())
-        rescale_node = exec_plan['nodes'][1]
-        pre_ship_strategy = rescale_node['predecessors'][0]['ship_strategy']
-        self.assertEqual(pre_ship_strategy, 'RESCALE')
-
-    def test_shuffle(self):
-        ds_1 = self.env.from_collection([1, 2, 3])
-        ds_1.shuffle().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
-        exec_plan = eval(self.env.get_execution_plan())
-        shuffle_node = exec_plan['nodes'][1]
-        pre_ship_strategy = shuffle_node['predecessors'][0]['ship_strategy']
-        self.assertEqual(pre_ship_strategy, 'SHUFFLE')
-
-    def test_partition_custom(self):
-        ds = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1), ('e', 2),
-                                       ('f', 7), ('g', 7), ('h', 8), ('i', 8), ('j', 9)],
-                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
-
-        expected_num_partitions = 5
-
-        def my_partitioner(key, num_partitions):
-            assert expected_num_partitions, num_partitions
-            return key % num_partitions
-
-        partitioned_stream = ds.map(lambda x: x, output_type=Types.ROW([Types.STRING(),
-                                                                        Types.INT()]))\
-            .set_parallelism(4).partition_custom(my_partitioner, lambda x: x[1])
-
-        JPartitionCustomTestMapFunction = get_gateway().jvm\
-            .org.apache.flink.python.util.PartitionCustomTestMapFunction
-        test_map_stream = DataStream(partitioned_stream
-                                     ._j_data_stream.map(JPartitionCustomTestMapFunction()))
-        test_map_stream.set_parallelism(expected_num_partitions).add_sink(self.test_sink)
-
-        self.env.execute('test_partition_custom')
-
-    def test_keyed_stream_partitioning(self):
-        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)])
-        keyed_stream = ds.key_by(lambda x: x[1])
-        with self.assertRaises(Exception):
-            keyed_stream.shuffle()
-
-        with self.assertRaises(Exception):
-            keyed_stream.rebalance()
-
-        with self.assertRaises(Exception):
-            keyed_stream.rescale()
-
-        with self.assertRaises(Exception):
-            keyed_stream.broadcast()
-
-        with self.assertRaises(Exception):
-            keyed_stream.forward()
-
-    def test_slot_sharing_group(self):
-        source_operator_name = 'collection source'
-        map_operator_name = 'map_operator'
-        slot_sharing_group_1 = 'slot_sharing_group_1'
-        slot_sharing_group_2 = 'slot_sharing_group_2'
-        ds_1 = self.env.from_collection([1, 2, 3]).name(source_operator_name)
-        ds_1.slot_sharing_group(slot_sharing_group_1).map(lambda x: x + 1).set_parallelism(3)\
-            .name(map_operator_name).slot_sharing_group(slot_sharing_group_2)\
-            .add_sink(self.test_sink)
-
-        j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
-
-        j_stream_nodes = list(j_generated_stream_graph.getStreamNodes().toArray())
-        for j_stream_node in j_stream_nodes:
-            if j_stream_node.getOperatorName() == source_operator_name:
-                self.assertEqual(j_stream_node.getSlotSharingGroup(), slot_sharing_group_1)
-            elif j_stream_node.getOperatorName() == map_operator_name:
-                self.assertEqual(j_stream_node.getSlotSharingGroup(), slot_sharing_group_2)
-
-    def test_chaining_strategy(self):
-        chained_operator_name_0 = "map_operator_0"
-        chained_operator_name_1 = "map_operator_1"
-        chained_operator_name_2 = "map_operator_2"
-
-        ds = self.env.from_collection([1, 2, 3])
-        ds.map(lambda x: x).set_parallelism(2).name(chained_operator_name_0)\
-            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_1)\
-            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_2)\
-            .add_sink(self.test_sink)
-
-        def assert_chainable(j_stream_graph, expected_upstream_chainable,
-                             expected_downstream_chainable):
-            j_stream_nodes = list(j_stream_graph.getStreamNodes().toArray())
-            for j_stream_node in j_stream_nodes:
-                if j_stream_node.getOperatorName() == chained_operator_name_1:
-                    JStreamingJobGraphGenerator = get_gateway().jvm \
-                        .org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator
-
-                    j_in_stream_edge = j_stream_node.getInEdges().get(0)
-                    upstream_chainable = JStreamingJobGraphGenerator.isChainable(j_in_stream_edge,
-                                                                                 j_stream_graph)
-                    self.assertEqual(expected_upstream_chainable, upstream_chainable)
-
-                    j_out_stream_edge = j_stream_node.getOutEdges().get(0)
-                    downstream_chainable = JStreamingJobGraphGenerator.isChainable(
-                        j_out_stream_edge, j_stream_graph)
-                    self.assertEqual(expected_downstream_chainable, downstream_chainable)
-
-        # The map_operator_1 has the same parallelism with map_operator_0 and map_operator_2, and
-        # ship_strategy for map_operator_0 and map_operator_1 is FORWARD, so the map_operator_1
-        # can be chained with map_operator_0 and map_operator_2.
-        j_generated_stream_graph = self.env._j_stream_execution_environment\
-            .getStreamGraph("test start new_chain", True)
-        assert_chainable(j_generated_stream_graph, True, True)
-
-        ds = self.env.from_collection([1, 2, 3])
-        # Start a new chain for map_operator_1
-        ds.map(lambda x: x).set_parallelism(2).name(chained_operator_name_0) \
-            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_1).start_new_chain() \
-            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_2) \
-            .add_sink(self.test_sink)
-
-        j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
-        # We start a new chain for map operator, therefore, it cannot be chained with upstream
-        # operator, but can be chained with downstream operator.
-        assert_chainable(j_generated_stream_graph, False, True)
-
-        ds = self.env.from_collection([1, 2, 3])
-        # Disable chaining for map_operator_1
-        ds.map(lambda x: x).set_parallelism(2).name(chained_operator_name_0) \
-            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_1).disable_chaining() \
-            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_2) \
-            .add_sink(self.test_sink)
-
-        j_generated_stream_graph = self.env._j_stream_execution_environment \
-            .getStreamGraph("test start new_chain", True)
-        # We disable chaining for map_operator_1, therefore, it cannot be chained with
-        # upstream and downstream operators.
-        assert_chainable(j_generated_stream_graph, False, False)
-
     def test_primitive_array_type_info(self):
         ds = self.env.from_collection([(1, [1.1, 1.2, 1.30]), (2, [2.1, 2.2, 2.3]),
                                       (3, [3.1, 3.2, 3.3])],
@@ -813,53 +603,6 @@ class DataStreamTests(PyFlinkTestCase):
         results = self.test_sink.get_results()
         expected = ['+I[2021-01-09, 12:00:00, 2021-01-09 12:00:00.011]']
         self.assertEqual(expected, results)
-
-    def test_timestamp_assigner_and_watermark_strategy(self):
-        self.env.set_parallelism(1)
-        self.env.get_config().set_auto_watermark_interval(2000)
-        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
-        data_stream = self.env.from_collection([(1, '1603708211000'),
-                                                (2, '1603708224000'),
-                                                (3, '1603708226000'),
-                                                (4, '1603708289000')],
-                                               type_info=Types.ROW([Types.INT(), Types.STRING()]))
-
-        class MyTimestampAssigner(TimestampAssigner):
-
-            def extract_timestamp(self, value, record_timestamp) -> int:
-                return int(value[1])
-
-        class MyProcessFunction(KeyedProcessFunction):
-
-            def process_element(self, value, ctx):
-                current_timestamp = ctx.timestamp()
-                current_watermark = ctx.timer_service().current_watermark()
-                current_key = ctx.get_current_key()
-                yield "current key: {}, current timestamp: {}, current watermark: {}, " \
-                      "current_value: {}".format(str(current_key), str(current_timestamp),
-                                                 str(current_watermark), str(value))
-
-            def on_timer(self, timestamp, ctx):
-                pass
-
-        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps()\
-            .with_timestamp_assigner(MyTimestampAssigner())
-        data_stream.assign_timestamps_and_watermarks(watermark_strategy)\
-            .key_by(lambda x: x[0], key_type_info=Types.INT()) \
-            .process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
-        self.env.execute('test time stamp assigner with keyed process function')
-        result = self.test_sink.get_results()
-        expected_result = ["current key: 1, current timestamp: 1603708211000, current watermark: "
-                           "9223372036854775807, current_value: Row(f0=1, f1='1603708211000')",
-                           "current key: 2, current timestamp: 1603708224000, current watermark: "
-                           "9223372036854775807, current_value: Row(f0=2, f1='1603708224000')",
-                           "current key: 3, current timestamp: 1603708226000, current watermark: "
-                           "9223372036854775807, current_value: Row(f0=3, f1='1603708226000')",
-                           "current key: 4, current timestamp: 1603708289000, current watermark: "
-                           "9223372036854775807, current_value: Row(f0=4, f1='1603708289000')"]
-        result.sort()
-        expected_result.sort()
-        self.assertEqual(expected_result, result)
 
     def test_process_function(self):
         self.env.set_parallelism(1)
@@ -1063,8 +806,317 @@ class DataStreamTests(PyFlinkTestCase):
         expected_result.sort()
         self.assertEqual(expected_result, result)
 
-    def tearDown(self) -> None:
-        self.test_sink.clear()
+
+class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
+    def test_data_stream_name(self):
+        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')])
+        test_name = 'test_name'
+        ds.name(test_name)
+        self.assertEqual(test_name, ds.get_name())
+
+    def test_set_parallelism(self):
+        parallelism = 3
+        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')]).map(lambda x: x)
+        ds.set_parallelism(parallelism).add_sink(self.test_sink)
+        plan = eval(str(self.env.get_execution_plan()))
+        self.assertEqual(parallelism, plan['nodes'][1]['parallelism'])
+
+    def test_set_max_parallelism(self):
+        max_parallelism = 4
+        self.env.set_parallelism(8)
+        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')]).map(lambda x: x)
+        ds.set_parallelism(max_parallelism).add_sink(self.test_sink)
+        plan = eval(str(self.env.get_execution_plan()))
+        self.assertEqual(max_parallelism, plan['nodes'][1]['parallelism'])
+
+    def test_force_non_parallel(self):
+        self.env.set_parallelism(8)
+        ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')])
+        ds.force_non_parallel().add_sink(self.test_sink)
+        plan = eval(str(self.env.get_execution_plan()))
+        self.assertEqual(1, plan['nodes'][0]['parallelism'])
+
+    def test_union_stream(self):
+        ds_1 = self.env.from_collection([1, 2, 3])
+        ds_2 = self.env.from_collection([4, 5, 6])
+        ds_3 = self.env.from_collection([7, 8, 9])
+
+        united_stream = ds_3.union(ds_1, ds_2)
+
+        united_stream.map(lambda x: x + 1).add_sink(self.test_sink)
+        exec_plan = eval(self.env.get_execution_plan())
+        source_ids = []
+        union_node_pre_ids = []
+        for node in exec_plan['nodes']:
+            if node['pact'] == 'Data Source':
+                source_ids.append(node['id'])
+            if node['pact'] == 'Operator':
+                for pre in node['predecessors']:
+                    union_node_pre_ids.append(pre['id'])
+
+        source_ids.sort()
+        union_node_pre_ids.sort()
+        self.assertEqual(source_ids, union_node_pre_ids)
+
+    def test_project(self):
+        ds = self.env.from_collection([[1, 2, 3, 4], [5, 6, 7, 8]],
+                                      type_info=Types.TUPLE(
+                                          [Types.INT(), Types.INT(), Types.INT(), Types.INT()]))
+        ds.project(1, 3).map(lambda x: (x[0], x[1] + 1)).add_sink(self.test_sink)
+        exec_plan = eval(self.env.get_execution_plan())
+        self.assertEqual(exec_plan['nodes'][1]['type'], 'Projection')
+
+    def test_broadcast(self):
+        ds_1 = self.env.from_collection([1, 2, 3])
+        ds_1.broadcast().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
+        exec_plan = eval(self.env.get_execution_plan())
+        broadcast_node = exec_plan['nodes'][1]
+        pre_ship_strategy = broadcast_node['predecessors'][0]['ship_strategy']
+        self.assertEqual(pre_ship_strategy, 'BROADCAST')
+
+    def test_rebalance(self):
+        ds_1 = self.env.from_collection([1, 2, 3])
+        ds_1.rebalance().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
+        exec_plan = eval(self.env.get_execution_plan())
+        rebalance_node = exec_plan['nodes'][1]
+        pre_ship_strategy = rebalance_node['predecessors'][0]['ship_strategy']
+        self.assertEqual(pre_ship_strategy, 'REBALANCE')
+
+    def test_rescale(self):
+        ds_1 = self.env.from_collection([1, 2, 3])
+        ds_1.rescale().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
+        exec_plan = eval(self.env.get_execution_plan())
+        rescale_node = exec_plan['nodes'][1]
+        pre_ship_strategy = rescale_node['predecessors'][0]['ship_strategy']
+        self.assertEqual(pre_ship_strategy, 'RESCALE')
+
+    def test_shuffle(self):
+        ds_1 = self.env.from_collection([1, 2, 3])
+        ds_1.shuffle().map(lambda x: x + 1).set_parallelism(3).add_sink(self.test_sink)
+        exec_plan = eval(self.env.get_execution_plan())
+        shuffle_node = exec_plan['nodes'][1]
+        pre_ship_strategy = shuffle_node['predecessors'][0]['ship_strategy']
+        self.assertEqual(pre_ship_strategy, 'SHUFFLE')
+
+    def test_partition_custom(self):
+        ds = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1), ('e', 2),
+                                       ('f', 7), ('g', 7), ('h', 8), ('i', 8), ('j', 9)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+
+        expected_num_partitions = 5
+
+        def my_partitioner(key, num_partitions):
+            assert expected_num_partitions, num_partitions
+            return key % num_partitions
+
+        partitioned_stream = ds.map(lambda x: x, output_type=Types.ROW([Types.STRING(),
+                                                                        Types.INT()]))\
+            .set_parallelism(4).partition_custom(my_partitioner, lambda x: x[1])
+
+        JPartitionCustomTestMapFunction = get_gateway().jvm\
+            .org.apache.flink.python.util.PartitionCustomTestMapFunction
+        test_map_stream = DataStream(partitioned_stream
+                                     ._j_data_stream.map(JPartitionCustomTestMapFunction()))
+        test_map_stream.set_parallelism(expected_num_partitions).add_sink(self.test_sink)
+
+        self.env.execute('test_partition_custom')
+
+    def test_keyed_stream_partitioning(self):
+        ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)])
+        keyed_stream = ds.key_by(lambda x: x[1])
+        with self.assertRaises(Exception):
+            keyed_stream.shuffle()
+
+        with self.assertRaises(Exception):
+            keyed_stream.rebalance()
+
+        with self.assertRaises(Exception):
+            keyed_stream.rescale()
+
+        with self.assertRaises(Exception):
+            keyed_stream.broadcast()
+
+        with self.assertRaises(Exception):
+            keyed_stream.forward()
+
+    def test_slot_sharing_group(self):
+        source_operator_name = 'collection source'
+        map_operator_name = 'map_operator'
+        slot_sharing_group_1 = 'slot_sharing_group_1'
+        slot_sharing_group_2 = 'slot_sharing_group_2'
+        ds_1 = self.env.from_collection([1, 2, 3]).name(source_operator_name)
+        ds_1.slot_sharing_group(slot_sharing_group_1).map(lambda x: x + 1).set_parallelism(3)\
+            .name(map_operator_name).slot_sharing_group(slot_sharing_group_2)\
+            .add_sink(self.test_sink)
+
+        j_generated_stream_graph = self.env._j_stream_execution_environment \
+            .getStreamGraph("test start new_chain", True)
+
+        j_stream_nodes = list(j_generated_stream_graph.getStreamNodes().toArray())
+        for j_stream_node in j_stream_nodes:
+            if j_stream_node.getOperatorName() == source_operator_name:
+                self.assertEqual(j_stream_node.getSlotSharingGroup(), slot_sharing_group_1)
+            elif j_stream_node.getOperatorName() == map_operator_name:
+                self.assertEqual(j_stream_node.getSlotSharingGroup(), slot_sharing_group_2)
+
+    def test_chaining_strategy(self):
+        chained_operator_name_0 = "map_operator_0"
+        chained_operator_name_1 = "map_operator_1"
+        chained_operator_name_2 = "map_operator_2"
+
+        ds = self.env.from_collection([1, 2, 3])
+        ds.map(lambda x: x).set_parallelism(2).name(chained_operator_name_0)\
+            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_1)\
+            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_2)\
+            .add_sink(self.test_sink)
+
+        def assert_chainable(j_stream_graph, expected_upstream_chainable,
+                             expected_downstream_chainable):
+            j_stream_nodes = list(j_stream_graph.getStreamNodes().toArray())
+            for j_stream_node in j_stream_nodes:
+                if j_stream_node.getOperatorName() == chained_operator_name_1:
+                    JStreamingJobGraphGenerator = get_gateway().jvm \
+                        .org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator
+
+                    j_in_stream_edge = j_stream_node.getInEdges().get(0)
+                    upstream_chainable = JStreamingJobGraphGenerator.isChainable(j_in_stream_edge,
+                                                                                 j_stream_graph)
+                    self.assertEqual(expected_upstream_chainable, upstream_chainable)
+
+                    j_out_stream_edge = j_stream_node.getOutEdges().get(0)
+                    downstream_chainable = JStreamingJobGraphGenerator.isChainable(
+                        j_out_stream_edge, j_stream_graph)
+                    self.assertEqual(expected_downstream_chainable, downstream_chainable)
+
+        # The map_operator_1 has the same parallelism with map_operator_0 and map_operator_2, and
+        # ship_strategy for map_operator_0 and map_operator_1 is FORWARD, so the map_operator_1
+        # can be chained with map_operator_0 and map_operator_2.
+        j_generated_stream_graph = self.env._j_stream_execution_environment\
+            .getStreamGraph("test start new_chain", True)
+        assert_chainable(j_generated_stream_graph, True, True)
+
+        ds = self.env.from_collection([1, 2, 3])
+        # Start a new chain for map_operator_1
+        ds.map(lambda x: x).set_parallelism(2).name(chained_operator_name_0) \
+            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_1).start_new_chain() \
+            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_2) \
+            .add_sink(self.test_sink)
+
+        j_generated_stream_graph = self.env._j_stream_execution_environment \
+            .getStreamGraph("test start new_chain", True)
+        # We start a new chain for map operator, therefore, it cannot be chained with upstream
+        # operator, but can be chained with downstream operator.
+        assert_chainable(j_generated_stream_graph, False, True)
+
+        ds = self.env.from_collection([1, 2, 3])
+        # Disable chaining for map_operator_1
+        ds.map(lambda x: x).set_parallelism(2).name(chained_operator_name_0) \
+            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_1).disable_chaining() \
+            .map(lambda x: x).set_parallelism(2).name(chained_operator_name_2) \
+            .add_sink(self.test_sink)
+
+        j_generated_stream_graph = self.env._j_stream_execution_environment \
+            .getStreamGraph("test start new_chain", True)
+        # We disable chaining for map_operator_1, therefore, it cannot be chained with
+        # upstream and downstream operators.
+        assert_chainable(j_generated_stream_graph, False, False)
+
+    def test_timestamp_assigner_and_watermark_strategy(self):
+        self.env.set_parallelism(1)
+        self.env.get_config().set_auto_watermark_interval(2000)
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        data_stream = self.env.from_collection([(1, '1603708211000'),
+                                                (2, '1603708224000'),
+                                                (3, '1603708226000'),
+                                                (4, '1603708289000')],
+                                               type_info=Types.ROW([Types.INT(), Types.STRING()]))
+
+        class MyTimestampAssigner(TimestampAssigner):
+
+            def extract_timestamp(self, value, record_timestamp) -> int:
+                return int(value[1])
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def process_element(self, value, ctx):
+                current_timestamp = ctx.timestamp()
+                current_watermark = ctx.timer_service().current_watermark()
+                current_key = ctx.get_current_key()
+                yield "current key: {}, current timestamp: {}, current watermark: {}, " \
+                      "current_value: {}".format(str(current_key), str(current_timestamp),
+                                                 str(current_watermark), str(value))
+
+            def on_timer(self, timestamp, ctx):
+                pass
+
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps()\
+            .with_timestamp_assigner(MyTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy)\
+            .key_by(lambda x: x[0], key_type_info=Types.INT()) \
+            .process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
+        self.env.execute('test time stamp assigner with keyed process function')
+        result = self.test_sink.get_results()
+        expected_result = ["current key: 1, current timestamp: 1603708211000, current watermark: "
+                           "9223372036854775807, current_value: Row(f0=1, f1='1603708211000')",
+                           "current key: 2, current timestamp: 1603708224000, current watermark: "
+                           "9223372036854775807, current_value: Row(f0=2, f1='1603708224000')",
+                           "current key: 3, current timestamp: 1603708226000, current watermark: "
+                           "9223372036854775807, current_value: Row(f0=3, f1='1603708226000')",
+                           "current key: 4, current timestamp: 1603708289000, current watermark: "
+                           "9223372036854775807, current_value: Row(f0=4, f1='1603708289000')"]
+        result.sort()
+        expected_result.sort()
+        self.assertEqual(expected_result, result)
+
+
+class BatchModeDataStreamTests(DataStreamTests, PyFlinkBatchTestCase):
+
+    def test_timestamp_assigner_and_watermark_strategy(self):
+        self.env.set_parallelism(1)
+        self.env.get_config().set_auto_watermark_interval(2000)
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        data_stream = self.env.from_collection([(1, '1603708211000'),
+                                                (2, '1603708224000'),
+                                                (3, '1603708226000'),
+                                                (4, '1603708289000')],
+                                               type_info=Types.ROW([Types.INT(), Types.STRING()]))
+
+        class MyTimestampAssigner(TimestampAssigner):
+
+            def extract_timestamp(self, value, record_timestamp) -> int:
+                return int(value[1])
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def process_element(self, value, ctx):
+                current_timestamp = ctx.timestamp()
+                current_watermark = ctx.timer_service().current_watermark()
+                current_key = ctx.get_current_key()
+                yield "current key: {}, current timestamp: {}, current watermark: {}, " \
+                      "current_value: {}".format(str(current_key), str(current_timestamp),
+                                                 str(current_watermark), str(value))
+
+            def on_timer(self, timestamp, ctx):
+                pass
+
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(MyTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type_info=Types.INT()) \
+            .process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
+        self.env.execute('test time stamp assigner with keyed process function')
+        result = self.test_sink.get_results()
+        expected_result = ["current key: 1, current timestamp: 1603708211000, current watermark: "
+                           "-9223372036854775808, current_value: Row(f0=1, f1='1603708211000')",
+                           "current key: 2, current timestamp: 1603708224000, current watermark: "
+                           "-9223372036854775808, current_value: Row(f0=2, f1='1603708224000')",
+                           "current key: 3, current timestamp: 1603708226000, current watermark: "
+                           "-9223372036854775808, current_value: Row(f0=3, f1='1603708226000')",
+                           "current key: 4, current timestamp: 1603708289000, current watermark: "
+                           "-9223372036854775808, current_value: Row(f0=4, f1='1603708289000')"]
+        result.sort()
+        expected_result.sort()
+        self.assertEqual(expected_result, result)
 
 
 class MyMapFunction(MapFunction):

--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -21,7 +21,7 @@ from pyflink.datastream.state_backend import (_from_j_state_backend, CustomState
 from pyflink.java_gateway import get_gateway
 from pyflink.pyflink_gateway_server import on_windows
 from pyflink.testing.test_case_utils import PyFlinkTestCase
-from pyflink.util.utils import load_java_class
+from pyflink.util.java_utils import load_java_class
 
 
 class MemoryStateBackendTests(PyFlinkTestCase):

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -581,17 +581,5 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         self.assertIsNotNone(env_config_with_dependencies['python.files'])
         self.assertIsNotNone(env_config_with_dependencies['python.archives'])
 
-    def test_batch_execution_mode(self):
-        # set the runtime execution mode to BATCH
-        JRuntimeExecutionMode = get_gateway().jvm \
-            .org.apache.flink.api.common.RuntimeExecutionMode.BATCH
-        self.env._j_stream_execution_environment.setRuntimeMode(JRuntimeExecutionMode)
-        self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')]).map(lambda x: x) \
-            .add_sink(self.test_sink)
-
-        # Running jobs in Batch mode is not supported yet, it should throw an exception.
-        with self.assertRaises(Exception):
-            self.env.get_execution_plan()
-
     def tearDown(self) -> None:
         self.test_sink.clear()

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -21,7 +21,7 @@ from typing import Union, TypeVar, Generic
 from pyflink import add_version_doc
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import DataType, _to_java_data_type
-from pyflink.util.utils import to_jarray
+from pyflink.util.java_utils import to_jarray
 
 __all__ = ['Expression', 'TimeIntervalUnit', 'TimePointUnit']
 

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -22,7 +22,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table.expression import Expression, _get_java_expression, TimePointUnit
 from pyflink.table.types import _to_java_data_type, DataType, _to_java_type
 from pyflink.table.udf import UserDefinedFunctionWrapper, UserDefinedTableFunctionWrapper
-from pyflink.util.utils import to_jarray, load_java_class
+from pyflink.util.java_utils import to_jarray, load_java_class
 
 __all__ = ['if_then_else', 'lit', 'col', 'range_', 'and_', 'or_', 'UNBOUNDED_ROW',
            'UNBOUNDED_RANGE', 'CURRENT_ROW', 'CURRENT_RANGE', 'current_date', 'current_time',

--- a/flink-python/pyflink/table/sinks.py
+++ b/flink-python/pyflink/table/sinks.py
@@ -18,7 +18,7 @@
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import _to_java_type
-from pyflink.util import utils
+from pyflink.util import java_utils
 
 __all__ = ['TableSink', 'CsvTableSink', 'WriteMode']
 
@@ -70,8 +70,9 @@ class CsvTableSink(TableSink):
             raise Exception('Unsupported write_mode: %s' % write_mode)
         j_csv_table_sink = gateway.jvm.CsvTableSink(
             path, field_delimiter, num_files, j_write_mode)
-        j_field_names = utils.to_jarray(gateway.jvm.String, field_names)
-        j_field_types = utils.to_jarray(gateway.jvm.TypeInformation,
-                                        [_to_java_type(field_type) for field_type in field_types])
+        j_field_names = java_utils.to_jarray(gateway.jvm.String, field_names)
+        j_field_types = java_utils.to_jarray(
+            gateway.jvm.TypeInformation,
+            [_to_java_type(field_type) for field_type in field_types])
         j_csv_table_sink = j_csv_table_sink.configure(j_field_names, j_field_types)
         super(CsvTableSink, self).__init__(j_csv_table_sink)

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -17,7 +17,7 @@
 ################################################################################
 from pyflink.table import ExplainDetail
 from pyflink.table.table_result import TableResult
-from pyflink.util.utils import to_j_explain_detail_arr
+from pyflink.util.java_utils import to_j_explain_detail_arr
 
 __all__ = ['StatementSet']
 

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -34,8 +34,8 @@ from pyflink.table.udf import UserDefinedScalarFunctionWrapper, \
 from pyflink.table.utils import tz_convert_from_internal, to_expression_jarray
 from pyflink.table.window import OverWindow, GroupWindow
 
-from pyflink.util.utils import to_jarray
-from pyflink.util.utils import to_j_explain_detail_arr
+from pyflink.util.java_utils import to_jarray
+from pyflink.util.java_utils import to_j_explain_detail_arr
 
 __all__ = ['Table', 'GroupedTable', 'GroupWindowedTable', 'OverWindowedTable', 'WindowGroupedTable']
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -48,8 +48,8 @@ from pyflink.table.types import _to_java_type, _create_type_verifier, RowType, D
 from pyflink.table.udf import UserDefinedFunctionWrapper, AggregateFunction, udaf, \
     UserDefinedAggregateFunctionWrapper, udtaf, TableAggregateFunction
 from pyflink.table.utils import to_expression_jarray
-from pyflink.util import utils
-from pyflink.util.utils import get_j_env_configuration, is_local_deployment, load_java_class, \
+from pyflink.util import java_utils
+from pyflink.util.java_utils import get_j_env_configuration, is_local_deployment, load_java_class, \
     to_j_explain_detail_arr, to_jarray
 
 __all__ = [
@@ -524,7 +524,7 @@ class TableEnvironment(object):
         """
         warnings.warn("Deprecated in 1.10. Use from_path instead.", DeprecationWarning)
         gateway = get_gateway()
-        j_table_paths = utils.to_jarray(gateway.jvm.String, table_path)
+        j_table_paths = java_utils.to_jarray(gateway.jvm.String, table_path)
         j_table = self._j_tenv.scan(j_table_paths)
         return Table(j_table, self)
 

--- a/flink-python/pyflink/table/table_schema.py
+++ b/flink-python/pyflink/table/table_schema.py
@@ -19,7 +19,7 @@ from typing import List, Optional, Union
 
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import _to_java_type, _from_java_type, DataType, RowType
-from pyflink.util.utils import to_jarray
+from pyflink.util.java_utils import to_jarray
 
 __all__ = ['TableSchema']
 

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -44,7 +44,7 @@ from pyflink.testing.test_case_utils import PyFlinkOldStreamTableTestCase, \
     PyFlinkOldBatchTableTestCase, PyFlinkBlinkBatchTableTestCase, PyFlinkBlinkStreamTableTestCase, \
     PyFlinkLegacyBlinkBatchTableTestCase, PyFlinkLegacyFlinkStreamTableTestCase, \
     PyFlinkLegacyBlinkStreamTableTestCase, _load_specific_flink_module_jars
-from pyflink.util.utils import get_j_env_configuration
+from pyflink.util.java_utils import get_j_env_configuration
 
 
 class TableEnvironmentTest(object):

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -32,7 +32,7 @@ from py4j.java_gateway import get_java_class
 from typing import List, Union
 
 from pyflink.common.types import _create_row
-from pyflink.util.utils import to_jarray, is_instance_of
+from pyflink.util.java_utils import to_jarray, is_instance_of
 from pyflink.java_gateway import get_gateway
 from pyflink.common import Row, RowKind
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -25,7 +25,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.metrics import MetricGroup
 from pyflink.table import Expression
 from pyflink.table.types import DataType, _to_java_type, _to_java_data_type
-from pyflink.util import utils
+from pyflink.util import java_utils
 
 __all__ = ['FunctionContext', 'AggregateFunction', 'ScalarFunction', 'TableFunction',
            'TableAggregateFunction', 'udf', 'udtf', 'udaf', 'udtaf']
@@ -377,7 +377,7 @@ class UserDefinedFunctionWrapper(object):
                     raise TypeError("Unsupported func_type: %s." % self._func_type)
 
             if self._input_types is not None:
-                j_input_types = utils.to_jarray(
+                j_input_types = java_utils.to_jarray(
                     gateway.jvm.TypeInformation, [_to_java_type(i) for i in self._input_types])
             else:
                 j_input_types = None
@@ -458,8 +458,8 @@ class UserDefinedTableFunctionWrapper(UserDefinedFunctionWrapper):
 
     def _create_judf(self, serialized_func, j_input_types, j_function_kind):
         gateway = get_gateway()
-        j_result_types = utils.to_jarray(gateway.jvm.TypeInformation,
-                                         [_to_java_type(i) for i in self._result_types])
+        j_result_types = java_utils.to_jarray(gateway.jvm.TypeInformation,
+                                              [_to_java_type(i) for i in self._result_types])
         j_result_type = gateway.jvm.org.apache.flink.api.java.typeutils.RowTypeInfo(j_result_types)
         PythonTableFunction = gateway.jvm \
             .org.apache.flink.table.functions.python.PythonTableFunction
@@ -514,7 +514,7 @@ class UserDefinedAggregateFunctionWrapper(UserDefinedFunctionWrapper):
 
         if j_input_types is not None:
             gateway = get_gateway()
-            j_input_types = utils.to_jarray(
+            j_input_types = java_utils.to_jarray(
                 gateway.jvm.DataType, [_to_java_data_type(i) for i in self._input_types])
         j_result_type = _to_java_data_type(self._result_type)
         j_accumulator_type = _to_java_data_type(self._accumulator_type)

--- a/flink-python/pyflink/table/utils.py
+++ b/flink-python/pyflink/table/utils.py
@@ -22,7 +22,7 @@ from pyflink.common.types import RowKind
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import DataType, LocalZonedTimestampType, Row, RowType, \
     TimeType, DateType, ArrayType, MapType, TimestampType, FloatType
-from pyflink.util.utils import to_jarray
+from pyflink.util.java_utils import to_jarray
 import datetime
 import pickle
 

--- a/flink-python/pyflink/testing/source_sink_utils.py
+++ b/flink-python/pyflink/testing/source_sink_utils.py
@@ -25,7 +25,7 @@ from pyflink.find_flink_home import _find_flink_source_root
 from pyflink.java_gateway import get_gateway
 from pyflink.table.sinks import TableSink
 from pyflink.table.types import _to_java_type
-from pyflink.util import utils
+from pyflink.util import java_utils
 
 
 class TestTableSink(TableSink):
@@ -37,9 +37,10 @@ class TestTableSink(TableSink):
 
     def __init__(self, j_table_sink, field_names, field_types):
         gateway = get_gateway()
-        j_field_names = utils.to_jarray(gateway.jvm.String, field_names)
-        j_field_types = utils.to_jarray(gateway.jvm.TypeInformation,
-                                        [_to_java_type(field_type) for field_type in field_types])
+        j_field_names = java_utils.to_jarray(gateway.jvm.String, field_names)
+        j_field_types = java_utils.to_jarray(
+            gateway.jvm.TypeInformation,
+            [_to_java_type(field_type) for field_type in field_types])
         j_table_sink = j_table_sink.configure(j_field_names, j_field_types)
         super(TestTableSink, self).__init__(j_table_sink)
 

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -29,6 +29,7 @@ from py4j.java_gateway import JavaObject
 from py4j.protocol import Py4JJavaError
 
 from pyflink.common import JobExecutionResult
+from pyflink.datastream.execution_mode import RuntimeExecutionMode
 from pyflink.table import TableConfig
 from pyflink.table.sources import CsvTableSource
 from pyflink.dataset.execution_environment import ExecutionEnvironment
@@ -38,7 +39,7 @@ from pyflink.table.table_environment import BatchTableEnvironment, StreamTableEn
     TableEnvironment
 from pyflink.table.environment_settings import EnvironmentSettings
 from pyflink.java_gateway import get_gateway
-from pyflink.util.utils import add_jars_to_context_class_loader, to_jarray
+from pyflink.util.java_utils import add_jars_to_context_class_loader, to_jarray
 
 if os.getenv("VERBOSE"):
     log_level = logging.DEBUG
@@ -256,6 +257,30 @@ class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")
+
+
+class PyFlinkStreamingTestCase(PyFlinkTestCase):
+    """
+    Base class for streaming tests.
+    """
+
+    def setUp(self):
+        super(PyFlinkStreamingTestCase, self).setUp()
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.env.set_parallelism(2)
+        self.env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+
+
+class PyFlinkBatchTestCase(PyFlinkTestCase):
+    """
+    Base class for batch tests.
+    """
+
+    def setUp(self):
+        super(PyFlinkBatchTestCase, self).setUp()
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.env.set_parallelism(2)
+        self.env.set_runtime_mode(RuntimeExecutionMode.BATCH)
 
 
 class PythonAPICompletenessTestCase(object):

--- a/flink-python/pyflink/util/java_utils.py
+++ b/flink-python/pyflink/util/java_utils.py
@@ -82,15 +82,24 @@ def is_instance_of(java_object, java_class):
 
 def get_j_env_configuration(t_env):
     if is_instance_of(t_env._get_j_env(), "org.apache.flink.api.java.ExecutionEnvironment"):
-        j_configuration = t_env._get_j_env().getConfiguration()
+        return t_env._get_j_env().getConfiguration()
     else:
-        env_clazz = load_java_class(
-            "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment")
-        method = env_clazz.getDeclaredMethod(
-            "getConfiguration", to_jarray(get_gateway().jvm.Class, []))
-        method.setAccessible(True)
-        j_configuration = method.invoke(t_env._get_j_env(), to_jarray(get_gateway().jvm.Object, []))
-    return j_configuration
+        return invoke_method(
+            t_env._get_j_env(),
+            "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment",
+            "getConfiguration"
+        )
+
+
+def invoke_method(obj, object_type, method_name, args=None, arg_types=None):
+    env_clazz = load_java_class(object_type)
+    method = env_clazz.getDeclaredMethod(
+        method_name,
+        to_jarray(
+            get_gateway().jvm.Class,
+            [load_java_class(arg_type) for arg_type in arg_types or []]))
+    method.setAccessible(True)
+    return method.invoke(obj, to_jarray(get_gateway().jvm.Object, args or []))
 
 
 def is_local_deployment(j_configuration):

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -168,10 +168,6 @@ public class PythonConfigUtil {
         Configuration mergedConfig = getEnvConfigWithDependencies(env);
 
         boolean executedInBatchMode = isExecuteInBatchMode(env, mergedConfig);
-        if (executedInBatchMode) {
-            throw new UnsupportedOperationException(
-                    "Batch mode is still not supported in Python DataStream API.");
-        }
 
         if (mergedConfig.getBoolean(PythonOptions.USE_MANAGED_MEMORY)) {
             Field transformationsField =


### PR DESCRIPTION

## What is the purpose of the change

*This pull request support batch mode in Python DataStream API for basic operations such as map, flatmap, filter, etc.*


## Verifying this change


This change is already covered by existing tests, such as BatchModeDataStreamTests in test_data_stream.py.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
