### PR TITLE
[FLINK-21148][tests] Fixes instability in YARN's detached-mode ITCases

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -161,7 +161,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
         }
 
         // make sure we have two TMs running in either mode
-        final long timeoutInSecs = 10;
+        final long timeoutInSecs = 20;
         long startTime = System.nanoTime();
         while (System.nanoTime() - startTime
                         < TimeUnit.NANOSECONDS.convert(timeoutInSecs, TimeUnit.SECONDS)

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -161,8 +161,10 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
         }
 
         // make sure we have two TMs running in either mode
+        final long timeoutInSecs = 10;
         long startTime = System.nanoTime();
-        while (System.nanoTime() - startTime < TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS)
+        while (System.nanoTime() - startTime
+                        < TimeUnit.NANOSECONDS.convert(timeoutInSecs, TimeUnit.SECONDS)
                 && !(verifyStringsInNamedLogFiles(
                         new String[] {"switched from state RUNNING to FINISHED"},
                         "jobmanager.log"))) {
@@ -170,7 +172,13 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
             sleep(500);
         }
 
-        LOG.info("Two containers are running. Killing the application");
+        if (!verifyStringsInNamedLogFiles(
+                new String[] {"switched from state RUNNING to FINISHED"}, "jobmanager.log")) {
+            Assert.fail(
+                    "The deployed job didn't finish on time reaching the timeout of "
+                            + timeoutInSecs
+                            + " seconds. The application will be cancelled forcefully.");
+        }
 
         // kill application "externally".
         try {


### PR DESCRIPTION
## What is the purpose of the change

There is a problem when killing the application before the job finishes. The TaskManager might get killed first. The TaskManager then runs into issues before being actually killed as well which might. This resulted in the concrete case in connection refused error when connecting to the JobManager's blob server.


## Brief change log

* The test is failing early now without cleanup
* The timeout was increased as the job itself looked like it was finishing without problems

## Verifying this change

No test was added as it's a test issue by itself.

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
