### PR TITLE
[FLINK-19646][python] Introduce StreamExecutionEnvironment.from_source to support FLIP-27 source in Python DataStream API

### DIFF
--- a/flink-python/pyflink/datastream/connectors.py
+++ b/flink-python/pyflink/datastream/connectors.py
@@ -22,12 +22,11 @@ from typing import Dict, List, Union
 from pyflink.common import typeinfo
 from pyflink.common.serialization import DeserializationSchema, Encoder, SerializationSchema
 from pyflink.common.typeinfo import RowTypeInfo, TypeInformation
-from pyflink.datastream.functions import SourceFunction, SinkFunction
+from pyflink.datastream.functions import SourceFunction, SinkFunction, JavaFunctionWrapper
 from pyflink.java_gateway import get_gateway
 from pyflink.util.java_utils import load_java_class, to_jarray
 
-from py4j.java_gateway import java_import
-
+from py4j.java_gateway import java_import, JavaObject
 
 __all__ = [
     'FlinkKafkaConsumer',
@@ -661,3 +660,17 @@ class OutputFileConfig(object):
 
         def build(self) -> 'OutputFileConfig':
             return OutputFileConfig(self.part_prefix, self.part_suffix)
+
+
+class Source(JavaFunctionWrapper):
+    """
+    Base class for all unified data source in Flink.
+    """
+
+    def __init__(self, source: Union[str, JavaObject]):
+        """
+        Constructor of Source.
+
+        :param source: The java Source object.
+        """
+        super(Source, self).__init__(source)

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,7 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
-                'clearJobListeners', 'getJobListeners', "fromSource", "fromSequence",
+                'clearJobListeners', 'getJobListeners', "fromSequence",
                 'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory'}
 
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request introduce StreamExecutionEnvironment.from_source to support FLIP-27 source in Python DataStream API*


## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
