### PR TITLE
[FLINK-21416] increase the ssl handshake timeout to avoid connection reset/close in FileBufferReaderITCase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileBufferReaderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileBufferReaderITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
@@ -105,6 +106,11 @@ public class FileBufferReaderITCase extends TestLogger {
         } else {
             configuration = new Configuration();
         }
+
+        // Increases the handshake timeout to avoid connection reset/close issues
+        // if the netty server thread could not response in time, like when it is
+        // busy reading the files.
+        configuration.setInteger(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT, 100000);
         configuration.setString(RestOptions.BIND_PORT, "0");
         configuration.setString(
                 NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");


### PR DESCRIPTION
## What is the purpose of the change

This PR increases the ssl handshake timeout to avoid the exception that when the netty thread is blocked, the SSL handshake timeout might happen and cause the channel get closed, which further cause "connection reset by peer" or "CloseChannelException".

## Brief change log

- 44bc558aa2f8216b37794d32b428d32e66bf3f3b increases the timeout.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
