### PR TITLE
[FLINK-21581][core] Remove @PublicEvolving from RuntimeContext.getJobID

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -194,9 +194,9 @@ under the License.
 							<exclude>org.apache.flink.api.common.functions.FoldFunction</exclude>
 							<exclude>org.apache.flink.api.common.functions.RichFoldFunction</exclude>
 
-                            <!-- added method to interface in 1.13 -->
-                            <exclude>org.apache.flink.api.common.functions.RuntimeContext#getJobId()</exclude>
-                        </excludes>
+							<!-- added method to interface in 1.13 -->
+							<exclude>org.apache.flink.api.common.functions.RuntimeContext#getJobId()</exclude>
+						</excludes>
 					</parameter>
 				</configuration>
 			</plugin>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -193,7 +193,10 @@ under the License.
 							<!-- it was decided to remove the fold opperations in 1.12 -->
 							<exclude>org.apache.flink.api.common.functions.FoldFunction</exclude>
 							<exclude>org.apache.flink.api.common.functions.RichFoldFunction</exclude>
-						</excludes>
+
+                            <!-- added method to interface in 1.13 -->
+                            <exclude>org.apache.flink.api.common.functions.RuntimeContext#getJobId()</exclude>
+                        </excludes>
 					</parameter>
 				</configuration>
 			</plugin>

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -63,7 +63,6 @@ public interface RuntimeContext {
      * standalone collection executor). Note that Job ID can change in particular upon manual
      * restart. The returned ID should NOT be used for any job management tasks.
      */
-    @PublicEvolving
     Optional<JobID> getJobId();
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Remove @PublicEvolving from RuntimeContext.getJobID
to make the API more consistent.

The method is added to japicmp ignore list.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
