### PR TITLE
[FLINK-21989][table] Add a SupportsSourceWatermark ability interface

### DIFF
--- a/docs/content.zh/docs/dev/table/sourcesSinks.md
+++ b/docs/content.zh/docs/dev/table/sourcesSinks.md
@@ -228,6 +228,13 @@ will be called with values for the given lookup keys during runtime.
         strategy is a builder/factory for timestamp extraction and watermark generation. During the runtime, the
         watermark generator is located inside the source and is able to generate per-partition watermarks.</td>
     </tr>
+    <tr>
+        <td><a href='https://github.com/apache/flink/blob/master/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsSourceWatermark.java'>SupportsSourceWatermark</a></td>
+        <td>Enables to fully rely on the watermark strategy provided by the <code>ScanTableSource</code>
+        itself. Thus, a <code>CREATE TABLE</code> DDL is able to use <code>SOURCE_WATERMARK()</code> which
+        is a built-in marker function that will be detected by the planner and translated into a call
+        to this interface if available.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/dev/table/sourcesSinks.md
+++ b/docs/content/docs/dev/table/sourcesSinks.md
@@ -228,6 +228,13 @@ will be called with values for the given lookup keys during runtime.
         strategy is a builder/factory for timestamp extraction and watermark generation. During the runtime, the
         watermark generator is located inside the source and is able to generate per-partition watermarks.</td>
     </tr>
+    <tr>
+        <td><a href='https://github.com/apache/flink/blob/master/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsSourceWatermark.java'>SupportsSourceWatermark</a></td>
+        <td>Enables to fully rely on the watermark strategy provided by the <code>ScanTableSource</code>
+        itself. Thus, a <code>CREATE TABLE</code> DDL is able to use <code>SOURCE_WATERMARK()</code> which
+        is a built-in marker function that will be detected by the planner and translated into a call
+        to this interface if available.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.types.RowKind;
 
@@ -49,6 +50,7 @@ import java.io.Serializable;
  *
  * <ul>
  *   <li>{@link SupportsWatermarkPushDown}
+ *   <li>{@link SupportsSourceWatermark}
  *   <li>{@link SupportsFilterPushDown}
  *   <li>{@link SupportsAggregatePushDown}
  *   <li>{@link SupportsProjectionPushDown}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsSourceWatermark.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsSourceWatermark.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+/**
+ * Enables to fully rely on the watermark strategy provided by the {@link ScanTableSource} itself.
+ *
+ * <p>The concept of watermarks defines when time operations based on an event time attribute will
+ * be triggered. A watermark tells operators that no elements with a timestamp older or equal to the
+ * watermark timestamp should arrive at the operator. Thus, watermarks are a trade-off between
+ * latency and completeness.
+ *
+ * <p>Given the following SQL:
+ *
+ * <pre>{@code
+ * CREATE TABLE t (i INT, ts TIMESTAMP(3), WATERMARK FOR ts AS SOURCE_WATERMARK())  // `ts` becomes a time attribute
+ * }</pre>
+ *
+ * <p>In the above example, the {@code SOURCE_WATERMARK()} is a built-in marker function that will
+ * be detected by the planner and translated into a call to this interface if available. If a source
+ * does not implement this interface, an exception will be thrown.
+ *
+ * <p>Compared to {@link SupportsWatermarkPushDown}, it is not possible to influence a source's
+ * watermark strategy using customs expressions if {@code SOURCE_WATERMARK()} is declared.
+ * Nevertheless, a source can implement both interfaces if necessary.
+ *
+ * @see SupportsWatermarkPushDown
+ */
+@PublicEvolving
+public interface SupportsSourceWatermark {
+
+    /** Instructs the source to emit source-specific watermarks during runtime. */
+    void applySourceWatermark();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
@@ -58,6 +58,8 @@ import org.apache.flink.table.data.RowData;
  *
  * <p>This interface provides a {@link WatermarkStrategy} that needs to be applied to the runtime
  * implementation. Most built-in Flink sources provide a way of setting the watermark generator.
+ *
+ * @see SupportsSourceWatermark
  */
 @PublicEvolving
 public interface SupportsWatermarkPushDown {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
@@ -39,7 +39,8 @@ import java.util.Optional;
     @JsonSubTypes.Type(value = PartitionPushDownSpec.class),
     @JsonSubTypes.Type(value = ProjectPushDownSpec.class),
     @JsonSubTypes.Type(value = ReadingMetadataSpec.class),
-    @JsonSubTypes.Type(value = WatermarkPushDownSpec.class)
+    @JsonSubTypes.Type(value = WatermarkPushDownSpec.class),
+    @JsonSubTypes.Type(value = SourceWatermarkSpec.class)
 })
 @Internal
 public interface SourceAbilitySpec {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceWatermarkSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceWatermarkSpec.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.abilities.source;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+/**
+ * A sub-class of {@link SourceAbilitySpec} that can not only serialize/deserialize the boolean flag
+ * whether a source watermark should be used to/from JSON, but can also apply it to {@link
+ * SupportsSourceWatermark}.
+ */
+@JsonTypeName("SourceWatermark")
+public class SourceWatermarkSpec extends SourceAbilitySpecBase {
+    public static final String FIELD_NAME_SOURCE_WATERMARK_ENABLED = "sourceWatermarkEnabled";
+
+    @JsonProperty(FIELD_NAME_SOURCE_WATERMARK_ENABLED)
+    private final boolean sourceWatermarkEnabled;
+
+    @JsonCreator
+    public SourceWatermarkSpec(
+            @JsonProperty(FIELD_NAME_SOURCE_WATERMARK_ENABLED) boolean sourceWatermarkEnabled,
+            @JsonProperty(FIELD_NAME_PRODUCED_TYPE) RowType producedType) {
+        super(producedType);
+        this.sourceWatermarkEnabled = sourceWatermarkEnabled;
+    }
+
+    @Override
+    public void apply(DynamicTableSource tableSource, SourceAbilityContext context) {
+        if (tableSource instanceof SupportsSourceWatermark) {
+            if (sourceWatermarkEnabled) {
+                ((SupportsSourceWatermark) tableSource).applySourceWatermark();
+            }
+        } else {
+            throw new TableException(
+                    String.format(
+                            "%s does not support SupportsSourceWatermark.",
+                            tableSource.getClass().getName()));
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -58,6 +58,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.ResolvedExpression;
@@ -910,7 +911,8 @@ public final class TestValuesTableFactory
 
     /** Values {@link ScanTableSource} for testing that supports watermark push down. */
     private static class TestValuesScanTableSourceWithWatermarkPushDown
-            extends TestValuesScanTableSource implements SupportsWatermarkPushDown {
+            extends TestValuesScanTableSource
+            implements SupportsWatermarkPushDown, SupportsSourceWatermark {
         private final String tableName;
 
         private WatermarkStrategy<RowData> watermarkStrategy;
@@ -951,6 +953,11 @@ public final class TestValuesTableFactory
         @Override
         public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
             this.watermarkStrategy = watermarkStrategy;
+        }
+
+        @Override
+        public void applySourceWatermark() {
+            this.watermarkStrategy = WatermarkStrategy.noWatermarks();
         }
 
         @Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.planner.plan.abilities.source.LimitPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.PartitionPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.ProjectPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.ReadingMetadataSpec;
+import org.apache.flink.table.planner.plan.abilities.source.SourceWatermarkSpec;
 import org.apache.flink.table.planner.plan.abilities.source.WatermarkPushDownSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -236,6 +237,14 @@ public class DynamicTableSourceSpecSerdeTest {
                                                                 TimeUnit.SECOND,
                                                                 SqlParserPos.ZERO))),
                                         5000,
+                                        RowType.of(
+                                                new BigIntType(),
+                                                new IntType(),
+                                                new IntType(),
+                                                new TimestampType(
+                                                        false, TimestampKind.ROWTIME, 3))),
+                                new SourceWatermarkSpec(
+                                        true,
                                         RowType.of(
                                                 new BigIntType(),
                                                 new IntType(),

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -191,4 +191,22 @@ Calc(select=[PROCTIME_MATERIALIZE(ptime) AS ptime, name, val, id])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTableSourceWithSourceWatermarks">
+    <Resource name="sql">
+      <![CDATA[SELECT rowtime, id, name, val FROM rowTimeT]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(rowtime=[$1], id=[$0], name=[$3], val=[$2])
++- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[SOURCE_WATERMARK()])
+   +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[rowtime, id, name, val])
++- TableSourceScan(table=[[default_catalog, default_database, rowTimeT, watermark=[SOURCE_WATERMARK()]]], fields=[id, rowtime, val, name])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -18,9 +18,8 @@
 
 package org.apache.flink.table.planner.plan.stream.sql
 
-import org.apache.flink.core.testutils.FlinkMatchers
 import org.apache.flink.core.testutils.FlinkMatchers.containsMessage
-import org.apache.flink.table.api.{TableException, ValidationException}
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.utils._
 
 import org.junit.Test
@@ -42,6 +41,28 @@ class TableSourceTest extends TableTestBase {
          |) WITH (
          |  'connector' = 'values',
          |  'bounded' = 'false'
+         |)
+       """.stripMargin
+    util.tableEnv.executeSql(ddl)
+
+    util.verifyExecPlan("SELECT rowtime, id, name, val FROM rowTimeT")
+  }
+
+  @Test
+  def testTableSourceWithSourceWatermarks(): Unit = {
+    val ddl =
+      s"""
+         |CREATE TABLE rowTimeT (
+         |  id INT,
+         |  rowtime TIMESTAMP(3),
+         |  val BIGINT,
+         |  name VARCHAR(32),
+         |  WATERMARK FOR rowtime AS SOURCE_WATERMARK()
+         |) WITH (
+         |  'connector' = 'values',
+         |  'bounded' = 'false',
+         |  'disable-lookup' = 'true',
+         |  'enable-watermark-push-down' = 'true'
          |)
        """.stripMargin
     util.tableEnv.executeSql(ddl)

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/scalar/SourceWatermarkFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/scalar/SourceWatermarkFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.functions.scalar;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
@@ -31,10 +32,14 @@ import javax.annotation.Nullable;
 public class SourceWatermarkFunction extends BuiltInScalarFunction {
 
     public static final String ERROR_MESSAGE =
-            "SOURCE_WATERMARK() is a declarative function and doesn't have concrete implementation. "
-                    + "It should only be used in WATERMARK FOR clause in CREATE TABLE DDL. "
-                    + "It must be pushed down into source and the source should emit system defined watermarks. "
-                    + "Please check the source connector implementation.";
+            String.format(
+                    "SOURCE_WATERMARK() is a declarative marker function and doesn't have concrete "
+                            + "runtime implementation. It can only be used as a single expression in a "
+                            + "WATERMARK FOR clause in the CREATE TABLE DDL. The declaration will be "
+                            + "pushed down into a table source that implements the '%s' interface. "
+                            + "The source will emit system-defined watermarks afterwards. Please "
+                            + "check the documentation whether the connector supports source watermarks.",
+                    SupportsSourceWatermark.class.getName());
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
## What is the purpose of the change

Enables to fully rely on the watermark strategy provided by the ScanTableSource itself.

## Brief change log

- Add a SupportsSourceWatermark ability interface
- Add ability spec
- Change planner rules

## Verifying this change

This change added tests and can be verified as follows: `TableSourceTest`

A full integration test will follow in one of the next PRs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs