### PR TITLE
[FLINK-21008][coordination] Register ClusterEntrypoint#closeAsync as shutdown hook for the cleanup

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -22,50 +22,417 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStore;
+import org.apache.flink.runtime.dispatcher.MemoryExecutionGraphInfoStore;
+import org.apache.flink.runtime.dispatcher.PartialDispatcherServices;
+import org.apache.flink.runtime.dispatcher.runner.DispatcherRunner;
+import org.apache.flink.runtime.dispatcher.runner.DispatcherRunnerFactory;
+import org.apache.flink.runtime.dispatcher.runner.TestingDispatcherRunner;
+import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServicesBuilder;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
+import org.apache.flink.runtime.jobmanager.JobGraphStoreFactory;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.ArbitraryWorkerResourceSpecFactory;
+import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
+import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServices;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesConfiguration;
+import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
+import org.apache.flink.runtime.resourcemanager.TestingJobLeaderIdService;
+import org.apache.flink.runtime.resourcemanager.TestingResourceManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
+import org.apache.flink.runtime.rest.SessionRestEndpointFactory;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.testutils.TestJvmProcess;
+import org.apache.flink.runtime.testutils.TestingClusterEntrypointProcess;
+import org.apache.flink.runtime.util.SignalHandler;
+import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
 
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import javax.annotation.Nullable;
+
+import java.io.File;
 import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 /** Tests for the {@link ClusterEntrypoint}. */
-public class ClusterEntrypointTest {
+public class ClusterEntrypointTest extends TestLogger {
+
+    private static final long TIMEOUT_MS = 3000;
+
+    private Configuration flinkConfig;
+
+    @ClassRule
+    public static final TestExecutorResource<?> TEST_EXECUTOR_RESOURCE =
+            new TestExecutorResource<>(Executors::newSingleThreadExecutor);
+
+    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    @Before
+    public void before() {
+        flinkConfig = new Configuration();
+    }
 
     @Test(expected = IllegalConfigurationException.class)
     public void testStandaloneSessionClusterEntrypointDeniedInReactiveMode() {
-        Configuration configuration = new Configuration();
-        configuration.set(JobManagerOptions.SCHEDULER_MODE, SchedulerExecutionMode.REACTIVE);
-        new MockEntryPoint(configuration);
+        flinkConfig.set(JobManagerOptions.SCHEDULER_MODE, SchedulerExecutionMode.REACTIVE);
+        new TestingEntryPoint.Builder().setConfiguration(flinkConfig).build();
         fail("Entrypoint initialization is supposed to fail");
     }
 
-    private static class MockEntryPoint extends ClusterEntrypoint {
+    @Test
+    public void testCloseAsyncShouldNotCleanUpHAData() throws Exception {
+        final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+        final CompletableFuture<Void> closeAndCleanupAllDataFuture = new CompletableFuture<>();
+        final HighAvailabilityServices testingHaService =
+                new TestingHighAvailabilityServicesBuilder()
+                        .setCloseFuture(closeFuture)
+                        .setCloseAndCleanupAllDataFuture(closeAndCleanupAllDataFuture)
+                        .build();
+        final TestingEntryPoint testingEntryPoint =
+                new TestingEntryPoint.Builder()
+                        .setConfiguration(flinkConfig)
+                        .setHighAvailabilityServices(testingHaService)
+                        .build();
 
-        protected MockEntryPoint(Configuration configuration) {
+        final CompletableFuture<ApplicationStatus> appStatusFuture =
+                startClusterEntrypoint(testingEntryPoint);
+
+        testingEntryPoint.closeAsync();
+        assertThat(
+                appStatusFuture.get(TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                is(ApplicationStatus.UNKNOWN));
+        assertThat(closeFuture.isDone(), is(true));
+        assertThat(closeAndCleanupAllDataFuture.isDone(), is(false));
+    }
+
+    @Test
+    public void testCloseAsyncShouldNotDeregisterApp() throws Exception {
+        final CompletableFuture<Void> deregisterFuture = new CompletableFuture<>();
+        final TestingResourceManagerFactory testingResourceManagerFactory =
+                new TestingResourceManagerFactory.Builder()
+                        .setInternalDeregisterApplicationConsumer(
+                                (ignored1, ignored2) -> deregisterFuture.complete(null))
+                        .build();
+        final TestingEntryPoint testingEntryPoint =
+                new TestingEntryPoint.Builder()
+                        .setConfiguration(flinkConfig)
+                        .setResourceManagerFactory(testingResourceManagerFactory)
+                        .build();
+
+        final CompletableFuture<ApplicationStatus> appStatusFuture =
+                startClusterEntrypoint(testingEntryPoint);
+
+        testingEntryPoint.closeAsync();
+        assertThat(
+                appStatusFuture.get(TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                is(ApplicationStatus.UNKNOWN));
+        assertThat(deregisterFuture.isDone(), is(false));
+    }
+
+    @Test
+    public void testClusterFinishedNormallyShouldDeregisterAppAndCleanupHAData() throws Exception {
+        final CompletableFuture<Void> deregisterFuture = new CompletableFuture<>();
+        final CompletableFuture<Void> closeAndCleanupAllDataFuture = new CompletableFuture<>();
+        final CompletableFuture<ApplicationStatus> dispatcherShutDownFuture =
+                new CompletableFuture<>();
+
+        final HighAvailabilityServices testingHaService =
+                new TestingHighAvailabilityServicesBuilder()
+                        .setCloseAndCleanupAllDataFuture(closeAndCleanupAllDataFuture)
+                        .build();
+        final TestingResourceManagerFactory testingResourceManagerFactory =
+                new TestingResourceManagerFactory.Builder()
+                        .setInternalDeregisterApplicationConsumer(
+                                (ignored1, ignored2) -> deregisterFuture.complete(null))
+                        .build();
+        final TestingDispatcherRunnerFactory testingDispatcherRunnerFactory =
+                new TestingDispatcherRunnerFactory.Builder()
+                        .setShutDownFuture(dispatcherShutDownFuture)
+                        .build();
+
+        final TestingEntryPoint testingEntryPoint =
+                new TestingEntryPoint.Builder()
+                        .setConfiguration(flinkConfig)
+                        .setResourceManagerFactory(testingResourceManagerFactory)
+                        .setDispatcherRunnerFactory(testingDispatcherRunnerFactory)
+                        .setHighAvailabilityServices(testingHaService)
+                        .build();
+
+        final CompletableFuture<ApplicationStatus> appStatusFuture =
+                startClusterEntrypoint(testingEntryPoint);
+
+        dispatcherShutDownFuture.complete(ApplicationStatus.SUCCEEDED);
+
+        assertThat(
+                appStatusFuture.get(TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                is(ApplicationStatus.SUCCEEDED));
+        assertThat(deregisterFuture.isDone(), is(true));
+        assertThat(closeAndCleanupAllDataFuture.isDone(), is(true));
+    }
+
+    @Test
+    public void testCloseAsyncShouldBeExecutedInShutdownHook() throws Exception {
+        // This test only works on Linux and Mac OS because we are sending SIGTERM to a
+        // JAVA process via "kill {pid}"
+        assumeTrue(OperatingSystem.isLinux() || OperatingSystem.isMac());
+        final File markerFile = new File(TEMPORARY_FOLDER.getRoot(), UUID.randomUUID() + ".marker");
+        final TestingClusterEntrypointProcess clusterEntrypointProcess =
+                new TestingClusterEntrypointProcess(markerFile);
+        try {
+            clusterEntrypointProcess.startProcess();
+            final long pid = clusterEntrypointProcess.getProcessId();
+            assertTrue("Cannot determine process ID", pid != -1);
+
+            // wait for the marker file to appear, which means the process is up properly
+            TestJvmProcess.waitForMarkerFile(markerFile, 30000);
+
+            TestJvmProcess.killProcessWithSigTerm(pid);
+
+            final boolean exited =
+                    clusterEntrypointProcess.waitFor(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            assertThat(
+                    String.format("Process %s does not exit within %s ms", pid, TIMEOUT_MS),
+                    exited,
+                    is(true));
+            assertThat(
+                    "markerFile should be deleted in closeAsync shutdownHook",
+                    markerFile.exists(),
+                    is(false));
+        } finally {
+            clusterEntrypointProcess.destroy();
+        }
+    }
+
+    private CompletableFuture<ApplicationStatus> startClusterEntrypoint(
+            TestingEntryPoint testingEntryPoint) throws Exception {
+        testingEntryPoint.startCluster();
+        return FutureUtils.supplyAsync(
+                () -> testingEntryPoint.getTerminationFuture().get(),
+                TEST_EXECUTOR_RESOURCE.getExecutor());
+    }
+
+    private static class TestingEntryPoint extends ClusterEntrypoint {
+
+        private final HighAvailabilityServices haService;
+
+        private final ResourceManagerFactory<ResourceID> resourceManagerFactory;
+
+        private final DispatcherRunnerFactory dispatcherRunnerFactory;
+
+        private TestingEntryPoint(
+                Configuration configuration,
+                HighAvailabilityServices haService,
+                ResourceManagerFactory<ResourceID> resourceManagerFactory,
+                DispatcherRunnerFactory dispatcherRunnerFactory) {
             super(configuration);
+            SignalHandler.register(LOG);
+            this.haService = haService;
+            this.resourceManagerFactory = resourceManagerFactory;
+            this.dispatcherRunnerFactory = dispatcherRunnerFactory;
         }
 
         @Override
         protected DispatcherResourceManagerComponentFactory
                 createDispatcherResourceManagerComponentFactory(Configuration configuration)
                         throws IOException {
-            throw new UnsupportedOperationException("Not needed for this test");
+            return new DefaultDispatcherResourceManagerComponentFactory(
+                    dispatcherRunnerFactory,
+                    resourceManagerFactory,
+                    SessionRestEndpointFactory.INSTANCE);
         }
 
         @Override
         protected ExecutionGraphInfoStore createSerializableExecutionGraphStore(
-                Configuration configuration, ScheduledExecutor scheduledExecutor)
-                throws IOException {
-            throw new UnsupportedOperationException("Not needed for this test");
+                Configuration configuration, ScheduledExecutor scheduledExecutor) {
+            return new MemoryExecutionGraphInfoStore();
+        }
+
+        @Override
+        protected HighAvailabilityServices createHaServices(
+                Configuration configuration, Executor executor) {
+            return haService;
         }
 
         @Override
         protected boolean supportsReactiveMode() {
             return false;
+        }
+
+        public static final class Builder {
+            private HighAvailabilityServices haService =
+                    new TestingHighAvailabilityServicesBuilder().build();
+
+            private ResourceManagerFactory<ResourceID> resourceManagerFactory =
+                    StandaloneResourceManagerFactory.getInstance();
+
+            private DispatcherRunnerFactory dispatcherRunnerFactory =
+                    new TestingDispatcherRunnerFactory.Builder().build();
+
+            private Configuration configuration = new Configuration();
+
+            public Builder setHighAvailabilityServices(HighAvailabilityServices haService) {
+                this.haService = haService;
+                return this;
+            }
+
+            public Builder setResourceManagerFactory(
+                    ResourceManagerFactory<ResourceID> resourceManagerFactory) {
+                this.resourceManagerFactory = resourceManagerFactory;
+                return this;
+            }
+
+            public Builder setConfiguration(Configuration configuration) {
+                this.configuration = configuration;
+                return this;
+            }
+
+            public Builder setDispatcherRunnerFactory(
+                    DispatcherRunnerFactory dispatcherRunnerFactory) {
+                this.dispatcherRunnerFactory = dispatcherRunnerFactory;
+                return this;
+            }
+
+            public TestingEntryPoint build() {
+                return new TestingEntryPoint(
+                        configuration, haService, resourceManagerFactory, dispatcherRunnerFactory);
+            }
+        }
+    }
+
+    private static class TestingDispatcherRunnerFactory implements DispatcherRunnerFactory {
+
+        private final CompletableFuture<ApplicationStatus> shutDownFuture;
+
+        private TestingDispatcherRunnerFactory(
+                CompletableFuture<ApplicationStatus> shutDownFuture) {
+            this.shutDownFuture = shutDownFuture;
+        }
+
+        @Override
+        public DispatcherRunner createDispatcherRunner(
+                LeaderElectionService leaderElectionService,
+                FatalErrorHandler fatalErrorHandler,
+                JobGraphStoreFactory jobGraphStoreFactory,
+                Executor ioExecutor,
+                RpcService rpcService,
+                PartialDispatcherServices partialDispatcherServices)
+                throws Exception {
+            return TestingDispatcherRunner.newBuilder().setShutDownFuture(shutDownFuture).build();
+        }
+
+        public static final class Builder {
+            private CompletableFuture<ApplicationStatus> shutDownFuture = new CompletableFuture<>();
+
+            public Builder setShutDownFuture(CompletableFuture<ApplicationStatus> shutDownFuture) {
+                this.shutDownFuture = shutDownFuture;
+                return this;
+            }
+
+            public TestingDispatcherRunnerFactory build() {
+                return new TestingDispatcherRunnerFactory(shutDownFuture);
+            }
+        }
+    }
+
+    private static class TestingResourceManagerFactory extends ResourceManagerFactory<ResourceID> {
+
+        private final BiConsumer<ApplicationStatus, String> deregisterAppConsumer;
+
+        private TestingResourceManagerFactory(
+                BiConsumer<ApplicationStatus, String> deregisterAppConsumer) {
+            this.deregisterAppConsumer = deregisterAppConsumer;
+        }
+
+        @Override
+        protected ResourceManager<ResourceID> createResourceManager(
+                Configuration configuration,
+                ResourceID resourceId,
+                RpcService rpcService,
+                HighAvailabilityServices highAvailabilityServices,
+                HeartbeatServices heartbeatServices,
+                FatalErrorHandler fatalErrorHandler,
+                ClusterInformation clusterInformation,
+                @Nullable String webInterfaceUrl,
+                ResourceManagerMetricGroup resourceManagerMetricGroup,
+                ResourceManagerRuntimeServices resourceManagerRuntimeServices,
+                Executor ioExecutor)
+                throws Exception {
+            final SlotManager slotManager =
+                    SlotManagerBuilder.newBuilder()
+                            .setScheduledExecutor(rpcService.getScheduledExecutor())
+                            .build();
+            final JobLeaderIdService jobLeaderIdService =
+                    new TestingJobLeaderIdService.Builder().build();
+            return new TestingResourceManager(
+                    rpcService,
+                    resourceId,
+                    highAvailabilityServices,
+                    heartbeatServices,
+                    slotManager,
+                    NoOpResourceManagerPartitionTracker::get,
+                    jobLeaderIdService,
+                    fatalErrorHandler,
+                    resourceManagerMetricGroup) {
+                @Override
+                protected void internalDeregisterApplication(
+                        ApplicationStatus finalStatus, @Nullable String diagnostics) {
+                    deregisterAppConsumer.accept(finalStatus, diagnostics);
+                }
+            };
+        }
+
+        @Override
+        protected ResourceManagerRuntimeServicesConfiguration
+                createResourceManagerRuntimeServicesConfiguration(Configuration configuration)
+                        throws ConfigurationException {
+            return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(
+                    configuration, ArbitraryWorkerResourceSpecFactory.INSTANCE);
+        }
+
+        public static final class Builder {
+            private BiConsumer<ApplicationStatus, String> deregisterAppConsumer =
+                    (ignore1, ignore2) -> {};
+
+            public Builder setInternalDeregisterApplicationConsumer(
+                    BiConsumer<ApplicationStatus, String> biConsumer) {
+                this.deregisterAppConsumer = biConsumer;
+                return this;
+            }
+
+            public TestingResourceManagerFactory build() {
+                return new TestingResourceManagerFactory(deregisterAppConsumer);
+            }
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -66,6 +67,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
     private volatile JobGraphStore jobGraphStore;
 
     private volatile RunningJobsRegistry runningJobsRegistry = new StandaloneRunningJobsRegistry();
+
+    private CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    private CompletableFuture<Void> closeAndCleanupAllDataFuture = new CompletableFuture<>();
 
     // ------------------------------------------------------------------------
     //  Setters for mock / testing implementations
@@ -129,6 +134,15 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
     public void setJobMasterLeaderRetrieverFunction(
             Function<JobID, LeaderRetrievalService> jobMasterLeaderRetrieverFunction) {
         this.jobMasterLeaderRetrieverFunction = jobMasterLeaderRetrieverFunction;
+    }
+
+    public void setCloseFuture(CompletableFuture<Void> closeFuture) {
+        this.closeFuture = closeFuture;
+    }
+
+    public void setCloseAndCleanupAllDataFuture(
+            CompletableFuture<Void> closeAndCleanupAllDataFuture) {
+        this.closeAndCleanupAllDataFuture = closeAndCleanupAllDataFuture;
     }
 
     // ------------------------------------------------------------------------
@@ -256,11 +270,11 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
     @Override
     public void close() throws Exception {
-        // nothing to do
+        closeFuture.complete(null);
     }
 
     @Override
     public void closeAndCleanupAllData() throws Exception {
-        // nothing to do
+        closeAndCleanupAllDataFuture.complete(null);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServicesBuilder.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.leaderelection.StandaloneLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.StandaloneLeaderRetrievalService;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 /** Builder for the {@link TestingHighAvailabilityServices}. */
@@ -70,6 +71,10 @@ public class TestingHighAvailabilityServicesBuilder {
 
     private RunningJobsRegistry runningJobsRegistry = new StandaloneRunningJobsRegistry();
 
+    private CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    private CompletableFuture<Void> closeAndCleanupAllDataFuture = new CompletableFuture<>();
+
     public TestingHighAvailabilityServices build() {
         final TestingHighAvailabilityServices testingHighAvailabilityServices =
                 new TestingHighAvailabilityServices();
@@ -95,6 +100,10 @@ public class TestingHighAvailabilityServicesBuilder {
         testingHighAvailabilityServices.setCheckpointRecoveryFactory(checkpointRecoveryFactory);
         testingHighAvailabilityServices.setJobGraphStore(jobGraphStore);
         testingHighAvailabilityServices.setRunningJobsRegistry(runningJobsRegistry);
+
+        testingHighAvailabilityServices.setCloseFuture(closeFuture);
+        testingHighAvailabilityServices.setCloseAndCleanupAllDataFuture(
+                closeAndCleanupAllDataFuture);
 
         return testingHighAvailabilityServices;
     }
@@ -161,6 +170,18 @@ public class TestingHighAvailabilityServicesBuilder {
     public TestingHighAvailabilityServicesBuilder setRunningJobsRegistry(
             RunningJobsRegistry runningJobsRegistry) {
         this.runningJobsRegistry = runningJobsRegistry;
+        return this;
+    }
+
+    public TestingHighAvailabilityServicesBuilder setCloseFuture(
+            CompletableFuture<Void> closeFuture) {
+        this.closeFuture = closeFuture;
+        return this;
+    }
+
+    public TestingHighAvailabilityServicesBuilder setCloseAndCleanupAllDataFuture(
+            CompletableFuture<Void> closeAndCleanupAllDataFuture) {
+        this.closeAndCleanupAllDataFuture = closeAndCleanupAllDataFuture;
         return this;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestJvmProcess.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.createTemporaryLog4JProperties;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getCurrentClasspath;
@@ -288,6 +289,15 @@ public abstract class TestJvmProcess {
         }
     }
 
+    public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+        final Process process = this.process;
+        if (process != null) {
+            return process.waitFor(timeout, unit);
+        } else {
+            throw new IllegalStateException("process not started");
+        }
+    }
+
     public int exitCode() {
         Process process = this.process;
         if (process != null) {
@@ -321,6 +331,15 @@ public abstract class TestJvmProcess {
 
         if (!exists) {
             fail("The marker file was not found within " + timeoutMillis + " msecs");
+        }
+    }
+
+    public static void killProcessWithSigTerm(long pid) throws Exception {
+        // send it a regular kill command (SIG_TERM)
+        final Process kill = Runtime.getRuntime().exec("kill " + pid);
+        kill.waitFor();
+        if (kill.exitValue() != 0) {
+            fail("failed to send SIG_TERM to process " + pid);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingClusterEntrypointProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingClusterEntrypointProcess.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStore;
+import org.apache.flink.runtime.dispatcher.MemoryExecutionGraphInfoStore;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
+import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
+import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
+import org.apache.flink.runtime.util.SignalHandler;
+import org.apache.flink.util.IOUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A testing {@link ClusterEntrypoint} instance running in a separate JVM. */
+public class TestingClusterEntrypointProcess extends TestJvmProcess {
+
+    private final File markerFile;
+
+    public TestingClusterEntrypointProcess(File markerFile) throws Exception {
+        this.markerFile = checkNotNull(markerFile, "marker file");
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getCanonicalName();
+    }
+
+    @Override
+    public String[] getJvmArgs() {
+        return new String[] {markerFile.getAbsolutePath()};
+    }
+
+    @Override
+    public String getEntryPointClassName() {
+        return TestingClusterEntrypointProcessEntryPoint.class.getName();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getCanonicalName();
+    }
+
+    /** Entrypoint for the testing cluster entrypoint process. */
+    public static class TestingClusterEntrypointProcessEntryPoint {
+
+        private static final Logger LOG =
+                LoggerFactory.getLogger(TestingClusterEntrypointProcessEntryPoint.class);
+
+        public static void main(String[] args) {
+            try {
+                final File markerFile = new File(args[0]);
+
+                final Configuration config = new Configuration();
+                config.setInteger(JobManagerOptions.PORT, 0);
+                config.setString(RestOptions.BIND_PORT, "0");
+
+                final TestingClusterEntrypoint clusterEntrypoint =
+                        new TestingClusterEntrypoint(config, markerFile);
+
+                SignalHandler.register(LOG);
+                clusterEntrypoint.startCluster();
+                TestJvmProcess.touchFile(markerFile);
+                final int returnCode =
+                        clusterEntrypoint.getTerminationFuture().get().processExitCode();
+                System.exit(returnCode);
+            } catch (Throwable t) {
+                LOG.error("Failed to start TestingClusterEntrypoint process", t);
+                System.exit(1);
+            }
+        }
+    }
+
+    private static class TestingClusterEntrypoint extends ClusterEntrypoint {
+
+        private final File markerFile;
+
+        protected TestingClusterEntrypoint(Configuration configuration, File markerFile) {
+            super(configuration);
+            this.markerFile = markerFile;
+        }
+
+        @Override
+        protected DispatcherResourceManagerComponentFactory
+                createDispatcherResourceManagerComponentFactory(Configuration configuration)
+                        throws IOException {
+            return DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(
+                    StandaloneResourceManagerFactory.getInstance());
+        }
+
+        @Override
+        protected ExecutionGraphInfoStore createSerializableExecutionGraphStore(
+                Configuration configuration, ScheduledExecutor scheduledExecutor)
+                throws IOException {
+            return new MemoryExecutionGraphInfoStore();
+        }
+
+        @Override
+        public CompletableFuture<Void> closeAsync() {
+            return super.closeAsync()
+                    .thenRun(
+                            () -> {
+                                LOG.info("Deleting markerFile {}", markerFile);
+                                IOUtils.deleteFileQuietly(markerFile.toPath());
+                            });
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockingShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockingShutdownTest.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -60,10 +59,7 @@ public class BlockingShutdownTest {
             // wait for the marker file to appear, which means the process is up properly
             TestJvmProcess.waitForMarkerFile(markerFile, 30000);
 
-            // send it a regular kill command (SIG_TERM)
-            Process kill = Runtime.getRuntime().exec("kill " + pid);
-            kill.waitFor();
-            assertEquals("failed to send SIG_TERM to process", 0, kill.exitValue());
+            TestJvmProcess.killProcessWithSigTerm(pid);
 
             // minimal delay until the Java process object notices that the process is gone
             // this will not let the test fail predictably if the process is actually in fact going
@@ -105,10 +101,7 @@ public class BlockingShutdownTest {
             // wait for the marker file to appear, which means the process is up properly
             TestJvmProcess.waitForMarkerFile(markerFile, 30000);
 
-            // send it a regular kill command (SIG_TERM)
-            Process kill = Runtime.getRuntime().exec("kill " + pid);
-            kill.waitFor();
-            assertEquals("failed to send SIG_TERM to process", 0, kill.exitValue());
+            TestJvmProcess.killProcessWithSigTerm(pid);
 
             // the process should eventually go away
             final long deadline = System.nanoTime() + 30_000_000_000L; // 30 secs in nanos

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -219,7 +219,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
                 taskManagerProcess.destroy();
             }
             if (dispatcherResourceManagerComponent != null) {
-                dispatcherResourceManagerComponent.deregisterApplicationAndClose(
+                dispatcherResourceManagerComponent.stopApplication(
                         ApplicationStatus.SUCCEEDED, null);
             }
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -92,7 +92,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
     }
 
     /** Test regular operation, including command line parameter parsing. */
-    void runDetachedModeTest(Map<String, String> securityProperties) throws Exception {
+    ApplicationId runDetachedModeTest(Map<String, String> securityProperties) throws Exception {
         LOG.info("Starting testDetachedMode()");
 
         File exampleJarLocation = getTestJarPath("StreamingWordCount.jar");
@@ -169,10 +169,12 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
                         + ")");
 
         LOG.info("Waiting until the job reaches FINISHED state");
+        final ApplicationId applicationId = getOnlyApplicationReport().getApplicationId();
         CommonTestUtils.waitUntilCondition(
                 () ->
                         verifyStringsInNamedLogFiles(
                                 new String[] {"switched from state RUNNING to FINISHED"},
+                                applicationId,
                                 "jobmanager.log"),
                 Deadline.fromNow(timeout),
                 testConditionIntervalInMillis,
@@ -242,6 +244,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
         }
 
         LOG.info("Finished testDetachedMode()");
+        return applicationId;
     }
 
     /**

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.yarn.util.TestHadoopModuleFactory;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.ResourceScheduler;
@@ -150,8 +151,8 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(),
                                 SecureTestEnvironment.getHadoopServicePrincipal());
                     }
-                    runDetachedModeTest(securityProperties);
-                    verifyResultContainsKerberosKeytab();
+                    final ApplicationId applicationId = runDetachedModeTest(securityProperties);
+                    verifyResultContainsKerberosKeytab(applicationId);
                 });
     }
 
@@ -171,17 +172,18 @@ public class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL.key(),
                                 SecureTestEnvironment.getHadoopServicePrincipal());
                     }
-                    runDetachedModeTest(securityProperties);
-                    verifyResultContainsKerberosKeytab();
+                    final ApplicationId applicationId = runDetachedModeTest(securityProperties);
+                    verifyResultContainsKerberosKeytab(applicationId);
                 });
     }
 
-    private static void verifyResultContainsKerberosKeytab() throws Exception {
+    private static void verifyResultContainsKerberosKeytab(ApplicationId applicationId)
+            throws Exception {
         final String[] mustHave = {"Login successful for user", "using keytab file"};
         final boolean jobManagerRunsWithKerberos =
-                verifyStringsInNamedLogFiles(mustHave, "jobmanager.log");
+                verifyStringsInNamedLogFiles(mustHave, applicationId, "jobmanager.log");
         final boolean taskManagerRunsWithKerberos =
-                verifyStringsInNamedLogFiles(mustHave, "taskmanager.log");
+                verifyStringsInNamedLogFiles(mustHave, applicationId, "taskmanager.log");
 
         Assert.assertThat(
                 "The JobManager and the TaskManager should both run with Kerberos.",

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -95,6 +95,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
@@ -599,14 +600,14 @@ public abstract class YarnTestBase extends TestLogger {
     }
 
     public static boolean verifyStringsInNamedLogFiles(
-            final String[] mustHave, final String fileName) {
-        List<String> mustHaveList = Arrays.asList(mustHave);
-        File cwd = new File("target/" + YARN_CONFIGURATION.get(TEST_CLUSTER_NAME_KEY));
+            final String[] mustHave, final ApplicationId applicationId, final String fileName) {
+        final List<String> mustHaveList = Arrays.asList(mustHave);
+        final File cwd = new File("target", YARN_CONFIGURATION.get(TEST_CLUSTER_NAME_KEY));
         if (!cwd.exists() || !cwd.isDirectory()) {
             return false;
         }
 
-        File foundFile =
+        final File foundFile =
                 TestUtils.findFile(
                         cwd.getAbsolutePath(),
                         new FilenameFilter() {
@@ -615,10 +616,15 @@ public abstract class YarnTestBase extends TestLogger {
                                 if (fileName != null && !name.equals(fileName)) {
                                     return false;
                                 }
-                                File f = new File(dir.getAbsolutePath() + "/" + name);
+                                final File f = new File(dir.getAbsolutePath(), name);
+                                // Only check the specified application logs
+                                if (StreamSupport.stream(f.toPath().spliterator(), false)
+                                        .noneMatch(p -> p.endsWith(applicationId.toString()))) {
+                                    return false;
+                                }
                                 LOG.info("Searching in {}", f.getAbsolutePath());
                                 try (Scanner scanner = new Scanner(f)) {
-                                    Set<String> foundSet = new HashSet<>(mustHave.length);
+                                    final Set<String> foundSet = new HashSet<>(mustHave.length);
                                     while (scanner.hasNextLine()) {
                                         final String lineFromFile = scanner.nextLine();
                                         for (String str : mustHave) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In `ClusterEntrypoint#shutDownAsync`, we first call the `closeClusterComponent`, which also includes deregistering the Flink application from cluster management(e.g. Yarn, K8s). Then we call the `stopClusterServices` and `cleanupDirectories`. Imagine that the cluster management do the deregister very fast, the JobManager process receives SIGTERM before or is being executing the `stopClusterServices` and `cleanupDirectories`. The JVM process will directly exit then. So the concurrent `shutDownAsync` may not be fully executed. This will cause Kubernetes ConfigMaps or ZooKeeper nodes leak.

This PR first fixes the behavior of `closeAsync` and then register it as shutdown for the clean up.

## Brief change log

* Register ClusterEntrypoint#closeAsync as shutdown hook for the cleanup


## Verifying this change

* Add two unit tests to guard the `closeAsync` behavior
* Start a standalone cluster and send `SIGTERM` to JobManager process, we will have following logs to verify that the `closeAsync` is executed in the shutdown hook.
```
2021-04-02 13:55:40,200 INFO  org.apache.flink.runtime.entrypoint.ClusterEntrypoint        [] - RECEIVED SIGNAL 15: SIGTERM. Shutting down as requested.
2021-04-02 13:55:40,202 INFO  org.apache.flink.runtime.entrypoint.ClusterEntrypoint        [] - Shutting StandaloneSessionClusterEntrypoint down with application status UNKNOWN. Diagnostics Cluster entrypoint has been closed externally..
2021-04-02 13:55:40,203 INFO  org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint   [] - Shutting down rest endpoint.
2021-04-02 13:55:40,209 INFO  org.apache.flink.runtime.blob.BlobServer                     [] - Stopped BLOB server at 0.0.0.0:50424
2021-04-02 13:55:40,221 INFO  org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint   [] - Removing cache directory /var/folders/8v/gjbsrg5n2c35bx10yky3_fv00000gn/T/flink-web-903e94a9-8990-4ca9-9711-b180f9f12eb2/flink-web-ui
2021-04-02 13:55:40,223 INFO  org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint   [] - http://localhost:8081 lost leadership
2021-04-02 13:55:40,223 INFO  org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint   [] - Shut down complete.
2021-04-02 13:55:40,223 INFO  org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent [] - Closing components.
2021-04-02 13:55:40,224 INFO  org.apache.flink.runtime.dispatcher.runner.SessionDispatcherLeaderProcess [] - Stopping SessionDispatcherLeaderProcess.
2021-04-02 13:55:40,224 INFO  org.apache.flink.runtime.dispatcher.StandaloneDispatcher     [] - Stopping dispatcher akka.tcp://flink@localhost:6123/user/rpc/dispatcher_1.
2021-04-02 13:55:40,224 INFO  org.apache.flink.runtime.dispatcher.StandaloneDispatcher     [] - Stopping all currently running jobs of dispatcher akka.tcp://flink@localhost:6123/user/rpc/dispatcher_1.
2021-04-02 13:55:40,225 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManager [] - Closing the slot manager.
2021-04-02 13:55:40,225 INFO  org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManager [] - Suspending the slot manager.
2021-04-02 13:55:40,225 INFO  org.apache.flink.runtime.dispatcher.StandaloneDispatcher     [] - Stopped dispatcher akka.tcp://flink@localhost:6123/user/rpc/dispatcher_1.
2021-04-02 13:55:40,232 INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService             [] - Stopping Akka RPC service.
2021-04-02 13:55:40,235 INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService             [] - Stopping Akka RPC service.
2021-04-02 13:55:40,243 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Shutting down remote daemon.
2021-04-02 13:55:40,243 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Shutting down remote daemon.
2021-04-02 13:55:40,245 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Remote daemon shut down; proceeding with flushing remote transports.
2021-04-02 13:55:40,245 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Remote daemon shut down; proceeding with flushing remote transports.
2021-04-02 13:55:40,265 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Remoting shut down.
2021-04-02 13:55:40,265 INFO  akka.remote.RemoteActorRefProvider$RemotingTerminator        [] - Remoting shut down.
2021-04-02 13:55:40,282 INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService             [] - Stopped Akka RPC service.
2021-04-02 13:55:40,285 INFO  org.apache.flink.runtime.rpc.akka.AkkaRpcService             [] - Stopped Akka RPC service.
2021-04-02 13:55:40,286 INFO  org.apache.flink.runtime.entrypoint.ClusterEntrypoint        [] - Terminating cluster entrypoint process StandaloneSessionClusterEntrypoint with exit code 1445.
```


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
