### PR TITLE
[FLINK-21940][table] Rowtime/proctime should be obtained from getTimestamp instead of getLong

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
@@ -219,7 +219,7 @@ class DeduplicateFunctionHelper {
     }
 
     private static long getRowtime(RowData input, int rowtimeIndex) {
-        return input.getLong(rowtimeIndex);
+        return input.getTimestamp(rowtimeIndex, 3).getMillisecond();
     }
 
     /** check message should be insert only. */

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoin.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/interval/RowTimeIntervalJoin.java
@@ -74,12 +74,12 @@ public final class RowTimeIntervalJoin extends TimeIntervalJoin {
 
     @Override
     long getTimeForLeftStream(Context ctx, RowData row) {
-        return row.getLong(leftTimeIdx);
+        return row.getTimestamp(leftTimeIdx, 3).getMillisecond();
     }
 
     @Override
     long getTimeForRightStream(Context ctx, RowData row) {
-        return row.getLong(rightTimeIdx);
+        return row.getTimestamp(rightTimeIdx, 3).getMillisecond();
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
@@ -400,11 +400,11 @@ public class TemporalRowTimeJoinOperator extends BaseTwoInputStreamOperatorWithS
     }
 
     private long getLeftTime(RowData leftRow) {
-        return leftRow.getLong(leftTimeAttribute);
+        return leftRow.getTimestamp(leftTimeAttribute, 3).getMillisecond();
     }
 
     private long getRightTime(RowData rightRow) {
-        return rightRow.getLong(rightTimeAttribute);
+        return rightRow.getTimestamp(rightTimeAttribute, 3).getMillisecond();
     }
 
     // ------------------------------------------------------------------------------------------
@@ -421,8 +421,8 @@ public class TemporalRowTimeJoinOperator extends BaseTwoInputStreamOperatorWithS
 
         @Override
         public int compare(RowData o1, RowData o2) {
-            long o1Time = o1.getLong(timeAttribute);
-            long o2Time = o2.getLong(timeAttribute);
+            long o1Time = o1.getTimestamp(timeAttribute, 3).getMillisecond();
+            long o2Time = o2.getTimestamp(timeAttribute, 3).getMillisecond();
             return Long.compare(o1Time, o2Time);
         }
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/AbstractRowTimeUnboundedPrecedingOver.java
@@ -145,7 +145,7 @@ public abstract class AbstractRowTimeUnboundedPrecedingOver<K>
         // register state-cleanup timer
         registerProcessingCleanupTimer(ctx, ctx.timerService().currentProcessingTime());
 
-        long timestamp = input.getLong(rowTimeIdx);
+        long timestamp = input.getTimestamp(rowTimeIdx, 3).getMillisecond();
         long curWatermark = ctx.timerService().currentWatermark();
 
         if (timestamp > curWatermark) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeBoundedPrecedingFunction.java
@@ -149,7 +149,7 @@ public class RowTimeRangeBoundedPrecedingFunction<K>
             Collector<RowData> out)
             throws Exception {
         // triggering timestamp for trigger calculation
-        long triggeringTs = input.getLong(rowTimeIdx);
+        long triggeringTs = input.getTimestamp(rowTimeIdx, 3).getMillisecond();
 
         Long lastTriggeringTs = lastTriggeringTsState.value();
         if (lastTriggeringTs == null) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunction.java
@@ -158,7 +158,7 @@ public class RowTimeRowsBoundedPrecedingFunction<K>
         registerProcessingCleanupTimer(ctx, ctx.timerService().currentProcessingTime());
 
         // triggering timestamp for trigger calculation
-        long triggeringTs = input.getLong(rowTimeIdx);
+        long triggeringTs = input.getTimestamp(rowTimeIdx, 3).getMillisecond();
 
         Long lastTriggeringTs = lastTriggeringTsState.value();
         if (lastTriggeringTs == null) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/RowTimeSortOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/RowTimeSortOperator.java
@@ -100,7 +100,7 @@ public class RowTimeSortOperator extends BaseTemporalSortOperator {
         RowData input = element.getValue();
 
         // timestamp of the processed row
-        long rowTime = input.getLong(rowTimeIdx);
+        long rowTime = input.getTimestamp(rowTimeIdx, 3).getMillisecond();
 
         Long lastTriggeringTs = lastTriggeringTsState.value();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
@@ -329,7 +329,7 @@ public abstract class WindowOperator<K, W extends Window> extends AbstractStream
         RowData inputRow = record.getValue();
         long timestamp;
         if (windowAssigner.isEventTime()) {
-            timestamp = inputRow.getLong(rowtimeIndex);
+            timestamp = inputRow.getTimestamp(rowtimeIndex, 3).getMillisecond();
         } else {
             timestamp = internalTimerService.currentProcessingTime();
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/grouping/WindowsGrouping.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/grouping/WindowsGrouping.java
@@ -213,7 +213,7 @@ public abstract class WindowsGrouping implements Closeable {
         if (isDate) {
             return row.getInt(timeIndex) * DateTimeUtils.MILLIS_PER_DAY;
         } else {
-            return row.getLong(timeIndex);
+            return row.getTimestamp(timeIndex, 3).getMillisecond();
         }
     }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
@@ -335,7 +335,7 @@ public final class SliceAssigners {
 
         @Override
         public long assignSliceEnd(RowData element, ClockService clock) {
-            return element.getLong(windowEndIndex);
+            return element.getTimestamp(windowEndIndex, 3).getMillisecond();
         }
 
         @Override
@@ -374,7 +374,7 @@ public final class SliceAssigners {
         public final long assignSliceEnd(RowData element, ClockService clock) {
             final long timestamp;
             if (rowtimeIndex >= 0) {
-                timestamp = element.getLong(rowtimeIndex);
+                timestamp = element.getTimestamp(rowtimeIndex, 3).getMillisecond();
             } else {
                 // in processing time mode
                 timestamp = clock.currentProcessingTime();


### PR DESCRIPTION

## What is the purpose of the change

Rowtime/proctime should be obtained from getTimestamp instead of getLong.

Because the input row is BinaryRowData, so legacy `getLong` can work. But we should avoid this, in future, the row may be a GenericRowData.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)no