### PR TITLE
[FLINK-21609][tests] Remove usage of LocalCollectionOutpuFormat from SimpleRecoveryITCaseBase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -43,7 +43,7 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
         Configuration config = new Configuration();
         config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
         config.setInteger(
-                RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
+                RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 3);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL,
                 Duration.ofSeconds(1));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
@@ -42,7 +42,7 @@ public class SimpleRecoveryFixedDelayRestartStrategyITBase extends SimpleRecover
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
         config.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
-        config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+        config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 3);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofMillis(100));
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -23,8 +23,11 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -38,6 +41,14 @@ import static org.junit.Assert.fail;
  */
 @SuppressWarnings("serial")
 public abstract class SimpleRecoveryITCaseBase extends TestLogger {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER_WITH_CLIENT_RESOURCE =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(4)
+                            .setNumberSlotsPerTaskManager(1)
+                            .build());
 
     @Test
     public void testFailedRunThenSuccessfulRun() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -130,7 +130,6 @@ public abstract class SimpleRecoveryITCaseBase extends TestLogger {
             ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
             env.setParallelism(4);
-            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 100));
 
             List<Long> resultCollection =
                     env.generateSequence(1, 10)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -18,23 +18,18 @@
 
 package org.apache.flink.test.recovery;
 
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -48,8 +43,6 @@ public abstract class SimpleRecoveryITCaseBase extends TestLogger {
     public void testFailedRunThenSuccessfulRun() throws Exception {
 
         try {
-            List<Long> resultCollection = new ArrayList<>();
-
             // attempt 1
             {
                 ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
@@ -57,19 +50,13 @@ public abstract class SimpleRecoveryITCaseBase extends TestLogger {
                 env.setParallelism(4);
                 env.setRestartStrategy(RestartStrategies.noRestart());
 
-                env.generateSequence(1, 10)
-                        .rebalance()
-                        .map(new FailingMapper1<>())
-                        .reduce(Long::sum)
-                        .output(new LocalCollectionOutputFormat<>(resultCollection));
-
                 try {
-                    JobExecutionResult res = env.execute();
-                    String msg =
-                            res == null
-                                    ? "null result"
-                                    : "result in " + res.getNetRuntime() + " ms";
-                    fail("The program should have failed, but returned " + msg);
+                    env.generateSequence(1, 10)
+                            .rebalance()
+                            .map(new FailingMapper1<>())
+                            .reduce(Long::sum)
+                            .collect();
+                    fail("The program should have failed, but run successfully");
                 } catch (JobExecutionException e) {
                     // expected
                 }
@@ -82,13 +69,12 @@ public abstract class SimpleRecoveryITCaseBase extends TestLogger {
                 env.setParallelism(4);
                 env.setRestartStrategy(RestartStrategies.noRestart());
 
-                env.generateSequence(1, 10)
-                        .rebalance()
-                        .map(new FailingMapper1<>())
-                        .reduce((ReduceFunction<Long>) Long::sum)
-                        .output(new LocalCollectionOutputFormat<>(resultCollection));
-
-                executeAndRunAssertions(env);
+                List<Long> resultCollection =
+                        env.generateSequence(1, 10)
+                                .rebalance()
+                                .map(new FailingMapper1<>())
+                                .reduce((ReduceFunction<Long>) Long::sum)
+                                .collect();
 
                 long sum = 0;
                 for (long l : resultCollection) {
@@ -102,34 +88,20 @@ public abstract class SimpleRecoveryITCaseBase extends TestLogger {
         }
     }
 
-    private void executeAndRunAssertions(ExecutionEnvironment env) throws Exception {
-        try {
-            JobExecutionResult result = env.execute();
-            assertTrue(result.getNetRuntime() >= 0);
-            assertNotNull(result.getAllAccumulatorResults());
-            assertTrue(result.getAllAccumulatorResults().isEmpty());
-        } catch (JobExecutionException e) {
-            throw new AssertionError("The program should have succeeded on the second run", e);
-        }
-    }
-
     @Test
     public void testRestart() throws Exception {
         try {
-            List<Long> resultCollection = new ArrayList<>();
-
             ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
             env.setParallelism(4);
             // the default restart strategy should be taken
 
-            env.generateSequence(1, 10)
-                    .rebalance()
-                    .map(new FailingMapper2<>())
-                    .reduce(Long::sum)
-                    .output(new LocalCollectionOutputFormat<>(resultCollection));
-
-            executeAndRunAssertions(env);
+            List<Long> resultCollection =
+                    env.generateSequence(1, 10)
+                            .rebalance()
+                            .map(new FailingMapper2<>())
+                            .reduce(Long::sum)
+                            .collect();
 
             long sum = 0;
             for (long l : resultCollection) {
@@ -144,20 +116,17 @@ public abstract class SimpleRecoveryITCaseBase extends TestLogger {
     @Test
     public void testRestartMultipleTimes() throws Exception {
         try {
-            List<Long> resultCollection = new ArrayList<>();
-
             ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
             env.setParallelism(4);
             env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 100));
 
-            env.generateSequence(1, 10)
-                    .rebalance()
-                    .map(new FailingMapper3<>())
-                    .reduce(Long::sum)
-                    .output(new LocalCollectionOutputFormat<>(resultCollection));
-
-            executeAndRunAssertions(env);
+            List<Long> resultCollection =
+                    env.generateSequence(1, 10)
+                            .rebalance()
+                            .map(new FailingMapper3<>())
+                            .reduce(Long::sum)
+                            .collect();
 
             long sum = 0;
             for (long l : resultCollection) {


### PR DESCRIPTION
The LocalCollectionOutputFormat does not work well together with restarts because it records results
from different attempts. Hence, instead of using this format we now use the collect() call in the
SimpleRecoveryITCaseBase.