### PR TITLE
[hotfix][format] package format-common to flink-csv and flink-json

### DIFF
--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -100,6 +100,31 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-format-common</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 	<profiles>
 		<!-- Create SQL Client uber jars by default -->
 		<profile>
@@ -113,15 +138,21 @@ under the License.
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-jar-plugin</artifactId>
+						<artifactId>maven-shade-plugin</artifactId>
 						<executions>
 							<execution>
 								<phase>package</phase>
 								<goals>
-									<goal>jar</goal>
+									<goal>shade</goal>
 								</goals>
 								<configuration>
-									<classifier>sql-jar</classifier>
+									<artifactSet>
+										<includes>
+											<include>org.apache.flink:flink-format-common</include>
+										</includes>
+									</artifactSet>
+									<shadedArtifactAttached>true</shadedArtifactAttached>
+									<shadedClassifierName>sql-jar</shadedClassifierName>
 								</configuration>
 							</execution>
 						</executions>

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -108,6 +108,31 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-format-common</include>
+								</includes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 	<profiles>
 		<!-- Create SQL Client uber jars by default -->
 		<profile>
@@ -121,15 +146,21 @@ under the License.
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-jar-plugin</artifactId>
+						<artifactId>maven-shade-plugin</artifactId>
 						<executions>
 							<execution>
 								<phase>package</phase>
 								<goals>
-									<goal>jar</goal>
+									<goal>shade</goal>
 								</goals>
 								<configuration>
-									<classifier>sql-jar</classifier>
+									<artifactSet>
+										<includes>
+											<include>org.apache.flink:flink-format-common</include>
+										</includes>
+									</artifactSet>
+									<shadedArtifactAttached>true</shadedArtifactAttached>
+									<shadedClassifierName>sql-jar</shadedClassifierName>
 								</configuration>
 							</execution>
 						</executions>
@@ -138,4 +169,5 @@ under the License.
 			</build>
 		</profile>
 	</profiles>
+
 </project>


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix that flink-csv and flink-json does not package the format-common moudule

## Brief change log

  -  update the pom.xml for flink-csv and flink-json


## Verifying this change

- validate in local with `jar -tvf ` command, cover it in current e2e tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
