### PR TITLE
[FLINK-15146][core][ttl] Fix check that incremental cleanup size must be greater than zero

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -413,8 +413,8 @@ public class StateTtlConfig implements Serializable {
 
         private IncrementalCleanupStrategy(int cleanupSize, boolean runCleanupForEveryRecord) {
             Preconditions.checkArgument(
-                    cleanupSize >= 0,
-                    "Number of incrementally cleaned up state entries cannot be negative.");
+                    cleanupSize > 0,
+                    "Number of incrementally cleaned up state entries should be positive.");
             this.cleanupSize = cleanupSize;
             this.runCleanupForEveryRecord = runCleanupForEveryRecord;
         }

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/StateTtlConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/StateTtlConfigTest.java
@@ -22,7 +22,11 @@ import org.apache.flink.api.common.state.StateTtlConfig.IncrementalCleanupStrate
 import org.apache.flink.api.common.state.StateTtlConfig.RocksdbCompactFilterCleanupStrategy;
 import org.apache.flink.api.common.time.Time;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -70,5 +74,21 @@ public class StateTtlConfigTest {
         assertThat(incrementalCleanupStrategy.getCleanupSize(), is(5));
         assertThat(incrementalCleanupStrategy.runCleanupForEveryRecord(), is(false));
         assertThat(rocksdbCleanupStrategy.getQueryTimeAfterNumEntries(), is(1000L));
+    }
+
+    @Test
+    public void testStateTtlConfigBuildWithNonPositiveCleanupIncrementalSize() {
+        List<Integer> illegalCleanUpSizes = Arrays.asList(0, -2);
+
+        for (Integer illegalCleanUpSize : illegalCleanUpSizes) {
+            try {
+                StateTtlConfig ttlConfig =
+                        StateTtlConfig.newBuilder(Time.seconds(1))
+                                .cleanupIncrementally(illegalCleanUpSize, false)
+                                .build();
+                Assert.fail();
+            } catch (IllegalArgumentException e) {
+            }
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

[ahead pr](https://github.com/apache/flink/pull/10507)

At the moment, we allow zero value for the TTL incremental cleanup size.
Although technically zero value will not break the cleanup but practically there will be no cleanup.
We change cleanupSize to be strictly greater than zero to avoid confusion.
![image](https://user-images.githubusercontent.com/18002496/70502733-98a34700-1b5c-11ea-8b68-88b8ac4f1c80.png)
![image](https://user-images.githubusercontent.com/18002496/70502745-9fca5500-1b5c-11ea-89fd-a1bc2486cc1c.png)



