### PR TITLE
[FLINK-21972][table-planner-blink] fix not check whether TemporalTableSourceSpec can be serialized or not

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
@@ -142,6 +142,16 @@ public class ExecNodeGraphJsonPlanGenerator {
                                             "%s does not implement @JsonCreator annotation on constructor.",
                                             node.getClass().getCanonicalName()));
                         }
+                        if (node instanceof StreamExecLookupJoin) {
+                            StreamExecLookupJoin streamExecLookupJoin = (StreamExecLookupJoin) node;
+                            if (null
+                                    == streamExecLookupJoin
+                                            .getTemporalTableSourceSpec()
+                                            .getTableSourceSpec()) {
+                                throw new TableException(
+                                        "TemporalTableSourceSpec can not be serialized.");
+                            }
+                        }
                         super.visitInputs(node);
                     }
                 };


### PR DESCRIPTION
## What is the purpose of the change

*check whether TemporalTableSourceSpec can be serialized or not*


## Brief change log

  -  4a84007 check whether TemporalTableSourceSpec can be serialized or not


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test `testLegacyTableSourceException` that validates that expected exception was thrown*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
