### PR TITLE
[FLINK-21661][FLINK-21993] Merge Kinesis bug fixes from 1.12.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -800,6 +800,12 @@ public class KinesisDataFetcher<T> {
      * executed and all shard consuming threads will be interrupted.
      */
     public void shutdownFetcher() {
+        if (LOG.isInfoEnabled()) {
+            LOG.info(
+                    "Starting shutdown of shard consumer threads and AWS SDK resources of subtask {} ...",
+                    indexOfThisConsumerSubtask);
+        }
+
         running = false;
 
         StreamConsumerRegistrarUtil.deregisterStreamConsumers(configProps, streams);
@@ -822,6 +828,15 @@ public class KinesisDataFetcher<T> {
                     "Shutting down the shard consumer threads of subtask {} ...",
                     indexOfThisConsumerSubtask);
         }
+    }
+
+    /**
+     * Returns a flag indicating if this fetcher is running.
+     *
+     * @return true if the fetch is running, false if it has been shutdown
+     */
+    boolean isRunning() {
+        return running;
     }
 
     /**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/RecordPublisher.java
@@ -45,7 +45,10 @@ public interface RecordPublisher {
         COMPLETE,
 
         /** There are more records to consume from this shard. */
-        INCOMPLETE
+        INCOMPLETE,
+
+        /** The record publisher has been cancelled. */
+        CANCELLED
     }
 
     /**

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTestUtils.java
@@ -58,6 +58,21 @@ public class ShardConsumerTestUtils {
             final SequenceNumber startingSequenceNumber,
             final Properties consumerProperties)
             throws InterruptedException {
+        return assertNumberOfMessagesReceivedFromKinesis(
+                expectedNumberOfMessages,
+                recordPublisherFactory,
+                startingSequenceNumber,
+                consumerProperties,
+                SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get());
+    }
+
+    public static <T> ShardConsumerMetricsReporter assertNumberOfMessagesReceivedFromKinesis(
+            final int expectedNumberOfMessages,
+            final RecordPublisherFactory recordPublisherFactory,
+            final SequenceNumber startingSequenceNumber,
+            final Properties consumerProperties,
+            final SequenceNumber expectedLastProcessedSequenceNum)
+            throws InterruptedException {
         ShardConsumerMetricsReporter shardMetricsReporter =
                 new ShardConsumerMetricsReporter(mock(MetricGroup.class));
 
@@ -118,7 +133,7 @@ public class ShardConsumerTestUtils {
 
         assertEquals(expectedNumberOfMessages, sourceContext.getCollectedOutputs().size());
         assertEquals(
-                SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+                expectedLastProcessedSequenceNum,
                 subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
 
         return shardMetricsReporter;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/polling/PollingRecordPublisherTest.java
@@ -34,6 +34,7 @@ import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -42,6 +43,8 @@ import static org.mockito.Mockito.verify;
 
 /** Tests for {@link PollingRecordPublisher}. */
 public class PollingRecordPublisherTest {
+
+    private static final long FETCH_INTERVAL_MILLIS = 500L;
 
     @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -56,6 +59,21 @@ public class PollingRecordPublisherTest {
         assertEquals(1, consumer.getRecordBatches().size());
         assertEquals(5, consumer.getRecordBatches().get(0).getDeaggregatedRecordSize());
         assertEquals(100L, consumer.getRecordBatches().get(0).getMillisBehindLatest(), 0);
+    }
+
+    @Test
+    public void testRunEmitsRunLoopTimeNanos() throws Exception {
+        PollingRecordPublisherMetricsReporter metricsReporter =
+                spy(new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class)));
+
+        KinesisProxyInterface fakeKinesis = totalNumOfRecordsAfterNumOfGetRecordsCalls(5, 5, 100);
+        PollingRecordPublisher recordPublisher =
+                createPollingRecordPublisher(fakeKinesis, metricsReporter);
+
+        recordPublisher.run(new TestConsumer());
+
+        // Expect that the run loop took at least FETCH_INTERVAL_MILLIS in nanos
+        verify(metricsReporter).setRunLoopTimeNanos(geq(FETCH_INTERVAL_MILLIS * 1_000_000));
     }
 
     @Test
@@ -136,12 +154,19 @@ public class PollingRecordPublisherTest {
         PollingRecordPublisherMetricsReporter metricsReporter =
                 new PollingRecordPublisherMetricsReporter(mock(MetricGroup.class));
 
+        return createPollingRecordPublisher(kinesis, metricsReporter);
+    }
+
+    PollingRecordPublisher createPollingRecordPublisher(
+            final KinesisProxyInterface kinesis,
+            final PollingRecordPublisherMetricsReporter metricGroupReporter)
+            throws Exception {
         return new PollingRecordPublisher(
                 StartingPosition.restartFromSequenceNumber(SENTINEL_EARLIEST_SEQUENCE_NUM.get()),
                 TestUtils.createDummyStreamShardHandle(),
-                metricsReporter,
+                metricGroupReporter,
                 kinesis,
                 10000,
-                500L);
+                FETCH_INTERVAL_MILLIS);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This change merged the following changes from 1.12 to 1.13:
- FLINK-21933 Gracefully handle Interrupted exceptions in Kinesis EFO source consumer [#15347](https://github.com/apache/flink/pull/15347)
- FLINK-21661 Kinesis Polling consumer does not respect the SHARD_GETRECORDS_INTERVAL_MILLIS configuration. This means consumer will poll Kinesis without any delay, resulting in throttle. This bug was introduced with FLINK-18512 [#15157](https://github.com/apache/flink/pull/15157)


## Brief change log

See related PR descriptions:
- [#15347](https://github.com/apache/flink/pull/15347)
- [#15157](https://github.com/apache/flink/pull/15157)

## Verifying this change

See related PR descriptions:
- [#15347](https://github.com/apache/flink/pull/15347)
- [#15157](https://github.com/apache/flink/pull/15157)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
