### PR TITLE
[FLINK-21715][table-planner] Support implicit cast conversion between timestamp and timestamp_ltz

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -185,7 +185,7 @@ public final class LogicalTypeCasts {
                 .build();
 
         castTo(TIMESTAMP_WITHOUT_TIME_ZONE)
-                .implicitFrom(TIMESTAMP_WITHOUT_TIME_ZONE)
+                .implicitFrom(TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE)
                 .explicitFromFamily(DATETIME, CHARACTER_STRING, BINARY_STRING, NUMERIC)
                 .build();
 
@@ -195,7 +195,7 @@ public final class LogicalTypeCasts {
                 .build();
 
         castTo(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
-                .implicitFrom(TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                .implicitFrom(TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITHOUT_TIME_ZONE)
                 .explicitFromFamily(DATETIME, CHARACTER_STRING, BINARY_STRING, NUMERIC)
                 .build();
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -158,15 +158,6 @@ public class LogicalTypeCastsTest {
                         false,
                         false
                     },
-                    {
-                        new RowType(
-                                Arrays.asList(
-                                        new RowField("f1", new IntType()),
-                                        new RowField("f2", new IntType()))),
-                        new VarCharType(Integer.MAX_VALUE),
-                        false,
-                        false
-                    },
                     // test implicit cast between timestamp type and timestamp_ltz type
                     {new TimestampType(9), new TimestampType(9), true, true},
                     {new LocalZonedTimestampType(9), new LocalZonedTimestampType(9), true, true},
@@ -174,10 +165,10 @@ public class LogicalTypeCastsTest {
                     {new LocalZonedTimestampType(3), new TimestampType(3), true, true},
                     {new TimestampType(3), new LocalZonedTimestampType(6), true, true},
                     {new LocalZonedTimestampType(3), new TimestampType(6), true, true},
-                    {new TimestampType(3), new LocalZonedTimestampType(6), true, true},
-                    {new LocalZonedTimestampType(3), new TimestampType(6), true, true},
                     {new TimestampType(false, 3), new LocalZonedTimestampType(6), true, true},
                     {new LocalZonedTimestampType(false, 3), new TimestampType(6), true, true},
+                    {new TimestampType(6), new LocalZonedTimestampType(3), true, true},
+                    {new LocalZonedTimestampType(6), new TimestampType(3), true, true},
                     {
                         new RowType(
                                 Arrays.asList(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -25,11 +25,13 @@ import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
@@ -155,7 +157,41 @@ public class LogicalTypeCastsTest {
                         new VarCharType(Integer.MAX_VALUE),
                         false,
                         false
-                    }
+                    },
+                    {
+                        new RowType(
+                                Arrays.asList(
+                                        new RowField("f1", new IntType()),
+                                        new RowField("f2", new IntType()))),
+                        new VarCharType(Integer.MAX_VALUE),
+                        false,
+                        false
+                    },
+                    // test implicit cast between timestamp type and timestamp_ltz type
+                    {new TimestampType(9), new TimestampType(9), true, true},
+                    {new LocalZonedTimestampType(9), new LocalZonedTimestampType(9), true, true},
+                    {new TimestampType(3), new LocalZonedTimestampType(3), true, true},
+                    {new LocalZonedTimestampType(3), new TimestampType(3), true, true},
+                    {new TimestampType(3), new LocalZonedTimestampType(6), true, true},
+                    {new LocalZonedTimestampType(3), new TimestampType(6), true, true},
+                    {new TimestampType(3), new LocalZonedTimestampType(6), true, true},
+                    {new LocalZonedTimestampType(3), new TimestampType(6), true, true},
+                    {new TimestampType(false, 3), new LocalZonedTimestampType(6), true, true},
+                    {new LocalZonedTimestampType(false, 3), new TimestampType(6), true, true},
+                    {
+                        new RowType(
+                                Arrays.asList(
+                                        new RowField("f1", new TimestampType()),
+                                        new RowField("f2", new LocalZonedTimestampType()),
+                                        new RowField("f3", new IntType()))),
+                        new RowType(
+                                Arrays.asList(
+                                        new RowField("f1", new LocalZonedTimestampType()),
+                                        new RowField("f2", new TimestampType()),
+                                        new RowField("f3", new IntType()))),
+                        true,
+                        true
+                    },
                 });
     }
 


### PR DESCRIPTION
## What is the purpose of the change

* This pull request to ensure the user defined function can still be used after the parameter type changes from TIMESTAMP type to TIMESTAMP_LTZ 
 
## Brief change log
  -   Support Implicit cast conversion between timestamp and timestamp_ltz

## Verifying this change
 - add Unit test and ITCase to cover the change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
