### PR TITLE
[FLINK-21975] Remove hamcrest dependency from SchedulerBenchmarkBase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerBenchmarkBase.java
@@ -51,8 +51,6 @@ import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createJobGraph;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 /**
  * The base class of benchmarks related to {@link DefaultScheduler}'s creation, scheduling and
@@ -124,10 +122,8 @@ public class SchedulerBenchmarkBase {
                                                                     i,
                                                                     ResourceProfile.ANY))
                                             .collect(Collectors.toList());
-                            final Collection<SlotOffer> acceptedOffers =
-                                    slotPool.offerSlots(
-                                            taskManagerLocation, taskManagerGateway, slotOffers);
-                            assertThat(acceptedOffers, is(slotOffers));
+                            slotPool.offerSlots(
+                                    taskManagerLocation, taskManagerGateway, slotOffers);
                         },
                         mainThreadExecutor)
                 .join();


### PR DESCRIPTION
## What is the purpose of the change

*When we are trying to add BenchmarkExecutor for benchmarks introduced in FLINK 21731, we find that the dependency of hamcrest is introduced into the benchmark by mistake. Since there's no hamcrest dependency in flink-benchmark, this will break the execution of scheduler benchmarks. Therefore, we need to remove this dependency from `SchedulerBenchmarkBase`.*


## Brief change log

  - *Remove usage of hamcrest in `SchedulerBenchmarkBase`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
