### PR TITLE
[FLINK-17012][streaming] Implemented the separated 'restore' method for  StreamTask

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -148,6 +148,7 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
     private void checkTasksStarted(List<Execution> toTrigger) throws CheckpointException {
         for (Execution execution : toTrigger) {
             if (execution.getState() == ExecutionState.CREATED
+                    || execution.getState() == ExecutionState.RECOVERING
                     || execution.getState() == ExecutionState.SCHEDULED
                     || execution.getState() == ExecutionState.DEPLOYING) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -955,7 +955,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     void failGlobalIfExecutionIsStillRunning(Throwable cause, ExecutionAttemptID failingAttempt) {
         final Execution failedExecution = currentExecutions.get(failingAttempt);
-        if (failedExecution != null && failedExecution.getState() == ExecutionState.RUNNING) {
+        if (failedExecution != null
+                && (failedExecution.getState() == ExecutionState.RUNNING
+                        || failedExecution.getState() == ExecutionState.RECOVERING)) {
             failGlobal(cause);
         } else {
             LOG.debug(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -856,7 +856,7 @@ public class Execution
             OperatorID operatorId, SerializedValue<OperatorEvent> event) {
         final LogicalSlot slot = assignedResource;
 
-        if (slot != null && getState() == RUNNING) {
+        if (slot != null && (getState() == RUNNING || getState() == RECOVERING)) {
             final TaskExecutorOperatorEventGateway eventGateway = slot.getTaskManagerGateway();
             return eventGateway.sendOperatorEventToTask(getAttemptId(), operatorId, event);
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -110,7 +110,9 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
         // needs to cause a job failure.
 
         final Execution exec = executionGraph.getRegisteredExecutions().get(taskExecutionId);
-        if (exec == null || exec.getState() != ExecutionState.RUNNING) {
+        if (exec == null
+                || exec.getState() != ExecutionState.RUNNING
+                        && exec.getState() != ExecutionState.RECOVERING) {
             // This situation is common when cancellation happens, or when the task failed while the
             // event was just being dispatched asynchronously on the TM side.
             // It should be fine in those expected situations to just ignore this event, but, to be

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1395,7 +1395,9 @@ public class Task
             throws FlinkException {
         final AbstractInvokable invokable = this.invokable;
 
-        if (invokable == null || executionState != ExecutionState.RUNNING) {
+        if (invokable == null
+                || (executionState != ExecutionState.RUNNING
+                        && executionState != ExecutionState.RECOVERING)) {
             throw new TaskNotRunningException("Task is not yet running.");
         }
 
@@ -1404,7 +1406,8 @@ public class Task
         } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
 
-            if (getExecutionState() == ExecutionState.RUNNING) {
+            if (getExecutionState() == ExecutionState.RUNNING
+                    || getExecutionState() == ExecutionState.RECOVERING) {
                 FlinkException e = new FlinkException("Error while handling operator event", t);
                 failExternally(e);
                 throw e;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.io.network.api.writer.RecordWriterDelegate;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.SingleRecordWriter;
 import org.apache.flink.runtime.io.network.partition.ChannelStateHolder;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
@@ -109,6 +110,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 
 import static org.apache.flink.runtime.concurrent.FutureUtils.assertNoException;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Base class for all streaming tasks. A task is the unit of local processing that is deployed and
@@ -448,7 +450,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     }
 
     private void setSynchronousSavepointId(long checkpointId, boolean ignoreEndOfInput) {
-        Preconditions.checkState(
+        checkState(
                 syncSavepointId == null,
                 "at most one stop-with-savepoint checkpoint at a time is allowed");
         syncSavepointId = checkpointId;
@@ -526,7 +528,12 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         }
     }
 
-    protected void beforeInvoke() throws Exception {
+    @Override
+    public void restore() throws Exception {
+        if (isRunning) {
+            LOG.debug("Re-restore attempt rejected.");
+            return;
+        }
         disposedOperators = false;
         LOG.debug("Initializing {}.", getName());
 
@@ -546,39 +553,60 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
 
         // we need to make sure that any triggers scheduled in open() cannot be
         // executed before all operators are opened
-        actionExecutor.runThrowing(
-                () -> {
-                    SequentialChannelStateReader reader =
-                            getEnvironment()
-                                    .getTaskStateManager()
-                                    .getSequentialChannelStateReader();
-                    reader.readOutputData(
-                            getEnvironment().getAllWriters(),
-                            !configuration.isGraphContainingLoops());
+        CompletableFuture<Void> allGatesRecoveredFuture =
+                actionExecutor.call(
+                        () -> {
+                            SequentialChannelStateReader reader =
+                                    getEnvironment()
+                                            .getTaskStateManager()
+                                            .getSequentialChannelStateReader();
+                            reader.readOutputData(
+                                    getEnvironment().getAllWriters(),
+                                    !configuration.isGraphContainingLoops());
 
-                    operatorChain.initializeStateAndOpenOperators(
-                            createStreamTaskStateInitializer());
+                            operatorChain.initializeStateAndOpenOperators(
+                                    createStreamTaskStateInitializer());
 
-                    channelIOExecutor.execute(
-                            () -> {
-                                try {
-                                    reader.readInputData(getEnvironment().getAllInputGates());
-                                } catch (Exception e) {
-                                    asyncExceptionHandler.handleAsyncException(
-                                            "Unable to read channel state", e);
-                                }
-                            });
+                            IndexedInputGate[] inputGates = getEnvironment().getAllInputGates();
+                            channelIOExecutor.execute(
+                                    () -> {
+                                        try {
+                                            reader.readInputData(inputGates);
+                                        } catch (Exception e) {
+                                            asyncExceptionHandler.handleAsyncException(
+                                                    "Unable to read channel state", e);
+                                        }
+                                    });
 
-                    for (InputGate inputGate : getEnvironment().getAllInputGates()) {
-                        inputGate
-                                .getStateConsumedFuture()
-                                .thenRun(
-                                        () ->
-                                                mainMailboxExecutor.execute(
-                                                        inputGate::requestPartitions,
-                                                        "Input gate request partitions"));
-                    }
-                });
+                            List<CompletableFuture<?>> recoveredFutures =
+                                    new ArrayList<>(inputGates.length);
+                            for (InputGate inputGate : inputGates) {
+                                recoveredFutures.add(inputGate.getStateConsumedFuture());
+
+                                inputGate
+                                        .getStateConsumedFuture()
+                                        .thenRun(
+                                                () ->
+                                                        mainMailboxExecutor.execute(
+                                                                inputGate::requestPartitions,
+                                                                "Input gate request partitions"));
+                            }
+
+                            return CompletableFuture.allOf(
+                                            recoveredFutures.toArray(new CompletableFuture[0]))
+                                    .thenRun(mailboxProcessor::suspend);
+                        });
+
+        // Run mailbox until all gates will be recovered.
+        mailboxProcessor.runMailboxLoop();
+
+        if (canceled) {
+            throw new CancelTaskException();
+        }
+
+        checkState(
+                allGatesRecoveredFuture.isDone(),
+                "Mailbox loop interrupted before recovery was finished.");
 
         isRunning = true;
     }
@@ -586,7 +614,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     @Override
     public final void invoke() throws Exception {
         try {
-            beforeInvoke();
+            // Allow invoking method 'invoke' without having to call 'restore' before it.
+            if (!isRunning) {
+                LOG.debug("Restoring during invoke will be called.");
+                restore();
+            }
 
             // final check to exit early before starting to run
             if (canceled) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -163,7 +163,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         streamMockEnvironment.setTaskMetricGroup(taskMetricGroup);
 
         StreamTask<OUT, ?> task = taskFactory.apply(streamMockEnvironment);
-        task.beforeInvoke();
+        task.restore();
 
         return new StreamTaskMailboxTestHarness<>(
                 task, outputList, inputGates, streamMockEnvironment);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1528,6 +1528,55 @@ public class StreamTaskTest extends TestLogger {
         }
     }
 
+    @Test
+    public void testRestorePerformedOnlyOnce() throws Exception {
+        // given: the operator with empty snapshot result (all state handles are null)
+        OneInputStreamOperator<String, String> statelessOperator =
+                streamOperatorWithSnapshot(new OperatorSnapshotFutures());
+        DummyEnvironment dummyEnvironment = new DummyEnvironment();
+
+        // when: Invoke the restore explicitly before launching the task.
+        RunningTask<MockStreamTask> task =
+                runTask(
+                        () -> {
+                            MockStreamTask mockStreamTask =
+                                    createMockStreamTask(
+                                            dummyEnvironment, operatorChain(statelessOperator));
+
+                            mockStreamTask.restore();
+
+                            return mockStreamTask;
+                        });
+        waitTaskIsRunning(task.streamTask, task.invocationFuture);
+
+        task.streamTask.cancel();
+
+        // then: 'restore' was called only once.
+        assertThat(task.streamTask.restoreInvocationCount, is(1));
+    }
+
+    @Test
+    public void testRestorePerformedFromInvoke() throws Exception {
+        // given: the operator with empty snapshot result (all state handles are null)
+        OneInputStreamOperator<String, String> statelessOperator =
+                streamOperatorWithSnapshot(new OperatorSnapshotFutures());
+        DummyEnvironment dummyEnvironment = new DummyEnvironment();
+
+        // when: Launch the task.
+        RunningTask<MockStreamTask> task =
+                runTask(
+                        () ->
+                                createMockStreamTask(
+                                        dummyEnvironment, operatorChain(statelessOperator)));
+
+        waitTaskIsRunning(task.streamTask, task.invocationFuture);
+
+        task.streamTask.cancel();
+
+        // then: 'restore' was called even without explicit 'restore' invocation.
+        assertThat(task.streamTask.restoreInvocationCount, is(1));
+    }
+
     private MockEnvironment setupEnvironment(boolean... outputAvailabilities) {
         final Configuration configuration = new Configuration();
         new MockStreamConfig(configuration, outputAvailabilities.length);
@@ -1843,6 +1892,7 @@ public class StreamTaskTest extends TestLogger {
     private static class MockStreamTask extends StreamTask<String, AbstractStreamOperator<String>> {
 
         private final OperatorChain<String, AbstractStreamOperator<String>> overrideOperatorChain;
+        private int restoreInvocationCount = 0;
 
         MockStreamTask(
                 Environment env,
@@ -1851,6 +1901,12 @@ public class StreamTaskTest extends TestLogger {
                 throws Exception {
             super(env, null, uncaughtExceptionHandler);
             this.overrideOperatorChain = operatorChain;
+        }
+
+        @Override
+        public void restore() throws Exception {
+            super.restore();
+            restoreInvocationCount++;
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
@@ -33,6 +33,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 /** Unit tests for {@link MailboxProcessor}. */
 public class TaskMailboxProcessorTest {
 
@@ -93,7 +96,7 @@ public class TaskMailboxProcessorTest {
         Assert.assertFalse(testRunnableFuture.isDone());
 
         mailboxProcessor.close();
-        Assert.assertTrue(testRunnableFuture.isCancelled());
+        assertTrue(testRunnableFuture.isCancelled());
     }
 
     @Test
@@ -183,7 +186,7 @@ public class TaskMailboxProcessorTest {
 
                         // If this is violated, it means that the default action was invoked while
                         // we assumed suspension
-                        Assert.assertTrue(
+                        assertTrue(
                                 suspendedActionRef.compareAndSet(
                                         null, controller.suspendDefaultAction()));
 
@@ -294,6 +297,105 @@ public class TaskMailboxProcessorTest {
 
         Assert.assertEquals(expectedInvocations, counter.get());
         Assert.assertEquals(expectedInvocations, index.get());
+    }
+
+    @Test
+    public void testSuspendRunningMailboxLoop() throws Exception {
+        // given: Thread for suspending the suspendable loop.
+        OneShotLatch doSomeWork = new OneShotLatch();
+        AtomicBoolean stop = new AtomicBoolean(false);
+
+        MailboxProcessor mailboxProcessor =
+                new MailboxProcessor(
+                        controller -> {
+                            doSomeWork.trigger();
+
+                            if (stop.get()) {
+                                controller.allActionsCompleted();
+                            }
+                        });
+
+        Thread suspendThread =
+                new Thread(
+                        () -> {
+                            try {
+                                // Ensure that loop was started.
+                                doSomeWork.await();
+
+                                // when: Suspend the suspendable loop.
+                                mailboxProcessor.suspend();
+
+                                // and: Execute the command for stopping the loop.
+                                mailboxProcessor
+                                        .getMailboxExecutor(DEFAULT_PRIORITY)
+                                        .execute(() -> stop.set(true), "stop");
+                            } catch (Exception ignore) {
+
+                            }
+                        });
+        suspendThread.start();
+
+        // when: Start the suspendable loop.
+        mailboxProcessor.runMailboxLoop();
+
+        suspendThread.join();
+
+        // then: Mailbox is not stopped because it was suspended before the stop command.
+        assertFalse(stop.get());
+
+        // when: Resume the suspendable loop.
+        mailboxProcessor.runMailboxLoop();
+
+        // then: Stop command successfully executed because it was in the queue.
+        assertFalse(mailboxProcessor.isMailboxLoopRunning());
+        assertTrue(stop.get());
+    }
+
+    @Test
+    public void testResumeMailboxLoopAfterAllActionsCompleted() throws Exception {
+        // given: Configured suspendable loop.
+        AtomicBoolean start = new AtomicBoolean(false);
+        MailboxProcessor mailboxProcessor = new MailboxProcessor(controller -> start.set(true));
+
+        // when: Complete mailbox loop immediately after start.
+        mailboxProcessor.allActionsCompleted();
+        mailboxProcessor.runMailboxLoop();
+
+        // then: Mailbox is finished without execution any job.
+        assertFalse(mailboxProcessor.isMailboxLoopRunning());
+        assertFalse(start.get());
+
+        // when: Start the suspendable loop again.
+        mailboxProcessor.runMailboxLoop();
+
+        // then: Nothing happens because mailbox is already permanently finished.
+        assertFalse(start.get());
+    }
+
+    @Test
+    public void testResumeMailboxLoop() throws Exception {
+        // given: Configured suspendable loop.
+        AtomicBoolean start = new AtomicBoolean(false);
+        MailboxProcessor mailboxProcessor =
+                new MailboxProcessor(
+                        controller -> {
+                            start.set(true);
+
+                            controller.allActionsCompleted();
+                        });
+
+        // when: Suspend mailbox loop immediately after start.
+        mailboxProcessor.suspend();
+        mailboxProcessor.runMailboxLoop();
+
+        // then: Mailbox is not finished but job didn't execute because it was suspended.
+        assertFalse(start.get());
+
+        // when: Start the suspendable loop again.
+        mailboxProcessor.runMailboxLoop();
+
+        // then: Job is done.
+        assertTrue(start.get());
     }
 
     static class MailboxThread extends Thread implements MailboxDefaultAction {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

This is the second part of the changes which based on https://github.com/apache/flink/pull/15221

## What is the purpose of the change

These changes implement the restore method which was introduced in https://github.com/apache/flink/pull/15221. This allows restoring data independently on a invoke method and it will be possible to call the restore and the invoke in different states.

## Brief change log

  - *The contract of MailboxProcessor#runMailboxLoop is changed. It can be suspended by calling 'suspend'.*
  - *StreamTask#beforeInvoke renamed to the restore with small changes and it can be invoked independently of 'invoke' now.*


## Verifying this change

This change is mostly covered by existing tests, such as *StreamTask, UnalignedCheckpoint\**.

This change added tests and can be verified as follows:
  - *Added tests for verifying that runMailboxLoop can be suspendable correctly*
  - *Extended StreamTask tests for checking that 'restore' method doesn't call more than 1 times*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
