### PR TITLE
[FLINK-22008] [Runtime/Checkpointing] add commit logic for checkpoint…

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SavepointOutputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SavepointOutputFormat.java
@@ -81,6 +81,7 @@ public class SavepointOutputFormat extends RichOutputFormat<CheckpointMetadata> 
                                 Checkpoints.storeCheckpointMetadata(metadata, out);
                                 CompletedCheckpointStorageLocation finalizedLocation =
                                         out.closeAndFinalizeCheckpoint();
+                                targetLocation.commitMetadata();
                                 return finalizedLocation.getExternalPointer();
                             }
                         });

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -321,6 +321,7 @@ public class PendingCheckpoint implements Checkpoint {
                         targetLocation.createMetadataOutputStream()) {
                     Checkpoints.storeCheckpointMetadata(savepoint, out);
                     finalizedLocation = out.closeAndFinalizeCheckpoint();
+                    targetLocation.commitMetadata();
                 }
 
                 CompletedCheckpoint completed =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLocation.java
@@ -54,4 +54,12 @@ public interface CheckpointStorageLocation extends CheckpointStreamFactory {
      * simply return {@link CheckpointStorageLocationReference#getDefault()}.
      */
     CheckpointStorageLocationReference getLocationReference();
+
+
+    /**
+     * Commit the temporary metadata file to the formal file.
+     *
+     * @throws IOException Thrown, if the stream cannot be opened due to an I/O error.
+     */
+    default void commitMetadata() throws IOException {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFsCheckpointStorageAccess.java
@@ -85,6 +85,9 @@ public abstract class AbstractFsCheckpointStorageAccess implements CheckpointSto
     /** The name of the metadata files in checkpoints / savepoints. */
     public static final String METADATA_FILE_NAME = "_metadata";
 
+    /** The name of the temporary metadata files in checkpoints / savepoints. */
+    public static final String TEMP_METADATA_FILE_NAME = "._metadata_temp";
+
     /** The magic number that is put in front of any reference. */
     private static final byte[] REFERENCE_MAGIC_NUMBER = new byte[] {0x05, 0x5F, 0x3F, 0x18};
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageLocation.java
@@ -45,6 +45,8 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory
 
     private final Path metadataFilePath;
 
+    private final Path metadataFilePathTemp;
+
     private final CheckpointStorageLocationReference reference;
 
     private final int fileStateSizeThreshold;
@@ -75,7 +77,9 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory
         Path metadataDir = EntropyInjector.removeEntropyMarkerIfPresent(fileSystem, checkpointDir);
 
         this.metadataFilePath =
-                new Path(metadataDir, AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME);
+                new Path(checkpointDir, AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME);
+        this.metadataFilePathTemp =
+                new Path(checkpointDir, AbstractFsCheckpointStorageAccess.TEMP_METADATA_FILE_NAME);
         this.fileStateSizeThreshold = fileStateSizeThreshold;
         this.writeBufferSize = writeBufferSize;
     }
@@ -107,7 +111,7 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory
     @Override
     public CheckpointMetadataOutputStream createMetadataOutputStream() throws IOException {
         return new FsCheckpointMetadataOutputStream(
-                fileSystem, metadataFilePath, checkpointDirectory);
+                fileSystem, metadataFilePathTemp, checkpointDirectory);
     }
 
     @Override
@@ -120,6 +124,11 @@ public class FsCheckpointStorageLocation extends FsCheckpointStreamFactory
     @Override
     public CheckpointStorageLocationReference getLocationReference() {
         return reference;
+    }
+
+    @Override
+    public void commitMetadata() throws IOException {
+        fileSystem.rename(metadataFilePathTemp, metadataFilePath);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/PersistentMetadataCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/PersistentMetadataCheckpointStorageLocation.java
@@ -43,6 +43,8 @@ public class PersistentMetadataCheckpointStorageLocation extends MemCheckpointSt
 
     private final Path metadataFilePath;
 
+    private final Path metadataFilePathTemp;
+
     /**
      * Creates a checkpoint storage persists metadata to a file system and stores state in line in
      * state handles with the metadata.
@@ -59,6 +61,8 @@ public class PersistentMetadataCheckpointStorageLocation extends MemCheckpointSt
         this.checkpointDirectory = checkNotNull(checkpointDir);
         this.metadataFilePath =
                 new Path(checkpointDir, AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME);
+        this.metadataFilePathTemp =
+                new Path(checkpointDir, AbstractFsCheckpointStorageAccess.TEMP_METADATA_FILE_NAME);
     }
 
     // ------------------------------------------------------------------------
@@ -66,7 +70,7 @@ public class PersistentMetadataCheckpointStorageLocation extends MemCheckpointSt
     @Override
     public CheckpointMetadataOutputStream createMetadataOutputStream() throws IOException {
         return new FsCheckpointMetadataOutputStream(
-                fileSystem, metadataFilePath, checkpointDirectory);
+                fileSystem, metadataFilePathTemp, checkpointDirectory);
     }
 
     @Override
@@ -79,5 +83,10 @@ public class PersistentMetadataCheckpointStorageLocation extends MemCheckpointSt
     @Override
     public CheckpointStorageLocationReference getLocationReference() {
         return CheckpointStorageLocationReference.getDefault();
+    }
+
+    @Override
+    public void commitMetadata() throws IOException {
+        fileSystem.rename(metadataFilePathTemp, metadataFilePath);
     }
 }


### PR DESCRIPTION
… location

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
