### PR TITLE
[FLINK-21629][python] Support Python UDAF in Sliding Window

### DIFF
--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -35,7 +35,8 @@ from pyflink.fn_execution.beam.beam_coders import DataViewFilterCoder
 from pyflink.fn_execution.operation_utils import extract_user_defined_aggregate_function
 from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend
 
-from pyflink.fn_execution.window_assigner import TumblingWindowAssigner, CountTumblingWindowAssigner
+from pyflink.fn_execution.window_assigner import TumblingWindowAssigner, \
+    CountTumblingWindowAssigner, SlidingWindowAssigner, CountSlidingWindowAssigner
 from pyflink.fn_execution.window_trigger import EventTimeTrigger, ProcessingTimeTrigger, \
     CountTrigger
 
@@ -441,8 +442,13 @@ class StreamGroupWindowAggregateOperation(AbstractStreamGroupAggregateOperation)
             else:
                 window_assigner = CountTumblingWindowAssigner(self._window.window_size)
         elif self._window.window_type == flink_fn_execution_pb2.GroupWindow.SLIDING_GROUP_WINDOW:
-            raise Exception("General Python UDAF in Sliding window will be implemented in "
-                            "FLINK-21629")
+            if self._is_time_window:
+                window_assigner = SlidingWindowAssigner(
+                    self._window.window_size, self._window.window_slide, 0,
+                    self._window.is_row_time)
+            else:
+                window_assigner = CountSlidingWindowAssigner(
+                    self._window.window_size, self._window.window_slide)
         else:
             raise Exception("General Python UDAF in Sessiong window will be implemented in "
                             "FLINK-21630")

--- a/flink-python/pyflink/fn_execution/window_aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/window_aggregate_fast.pxd
@@ -23,7 +23,7 @@ cdef class NamespaceAggsHandleFunctionBase:
     cdef void open(self, object state_data_view_store)
     cdef void accumulate(self, list input_data)
     cdef void retract(self, list input_data)
-    cdef void merge(self, object namespace, list accumulators)
+    cpdef void merge(self, object namespace, list accumulators)
     cpdef void set_accumulators(self, object namespace, list accumulators)
     cdef list get_accumulators(self)
     cpdef list create_accumulators(self)

--- a/flink-python/pyflink/fn_execution/window_assigner.py
+++ b/flink-python/pyflink/fn_execution/window_assigner.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import math
 from abc import ABC, abstractmethod
 from typing import Generic, List, Any, Iterable
 
@@ -55,6 +56,24 @@ class WindowAssigner(Generic[W], ABC):
         """
         Returns True if elements are assigned to windows based on event time, False otherwise.
         """
+        pass
+
+
+class PanedWindowAssigner(WindowAssigner[W], ABC):
+    """
+    A WindowAssigner that window can be split into panes.
+    """
+
+    @abstractmethod
+    def assign_pane(self, element, timestamp: int) -> W:
+        pass
+
+    @abstractmethod
+    def split_into_panes(self, window: W) -> Iterable[W]:
+        pass
+
+    @abstractmethod
+    def get_last_window(self, pane: W) -> W:
         pass
 
 
@@ -109,3 +128,85 @@ class CountTumblingWindowAssigner(WindowAssigner[CountWindow]):
 
     def __repr__(self):
         return "CountTumblingWindow(%s)" % self._size
+
+
+class SlidingWindowAssigner(PanedWindowAssigner[TimeWindow]):
+    """
+    A WindowAssigner that windows elements into sliding windows based on the timestamp of the
+    elements. Windows can possibly overlap.
+    """
+
+    def __init__(self, size: int, slide: int, offset: int, is_event_time: bool):
+        self._size = size
+        self._slide = slide
+        self._offset = offset
+        self._is_event_time = is_event_time
+        self._pane_size = math.gcd(size, slide)
+        self._num_panes_per_window = size // self._pane_size
+
+    def assign_pane(self, element, timestamp: int) -> TimeWindow:
+        start = TimeWindow.get_window_start_with_offset(timestamp, self._offset, self._pane_size)
+        return TimeWindow(start, start + self._pane_size)
+
+    def split_into_panes(self, window: W) -> Iterable[TimeWindow]:
+        start = window.start
+        for i in range(self._num_panes_per_window):
+            yield TimeWindow(start, start + self._pane_size)
+            start += self._pane_size
+
+    def get_last_window(self, pane: W) -> TimeWindow:
+        last_start = TimeWindow.get_window_start_with_offset(pane.start, self._offset, self._slide)
+        return TimeWindow(last_start, last_start + self._size)
+
+    def assign_windows(self, element: List, timestamp: int) -> Iterable[TimeWindow]:
+        last_start = TimeWindow.get_window_start_with_offset(timestamp, self._offset, self._slide)
+        windows = [TimeWindow(start, start + self._size)
+                   for start in range(last_start, timestamp - self._size, -self._slide)]
+        return windows
+
+    def is_event_time(self) -> bool:
+        return self._is_event_time
+
+    def __repr__(self):
+        return "SlidingWindowAssigner(%s, %s)" % (self._size, self._slide)
+
+
+class CountSlidingWindowAssigner(WindowAssigner[CountWindow]):
+    """
+    A WindowAssigner that windows elements into sliding windows based on the count number of
+    the elements. Windows can possibly overlap.
+    """
+
+    def __init__(self, size, slide):
+        self._size = size
+        self._slide = slide
+        self._count = None  # type: ValueState
+
+    def open(self, ctx: Context[Any, CountWindow]):
+        count_descriptor = ValueStateDescriptor('slide-count-assigner', Types.LONG())
+        self._count = ctx.get_partitioned_state(count_descriptor)
+
+    def assign_windows(self, element: List, timestamp: int) -> Iterable[W]:
+        count_value = self._count.value()
+        if count_value is None:
+            current_count = 0
+        else:
+            current_count = count_value
+        self._count.update(current_count + 1)
+        last_id = current_count // self._slide
+        last_start = last_id * self._slide
+        last_end = last_start + self._size - 1
+        windows = []
+        while last_id >= 0 and last_start <= current_count <= last_end:
+            if last_start <= current_count <= last_end:
+                windows.append(CountWindow(last_id))
+            last_id -= 1
+            last_start -= self._slide
+            last_end -= self._slide
+        return windows
+
+    def is_event_time(self) -> bool:
+        return False
+
+    def __repr__(self):
+        return "CountSlidingWindowAssigner(%s, %s)" % (self._size, self._slide)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support Python UDAF in Sliding Window*


## Brief change log

  - *Add `PanedWindowAssigner`, `SlidingWindowAssigner` and `CountSlidingWindowAssigner`*
  - *Add `PanedWindowProcessFunction`*

## Verifying this change

This change added tests and can be verified as follows:

  - *integration tests `test_sliding_group_window_over_time` and `test_sliding_group_window_over_count` in `test_udaf.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
