### PR TITLE
[FLINK-20557][sql-client] Support STATEMENT SET in SQL CLI

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -115,6 +115,11 @@ public final class CliStrings {
                             formatCommand(
                                     "USE MODULES",
                                     "Enable loaded modules. Syntax: 'USE MODULES <name1> [, <name2>, ...];'"))
+                    .append(
+                            formatCommand(
+                                    "BEGIN STATEMENT SET",
+                                    "Begins a statement set. Syntax: 'BEGIN STATEMENT SET;'"))
+                    .append(formatCommand("END", "Ends a statement set. Syntax: 'END;'"))
                     .style(AttributedStyle.DEFAULT.underline())
                     .append("\nHint")
                     .style(AttributedStyle.DEFAULT)
@@ -174,6 +179,12 @@ public final class CliStrings {
 
     public static final String MESSAGE_SQL_EXECUTION_ERROR = "Could not execute SQL statement.";
 
+    public static final String MESSAGE_STATEMENT_SET_SQL_EXECUTION_ERROR =
+            "Only INSERT statement is allowed in Statement Set.";
+
+    public static final String MESSAGE_STATEMENT_SET_END_CALL_ERROR =
+            "No Statement Set to submit, \"END;\" command should be used after \"BEGIN STATEMENT SET;\".";
+
     public static final String MESSAGE_RESET =
             "All session properties have been set to their default values.";
 
@@ -197,7 +208,12 @@ public final class CliStrings {
             "Complete execution of the SQL update statement.";
 
     public static final String MESSAGE_STATEMENT_SUBMITTED =
-            "Table update statement has been successfully submitted to the cluster:";
+            "SQL update statement has been successfully submitted to the cluster:";
+
+    public static final String MESSAGE_BEGIN_STATEMENT_SET = "Begin a statement set.";
+
+    public static final String MESSAGE_ADD_STATEMENT_TO_STATEMENT_SET =
+            "Add SQL update statement to the statement set.";
 
     public static final String MESSAGE_WILL_EXECUTE = "Executing the SQL from the file:";
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.client.gateway;
 
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.types.Row;
@@ -106,6 +107,10 @@ public interface Executor {
 
     /** Executes an operation, and return {@link TableResult} as execution result. */
     TableResult executeOperation(String sessionId, Operation operation)
+            throws SqlExecutionException;
+
+    /** Executes modify operations, and return {@link TableResult} as execution result. */
+    TableResult executeModifyOperations(String sessionId, List<ModifyOperation> operations)
             throws SqlExecutionException;
 
     /** Submits a Flink SQL query job (detached) and returns the result descriptor. */

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.client.gateway.local.result.ChangelogResult;
 import org.apache.flink.table.client.gateway.local.result.DynamicResult;
 import org.apache.flink.table.client.gateway.local.result.MaterializedResult;
 import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.types.Row;
@@ -210,6 +211,19 @@ public class LocalExecutor implements Executor {
                 (TableEnvironmentInternal) context.getTableEnvironment();
         try {
             return context.wrapClassLoader(() -> tEnv.executeInternal(operation));
+        } catch (Exception e) {
+            throw new SqlExecutionException(MESSAGE_SQL_EXECUTION_ERROR, e);
+        }
+    }
+
+    @Override
+    public TableResult executeModifyOperations(String sessionId, List<ModifyOperation> operations)
+            throws SqlExecutionException {
+        final ExecutionContext context = getExecutionContext(sessionId);
+        final TableEnvironmentInternal tEnv =
+                (TableEnvironmentInternal) context.getTableEnvironment();
+        try {
+            return context.wrapClassLoader(() -> tEnv.executeInternal(operations));
         } catch (Exception e) {
             throw new SqlExecutionException(MESSAGE_SQL_EXECUTION_ERROR, e);
         }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientITCase.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jline.reader.MaskingCallback;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.DumbTerminal;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -115,6 +116,11 @@ public class CliClientITCase extends AbstractTestBase {
         replaceVars.put(
                 "$VAR_JOBMANAGER_RPC_ADDRESS",
                 miniClusterResource.getClientConfiguration().get(ADDRESS));
+    }
+
+    @Before
+    public void before() throws IOException {
+        // initialize new folders for every tests, so the vars can be reused by every SQL scripts
         replaceVars.put("$VAR_STREAMING_PATH", tempFolder.newFolder().toPath().toString());
         replaceVars.put("$VAR_BATCH_PATH", tempFolder.newFolder().toPath().toString());
     }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -219,7 +219,7 @@ public class CliClientTest extends TestLogger {
         executeSqlFromContent(mockExecutor, content);
     }
 
-    @Test
+    @Test(timeout = 10000)
     public void testCancelExecutionInNonInteractiveMode() throws Exception {
         // add "\n" with quit to trigger commit the line
         final List<String> statements =
@@ -410,7 +410,7 @@ public class CliClientTest extends TestLogger {
                 if (isSync) {
                     isAwait = true;
                     try {
-                        Thread.sleep(Long.MAX_VALUE);
+                        Thread.sleep(60_000L);
                     } catch (InterruptedException e) {
                         throw new SqlExecutionException("Fail to execute", e);
                     }
@@ -423,6 +423,28 @@ public class CliClientTest extends TestLogger {
                                 Collections.singletonList(Row.of(-1L)).iterator()));
             }
             return TestTableResult.TABLE_RESULT_OK;
+        }
+
+        @Override
+        public TableResult executeModifyOperations(
+                String sessionId, List<ModifyOperation> operations) throws SqlExecutionException {
+            if (failExecution) {
+                throw new SqlExecutionException("Fail execution.");
+            }
+            if (isSync) {
+                isAwait = true;
+                try {
+                    Thread.sleep(60_000L);
+                } catch (InterruptedException e) {
+                    throw new SqlExecutionException("Fail to execute", e);
+                }
+            }
+            return new TestTableResult(
+                    new TestingJobClient(),
+                    ResultKind.SUCCESS_WITH_CONTENT,
+                    ResolvedSchema.of(Column.physical("result", DataTypes.BIGINT())),
+                    CloseableIterator.adapterForIterator(
+                            Collections.singletonList(Row.of(-1L)).iterator()));
         }
 
         @Override

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.types.Row;
@@ -176,6 +177,12 @@ public class CliResultViewTest {
         @Override
         public TableResult executeOperation(String sessionId, Operation operation)
                 throws SqlExecutionException {
+            return null;
+        }
+
+        @Override
+        public TableResult executeModifyOperations(
+                String sessionId, List<ModifyOperation> operations) throws SqlExecutionException {
             return null;
         }
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.types.Row;
@@ -128,6 +129,12 @@ class TestingExecutor implements Executor {
 
     @Override
     public TableResult executeOperation(String sessionId, Operation operation)
+            throws SqlExecutionException {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    public TableResult executeModifyOperations(String sessionId, List<ModifyOperation> operations)
             throws SqlExecutionException {
         throw new UnsupportedOperationException("Not implemented.");
     }

--- a/flink-table/flink-sql-client/src/test/resources/sql/misc.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/misc.q
@@ -41,6 +41,8 @@ USE		Sets the current default database. Experimental! Syntax: 'USE <name>;'
 LOAD MODULE		Load a module. Syntax: 'LOAD MODULE <name> [WITH ('<key1>' = '<value1>' [, '<key2>' = '<value2>', ...])];'
 UNLOAD MODULE		Unload a module. Syntax: 'UNLOAD MODULE <name>;'
 USE MODULES		Enable loaded modules. Syntax: 'USE MODULES <name1> [, <name2>, ...];'
+BEGIN STATEMENT SET		Begins a statement set. Syntax: 'BEGIN STATEMENT SET;'
+END		Ends a statement set. Syntax: 'END;'
 
 Hint: Make sure that a statement ends with ';' for finalizing (multi-line) statements.
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/statement_set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/statement_set.q
@@ -1,0 +1,154 @@
+# statement-set.q - BEGIN STATEMENT SET, END
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SET sql-client.execution.result-mode = tableau;
+[INFO] Session property has been set.
+!info
+
+SET table.dml-sync=true;
+[INFO] Session property has been set.
+!info
+
+create table src (
+  id int,
+  str string
+) with (
+  'connector' = 'values'
+);
+[INFO] Execute statement succeed.
+!info
+
+# ==========================================================================
+# test statement set with streaming insert
+# ==========================================================================
+
+SET execution.runtime-mode = streaming;
+[INFO] Session property has been set.
+!info
+
+create table StreamingTable (
+  id int,
+  str string
+) with (
+  'connector' = 'filesystem',
+  'path' = '$VAR_STREAMING_PATH',
+  'format' = 'csv'
+);
+[INFO] Execute statement succeed.
+!info
+
+BEGIN STATEMENT SET;
+[INFO] Begin a statement set.
+!info
+
+BEGIN STATEMENT SET;
+[ERROR] Only INSERT statement is allowed in Statement Set.
+!error
+
+create table src (
+  id int,
+  str string
+) with (
+  'connector' = 'values'
+);
+[ERROR] Only INSERT statement is allowed in Statement Set.
+!error
+
+SELECT id, str FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi')) as T(id, str);
+[ERROR] Only INSERT statement is allowed in Statement Set.
+!error
+
+INSERT INTO StreamingTable SELECT * FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi'), (3, 'Hello'), (3, 'World'), (4, 'ADD'), (5, 'LINE'));
+[INFO] Add SQL update statement to the statement set.
+!info
+
+END;
+[INFO] Submitting SQL update statement to the cluster...
+[INFO] Execute statement in sync mode. Please wait for the execution finish...
+[INFO] Complete execution of the SQL update statement.
+!info
+
+END;
+[ERROR] No Statement Set to submit, "END;" command should be used after "BEGIN STATEMENT SET;".
+!error
+
+SELECT * FROM StreamingTable;
++----+-------------+----------------------+
+| op |          id |                  str |
++----+-------------+----------------------+
+| +I |           1 |          Hello World |
+| +I |           2 |                   Hi |
+| +I |           2 |                   Hi |
+| +I |           3 |                Hello |
+| +I |           3 |                World |
+| +I |           4 |                  ADD |
+| +I |           5 |                 LINE |
++----+-------------+----------------------+
+Received a total of 7 rows
+!ok
+
+# ==========================================================================
+# test statement set with batch inserts
+# ==========================================================================
+
+SET execution.runtime-mode = batch;
+[INFO] Session property has been set.
+!info
+
+create table BatchTable (
+id int,
+str string
+) with (
+'connector' = 'filesystem',
+'path' = '$VAR_BATCH_PATH',
+'format' = 'csv'
+);
+[INFO] Execute statement succeed.
+!info
+
+BEGIN STATEMENT SET;
+[INFO] Begin a statement set.
+!info
+
+BEGIN STATEMENT SET;
+[ERROR] Only INSERT statement is allowed in Statement Set.
+!error
+
+INSERT INTO BatchTable SELECT * FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi'), (3, 'Hello'), (3, 'World'), (4, 'ADD'), (5, 'LINE'));
+[INFO] Add SQL update statement to the statement set.
+!info
+
+END;
+[INFO] Submitting SQL update statement to the cluster...
+[INFO] Execute statement in sync mode. Please wait for the execution finish...
+[INFO] Complete execution of the SQL update statement.
+!info
+
+SELECT * FROM BatchTable;
++-------------+----------------------+
+|          id |                  str |
++-------------+----------------------+
+|           1 |          Hello World |
+|           2 |                   Hi |
+|           2 |                   Hi |
+|           3 |                Hello |
+|           3 |                World |
+|           4 |                  ADD |
+|           5 |                 LINE |
++-------------+----------------------+
+Received a total of 7 rows
+!ok


### PR DESCRIPTION
## What is the purpose of the change

In the sql-client, users should submit statements for statement set as follows:
```
Flink SQL> BEGIN STATEMENT SET;
[Info] Begin the statement set.

Flink SQL> INSERT INTO emps1 SELECT * FROM emps(x, y);
[Info] Add SQL update statement to the statement set.

Flink SQL> INSERT INTO emps2 SELECT * FROM emps(x, y);
[Info] Add SQL update statement to the statement set.

Flink SQL> END;
[Info] Submitting SQL statement set to the cluster...
```
`CliClient` should support STATEMENT SET syntax in SQL Client.

## Brief change log

  - *Add `BeginStatementSetOperation` and `EndStatementSetOperation` to support STATEMENT SET syntax for `CliClient`.*

## Verifying this change

  - *`CliClientITCase` adds `statement-set.q` for `testSqlStatements` to verify whether `CliClient` supports the `STATEMENT SET` syntax.*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)