### PR TITLE
[FLINK-21946] [table-planner-blink] FlinkRelMdUtil.numDistinctVals produces exceptional Double.NaN result when domainSize is in range(0,1)

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtil.scala
@@ -236,7 +236,7 @@ object FlinkRelMdUtil {
    */
   def numDistinctVals(domainSize: Double, numSelected: Double): Double = {
     val EPS = 1e-9
-    if (Math.abs(1 / domainSize) < EPS) {
+    if (Math.abs(1 / domainSize) < EPS || domainSize < 1) {
       // ln(1+x) ~= x for small x
       val dSize = RelMdUtil.capInfinity(domainSize)
       val numSel = RelMdUtil.capInfinity(numSelected)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCountTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.plan.metadata
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalRank
 import org.apache.flink.table.planner.plan.utils.FlinkRelMdUtil
 
-import org.apache.calcite.rel.metadata.RelMdUtil
 import org.apache.calcite.sql.fun.SqlStdOperatorTable._
 import org.apache.calcite.util.ImmutableBitSet
 import org.junit.Assert._
@@ -82,7 +81,7 @@ class FlinkRelMdDistinctRowCountTest extends FlinkRelMdHandlerTestBase {
       mq.getDistinctRowCount(logicalValues, ImmutableBitSet.of(0, 1), null))
 
     (0 until logicalValues.getRowType.getFieldCount).foreach { idx =>
-      assertEquals(Double.NaN, mq.getDistinctRowCount(emptyValues, ImmutableBitSet.of(idx), null))
+      assertEquals(1.0, mq.getDistinctRowCount(emptyValues, ImmutableBitSet.of(idx), null))
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtilTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtilTest.scala
@@ -28,6 +28,13 @@ class FlinkRelMdUtilTest {
     Assert.assertEquals(
       RelMdUtil.numDistinctVals(1e5, 1e4),
       FlinkRelMdUtil.numDistinctVals(1e5, 1e4))
+
+    Assert.assertEquals(
+      BigDecimal(0.31606027941427883),
+      BigDecimal.valueOf(FlinkRelMdUtil.numDistinctVals(0.5, 0.5)))
+
+    // This case should be removed once CALCITE-4351 is fixed.
+    Assert.assertEquals(Double.NaN, RelMdUtil.numDistinctVals(0.5, 0.5))
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix Double.NaN result produced by FlinkRelMdUtil.numDistinctVals when domainSize is in range(0,1)

## Brief change log
  - add value check for FlinkRelMdUtil.numDistinctVals, entering old formula if matched

## Verifying this change

Added ut & it case

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): ( no )
- The public API, i.e., is any changed class annotated with @Public(Evolving): ( no )
- The serializers: ( no )
- The runtime per-record code paths (performance sensitive): ( no )
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
- The S3 file system connector: ( no )

## Documentation
  - Does this pull request introduce a new feature? (no)
