### PR TITLE
[FLINK-21920] Optimize DefaultScheduler#allocateSlots

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/LocalInputPreferredSlotSharingStrategy.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
@@ -214,7 +215,10 @@ class LocalInputPreferredSlotSharingStrategy implements SlotSharingStrategy {
 
             final ExecutionVertexID executionVertexId = executionVertex.getId();
 
-            for (SchedulingResultPartition partition : executionVertex.getConsumedResults()) {
+            for (ConsumedPartitionGroup consumedPartitionGroup :
+                    executionVertex.getConsumedPartitionGroups()) {
+                final SchedulingResultPartition partition =
+                        topology.getResultPartition(consumedPartitionGroup.getFirst());
                 final ExecutionVertexID producerVertexId = partition.getProducer().getId();
                 if (!inSameLogicalSlotSharingGroup(producerVertexId, executionVertexId)) {
                     continue;


### PR DESCRIPTION
## What is the purpose of the change

*Based on the scheduler benchmark introduced in FLINK-21731, we find that there are two procedures related to DefaultScheduler#allocateSlots have O(N^2) complexity:*

- *ExecutionSlotSharingGroupBuilder#tryFindAvailableProducerExecutionSlotSharingGroupFor*
- *ExecutionGraphToInputsLocationsRetrieverAdapter#getConsumedResultPartitionsProducers*

*Based on FLINK-21326, we can replace the usages of consumed partitions with ConsumedPartitionGroup and optimize the complexity from O(N^2) to O(N).*

## Brief change log

  - *Optimize `ExecutionSlotSharingGroupBuilder#tryFindAvailableProducerExecutionSlotSharingGroupFor`*
  - *Optimize `ExecutionGraphToInputsLocationsRetrieverAdapter#getConsumedResultPartitionsProducers`*

## Verifying this change

*Since these optimizations don't change the original logic of related procedures, we believe these changes should be covered by existing test cases, such as `ExecutionGraphToInputsLocationsRetrieverAdapterTest`, `LocalInputPreferredSlotSharingStrategyTest`, and etc.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
