### PR TITLE
[FLINK-21978][table-planner] Disable cast conversion between Numeric type and TIMESTAMP_LTZ type

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -254,44 +254,6 @@ class TemporalTypesTest extends ExpressionTestBase {
       "CAST(f2 AS TIMESTAMP_LTZ(3))",
       "1990-10-14 10:20:45.123")
 
-    // TINYINT -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(100 AS TINYINT) AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.000")
-
-    // SMALLINT -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(100 AS SMALLINT) AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.000")
-
-    // INT -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(100 AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.000")
-
-    // BIGINT -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(100 AS BIGINT) AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.000")
-
-    // FLOAT -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(100.01 AS FLOAT) AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.010")
-
-    // DOUBLE -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(100.123 AS DOUBLE) AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.123")
-
-    // DECIMAL -> TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(100.1234 as DECIMAL(38, 18)) AS TIMESTAMP_LTZ(3))",
-      "1970-01-01 08:01:40.123")
-    testSqlApi(
-      "CAST(CAST(1616490480.123 AS DECIMAL(38, 18)) AS TIMESTAMP_LTZ(9))",
-      "2021-03-23 17:08:00.123000000")
-
     // TIMESTAMP_LTZ -> TIME
     testSqlApi(
       s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS TIME)",
@@ -307,79 +269,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       s"CAST(${timestampLtz("2018-03-14 01:02:03")} AS TIMESTAMP(3))",
       "2018-03-14 01:02:03.000")
 
-    // TIMESTAMP_LTZ -> TINYINT
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS TINYINT)",
-      "123")
-
-    // TIMESTAMP_LTZ -> SMALLINT
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS SMALLINT)",
-      "123")
-
-    // TIMESTAMP_LTZ -> INT
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS INT)",
-      "123")
-
-    // TIMESTAMP_LTZ -> BIGINT
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS BIGINT)",
-      "123")
-
-    // TIMESTAMP_LTZ -> FLOAT
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS FLOAT)",
-      "123.123")
-
-    // TIMESTAMP_LTZ -> DOUBLE
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS DOUBLE)",
-      "123.123")
-
-    // TIMESTAMP_LTZ -> DECIMAL
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS DECIMAL(38, 3))",
-      "123.123")
-
-    // test precision when cast to TIMESTAMP_LTZ
-    testSqlApi(
-      "CAST(CAST(1.1234567 AS FLOAT) AS TIMESTAMP_LTZ(6))",
-      "1970-01-01 08:00:01.123456")
-    testSqlApi(
-      "CAST(CAST(1.12 AS FLOAT) AS TIMESTAMP_LTZ(6))",
-      "1970-01-01 08:00:01.120000")
-    testSqlApi(
-      "CAST(CAST(1.1234567899 AS DOUBLE) AS TIMESTAMP_LTZ(9))",
-      "1970-01-01 08:00:01.123456789")
-    testSqlApi(
-      "CAST(CAST(1.12 AS DOUBLE) AS TIMESTAMP_LTZ(6))",
-      "1970-01-01 08:00:01.120000")
-    testSqlApi(
-      "CAST(CAST(1.1234567899 AS DECIMAL(38, 18)) AS TIMESTAMP_LTZ(9))",
-      "1970-01-01 08:00:01.123456789")
-    testSqlApi(
-      "CAST(CAST(1.12 AS DECIMAL(38, 18)) AS TIMESTAMP_LTZ(6))",
-      "1970-01-01 08:00:01.120000")
-
-    // test precision when cast from TIMESTAMP_LTZ
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS FLOAT)",
-      "1.123456")
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DOUBLE)",
-      "123.123456")
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 6))",
-      "123.123456")
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456789")} AS DECIMAL(38, 9))",
-      "123.123456789")
-    testSqlApi(
-      s"CAST(${timestampLtz("1970-01-01 08:02:03.123456")} AS DECIMAL(38, 4))",
-      "123.1235")
-
-    // test cast between TIMESTAMP_LTZ and TIMESTAMP_LTZ
+    // test precision when cast between TIMESTAMP_LTZ and TIMESTAMP_LTZ
     testSqlApi(
       s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS TIMESTAMP_LTZ(3))",
       "1970-01-01 08:00:01.123")
@@ -389,14 +279,86 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(
       s"CAST(${timestampLtz("1970-01-01 08:00:01.123456")} AS TIMESTAMP_LTZ(9))",
       "1970-01-01 08:00:01.123456000")
+  }
 
-    // test cast with null value
-    testSqlApi(
-      s"CAST(CAST(null AS BIGINT) AS TIMESTAMP_LTZ(3))",
-      "null")
-    testSqlApi(
-      s"CAST(CAST(null AS TIMESTAMP_LTZ(3)) AS BIGINT)",
-      "null")
+  @Test
+  def tesInvalidCastBetweenNumericAndTimestampLtz(): Unit = {
+    val castFromTimestampLtzExceptionMsg = "The cast conversion from TIMESTAMP_LTZ type to" +
+      " NUMERIC type is not allowed."
+
+    val castToTimestampLtzExceptionMsg = "The cast conversion from NUMERIC type to TIMESTAMP_LTZ" +
+      " type is not allowed, it's recommended to use" +
+      " TO_TIMESTAMP_LTZ(numeric_col, precision) instead."
+
+    // TINYINT -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(CAST(100 AS TINYINT) AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // SMALLINT -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(CAST(100 AS SMALLINT) AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // INT -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(100 AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // BIGINT -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(CAST(100 AS BIGINT) AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // FLOAT -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(CAST(100.01 AS FLOAT) AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // DOUBLE -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(CAST(100.123 AS DOUBLE) AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // DECIMAL -> TIMESTAMP_LTZ
+    testExpectedSqlException(
+      "CAST(CAST(100.1234 as DECIMAL(38, 18)) AS TIMESTAMP_LTZ(3))",
+      castToTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> TINYINT
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS TINYINT)",
+      castFromTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> SMALLINT
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS SMALLINT)",
+      castFromTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> INT
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS INT)",
+      castFromTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> BIGINT
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS BIGINT)",
+      castFromTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> FLOAT
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS FLOAT)",
+      castFromTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> DOUBLE
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS DOUBLE)",
+      castFromTimestampLtzExceptionMsg)
+
+    // TIMESTAMP_LTZ -> DECIMAL
+    testExpectedSqlException(
+      s"CAST(${timestampLtz("1970-01-01 08:02:03.123")} AS DECIMAL(38, 3))",
+      castFromTimestampLtzExceptionMsg)
   }
 
   @Test

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -38,9 +38,6 @@ import static org.apache.flink.table.data.DecimalData.fromBigDecimal;
 public final class DecimalDataUtils {
 
     private static final MathContext MC_DIVIDE = new MathContext(38, RoundingMode.HALF_UP);
-    private static final long MILLS_PER_SECOND = 1000L;
-    private static final long NANOS_PER_SECOND = 1000_000_000L;
-    private static final long NANOS_PER_MILLISECOND = 1000_000L;
 
     public static final DecimalType DECIMAL_SYSTEM_DEFAULT =
             new DecimalType(DecimalType.MAX_PRECISION, 18);
@@ -208,23 +205,8 @@ public final class DecimalDataUtils {
         return dec.toBigDecimal().compareTo(BigDecimal.ZERO) != 0;
     }
 
-    public static TimestampData castToTimestamp(DecimalData dec) {
-        BigDecimal bd = dec.toBigDecimal().multiply(new BigDecimal(MILLS_PER_SECOND));
-        long mills = bd.longValue();
-        int nanos =
-                bd.remainder(BigDecimal.ONE)
-                        .multiply(new BigDecimal(NANOS_PER_MILLISECOND))
-                        .intValue();
-        return TimestampData.fromEpochMillis(mills, nanos);
-    }
-
-    public static DecimalData castFrom(TimestampData val, int precision, int scale) {
-        BigDecimal decimalSeconds =
-                new BigDecimal(val.getMillisecond())
-                        .multiply(new BigDecimal(NANOS_PER_MILLISECOND))
-                        .add(new BigDecimal(val.getNanoOfMillisecond()))
-                        .divide(new BigDecimal(NANOS_PER_SECOND));
-        return fromBigDecimal(decimalSeconds, precision, scale);
+    public static long castToTimestamp(DecimalData dec) {
+        return (long) (doubleValue(dec) * 1000);
     }
 
     public static DecimalData castFrom(DecimalData dec, int precision, int scale) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -205,10 +205,6 @@ public final class DecimalDataUtils {
         return dec.toBigDecimal().compareTo(BigDecimal.ZERO) != 0;
     }
 
-    public static long castToTimestamp(DecimalData dec) {
-        return (long) (doubleValue(dec) * 1000);
-    }
-
     public static DecimalData castFrom(DecimalData dec, int precision, int scale) {
         return fromBigDecimal(dec.toBigDecimal(), precision, scale);
     }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -28,7 +28,6 @@ import static org.apache.flink.table.data.DecimalDataUtils.castFrom;
 import static org.apache.flink.table.data.DecimalDataUtils.castToBoolean;
 import static org.apache.flink.table.data.DecimalDataUtils.castToDecimal;
 import static org.apache.flink.table.data.DecimalDataUtils.castToIntegral;
-import static org.apache.flink.table.data.DecimalDataUtils.castToTimestamp;
 import static org.apache.flink.table.data.DecimalDataUtils.ceil;
 import static org.apache.flink.table.data.DecimalDataUtils.compare;
 import static org.apache.flink.table.data.DecimalDataUtils.divide;
@@ -115,7 +114,6 @@ public class DecimalDataTest {
         assertTrue(castToBoolean(castFrom(true, 5, 0)));
         assertEquals(5, castToIntegral(castFrom(5, 5, 0)));
         assertEquals(5, castToIntegral(castFrom("5", 5, 0)));
-        assertEquals(5000, castToTimestamp(castFrom("5", 5, 0)));
 
         DecimalData newDecimal = castFrom(castFrom(10, 5, 2), 10, 4);
         assertEquals(10, newDecimal.precision());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -115,10 +115,7 @@ public class DecimalDataTest {
         assertTrue(castToBoolean(castFrom(true, 5, 0)));
         assertEquals(5, castToIntegral(castFrom(5, 5, 0)));
         assertEquals(5, castToIntegral(castFrom("5", 5, 0)));
-        assertEquals(5000, castToTimestamp(castFrom("5", 5, 0)).getMillisecond());
-        assertEquals(12300456, castToTimestamp(castFrom("12300.4567", 10, 4)).getMillisecond());
-        assertEquals(
-                780000, castToTimestamp(castFrom("12300.45678", 10, 5)).getNanoOfMillisecond());
+        assertEquals(5000, castToTimestamp(castFrom("5", 5, 0)));
 
         DecimalData newDecimal = castFrom(castFrom(10, 5, 2), 10, 4);
         assertEquals(10, newDecimal.precision());
@@ -173,8 +170,6 @@ public class DecimalDataTest {
         assertNull(DecimalData.fromBigDecimal(new BigDecimal(Long.MAX_VALUE), 5, 0));
         assertEquals(0, DecimalData.zero(20, 2).toBigDecimal().intValue());
         assertEquals(0, DecimalData.zero(20, 2).toBigDecimal().intValue());
-        assertEquals(1234000, castToTimestamp(castFrom("1234", 20, 4)).getMillisecond());
-        assertEquals(0, castToTimestamp(castFrom("1234", 20, 4)).getNanoOfMillisecond());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change 

Currently we has supported the cast conversion between Numeric type and TIMESTAMP_LTZ type, we suppose the numeric value e.g `Long type 1000L` as epoch seconds and then cast  to TIMESTAMP_LTZ, but the java.lang.Long is a conversion class of `LocalZonedTimestampType`  and treats as milliseconds.

To avoid the inconsistency, we disable it and encourage user to use `TO_TIMESTAMP_LTZ(numeric, precision)`.


## Brief change log

  -  Disable the cast conversion between Numeric type and TIMESTAMP_LTZ

## Verifying this change

- Add unit test to cover the cast conversion and function
- 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
