### PR TITLE
[FLINK-21915] Optimize Execution#finishPartitionsAndUpdateConsumers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -486,8 +487,8 @@ public class ExecutionVertex
         partition.markDataProduced();
     }
 
-    void cachePartitionInfo(PartitionInfo partitionInfo) {
-        getCurrentExecutionAttempt().cachePartitionInfo(partitionInfo);
+    void cachePartitionInfo(Collection<PartitionInfo> partitionInfos) {
+        getCurrentExecutionAttempt().cachePartitionInfo(partitionInfos);
     }
 
     /** Returns all blocking result partitions whose receivers can be scheduled/updated. */


### PR DESCRIPTION
## What is the purpose of the change

*Based on the scheduler benchmark PartitionReleaseInBatchJobBenchmark introduced in FLINK-20612, we find that there's another procedure that has O(N^2) computation complexity: Execution#finishPartitionsAndUpdateConsumers.*

*Once an execution is finished, it will finish all its BLOCKING partitions and update the partition info to all consumer vertices. The procedure can be illustrated as the following pseudo code:*

```
for all Execution in ExecutionGraph:
  for all produced IntermediateResultPartition of the Execution:
    for all consumer ExecutionVertex of the IntermediateResultPartition:
      update or cache partition info
```

*This procedure has O(N^2) complexity in total.*

*Based on FLINK-21326, the consumed partitions are grouped if they are connected to the same consumer vertices. Therefore, we can update partition info of the entire ConsumedPartitionGroup in batch, rather than one by one. This will decrease the complexity from O(N^2) to O(N).*


## Brief change log

  - *Make Execution#updatePartitionConsumers update the partition info of IntermediateResultPartitions in batch*
  - *Optimize Execution#finishPartitionsAndUpdateConsumers will firstly calculate the connections between ConsumerVertexGroups and IntermediateResultPartitions, then update partition info for each pair of them*

## Verifying this change

*Since this optimization does not change the original logic of Execution#finishPartitionsAndUpdateConsumers, we believe that this change is already covered by existing tests, like ExecutionPartitionLifecycleTest, DefaultExecutionGraphDeploymentTest, and etc.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
