### PR TITLE
[FLINK-21980][Runtime/Coordination] ZooKeeperRunningJobsRegistry creates an empty znode

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperRegistryTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.highavailability.RunningJobsRegistry.JobScheduli
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
+
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
@@ -53,7 +55,7 @@ public class ZooKeeperRegistryTest extends TestLogger {
 
     /**
      * Tests that the function of ZookeeperRegistry, setJobRunning(), setJobFinished(),
-     * isJobRunning()
+     * isJobRunning().
      */
     @Test
     public void testZooKeeperRegistry() throws Exception {
@@ -62,12 +64,11 @@ public class ZooKeeperRegistryTest extends TestLogger {
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
         configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
+        final CuratorFramework zkClient = ZooKeeperUtils.startCuratorFramework(configuration);
+
         final HighAvailabilityServices zkHaService =
                 new ZooKeeperHaServices(
-                        ZooKeeperUtils.startCuratorFramework(configuration),
-                        Executors.directExecutor(),
-                        configuration,
-                        new VoidBlobStore());
+                        zkClient, Executors.directExecutor(), configuration, new VoidBlobStore());
 
         final RunningJobsRegistry zkRegistry = zkHaService.getRunningJobsRegistry();
 
@@ -75,16 +76,21 @@ public class ZooKeeperRegistryTest extends TestLogger {
             JobID jobID = JobID.generate();
             assertEquals(JobSchedulingStatus.PENDING, zkRegistry.getJobSchedulingStatus(jobID));
 
+            // set when znode does not exist for job
             zkRegistry.setJobRunning(jobID);
             assertEquals(JobSchedulingStatus.RUNNING, zkRegistry.getJobSchedulingStatus(jobID));
 
+            // set when znode does exist for job
             zkRegistry.setJobFinished(jobID);
             assertEquals(JobSchedulingStatus.DONE, zkRegistry.getJobSchedulingStatus(jobID));
 
             zkRegistry.clearJob(jobID);
             assertEquals(JobSchedulingStatus.PENDING, zkRegistry.getJobSchedulingStatus(jobID));
+
+            // clear when znode does not exist for job
+            zkRegistry.clearJob(jobID);
         } finally {
-            zkHaService.close();
+            zkHaService.closeAndCleanupAllData();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This removes a race condition in which the ZooKeeperRunningJobsRegistry leaves Zookeeper with a znode in the `running_job_registry` with an empty value, resulting in the Job Manager failing on subsequent restart due to a test in ZooKeeperRunningJobsRegistry#getJobSchedulingStatus throwing an exception on the empty value.

## Brief change log

ZooKeeperRunningJobsRegistry no longer uses `newNamespaceAwareEnsurePath` to ensure the path exists. 

## Verifying this change

This change is already covered by existing tests. `ZooKeeperRegistryTest#testZooKeeperRegistry` verifies that functionality is unchanged.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
