### PR TITLE
[FLINK-21929][statebackend][tests] Ensure to dispose keyed state backend to avoid core dump

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -75,6 +75,7 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.testutils.statemigration.TestType;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.types.IntValue;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.StateMigrationException;
 import org.apache.flink.util.TestLogger;
@@ -282,46 +283,56 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
         String fieldName = "key-grouped-priority-queue";
         CheckpointableKeyedStateBackend<Integer> backend =
                 createKeyedBackend(IntSerializer.INSTANCE);
-        KeyGroupedInternalPriorityQueue<TestType> priorityQueue =
-                backend.create(fieldName, new TestType.V1TestTypeSerializer());
+        try {
+            KeyGroupedInternalPriorityQueue<TestType> priorityQueue =
+                    backend.create(fieldName, new TestType.V1TestTypeSerializer());
 
-        TestType elementA42 = new TestType("a", 42);
-        TestType elementA44 = new TestType("a", 44);
-        TestType elementB1 = new TestType("b", 1);
-        TestType elementB3 = new TestType("b", 3);
+            TestType elementA42 = new TestType("a", 42);
+            TestType elementA44 = new TestType("a", 44);
+            TestType elementB1 = new TestType("b", 1);
+            TestType elementB3 = new TestType("b", 3);
 
-        TestType[] elements = {
-            elementA44, elementB1, elementB1, elementB3, elementA42,
-        };
+            TestType[] elements = {
+                elementA44, elementB1, elementB1, elementB3, elementA42,
+            };
 
-        if (addAll) {
-            priorityQueue.addAll(asList(elements));
-        } else {
-            assertTrue(priorityQueue.add(elements[0]));
-            assertTrue(priorityQueue.add(elements[1]));
-            assertFalse(priorityQueue.add(elements[2]));
-            assertFalse(priorityQueue.add(elements[3]));
-            assertFalse(priorityQueue.add(elements[4]));
+            if (addAll) {
+                priorityQueue.addAll(asList(elements));
+            } else {
+                assertTrue(priorityQueue.add(elements[0]));
+                assertTrue(priorityQueue.add(elements[1]));
+                assertFalse(priorityQueue.add(elements[2]));
+                assertFalse(priorityQueue.add(elements[3]));
+                assertFalse(priorityQueue.add(elements[4]));
+            }
+            assertFalse(priorityQueue.isEmpty());
+            assertThat(
+                    priorityQueue.getSubsetForKeyGroup(1),
+                    containsInAnyOrder(elementA42, elementA44));
+            assertThat(
+                    priorityQueue.getSubsetForKeyGroup(8),
+                    containsInAnyOrder(elementB1, elementB3));
+
+            assertThat(priorityQueue.peek(), equalTo(elementB1));
+            assertThat(priorityQueue.poll(), equalTo(elementB1));
+            assertThat(priorityQueue.peek(), equalTo(elementB3));
+
+            List<TestType> actualList = new ArrayList<>();
+            try (CloseableIterator<TestType> iterator = priorityQueue.iterator()) {
+                iterator.forEachRemaining(actualList::add);
+            }
+
+            assertThat(actualList, containsInAnyOrder(elementB3, elementA42, elementA44));
+
+            assertEquals(3, priorityQueue.size());
+
+            assertFalse(priorityQueue.remove(elementB1));
+            assertTrue(priorityQueue.remove(elementB3));
+            assertThat(priorityQueue.peek(), equalTo(elementA42));
+        } finally {
+            IOUtils.closeQuietly(backend);
+            backend.dispose();
         }
-        assertFalse(priorityQueue.isEmpty());
-        assertThat(
-                priorityQueue.getSubsetForKeyGroup(1), containsInAnyOrder(elementA42, elementA44));
-        assertThat(priorityQueue.getSubsetForKeyGroup(8), containsInAnyOrder(elementB1, elementB3));
-
-        assertThat(priorityQueue.peek(), equalTo(elementB1));
-        assertThat(priorityQueue.poll(), equalTo(elementB1));
-        assertThat(priorityQueue.peek(), equalTo(elementB3));
-
-        List<TestType> actualList = new ArrayList<>();
-        priorityQueue.iterator().forEachRemaining(actualList::add);
-
-        assertThat(actualList, containsInAnyOrder(elementB3, elementA42, elementA44));
-
-        assertEquals(3, priorityQueue.size());
-
-        assertFalse(priorityQueue.remove(elementB1));
-        assertTrue(priorityQueue.remove(elementB3));
-        assertThat(priorityQueue.peek(), equalTo(elementA42));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This change includes two commits:
`[FLINK-21929][rocksdb][tests] Ensure to dispose state backend in StateBackendTestBase#testKeyGroupedInternalPriorityQueue finally` to fix FLINK-21929

`[FLINK-21929][statebackend][tests] Refactor StateBackendTestBase to ensure created keyed state backend could be disposed finally` to stabilize all state backend tests.  


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
