### PR TITLE
[FLINK-21817][connector/common] Remove split assignment tracker from coordinator state

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/TestingSourceSplit.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/TestingSourceSplit.java
@@ -20,6 +20,8 @@ package org.apache.flink.connector.base.source.reader.mocks;
 
 import org.apache.flink.api.connector.source.SourceSplit;
 
+import java.util.Objects;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A {@link SourceSplit} that only has an ID. */
@@ -39,5 +41,18 @@ public class TestingSourceSplit implements SourceSplit {
     @Override
     public String toString() {
         return splitId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(splitId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof TestingSourceSplit)) {
+            return false;
+        }
+        return this.splitId.equals(((TestingSourceSplit) obj).splitId);
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/utils/SerdeUtilsTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/utils/SerdeUtilsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.utils;
+
+import org.apache.flink.connector.base.source.reader.mocks.TestingSourceSplit;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link SerdeUtils}. */
+public class SerdeUtilsTest {
+
+    private static final int READER0 = 0;
+    private static final int READER1 = 1;
+
+    @Test
+    public void testSerdeSplitAssignments() throws IOException {
+        final Map<Integer, Set<TestingSourceSplit>> splitAssignments = new HashMap<>();
+
+        final HashSet<TestingSourceSplit> splitsForReader0 = new HashSet<>();
+        splitsForReader0.add(new TestingSourceSplit("split-0"));
+        splitsForReader0.add(new TestingSourceSplit("split-1"));
+        splitsForReader0.add(new TestingSourceSplit("split-2"));
+
+        final HashSet<TestingSourceSplit> splitsForReader1 = new HashSet<>();
+        splitsForReader1.add(new TestingSourceSplit("split-3"));
+        splitsForReader1.add(new TestingSourceSplit("split-4"));
+        splitsForReader1.add(new TestingSourceSplit("split-5"));
+
+        splitAssignments.put(READER0, splitsForReader0);
+        splitAssignments.put(READER1, splitsForReader1);
+
+        final byte[] serializedSplitAssignments =
+                SerdeUtils.serializeSplitAssignments(
+                        splitAssignments, new TestingSourceSplitSerializer());
+
+        final Map<Integer, HashSet<TestingSourceSplit>> deseredSplitAssignments =
+                SerdeUtils.deserializeSplitAssignments(
+                        serializedSplitAssignments,
+                        new TestingSourceSplitSerializer(),
+                        HashSet::new);
+
+        assertEquals(splitAssignments, deseredSplitAssignments);
+    }
+
+    private static class TestingSourceSplitSerializer
+            implements SimpleVersionedSerializer<TestingSourceSplit> {
+
+        @Override
+        public int getVersion() {
+            return 0;
+        }
+
+        @Override
+        public byte[] serialize(TestingSourceSplit split) throws IOException {
+            return split.splitId().getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public TestingSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+            return new TestingSourceSplit(new String(serialized, StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -46,6 +46,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -84,8 +85,6 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     private final Source<?, SplitT, EnumChkT> source;
     /** The serializer that handles the serde of the SplitEnumerator checkpoints. */
     private final SimpleVersionedSerializer<EnumChkT> enumCheckpointSerializer;
-    /** The serializer for the SourceSplit of the associated Source. */
-    private final SimpleVersionedSerializer<SplitT> splitSerializer;
     /** The context containing the states of the coordinator. */
     private final SourceCoordinatorContext<SplitT> context;
     /**
@@ -105,7 +104,6 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         this.coordinatorExecutor = coordinatorExecutor;
         this.source = source;
         this.enumCheckpointSerializer = source.getEnumeratorCheckpointSerializer();
-        this.splitSerializer = source.getSplitSerializer();
         this.context = context;
     }
 
@@ -225,7 +223,8 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                             operatorName,
                             checkpointId);
                     try {
-                        result.complete(toBytes(checkpointId));
+                        context.onCheckpoint(checkpointId);
+                        result.complete(toBytes());
                     } catch (Throwable e) {
                         ExceptionUtils.rethrowIfFatalErrorOrOOM(e);
                         result.completeExceptionally(
@@ -288,8 +287,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                 context.getCoordinatorContext().getUserCodeClassloader();
         try (TemporaryClassLoaderContext ignored =
                 TemporaryClassLoaderContext.of(userCodeClassLoader)) {
-            final EnumChkT enumeratorCheckpoint =
-                    deserializeCheckpointAndRestoreContext(checkpointData);
+            final EnumChkT enumeratorCheckpoint = deserializeCheckpoint(checkpointData);
             enumerator = source.restoreEnumerator(context, enumeratorCheckpoint);
         }
     }
@@ -343,32 +341,24 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
      * @return A byte array containing the serialized state of the source coordinator.
      * @throws Exception When something goes wrong in serialization.
      */
-    private byte[] toBytes(long checkpointId) throws Exception {
-        return writeCheckpointBytes(
-                checkpointId,
-                enumerator.snapshotState(),
-                context,
-                enumCheckpointSerializer,
-                splitSerializer);
+    private byte[] toBytes() throws Exception {
+        return writeCheckpointBytes(enumerator.snapshotState(), enumCheckpointSerializer);
     }
 
-    static <SplitT extends SourceSplit, EnumChkT> byte[] writeCheckpointBytes(
-            final long checkpointId,
+    static <EnumChkT> byte[] writeCheckpointBytes(
             final EnumChkT enumeratorCheckpoint,
-            final SourceCoordinatorContext<SplitT> coordinatorContext,
-            final SimpleVersionedSerializer<EnumChkT> checkpointSerializer,
-            final SimpleVersionedSerializer<SplitT> splitSerializer)
+            final SimpleVersionedSerializer<EnumChkT> enumeratorCheckpointSerializer)
             throws Exception {
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 DataOutputStream out = new DataOutputViewStreamWrapper(baos)) {
 
             writeCoordinatorSerdeVersion(out);
-            out.writeInt(checkpointSerializer.getVersion());
-            byte[] serialziedEnumChkpt = checkpointSerializer.serialize(enumeratorCheckpoint);
+            out.writeInt(enumeratorCheckpointSerializer.getVersion());
+            byte[] serialziedEnumChkpt =
+                    enumeratorCheckpointSerializer.serialize(enumeratorCheckpoint);
             out.writeInt(serialziedEnumChkpt.length);
             out.write(serialziedEnumChkpt);
-            coordinatorContext.snapshotState(checkpointId, splitSerializer, out);
             out.flush();
             return baos.toByteArray();
         }
@@ -377,17 +367,22 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     /**
      * Restore the state of this source coordinator from the state bytes.
      *
-     * @param bytes The checkpoint bytes that was returned from {@link #toBytes(long)}
+     * @param bytes The checkpoint bytes that was returned from {@link #toBytes()}
      * @throws Exception When the deserialization failed.
      */
-    private EnumChkT deserializeCheckpointAndRestoreContext(byte[] bytes) throws Exception {
+    private EnumChkT deserializeCheckpoint(byte[] bytes) throws Exception {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
                 DataInputStream in = new DataInputViewStreamWrapper(bais)) {
-            readAndVerifyCoordinatorSerdeVersion(in);
+            final int coordinatorSerdeVersion = readAndVerifyCoordinatorSerdeVersion(in);
             int enumSerializerVersion = in.readInt();
             int serializedEnumChkptSize = in.readInt();
             byte[] serializedEnumChkpt = readBytes(in, serializedEnumChkptSize);
-            context.restoreState(splitSerializer, in);
+
+            if (coordinatorSerdeVersion != SourceCoordinatorSerdeUtils.VERSION_0
+                    && bais.available() > 0) {
+                throw new IOException("Unexpected trailing bytes in enumerator checkpoint data");
+            }
+
             return enumCheckpointSerializer.deserialize(enumSerializerVersion, serializedEnumChkpt);
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorSerdeUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorSerdeUtils.java
@@ -18,20 +18,18 @@ limitations under the License.
 
 package org.apache.flink.runtime.source.coordinator;
 
-import org.apache.flink.api.connector.source.ReaderInfo;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
 
 /** A serialization util class for the {@link SourceCoordinator}. */
 public class SourceCoordinatorSerdeUtils {
+
+    public static final int VERSION_0 = 0;
+    public static final int VERSION_1 = 1;
+
     /** The current source coordinator serde version. */
-    private static final int CURRENT_VERSION = 0;
+    private static final int CURRENT_VERSION = VERSION_1;
 
     /** Private constructor for utility class. */
     private SourceCoordinatorSerdeUtils() {}
@@ -42,97 +40,17 @@ public class SourceCoordinatorSerdeUtils {
     }
 
     /** Read and verify the serde version. */
-    static void readAndVerifyCoordinatorSerdeVersion(DataInputStream in) throws IOException {
+    static int readAndVerifyCoordinatorSerdeVersion(DataInputStream in) throws IOException {
         int version = in.readInt();
         if (version > CURRENT_VERSION) {
             throw new IOException("Unsupported source coordinator serde version " + version);
         }
-    }
-
-    static Map<Integer, ReaderInfo> readRegisteredReaders(DataInputStream in) throws IOException {
-        int numReaders = in.readInt();
-        Map<Integer, ReaderInfo> registeredReaders = new HashMap<>();
-        for (int i = 0; i < numReaders; i++) {
-            ReaderInfo info = readReaderInfo(in);
-            registeredReaders.put(info.getSubtaskId(), info);
-        }
-        return registeredReaders;
-    }
-
-    /** Serialize the assignment by checkpoint ids. */
-    static <SplitT> void writeAssignmentsByCheckpointId(
-            Map<Long, Map<Integer, LinkedHashSet<SplitT>>> assignmentByCheckpointIds,
-            SimpleVersionedSerializer<SplitT> splitSerializer,
-            DataOutputStream out)
-            throws IOException {
-        // SplitSerializer version.
-        out.writeInt(splitSerializer.getVersion());
-        // Num checkpoints.
-        out.writeInt(assignmentByCheckpointIds.size());
-        for (Map.Entry<Long, Map<Integer, LinkedHashSet<SplitT>>> assignments :
-                assignmentByCheckpointIds.entrySet()) {
-            long checkpointId = assignments.getKey();
-            out.writeLong(checkpointId);
-
-            int numSubtasks = assignments.getValue().size();
-            out.writeInt(numSubtasks);
-            for (Map.Entry<Integer, LinkedHashSet<SplitT>> assignment :
-                    assignments.getValue().entrySet()) {
-                int subtaskId = assignment.getKey();
-                out.writeInt(subtaskId);
-
-                int numAssignedSplits = assignment.getValue().size();
-                out.writeInt(numAssignedSplits);
-                for (SplitT split : assignment.getValue()) {
-                    byte[] serializedSplit = splitSerializer.serialize(split);
-                    out.writeInt(serializedSplit.length);
-                    out.write(serializedSplit);
-                }
-            }
-        }
-    }
-
-    /** Deserialize the assignment by checkpoint ids. */
-    static <SplitT> Map<Long, Map<Integer, LinkedHashSet<SplitT>>> readAssignmentsByCheckpointId(
-            DataInputStream in, SimpleVersionedSerializer<SplitT> splitSerializer)
-            throws IOException {
-        int splitSerializerVersion = in.readInt();
-        int numCheckpoints = in.readInt();
-        Map<Long, Map<Integer, LinkedHashSet<SplitT>>> assignmentsByCheckpointIds =
-                new HashMap<>(numCheckpoints);
-        for (int i = 0; i < numCheckpoints; i++) {
-            long checkpointId = in.readLong();
-            int numSubtasks = in.readInt();
-            Map<Integer, LinkedHashSet<SplitT>> assignments = new HashMap<>();
-            assignmentsByCheckpointIds.put(checkpointId, assignments);
-            for (int j = 0; j < numSubtasks; j++) {
-                int subtaskId = in.readInt();
-                int numAssignedSplits = in.readInt();
-                LinkedHashSet<SplitT> splits = new LinkedHashSet<>(numAssignedSplits);
-                assignments.put(subtaskId, splits);
-                for (int k = 0; k < numAssignedSplits; k++) {
-                    int serializedSplitSize = in.readInt();
-                    byte[] serializedSplit = readBytes(in, serializedSplitSize);
-                    SplitT split =
-                            splitSerializer.deserialize(splitSerializerVersion, serializedSplit);
-                    splits.add(split);
-                }
-            }
-        }
-        return assignmentsByCheckpointIds;
+        return version;
     }
 
     static byte[] readBytes(DataInputStream in, int size) throws IOException {
         byte[] bytes = new byte[size];
         in.readFully(bytes);
         return bytes;
-    }
-
-    // ----- private helper methods -----
-
-    private static ReaderInfo readReaderInfo(DataInputStream in) throws IOException {
-        int subtaskId = in.readInt();
-        String location = in.readUTF();
-        return new ReaderInfo(subtaskId, location);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTracker.java
@@ -23,10 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.core.io.SimpleVersionedSerializer;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -35,9 +32,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
-import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.readAssignmentsByCheckpointId;
-import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.writeAssignmentsByCheckpointId;
 
 /**
  * A class that is responsible for tracking the past split assignments made by {@link
@@ -59,34 +53,15 @@ public class SplitAssignmentTracker<SplitT extends SourceSplit> {
     }
 
     /**
-     * Take a snapshot of the uncheckpointed split assignments.
+     * Behavior of SplitAssignmentTracker on checkpoint. Tracker will mark uncheckpointed assignment
+     * as checkpointed with current checkpoint ID.
      *
      * @param checkpointId the id of the ongoing checkpoint
      */
-    public void snapshotState(
-            long checkpointId,
-            SimpleVersionedSerializer<SplitT> splitSerializer,
-            DataOutputStream out)
-            throws Exception {
+    public void onCheckpoint(long checkpointId) throws Exception {
         // Include the uncheckpointed assignments to the snapshot.
         assignmentsByCheckpointId.put(checkpointId, uncheckpointedAssignments);
         uncheckpointedAssignments = new HashMap<>();
-        writeAssignmentsByCheckpointId(assignmentsByCheckpointId, splitSerializer, out);
-    }
-
-    /**
-     * Restore the state of the SplitAssignmentTracker.
-     *
-     * @param splitSerializer The serializer of the splits.
-     * @param in The ObjectInput that contains the state of the SplitAssignmentTracker.
-     * @throws Exception when the state deserialization fails.
-     */
-    public void restoreState(SimpleVersionedSerializer<SplitT> splitSerializer, DataInputStream in)
-            throws Exception {
-        // Read the split assignments by checkpoint id.
-        Map<Long, Map<Integer, LinkedHashSet<SplitT>>> deserializedAssignments =
-                readAssignmentsByCheckpointId(in, splitSerializer);
-        assignmentsByCheckpointId.putAll(deserializedAssignments);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -22,21 +22,13 @@ import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
-import org.apache.flink.runtime.util.ExecutorThreadFactory;
-
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.getSplitsAssignment;
@@ -150,48 +142,6 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testSnapshotAndRestore() throws Exception {
-        registerReaders();
-
-        // Assign splits to the readers.
-        SplitsAssignment<MockSourceSplit> splitsAssignment = getSplitsAssignment(2, 0);
-        coordinatorExecutor.submit(() -> context.assignSplits(splitsAssignment)).get();
-        // Take the first snapshot;
-        byte[] bytes = takeSnapshot(context, 100L);
-
-        SourceCoordinatorContext<MockSourceSplit> restoredContext;
-        SplitAssignmentTracker<MockSourceSplit> restoredTracker = new SplitAssignmentTracker<>();
-        SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory =
-                new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
-                        TEST_OPERATOR_ID.toHexString(), getClass().getClassLoader());
-
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-                DataInputStream in = new DataInputStream(bais)) {
-            restoredContext =
-                    new SourceCoordinatorContext<>(
-                            coordinatorExecutor,
-                            Executors.newScheduledThreadPool(
-                                    1,
-                                    new ExecutorThreadFactory(
-                                            coordinatorThreadFactory.getCoordinatorThreadName()
-                                                    + "-worker")),
-                            coordinatorThreadFactory,
-                            operatorCoordinatorContext,
-                            new MockSourceSplitSerializer(),
-                            restoredTracker);
-            restoredContext.restoreState(new MockSourceSplitSerializer(), in);
-        }
-        // FLINK-21452: do not (re)store registered readers
-        assertEquals(0, restoredContext.registeredReaders().size());
-        assertEquals(
-                splitSplitAssignmentTracker.uncheckpointedAssignments(),
-                restoredTracker.uncheckpointedAssignments());
-        assertEquals(
-                splitSplitAssignmentTracker.assignmentsByCheckpointId(),
-                restoredTracker.assignmentsByCheckpointId());
-    }
-
-    @Test
     public void testCallableInterruptedDuringShutdownDoNotFailJob() throws InterruptedException {
         AtomicReference<Throwable> expectedError = new AtomicReference<>(null);
 
@@ -240,17 +190,5 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         context.registerSourceReader(readerInfo1);
         context.registerSourceReader(readerInfo2);
         return Arrays.asList(readerInfo0, readerInfo1, readerInfo2);
-    }
-
-    private byte[] takeSnapshot(
-            SourceCoordinatorContext<MockSourceSplit> context, long checkpointId) throws Exception {
-        byte[] bytes;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                DataOutputStream out = new DataOutputViewStreamWrapper(baos)) {
-            context.snapshotState(checkpointId, new MockSourceSplitSerializer(), out);
-            out.flush();
-            bytes = baos.toByteArray();
-        }
-        return bytes;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -45,11 +45,12 @@ public abstract class SourceCoordinatorTestBase {
     protected static final OperatorID TEST_OPERATOR_ID = new OperatorID(1234L, 5678L);
     protected static final int NUM_SUBTASKS = 3;
 
+    protected SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory;
     protected ExecutorService coordinatorExecutor;
     protected MockOperatorCoordinatorContext operatorCoordinatorContext;
     protected SplitAssignmentTracker<MockSourceSplit> splitSplitAssignmentTracker;
     protected SourceCoordinatorContext<MockSourceSplit> context;
-    protected SourceCoordinator<?, ?> sourceCoordinator;
+    protected SourceCoordinator<MockSourceSplit, Set<MockSourceSplit>> sourceCoordinator;
     private MockSplitEnumerator enumerator;
 
     @Before
@@ -58,24 +59,13 @@ public abstract class SourceCoordinatorTestBase {
                 new MockOperatorCoordinatorContext(TEST_OPERATOR_ID, NUM_SUBTASKS);
         splitSplitAssignmentTracker = new SplitAssignmentTracker<>();
         String coordinatorThreadName = TEST_OPERATOR_ID.toHexString();
-        SourceCoordinatorProvider.CoordinatorExecutorThreadFactory coordinatorThreadFactory =
+        coordinatorThreadFactory =
                 new SourceCoordinatorProvider.CoordinatorExecutorThreadFactory(
                         coordinatorThreadName, getClass().getClassLoader());
 
         coordinatorExecutor = Executors.newSingleThreadExecutor(coordinatorThreadFactory);
-        context =
-                new SourceCoordinatorContext<>(
-                        coordinatorExecutor,
-                        Executors.newScheduledThreadPool(
-                                1,
-                                new ExecutorThreadFactory(
-                                        coordinatorThreadFactory.getCoordinatorThreadName()
-                                                + "-worker")),
-                        coordinatorThreadFactory,
-                        operatorCoordinatorContext,
-                        new MockSourceSplitSerializer(),
-                        splitSplitAssignmentTracker);
         sourceCoordinator = getNewSourceCoordinator();
+        context = sourceCoordinator.getContext();
     }
 
     @After
@@ -96,10 +86,26 @@ public abstract class SourceCoordinatorTestBase {
 
     // --------------------------
 
-    protected SourceCoordinator getNewSourceCoordinator() throws Exception {
+    protected SourceCoordinator<MockSourceSplit, Set<MockSourceSplit>> getNewSourceCoordinator()
+            throws Exception {
         Source<Integer, MockSourceSplit, Set<MockSourceSplit>> mockSource =
                 new MockSource(Boundedness.BOUNDED, NUM_SUBTASKS * 2);
 
-        return new SourceCoordinator<>(OPERATOR_NAME, coordinatorExecutor, mockSource, context);
+        return new SourceCoordinator<>(
+                OPERATOR_NAME, coordinatorExecutor, mockSource, getNewSourceCoordinatorContext());
+    }
+
+    protected SourceCoordinatorContext<MockSourceSplit> getNewSourceCoordinatorContext() {
+        return new SourceCoordinatorContext<>(
+                coordinatorExecutor,
+                Executors.newScheduledThreadPool(
+                        1,
+                        new ExecutorThreadFactory(
+                                coordinatorThreadFactory.getCoordinatorThreadName()
+                                        + "-worker")),
+                coordinatorThreadFactory,
+                operatorCoordinatorContext,
+                new MockSourceSplitSerializer(),
+                splitSplitAssignmentTracker);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTrackerTest.java
@@ -19,16 +19,9 @@ limitations under the License.
 package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
-import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -58,13 +51,13 @@ public class SplitAssignmentTrackerTest {
     }
 
     @Test
-    public void testTakeSnapshot() throws Exception {
+    public void testOnCheckpoint() throws Exception {
         final long checkpointId = 123L;
         SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
         tracker.recordSplitAssignment(getSplitsAssignment(3, 0));
 
         // Serialize
-        takeSnapshot(tracker, checkpointId);
+        tracker.onCheckpoint(checkpointId);
 
         // Verify the uncheckpointed assignments.
         assertTrue(tracker.uncheckpointedAssignments().isEmpty());
@@ -84,26 +77,6 @@ public class SplitAssignmentTrackerTest {
     }
 
     @Test
-    public void testRestore() throws Exception {
-        final long checkpointId = 123L;
-        SplitAssignmentTracker<MockSourceSplit> tracker = new SplitAssignmentTracker<>();
-        tracker.recordSplitAssignment(getSplitsAssignment(1, 0));
-
-        // Serialize
-        byte[] bytes = takeSnapshot(tracker, checkpointId);
-
-        // Deserialize
-        SplitAssignmentTracker<MockSourceSplit> deserializedTracker = restoreSnapshot(bytes);
-        // Verify the restore was successful.
-        assertEquals(
-                deserializedTracker.assignmentsByCheckpointId(),
-                tracker.assignmentsByCheckpointId());
-        assertEquals(
-                deserializedTracker.uncheckpointedAssignments(),
-                tracker.uncheckpointedAssignments());
-    }
-
-    @Test
     public void testOnCheckpointComplete() throws Exception {
         final long checkpointId1 = 100L;
         final long checkpointId2 = 101L;
@@ -113,7 +86,7 @@ public class SplitAssignmentTrackerTest {
         tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
 
         // Take the first snapshot.
-        takeSnapshot(tracker, checkpointId1);
+        tracker.onCheckpoint(checkpointId1);
         verifyAssignment(
                 Arrays.asList("0"), tracker.assignmentsByCheckpointId(checkpointId1).get(0));
         verifyAssignment(
@@ -123,7 +96,7 @@ public class SplitAssignmentTrackerTest {
         tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
 
         // Take the second snapshot.
-        takeSnapshot(tracker, checkpointId2);
+        tracker.onCheckpoint(checkpointId2);
         verifyAssignment(
                 Arrays.asList("0"), tracker.assignmentsByCheckpointId(checkpointId1).get(0));
         verifyAssignment(
@@ -150,11 +123,11 @@ public class SplitAssignmentTrackerTest {
 
         // Assign some splits and take snapshot 1.
         tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
-        takeSnapshot(tracker, checkpointId1);
+        tracker.onCheckpoint(checkpointId1);
 
         // Assign some more splits and take snapshot 2.
         tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
-        takeSnapshot(tracker, checkpointId2);
+        tracker.onCheckpoint(checkpointId2);
 
         // Now assume subtask 0 has failed.
         List<MockSourceSplit> splitsToPutBack =
@@ -170,11 +143,11 @@ public class SplitAssignmentTrackerTest {
 
         // Assign some splits and take snapshot 1.
         tracker.recordSplitAssignment(getSplitsAssignment(2, 0));
-        takeSnapshot(tracker, checkpointId1);
+        tracker.onCheckpoint(checkpointId1);
 
         // Assign some more splits and take snapshot 2.
         tracker.recordSplitAssignment(getSplitsAssignment(2, 3));
-        takeSnapshot(tracker, checkpointId2);
+        tracker.onCheckpoint(checkpointId2);
 
         // Now assume subtask 0 has failed.
         List<MockSourceSplit> splitsToPutBack =
@@ -183,26 +156,4 @@ public class SplitAssignmentTrackerTest {
     }
 
     // ---------------------
-
-    private byte[] takeSnapshot(SplitAssignmentTracker<MockSourceSplit> tracker, long checkpointId)
-            throws Exception {
-        byte[] bytes;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                DataOutputStream out = new DataOutputViewStreamWrapper(baos)) {
-            tracker.snapshotState(checkpointId, new MockSourceSplitSerializer(), out);
-            out.flush();
-            bytes = baos.toByteArray();
-        }
-        return bytes;
-    }
-
-    private SplitAssignmentTracker<MockSourceSplit> restoreSnapshot(byte[] bytes) throws Exception {
-        SplitAssignmentTracker<MockSourceSplit> deserializedTracker;
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-                DataInputStream in = new DataInputViewStreamWrapper(bais)) {
-            deserializedTracker = new SplitAssignmentTracker<>();
-            deserializedTracker.restoreState(new MockSourceSplitSerializer(), in);
-        }
-        return deserializedTracker;
-    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes split assignment tracker from source coordinator's state, because the mapping of subtask lD to split assignment might change after job rescaling.


## Brief change log
- Skip writing split assignment tracker into coordinator' state when taking snapshot
- Skip restoring split assignment tracker from state then restoring from snapshot
- Modify test of ```SourceCoordinatorContext``` and ```SplitAssignmentTracker``` to fit the new coordinator state


## Verifying this change

This change modifies some test that already exists, such as ```testSnapshotAndRestore()``` in ```SourceCoordinatorContextTest```, and ```testRestore()``` in ```SplitAssignmentTrackerTest```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
