### PR TITLE
[FLINK-21356] Implement incremental checkpointing and recovery using state changelog

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -318,6 +318,8 @@ public abstract class MetadataV2V3SerializerBase {
         } else if (stateHandle instanceof InMemoryStateChangelogHandle) {
             InMemoryStateChangelogHandle handle = (InMemoryStateChangelogHandle) stateHandle;
             dos.writeByte(CHANGELOG_BYTE_INCREMENT_HANDLE);
+            dos.writeInt(handle.getKeyGroupRange().getStartKeyGroup());
+            dos.writeInt(handle.getKeyGroupRange().getNumberOfKeyGroups());
             dos.writeLong(handle.getFrom());
             dos.writeLong(handle.getTo());
             List<StateChange> list = new ArrayList<>();
@@ -406,6 +408,9 @@ public abstract class MetadataV2V3SerializerBase {
                     metaDataStateHandle);
 
         } else if (CHANGELOG_BYTE_INCREMENT_HANDLE == type) {
+            int start = dis.readInt();
+            int numKeyGroups = dis.readInt();
+            KeyGroupRange keyGroupRange = KeyGroupRange.of(start, start + numKeyGroups - 1);
             long from = dis.readLong();
             long to = dis.readLong();
             int size = dis.readInt();
@@ -417,7 +422,7 @@ public abstract class MetadataV2V3SerializerBase {
                 dis.read(bytes);
                 changes.add(new StateChange(keyGroup, bytes));
             }
-            return new InMemoryStateChangelogHandle(changes, from, to);
+            return new InMemoryStateChangelogHandle(changes, from, to, keyGroupRange);
 
         } else if (CHANGELOG_FILE_INCREMENT_HANDLE == type) {
             int start = dis.readInt();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -53,7 +53,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class AbstractKeyedStateBackend<K>
         implements CheckpointableKeyedStateBackend<K>,
                 CheckpointListener,
-                TestableKeyedStateBackend<K> {
+                TestableKeyedStateBackend<K>,
+                InternalKeyContext<K> {
 
     /** The key serializer. */
     protected final TypeSerializer<K> keySerializer;
@@ -393,5 +394,10 @@ public abstract class AbstractKeyedStateBackend<K>
                 final TypeSerializer<N> namespaceSerializer,
                 final StateDescriptor<S, ?> stateDescriptor)
                 throws Exception;
+    }
+
+    @Override
+    public void setCurrentKeyGroupIndex(int currentKeyGroupIndex) {
+        keyContext.setCurrentKeyGroupIndex(currentKeyGroupIndex);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -46,17 +46,17 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public interface ChangelogStateBackendHandle extends KeyedStateHandle {
     List<KeyedStateHandle> getMaterializedStateHandles();
 
-    List<StateChangelogHandle> getNonMaterializedStateHandles();
+    List<ChangelogStateHandle> getNonMaterializedStateHandles();
 
     class ChangelogStateBackendHandleImpl implements ChangelogStateBackendHandle {
         private static final long serialVersionUID = 1L;
         private final List<KeyedStateHandle> materialized;
-        private final List<StateChangelogHandle> nonMaterialized;
+        private final List<ChangelogStateHandle> nonMaterialized;
         private final KeyGroupRange keyGroupRange;
 
         public ChangelogStateBackendHandleImpl(
                 List<KeyedStateHandle> materialized,
-                List<StateChangelogHandle> nonMaterialized,
+                List<ChangelogStateHandle> nonMaterialized,
                 KeyGroupRange keyGroupRange) {
             this.materialized = unmodifiableList(materialized);
             this.nonMaterialized = unmodifiableList(nonMaterialized);
@@ -96,11 +96,11 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
                             .map(handle -> handle.getIntersection(keyGroupRange))
                             .filter(Objects::nonNull)
                             .collect(Collectors.toList());
-            List<StateChangelogHandle> deltaPart =
+            List<ChangelogStateHandle> deltaPart =
                     this.nonMaterialized.stream()
                             .map(
                                     handle ->
-                                            (StateChangelogHandle)
+                                            (ChangelogStateHandle)
                                                     handle.getIntersection(keyGroupRange))
                             .filter(Objects::nonNull)
                             .collect(Collectors.toList());
@@ -119,7 +119,7 @@ public interface ChangelogStateBackendHandle extends KeyedStateHandle {
         }
 
         @Override
-        public List<StateChangelogHandle> getNonMaterializedStateHandles() {
+        public List<ChangelogStateHandle> getNonMaterializedStateHandles() {
             return nonMaterialized;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.changelog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.guava18.com.google.common.io.Closer;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableList;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A handle to ChangelogStateBackend state. Consists of the base and delta parts. Base part
+ * references materialized state (e.g. SST files), while delta part references state changes that
+ * were not not materialized at the time of the snapshot. Both are potentially empty lists as there
+ * can be no state or multiple states (e.g. after rescaling).
+ */
+@Internal
+public interface ChangelogStateBackendHandle extends KeyedStateHandle {
+    List<KeyedStateHandle> getMaterializedStateHandles();
+
+    List<StateChangelogHandle> getNonMaterializedStateHandles();
+
+    class ChangelogStateBackendHandleImpl implements ChangelogStateBackendHandle {
+        private static final long serialVersionUID = 1L;
+        private final List<KeyedStateHandle> materialized;
+        private final List<StateChangelogHandle> nonMaterialized;
+        private final KeyGroupRange keyGroupRange;
+
+        public ChangelogStateBackendHandleImpl(
+                List<KeyedStateHandle> materialized,
+                List<StateChangelogHandle> nonMaterialized,
+                KeyGroupRange keyGroupRange) {
+            this.materialized = unmodifiableList(materialized);
+            this.nonMaterialized = unmodifiableList(nonMaterialized);
+            this.keyGroupRange = keyGroupRange;
+            checkArgument(keyGroupRange.getNumberOfKeyGroups() > 0);
+        }
+
+        @Override
+        public void registerSharedStates(SharedStateRegistry stateRegistry) {
+            stateRegistry.registerAll(materialized);
+            stateRegistry.registerAll(nonMaterialized);
+        }
+
+        @Override
+        public void discardState() throws Exception {
+            try (Closer closer = Closer.create()) {
+                materialized.forEach(h -> closer.register(asCloseable(h)));
+                nonMaterialized.forEach(h -> closer.register(asCloseable(h)));
+            }
+        }
+
+        @Override
+        public KeyGroupRange getKeyGroupRange() {
+            return keyGroupRange;
+        }
+
+        @Nullable
+        @Override
+        public KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange) {
+            // todo: revisit/review
+            KeyGroupRange intersection = this.keyGroupRange.getIntersection(keyGroupRange);
+            if (intersection.getNumberOfKeyGroups() == 0) {
+                return null;
+            }
+            List<KeyedStateHandle> basePart =
+                    this.materialized.stream()
+                            .map(handle -> handle.getIntersection(keyGroupRange))
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+            List<StateChangelogHandle> deltaPart =
+                    this.nonMaterialized.stream()
+                            .map(
+                                    handle ->
+                                            (StateChangelogHandle)
+                                                    handle.getIntersection(keyGroupRange))
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList());
+            return new ChangelogStateBackendHandleImpl(basePart, deltaPart, intersection);
+        }
+
+        @Override
+        public long getStateSize() {
+            return materialized.stream().mapToLong(StateObject::getStateSize).sum()
+                    + nonMaterialized.stream().mapToLong(StateObject::getStateSize).sum();
+        }
+
+        @Override
+        public List<KeyedStateHandle> getMaterializedStateHandles() {
+            return materialized;
+        }
+
+        @Override
+        public List<StateChangelogHandle> getNonMaterializedStateHandles() {
+            return nonMaterialized;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                    "keyGroupRange=%s, basePartSize=%d, deltaPartSize=%d",
+                    keyGroupRange, materialized.size(), nonMaterialized.size());
+        }
+
+        private static Closeable asCloseable(KeyedStateHandle h) {
+            return () -> {
+                try {
+                    h.discardState();
+                } catch (Exception e) {
+                    ExceptionUtils.rethrowIOException(e);
+                }
+            };
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandle.java
@@ -22,4 +22,4 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 
 /** A handle to saved {@link StateChange state changes}. */
 @Internal
-public interface StateChangelogHandle extends KeyedStateHandle {}
+public interface ChangelogStateHandle extends KeyedStateHandle {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateHandleStreamImpl.java
@@ -36,9 +36,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/** {@link StateChangelogHandle} implementation based on {@link StreamStateHandle}. */
+/** {@link ChangelogStateHandle} implementation based on {@link StreamStateHandle}. */
 @Internal
-public final class StateChangelogHandleStreamImpl implements StateChangelogHandle {
+public final class ChangelogStateHandleStreamImpl implements ChangelogStateHandle {
 
     private static final long serialVersionUID = -8070326169926626355L;
 
@@ -49,7 +49,7 @@ public final class StateChangelogHandleStreamImpl implements StateChangelogHandl
     private transient SharedStateRegistry stateRegistry;
     private final long size;
 
-    public StateChangelogHandleStreamImpl(
+    public ChangelogStateHandleStreamImpl(
             List<Tuple2<StreamStateHandle, Long>> handlesAndOffsets,
             KeyGroupRange keyGroupRange,
             long size) {
@@ -58,7 +58,7 @@ public final class StateChangelogHandleStreamImpl implements StateChangelogHandl
         this.size = size;
     }
 
-    public StateChangelogHandleStreamImpl(
+    public ChangelogStateHandleStreamImpl(
             List<Tuple3<StreamStateHandle, Long, Long>> sorted, KeyGroupRange keyGroupRange) {
         this(
                 sorted.stream().map(t -> Tuple2.of(t.f0, t.f1)).collect(Collectors.toList()),
@@ -87,7 +87,7 @@ public final class StateChangelogHandleStreamImpl implements StateChangelogHandl
         if (offsets.getNumberOfKeyGroups() == 0) {
             return null;
         }
-        return new StateChangelogHandleStreamImpl(handlesAndOffsets, offsets, 0L /* unknown */);
+        return new ChangelogStateHandleStreamImpl(handlesAndOffsets, offsets, 0L /* unknown */);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/SequenceNumber.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/SequenceNumber.java
@@ -27,7 +27,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * A logical timestamp to draw a boundary between the materialized and non-materialized changes.
  * Maintained by the state backend but implementations may choose to move its generation to {@link
- * StateChangelogWriterFactory} as an optimization.
+ * StateChangelogStorage} as an optimization.
  */
 @Internal
 public interface SequenceNumber extends Comparable<SequenceNumber> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleReader.java
@@ -18,8 +18,12 @@
 package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.util.CloseableIterator;
 
-/** A handle to saved {@link StateChange state changes}. */
+import java.io.IOException;
+
+/** Allows to read state changelog referenced by the provided {@link StateChangelogHandle}. */
 @Internal
-public interface StateChangelogHandle extends KeyedStateHandle {}
+public interface StateChangelogHandleReader<Handle extends StateChangelogHandle> {
+    CloseableIterator<StateChange> getChanges(Handle handle) throws IOException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleReader.java
@@ -22,8 +22,8 @@ import org.apache.flink.util.CloseableIterator;
 
 import java.io.IOException;
 
-/** Allows to read state changelog referenced by the provided {@link StateChangelogHandle}. */
+/** Allows to read state changelog referenced by the provided {@link ChangelogStateHandle}. */
 @Internal
-public interface StateChangelogHandleReader<Handle extends StateChangelogHandle> {
+public interface StateChangelogHandleReader<Handle extends ChangelogStateHandle> {
     CloseableIterator<StateChange> getChanges(Handle handle) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.changelog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * A reader for {@link StateChangelogHandleStreamImpl} that iterates over its underlying {@link
+ * StreamStateHandle stream handles} and offsets. Starting from each offset, it enumerates the
+ * {@link StateChange state changes} using the provided {@link StateChangeIterator}. Different
+ * {@link StateChangelogStorage} implementations may have different <b>iterator</b> implementations.
+ * Using a different {@link StateChangelogHandle} (and reader) is problematic as it needs to be
+ * serialized.
+ */
+@Internal
+public class StateChangelogHandleStreamHandleReader
+        implements StateChangelogHandleReader<StateChangelogHandleStreamImpl> {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(StateChangelogHandleStreamHandleReader.class);
+
+    /** Reads a stream of state changes starting from a specified offset. */
+    public interface StateChangeIterator {
+        CloseableIterator<StateChange> read(StreamStateHandle handle, long offset);
+    }
+
+    private final StateChangeIterator changeIterator;
+
+    public StateChangelogHandleStreamHandleReader(StateChangeIterator changeIterator) {
+        this.changeIterator = changeIterator;
+    }
+
+    @Override
+    public CloseableIterator<StateChange> getChanges(StateChangelogHandleStreamImpl handle)
+            throws IOException {
+        return new CloseableIterator<StateChange>() {
+            private final Iterator<Tuple2<StreamStateHandle, Long>> handleIterator =
+                    handle.getHandlesAndOffsets().iterator();
+
+            private CloseableIterator<StateChange> current = CloseableIterator.empty();
+
+            @Override
+            public boolean hasNext() {
+                advance();
+                return current.hasNext();
+            }
+
+            @Override
+            public StateChange next() {
+                advance();
+                return current.next();
+            }
+
+            private void advance() {
+                while (!current.hasNext() && handleIterator.hasNext()) {
+                    try {
+                        current.close();
+                        Tuple2<StreamStateHandle, Long> tuple2 = handleIterator.next();
+                        LOG.debug("read at {} from {}", tuple2.f1, tuple2.f0);
+                        current = changeIterator.read(tuple2.f0, tuple2.f1);
+                    } catch (Exception e) {
+                        ExceptionUtils.rethrow(e);
+                    }
+                }
+            }
+
+            @Override
+            public void close() throws Exception {
+                current.close();
+            }
+        };
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
@@ -45,6 +45,7 @@ public class StateChangelogHandleStreamHandleReader
 
     /** Reads a stream of state changes starting from a specified offset. */
     public interface StateChangeIterator {
+        // todo: add implementation (FLINK-21353)
         CloseableIterator<StateChange> read(StreamStateHandle handle, long offset);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogHandleStreamHandleReader.java
@@ -30,16 +30,16 @@ import java.io.IOException;
 import java.util.Iterator;
 
 /**
- * A reader for {@link StateChangelogHandleStreamImpl} that iterates over its underlying {@link
+ * A reader for {@link ChangelogStateHandleStreamImpl} that iterates over its underlying {@link
  * StreamStateHandle stream handles} and offsets. Starting from each offset, it enumerates the
  * {@link StateChange state changes} using the provided {@link StateChangeIterator}. Different
  * {@link StateChangelogStorage} implementations may have different <b>iterator</b> implementations.
- * Using a different {@link StateChangelogHandle} (and reader) is problematic as it needs to be
+ * Using a different {@link ChangelogStateHandle} (and reader) is problematic as it needs to be
  * serialized.
  */
 @Internal
 public class StateChangelogHandleStreamHandleReader
-        implements StateChangelogHandleReader<StateChangelogHandleStreamImpl> {
+        implements StateChangelogHandleReader<ChangelogStateHandleStreamImpl> {
     private static final Logger LOG =
             LoggerFactory.getLogger(StateChangelogHandleStreamHandleReader.class);
 
@@ -56,7 +56,7 @@ public class StateChangelogHandleStreamHandleReader
     }
 
     @Override
-    public CloseableIterator<StateChange> getChanges(StateChangelogHandleStreamImpl handle)
+    public CloseableIterator<StateChange> getChanges(ChangelogStateHandleStreamImpl handle)
             throws IOException {
         return new CloseableIterator<StateChange>() {
             private final Iterator<Tuple2<StreamStateHandle, Long>> handleIterator =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
@@ -23,11 +23,10 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 
 /**
  * A factory for {@link StateChangelogWriter} and {@link StateChangelogHandleReader}. Please use
- * {@link StateChangelogWriterFactoryLoader} to obtain an instance.
+ * {@link StateChangelogStorageLoader} to obtain an instance.
  */
 @Internal
-public interface StateChangelogWriterFactory<Handle extends StateChangelogHandle>
-        extends AutoCloseable {
+public interface StateChangelogStorage<Handle extends StateChangelogHandle> extends AutoCloseable {
 
     StateChangelogWriter<Handle> createWriter(String operatorID, KeyGroupRange keyGroupRange);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorage.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
  * {@link StateChangelogStorageLoader} to obtain an instance.
  */
 @Internal
-public interface StateChangelogStorage<Handle extends StateChangelogHandle> extends AutoCloseable {
+public interface StateChangelogStorage<Handle extends ChangelogStateHandle> extends AutoCloseable {
 
     StateChangelogWriter<Handle> createWriter(String operatorID, KeyGroupRange keyGroupRange);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -25,19 +25,19 @@ import java.util.ServiceLoader;
 
 import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterators.concat;
 
-/** A thin wrapper around {@link PluginManager} to load {@link StateChangelogWriterFactory}. */
+/** A thin wrapper around {@link PluginManager} to load {@link StateChangelogStorage}. */
 @Internal
-public class StateChangelogWriterFactoryLoader {
+public class StateChangelogStorageLoader {
     private final PluginManager pluginManager;
 
-    public StateChangelogWriterFactoryLoader(PluginManager pluginManager) {
+    public StateChangelogStorageLoader(PluginManager pluginManager) {
         this.pluginManager = pluginManager;
     }
 
     @SuppressWarnings({"rawtypes"})
-    public Iterator<StateChangelogWriterFactory> load() {
+    public Iterator<StateChangelogStorage> load() {
         return concat(
-                pluginManager.load(StateChangelogWriterFactory.class),
-                ServiceLoader.load(StateChangelogWriterFactory.class).iterator());
+                pluginManager.load(StateChangelogStorage.class),
+                ServiceLoader.load(StateChangelogStorage.class).iterator());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 
 /** Allows to write data to the log. Scoped to a single writer (e.g. state backend). */
 @Internal
-public interface StateChangelogWriter<Handle extends StateChangelogHandle> extends AutoCloseable {
+public interface StateChangelogWriter<Handle extends ChangelogStateHandle> extends AutoCloseable {
 
     /** Get the initial {@link SequenceNumber} that is used for the first element. */
     SequenceNumber initialSequenceNumber();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -24,8 +24,10 @@ import java.util.concurrent.CompletableFuture;
 
 /** Allows to write data to the log. Scoped to a single writer (e.g. state backend). */
 @Internal
-public interface StateChangelogWriter<Handle extends StateChangelogHandle<?>>
-        extends AutoCloseable {
+public interface StateChangelogWriter<Handle extends StateChangelogHandle> extends AutoCloseable {
+
+    /** Get the initial {@link SequenceNumber} that is used for the first element. */
+    SequenceNumber initialSequenceNumber();
 
     /**
      * Get {@link SequenceNumber} of the last element added by {@link #append(int, byte[]) append}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriterFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriterFactory.java
@@ -22,14 +22,16 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyGroupRange;
 
 /**
- * {@link StateChangelogWriter} factory. Scoped to a single entity (e.g. a SubTask or
- * OperatorCoordinator). Please use {@link StateChangelogWriterFactoryLoader} to obtain an instance.
+ * A factory for {@link StateChangelogWriter} and {@link StateChangelogHandleReader}. Please use
+ * {@link StateChangelogWriterFactoryLoader} to obtain an instance.
  */
 @Internal
-public interface StateChangelogWriterFactory<Handle extends StateChangelogHandle<?>>
+public interface StateChangelogWriterFactory<Handle extends StateChangelogHandle>
         extends AutoCloseable {
 
     StateChangelogWriter<Handle> createWriter(String operatorID, KeyGroupRange keyGroupRange);
+
+    StateChangelogHandleReader<Handle> createReader();
 
     @Override
     default void close() throws Exception {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
@@ -21,18 +21,18 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChange;
-import org.apache.flink.runtime.state.changelog.StateChangelogHandle;
 
 import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
 
-/** In-memory {@link StateChangelogHandle}. */
+/** In-memory {@link ChangelogStateHandle}. */
 @Internal
-public class InMemoryStateChangelogHandle implements StateChangelogHandle {
+public class InMemoryChangelogStateHandle implements ChangelogStateHandle {
 
     private static final long serialVersionUID = 1L;
 
@@ -41,12 +41,12 @@ public class InMemoryStateChangelogHandle implements StateChangelogHandle {
     private final SequenceNumber to; // for debug purposes
     private final KeyGroupRange keyGroupRange;
 
-    public InMemoryStateChangelogHandle(
+    public InMemoryChangelogStateHandle(
             List<StateChange> changes, long from, long to, KeyGroupRange keyGroupRange) {
         this(changes, SequenceNumber.of(from), SequenceNumber.of(to), keyGroupRange);
     }
 
-    public InMemoryStateChangelogHandle(
+    public InMemoryChangelogStateHandle(
             List<StateChange> changes,
             SequenceNumber from,
             SequenceNumber to,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogHandle.java
@@ -39,16 +39,22 @@ public class InMemoryStateChangelogHandle implements StateChangelogHandle<Void> 
     private final List<StateChange> changes;
     private final SequenceNumber from; // for debug purposes
     private final SequenceNumber to; // for debug purposes
+    private final KeyGroupRange keyGroupRange;
 
-    public InMemoryStateChangelogHandle(List<StateChange> changes, long from, long to) {
-        this(changes, SequenceNumber.of(from), SequenceNumber.of(to));
+    public InMemoryStateChangelogHandle(
+            List<StateChange> changes, long from, long to, KeyGroupRange keyGroupRange) {
+        this(changes, SequenceNumber.of(from), SequenceNumber.of(to), keyGroupRange);
     }
 
     public InMemoryStateChangelogHandle(
-            List<StateChange> changes, SequenceNumber from, SequenceNumber to) {
+            List<StateChange> changes,
+            SequenceNumber from,
+            SequenceNumber to,
+            KeyGroupRange keyGroupRange) {
         this.changes = changes;
         this.from = from;
         this.to = to;
+        this.keyGroupRange = keyGroupRange;
     }
 
     @Override
@@ -66,7 +72,7 @@ public class InMemoryStateChangelogHandle implements StateChangelogHandle<Void> 
 
     @Override
     public KeyGroupRange getKeyGroupRange() {
-        throw new UnsupportedOperationException();
+        return keyGroupRange;
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogHandle.java
@@ -24,15 +24,15 @@ import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandle;
-import org.apache.flink.util.CloseableIterator;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 
 /** In-memory {@link StateChangelogHandle}. */
 @Internal
-public class InMemoryStateChangelogHandle implements StateChangelogHandle<Void> {
+public class InMemoryStateChangelogHandle implements StateChangelogHandle {
 
     private static final long serialVersionUID = 1L;
 
@@ -65,9 +65,8 @@ public class InMemoryStateChangelogHandle implements StateChangelogHandle<Void> 
         return changes.stream().mapToLong(change -> change.getChange().length).sum();
     }
 
-    @Override
-    public CloseableIterator<StateChange> getChanges(Void unused) {
-        return CloseableIterator.fromList(changes, change -> {});
+    public List<StateChange> getChanges() {
+        return Collections.unmodifiableList(changes);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogHandle.java
@@ -84,7 +84,7 @@ public class InMemoryStateChangelogHandle implements StateChangelogHandle {
 
     @Override
     public void registerSharedStates(SharedStateRegistry stateRegistry) {
-        throw new UnsupportedOperationException();
+        // do nothing
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorage.java
@@ -19,12 +19,12 @@ package org.apache.flink.runtime.state.changelog.inmemory;
 
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
-import org.apache.flink.runtime.state.changelog.StateChangelogWriterFactory;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.util.CloseableIterator;
 
-/** An in-memory (non-production) implementation of {@link StateChangelogWriterFactory}. */
-public class InMemoryStateChangelogWriterFactory
-        implements StateChangelogWriterFactory<InMemoryStateChangelogHandle> {
+/** An in-memory (non-production) implementation of {@link StateChangelogStorage}. */
+public class InMemoryStateChangelogStorage
+        implements StateChangelogStorage<InMemoryStateChangelogHandle> {
 
     @Override
     public InMemoryStateChangelogWriter createWriter(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorage.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.CloseableIterator;
 
 /** An in-memory (non-production) implementation of {@link StateChangelogStorage}. */
 public class InMemoryStateChangelogStorage
-        implements StateChangelogStorage<InMemoryStateChangelogHandle> {
+        implements StateChangelogStorage<InMemoryChangelogStateHandle> {
 
     @Override
     public InMemoryStateChangelogWriter createWriter(
@@ -33,7 +33,7 @@ public class InMemoryStateChangelogStorage
     }
 
     @Override
-    public StateChangelogHandleReader<InMemoryStateChangelogHandle> createReader() {
+    public StateChangelogHandleReader<InMemoryChangelogStateHandle> createReader() {
         return handle -> CloseableIterator.fromList(handle.getChanges(), change -> {});
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -42,7 +42,7 @@ import java.util.stream.Stream;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 @NotThreadSafe
-class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryStateChangelogHandle> {
+class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChangelogStateHandle> {
     private static final Logger LOG = LoggerFactory.getLogger(InMemoryStateChangelogWriter.class);
     private static final SequenceNumber INITIAL_SQN = SequenceNumber.of(0L);
 
@@ -75,11 +75,11 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryState
     }
 
     @Override
-    public CompletableFuture<InMemoryStateChangelogHandle> persist(SequenceNumber from) {
+    public CompletableFuture<InMemoryChangelogStateHandle> persist(SequenceNumber from) {
         LOG.debug("Persist after {}", from);
         Preconditions.checkNotNull(from);
         return completedFuture(
-                new InMemoryStateChangelogHandle(collectChanges(from), from, sqn, keyGroupRange));
+                new InMemoryChangelogStateHandle(collectChanges(from), from, sqn, keyGroupRange));
     }
 
     private List<StateChange> collectChanges(SequenceNumber after) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -104,16 +104,13 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryState
 
     @Override
     public void truncate(SequenceNumber before) {
-        changesByKeyGroup.forEach((k, v) -> {});
+        changesByKeyGroup.forEach(
+                (kg, changesBySqn) -> changesBySqn.headMap(before, false).clear());
     }
 
     @Override
-    public void confirm(SequenceNumber from, SequenceNumber to) {
-        throw new UnsupportedOperationException();
-    }
+    public void confirm(SequenceNumber from, SequenceNumber to) {}
 
     @Override
-    public void reset(SequenceNumber from, SequenceNumber to) {
-        throw new UnsupportedOperationException();
-    }
+    public void reset(SequenceNumber from, SequenceNumber to) {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriterFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriterFactory.java
@@ -18,7 +18,9 @@
 package org.apache.flink.runtime.state.changelog.inmemory;
 
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriterFactory;
+import org.apache.flink.util.CloseableIterator;
 
 /** An in-memory (non-production) implementation of {@link StateChangelogWriterFactory}. */
 public class InMemoryStateChangelogWriterFactory
@@ -28,5 +30,10 @@ public class InMemoryStateChangelogWriterFactory
     public InMemoryStateChangelogWriter createWriter(
             String operatorID, KeyGroupRange keyGroupRange) {
         return new InMemoryStateChangelogWriter(keyGroupRange);
+    }
+
+    @Override
+    public StateChangelogHandleReader<InMemoryStateChangelogHandle> createReader() {
+        return handle -> CloseableIterator.fromList(handle.getChanges(), change -> {});
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriterFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriterFactory.java
@@ -27,6 +27,6 @@ public class InMemoryStateChangelogWriterFactory
     @Override
     public InMemoryStateChangelogWriter createWriter(
             String operatorID, KeyGroupRange keyGroupRange) {
-        return new InMemoryStateChangelogWriter();
+        return new InMemoryStateChangelogWriter(keyGroupRange);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
@@ -38,10 +38,28 @@ public class StateMetaInfoSnapshot {
 
     /** Enum that defines the different types of state that live in Flink backends. */
     public enum BackendStateType {
-        KEY_VALUE,
-        OPERATOR,
-        BROADCAST,
-        PRIORITY_QUEUE
+        KEY_VALUE(0),
+        OPERATOR(1),
+        BROADCAST(2),
+        PRIORITY_QUEUE(3);
+        private final byte code;
+
+        BackendStateType(int code) {
+            this.code = (byte) code;
+        }
+
+        public byte getCode() {
+            return code;
+        }
+
+        public static BackendStateType byCode(int code) {
+            for (BackendStateType type : values()) {
+                if (type.code == code) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Unknown BackendStateType: " + code);
+        }
     }
 
     /** Predefined keys for the most common options in the meta info. */

--- a/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.state.changelog.StateChangelogStorage
+++ b/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.state.changelog.StateChangelogStorage
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogWriterFactory
+org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageLoaderTest.java
@@ -18,8 +18,8 @@
 package org.apache.flink.runtime.state.changelog.inmemory;
 
 import org.apache.flink.core.plugin.PluginManager;
-import org.apache.flink.runtime.state.changelog.StateChangelogWriterFactory;
-import org.apache.flink.runtime.state.changelog.StateChangelogWriterFactoryLoader;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
 
 import org.junit.Test;
 
@@ -31,12 +31,12 @@ import static org.apache.flink.shaded.curator4.com.google.common.collect.Immutab
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.junit.Assert.assertTrue;
 
-public class StateChangelogWriterFactoryLoaderTest {
+public class StateChangelogStorageLoaderTest {
 
     @Test
     public void testLoadSpiImplementation() {
         assertTrue(
-                new StateChangelogWriterFactoryLoader(getPluginManager(emptyIterator()))
+                new StateChangelogStorageLoader(getPluginManager(emptyIterator()))
                         .load()
                         .hasNext());
     }
@@ -44,20 +44,19 @@ public class StateChangelogWriterFactoryLoaderTest {
     @Test
     @SuppressWarnings("rawtypes")
     public void testLoadPluginImplementation() {
-        StateChangelogWriterFactory<?> impl = new InMemoryStateChangelogWriterFactory();
+        StateChangelogStorage<?> impl = new InMemoryStateChangelogStorage();
         PluginManager pluginManager = getPluginManager(singletonList(impl).iterator());
-        Iterator<StateChangelogWriterFactory> loaded =
-                new StateChangelogWriterFactoryLoader(pluginManager).load();
+        Iterator<StateChangelogStorage> loaded =
+                new StateChangelogStorageLoader(pluginManager).load();
         assertTrue(copyOf(loaded).contains(impl));
     }
 
-    private PluginManager getPluginManager(
-            Iterator<? extends StateChangelogWriterFactory<?>> iterator) {
+    private PluginManager getPluginManager(Iterator<? extends StateChangelogStorage<?>> iterator) {
         return new PluginManager() {
 
             @Override
             public <P> Iterator<P> load(Class<P> service) {
-                checkArgument(service.equals(StateChangelogWriterFactory.class));
+                checkArgument(service.equals(StateChangelogStorage.class));
                 //noinspection unchecked
                 return (Iterator<P>) iterator;
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandle;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
-import org.apache.flink.runtime.state.changelog.StateChangelogWriterFactory;
 import org.apache.flink.util.CloseableIterator;
 
 import org.junit.Rule;
@@ -48,8 +48,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-/** {@link InMemoryStateChangelogWriterFactory} test. */
-public class StateChangelogWriterFactoryTest<T extends StateChangelogHandle> {
+/** {@link InMemoryStateChangelogStorage} test. */
+public class StateChangelogStorageTest<T extends StateChangelogHandle> {
 
     private final Random random = new Random();
 
@@ -68,7 +68,7 @@ public class StateChangelogWriterFactoryTest<T extends StateChangelogHandle> {
         KeyGroupRange kgRange = KeyGroupRange.of(0, 5);
         Map<Integer, List<byte[]>> appendsByKeyGroup = generateAppends(kgRange, 10, 20);
 
-        try (StateChangelogWriterFactory<T> client = getFactory();
+        try (StateChangelogStorage<T> client = getFactory();
                 StateChangelogWriter<T> writer =
                         client.createWriter(new OperatorID().toString(), kgRange)) {
             SequenceNumber prev = writer.initialSequenceNumber();
@@ -133,7 +133,7 @@ public class StateChangelogWriterFactoryTest<T extends StateChangelogHandle> {
         return bytes;
     }
 
-    protected StateChangelogWriterFactory<T> getFactory() {
-        return (StateChangelogWriterFactory<T>) new InMemoryStateChangelogWriterFactory();
+    protected StateChangelogStorage<T> getFactory() {
+        return (StateChangelogStorage<T>) new InMemoryStateChangelogStorage();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
@@ -19,9 +19,9 @@ package org.apache.flink.runtime.state.changelog.inmemory;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChange;
-import org.apache.flink.runtime.state.changelog.StateChangelogHandle;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /** {@link InMemoryStateChangelogStorage} test. */
-public class StateChangelogStorageTest<T extends StateChangelogHandle> {
+public class StateChangelogStorageTest<T extends ChangelogStateHandle> {
 
     private final Random random = new Random();
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogState.java
@@ -33,7 +33,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <S> Type of originally wrapped state object
  */
 abstract class AbstractChangelogState<K, N, V, S extends InternalKvState<K, N, V>>
-        implements InternalKvState<K, N, V> {
+        implements InternalKvState<K, N, V>, ChangelogState {
 
     protected final S delegatedState;
     protected final KvStateChangeLogger<V, N> changeLogger;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
@@ -18,9 +18,12 @@
 package org.apache.flink.state.changelog;
 
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshotReadersWriters;
 import org.apache.flink.util.function.ThrowingConsumer;
 
@@ -28,20 +31,18 @@ import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType.KEY_VALUE;
+import static org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE;
 import static org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshotReadersWriters.CURRENT_STATE_META_INFO_SNAPSHOT_VERSION;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.ADD;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.ADD_ELEMENT;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.ADD_OR_UPDATE_ELEMENT;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.CLEAR;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.METADATA;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.REMOVE_ELEMENT;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.SET;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.SET_INTERNAL;
+import static org.apache.flink.state.changelog.StateChangeOperation.ADD;
+import static org.apache.flink.state.changelog.StateChangeOperation.ADD_ELEMENT;
+import static org.apache.flink.state.changelog.StateChangeOperation.ADD_OR_UPDATE_ELEMENT;
+import static org.apache.flink.state.changelog.StateChangeOperation.CLEAR;
+import static org.apache.flink.state.changelog.StateChangeOperation.METADATA;
+import static org.apache.flink.state.changelog.StateChangeOperation.REMOVE_ELEMENT;
+import static org.apache.flink.state.changelog.StateChangeOperation.SET;
+import static org.apache.flink.state.changelog.StateChangeOperation.SET_INTERNAL;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeLogger<Value, Ns> {
@@ -49,6 +50,7 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
     protected final StateChangelogWriter<?> stateChangelogWriter;
     protected final InternalKeyContext<Key> keyContext;
     protected final RegisteredStateMetaInfoBase metaInfo;
+    private final StateMetaInfoSnapshot.BackendStateType stateType;
     private boolean metaDataWritten = false;
 
     public AbstractStateChangeLogger(
@@ -58,6 +60,13 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
         this.stateChangelogWriter = checkNotNull(stateChangelogWriter);
         this.keyContext = checkNotNull(keyContext);
         this.metaInfo = checkNotNull(metaInfo);
+        if (metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo) {
+            this.stateType = KEY_VALUE;
+        } else if (metaInfo instanceof RegisteredPriorityQueueStateBackendMetaInfo) {
+            this.stateType = PRIORITY_QUEUE;
+        } else {
+            throw new IllegalArgumentException("Unsupported state type: " + metaInfo);
+        }
     }
 
     @Override
@@ -135,7 +144,7 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
                     COMMON_KEY_GROUP,
                     serializeRaw(
                             out -> {
-                                out.writeByte(METADATA.code);
+                                out.writeByte(METADATA.getCode());
                                 out.writeInt(CURRENT_STATE_META_INFO_SNAPSHOT_VERSION);
                                 StateMetaInfoSnapshotReadersWriters.getWriter()
                                         .writeStateMetaInfoSnapshot(metaInfo.snapshot(), out);
@@ -151,10 +160,11 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
             throws IOException {
         return serializeRaw(
                 wrapper -> {
-                    wrapper.writeByte(op.code);
+                    wrapper.writeByte(op.getCode());
                     // todo: optimize in FLINK-22944 by either writing short code or grouping and
                     // writing once (same for key, ns)
                     wrapper.writeUTF(metaInfo.getName());
+                    wrapper.writeByte(stateType.getCode());
                     serializeScope(ns, wrapper);
                     if (dataWriter != null) {
                         dataWriter.accept(wrapper);
@@ -168,50 +178,11 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
     private byte[] serializeRaw(
             ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataWriter)
             throws IOException {
+        // todo: optimize performance
         try (ByteArrayOutputStream out = new ByteArrayOutputStream();
                 DataOutputViewStreamWrapper wrapper = new DataOutputViewStreamWrapper(out)) {
             dataWriter.accept(wrapper);
             return out.toByteArray();
-        }
-    }
-
-    enum StateChangeOperation {
-        /** Scope: key + namespace. */
-        CLEAR((byte) 0),
-        /** Scope: key + namespace. */
-        SET((byte) 1),
-        /** Scope: key + namespace. */
-        SET_INTERNAL((byte) 2),
-        /** Scope: key + namespace. */
-        ADD((byte) 3),
-        /** Scope: key + namespace, also affecting other (source) namespaces. */
-        MERGE_NS((byte) 4),
-        /** Scope: key + namespace + element (e.g. user list append). */
-        ADD_ELEMENT((byte) 5),
-        /** Scope: key + namespace + element (e.g. user map key put). */
-        ADD_OR_UPDATE_ELEMENT((byte) 6),
-        /** Scope: key + namespace + element (e.g. user map remove or iterator remove). */
-        REMOVE_ELEMENT((byte) 7),
-        /** Scope: key + namespace, first element (e.g. priority queue poll). */
-        REMOVE_FIRST_ELEMENT((byte) 8),
-        /** State metadata (name, serializers, etc.). */
-        METADATA((byte) 9);
-        private final byte code;
-
-        StateChangeOperation(byte code) {
-            this.code = code;
-        }
-
-        private static final Map<Byte, KvStateChangeLoggerImpl.StateChangeOperation> BY_CODES =
-                Arrays.stream(AbstractStateChangeLogger.StateChangeOperation.values())
-                        .collect(Collectors.toMap(o -> o.code, Function.identity()));
-
-        public static StateChangeOperation byCode(byte opCode) {
-            return checkNotNull(BY_CODES.get(opCode), Byte.toString(opCode));
-        }
-
-        public byte getCode() {
-            return code;
         }
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
@@ -20,6 +20,8 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.state.changelog.restore.ChangelogApplierFactory;
+import org.apache.flink.state.changelog.restore.StateChangeApplier;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.ExceptionUtils;
 
@@ -37,7 +39,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A {@link KeyGroupedInternalPriorityQueue} that keeps state on the underlying delegated {@link
  * KeyGroupedInternalPriorityQueue} as well as on the state change log.
  */
-public class ChangelogKeyGroupedPriorityQueue<T> implements KeyGroupedInternalPriorityQueue<T> {
+public class ChangelogKeyGroupedPriorityQueue<T>
+        implements KeyGroupedInternalPriorityQueue<T>, ChangelogState {
     private final KeyGroupedInternalPriorityQueue<T> delegatedPriorityQueue;
     private final PriorityQueueStateChangeLogger<T> logger;
     private final TypeSerializer<T> serializer;
@@ -109,9 +112,6 @@ public class ChangelogKeyGroupedPriorityQueue<T> implements KeyGroupedInternalPr
     }
 
     private void logAddition(Collection<? extends T> toAdd) {
-        if (toAdd == null) {
-            return;
-        }
         try {
             logger.valueElementAdded(
                     out -> {
@@ -132,5 +132,10 @@ public class ChangelogKeyGroupedPriorityQueue<T> implements KeyGroupedInternalPr
         return CloseableIterator.adapterForIterator(
                 StateChangeLoggingIterator.create(
                         delegatedPriorityQueue.iterator(), logger, serializer::serialize, null));
+    }
+
+    @Override
+    public StateChangeApplier getChangeApplier(ChangelogApplierFactory factory) {
+        return factory.forPriorityQueue(delegatedPriorityQueue, serializer);
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
@@ -23,8 +23,11 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.state.changelog.restore.ChangelogApplierFactory;
+import org.apache.flink.state.changelog.restore.StateChangeApplier;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
 
@@ -45,10 +48,14 @@ class ChangelogMapState<K, N, UK, UV>
         extends AbstractChangelogState<K, N, Map<UK, UV>, InternalMapState<K, N, UK, UV>>
         implements InternalMapState<K, N, UK, UV> {
 
+    private final InternalKeyContext<K> keyContext;
+
     ChangelogMapState(
             InternalMapState<K, N, UK, UV> delegatedState,
-            KvStateChangeLogger<Map<UK, UV>, N> changeLogger) {
+            KvStateChangeLogger<Map<UK, UV>, N> changeLogger,
+            InternalKeyContext<K> keyContext) {
         super(delegatedState, changeLogger);
+        this.keyContext = keyContext;
     }
 
     private Map.Entry<UK, UV> loggingMapEntry(
@@ -210,10 +217,18 @@ class ChangelogMapState<K, N, UK, UV>
 
     @SuppressWarnings("unchecked")
     static <UK, UV, K, N, SV, S extends State, IS extends S> IS create(
-            InternalKvState<K, N, SV> mapState, KvStateChangeLogger<SV, N> changeLogger) {
+            InternalKvState<K, N, SV> mapState,
+            KvStateChangeLogger<SV, N> changeLogger,
+            InternalKeyContext<K> keyContext) {
         return (IS)
                 new ChangelogMapState<>(
                         (InternalMapState<K, N, UK, UV>) mapState,
-                        (KvStateChangeLogger<Map<UK, UV>, N>) changeLogger);
+                        (KvStateChangeLogger<Map<UK, UV>, N>) changeLogger,
+                        keyContext);
+    }
+
+    @Override
+    public StateChangeApplier getChangeApplier(ChangelogApplierFactory factory) {
+        return factory.forMap(delegatedState, keyContext);
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogReducingState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogReducingState.java
@@ -21,8 +21,11 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.api.common.state.ReducingState;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.state.changelog.restore.ChangelogApplierFactory;
+import org.apache.flink.state.changelog.restore.StateChangeApplier;
 import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
@@ -40,9 +43,14 @@ class ChangelogReducingState<K, N, V>
         extends AbstractChangelogState<K, N, V, InternalReducingState<K, N, V>>
         implements InternalReducingState<K, N, V> {
 
+    private final InternalKeyContext<K> keyContext;
+
     ChangelogReducingState(
-            InternalReducingState<K, N, V> delegatedState, KvStateChangeLogger<V, N> changeLogger) {
+            InternalReducingState<K, N, V> delegatedState,
+            KvStateChangeLogger<V, N> changeLogger,
+            InternalKeyContext<K> keyContext) {
         super(delegatedState, changeLogger);
+        this.keyContext = keyContext;
     }
 
     @Override
@@ -94,9 +102,16 @@ class ChangelogReducingState<K, N, V>
 
     @SuppressWarnings("unchecked")
     static <K, N, SV, S extends State, IS extends S> IS create(
-            InternalKvState<K, N, SV> reducingState, KvStateChangeLogger<SV, N> changeLogger) {
+            InternalKvState<K, N, SV> reducingState,
+            KvStateChangeLogger<SV, N> changeLogger,
+            InternalKeyContext<K> keyContext) {
         return (IS)
                 new ChangelogReducingState<>(
-                        (InternalReducingState<K, N, SV>) reducingState, changeLogger);
+                        (InternalReducingState<K, N, SV>) reducingState, changeLogger, keyContext);
+    }
+
+    @Override
+    public StateChangeApplier getChangeApplier(ChangelogApplierFactory factory) {
+        return factory.forReducing(delegatedState, keyContext);
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
@@ -1,3 +1,4 @@
+package org.apache.flink.state.changelog;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,35 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.changelog;
-
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.state.changelog.restore.ChangelogApplierFactory;
+import org.apache.flink.state.changelog.restore.StateChangeApplier;
 
-/** Change of state of a keyed operator. Used for generic incremental checkpoints. */
+/**
+ * State used by {@link ChangelogKeyedStateBackend}. Allows replaying recorded changes on recovery
+ * using {@link StateChangeApplier}
+ */
 @Internal
-public class StateChange {
-
-    private final int keyGroup;
-    private final byte[] change;
-
-    public StateChange(int keyGroup, byte[] change) {
-        // todo: enable check in FLINK-23035
-        // Preconditions.checkArgument(keyGroup >= 0);
-        this.keyGroup = keyGroup;
-        this.change = Preconditions.checkNotNull(change);
-    }
-
-    @Override
-    public String toString() {
-        return String.format("keyGroup=%d, dataSize=%d", keyGroup, change.length);
-    }
-
-    public int getKeyGroup() {
-        return keyGroup;
-    }
-
-    public byte[] getChange() {
-        return change;
-    }
+public interface ChangelogState {
+    StateChangeApplier getChangeApplier(ChangelogApplierFactory factory);
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -35,7 +35,7 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
-import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogWriterFactory;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.Preconditions;
@@ -108,8 +108,7 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
                                 stateHandles,
                                 cancelStreamRegistry);
         // todo: FLINK-21804 get from Environment.getTaskStateManager
-        InMemoryStateChangelogWriterFactory changelogWriterFactory =
-                new InMemoryStateChangelogWriterFactory();
+        InMemoryStateChangelogStorage changelogWriterFactory = new InMemoryStateChangelogStorage();
         return new ChangelogKeyedStateBackend<>(
                 keyedStateBackend,
                 env.getExecutionConfig(),
@@ -150,8 +149,7 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
                                 managedMemoryFraction);
 
         // todo: FLINK-21804 get from Environment.getTaskStateManager
-        InMemoryStateChangelogWriterFactory changelogWriterFactory =
-                new InMemoryStateChangelogWriterFactory();
+        InMemoryStateChangelogStorage changelogWriterFactory = new InMemoryStateChangelogStorage();
         return new ChangelogKeyedStateBackend<>(
                 keyedStateBackend,
                 env.getExecutionConfig(),

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.util.Collection;
 
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.MERGE_NS;
+import static org.apache.flink.state.changelog.StateChangeOperation.MERGE_NS;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 @NotThreadSafe

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeOperation.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeOperation.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The operation applied to {@link ChangelogState}. */
+@Internal
+public enum StateChangeOperation {
+    /** Scope: key + namespace. */
+    CLEAR((byte) 0),
+    /** Scope: key + namespace. */
+    SET((byte) 1),
+    /** Scope: key + namespace. */
+    SET_INTERNAL((byte) 2),
+    /** Scope: key + namespace. */
+    ADD((byte) 3),
+    /** Scope: key + namespace, also affecting other (source) namespaces. */
+    MERGE_NS((byte) 4),
+    /** Scope: key + namespace + element (e.g. user list append). */
+    ADD_ELEMENT((byte) 5),
+    /** Scope: key + namespace + element (e.g. user map key put). */
+    ADD_OR_UPDATE_ELEMENT((byte) 6),
+    /** Scope: key + namespace + element (e.g. user map remove or iterator remove). */
+    REMOVE_ELEMENT((byte) 7),
+    /** Scope: key + namespace, first element (e.g. priority queue poll). */
+    REMOVE_FIRST_ELEMENT((byte) 8),
+    /** State metadata (name, serializers, etc.). */
+    METADATA((byte) 9);
+    private final byte code;
+
+    StateChangeOperation(byte code) {
+        this.code = code;
+    }
+
+    private static final Map<Byte, StateChangeOperation> BY_CODES =
+            Arrays.stream(StateChangeOperation.values())
+                    .collect(Collectors.toMap(o -> o.code, Function.identity()));
+
+    public static StateChangeOperation byCode(byte opCode) {
+        return checkNotNull(BY_CODES.get(opCode), Byte.toString(opCode));
+    }
+
+    public byte getCode() {
+        return code;
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/AggregatingStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/AggregatingStateChangeApplier.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+class AggregatingStateChangeApplier<K, N, IN, SV, OUT> extends KvStateChangeApplier<K, N> {
+    private final InternalAggregatingState<K, N, IN, SV, OUT> state;
+
+    protected AggregatingStateChangeApplier(
+            InternalKeyContext<K> keyContext, InternalAggregatingState<K, N, IN, SV, OUT> state) {
+        super(keyContext);
+        this.state = state;
+    }
+
+    @Override
+    protected InternalKvState<K, N, ?> getState() {
+        return state;
+    }
+
+    protected void applyInternal(StateChangeOperation operation, DataInputView in)
+            throws Exception {
+        switch (operation) {
+            case SET:
+            case SET_INTERNAL:
+                state.updateInternal(state.getValueSerializer().deserialize(in));
+                break;
+            case MERGE_NS:
+                applyMergeNamespaces(state, in);
+                break;
+            case CLEAR:
+                state.clear();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown state change operation: " + operation);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogApplierFactory.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogApplierFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+/**
+ * {@link StateChangeApplier} factory. It's purpose is to decouple restore/apply logic from state
+ * logic.
+ */
+@Internal
+public interface ChangelogApplierFactory {
+
+    <K, N, UK, UV> KvStateChangeApplier<K, N> forMap(
+            InternalMapState<K, N, UK, UV> map, InternalKeyContext<K> keyContext);
+
+    <K, N, T> KvStateChangeApplier<K, N> forValue(
+            InternalValueState<K, N, T> value, InternalKeyContext<K> keyContext);
+
+    <K, N, T> KvStateChangeApplier<K, N> forList(
+            InternalListState<K, N, T> list, InternalKeyContext<K> keyContext);
+
+    <K, N, T> KvStateChangeApplier<K, N> forReducing(
+            InternalReducingState<K, N, T> reducing, InternalKeyContext<K> keyContext);
+
+    <K, N, IN, SV, OUT> KvStateChangeApplier<K, N> forAggregating(
+            InternalAggregatingState<K, N, IN, SV, OUT> aggregating,
+            InternalKeyContext<K> keyContext);
+
+    <T> StateChangeApplier forPriorityQueue(
+            KeyGroupedInternalPriorityQueue<T> priorityQueue, TypeSerializer<T> serializer);
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogApplierFactoryImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogApplierFactoryImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalAggregatingState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+
+class ChangelogApplierFactoryImpl implements ChangelogApplierFactory {
+    public static final ChangelogApplierFactoryImpl INSTANCE = new ChangelogApplierFactoryImpl();
+
+    private ChangelogApplierFactoryImpl() {}
+
+    @Override
+    public <K, N, UK, UV> KvStateChangeApplier<K, N> forMap(
+            InternalMapState<K, N, UK, UV> map, InternalKeyContext<K> keyContext) {
+        return new MapStateChangeApplier<>(map, keyContext);
+    }
+
+    @Override
+    public <K, N, T> KvStateChangeApplier<K, N> forList(
+            InternalListState<K, N, T> state, InternalKeyContext<K> keyContext) {
+        return new ListStateChangeApplier<>(keyContext, state);
+    }
+
+    @Override
+    public <K, N, T> KvStateChangeApplier<K, N> forReducing(
+            InternalReducingState<K, N, T> state, InternalKeyContext<K> keyContext) {
+        return new ReducingStateChangeApplier<>(keyContext, state);
+    }
+
+    @Override
+    public <K, N, IN, SV, OUT> KvStateChangeApplier<K, N> forAggregating(
+            InternalAggregatingState<K, N, IN, SV, OUT> state, InternalKeyContext<K> keyContext) {
+        return new AggregatingStateChangeApplier<>(keyContext, state);
+    }
+
+    @Override
+    public <K, N, T> KvStateChangeApplier<K, N> forValue(
+            InternalValueState<K, N, T> state, InternalKeyContext<K> keyContext) {
+        return new ValueStateChangeApplier<>(keyContext, state);
+    }
+
+    @Override
+    public <T> StateChangeApplier forPriorityQueue(
+            KeyGroupedInternalPriorityQueue<T> queue, TypeSerializer<T> serializer) {
+        return new PriorityQueueStateChangeApplier<>(queue, serializer);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendLogApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendLogApplier.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoReader;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshotReadersWriters;
+import org.apache.flink.state.changelog.ChangelogKeyedStateBackend;
+import org.apache.flink.state.changelog.ChangelogState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshotReadersWriters.StateTypeHint.KEYED_STATE;
+import static org.apache.flink.state.changelog.StateChangeOperation.METADATA;
+import static org.apache.flink.state.changelog.restore.FunctionDelegationHelper.delegateAggregateFunction;
+import static org.apache.flink.state.changelog.restore.FunctionDelegationHelper.delegateReduceFunction;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Applies {@link StateChange}s to a {@link ChangelogKeyedStateBackend}. */
+@SuppressWarnings({"rawtypes", "unchecked"})
+class ChangelogBackendLogApplier {
+    private static final Logger LOG = LoggerFactory.getLogger(ChangelogBackendLogApplier.class);
+
+    public static void apply(
+            StateChange stateChange,
+            ChangelogKeyedStateBackend<?> changelogBackend,
+            ClassLoader classLoader)
+            throws Exception {
+        DataInputViewStreamWrapper in =
+                new DataInputViewStreamWrapper(new ByteArrayInputStream(stateChange.getChange()));
+        applyOperation(
+                StateChangeOperation.byCode(in.readByte()),
+                stateChange.getKeyGroup(),
+                changelogBackend,
+                in,
+                classLoader,
+                ChangelogApplierFactoryImpl.INSTANCE);
+    }
+
+    private static void applyOperation(
+            StateChangeOperation operation,
+            int keyGroup,
+            ChangelogKeyedStateBackend<?> backend,
+            DataInputView in,
+            ClassLoader classLoader,
+            ChangelogApplierFactory factory)
+            throws Exception {
+        LOG.debug("apply {} in key group {}", operation, keyGroup);
+        if (operation == METADATA) {
+            applyMetaDataChange(in, backend, classLoader);
+        } else if (backend.getKeyGroupRange().contains(keyGroup)) {
+            applyDataChange(in, factory, backend, operation);
+        }
+    }
+
+    private static void applyMetaDataChange(
+            DataInputView in, ChangelogKeyedStateBackend<?> backend, ClassLoader classLoader)
+            throws Exception {
+        StateMetaInfoSnapshot snapshot = readStateMetaInfoSnapshot(in, classLoader);
+        switch (snapshot.getBackendStateType()) {
+            case KEY_VALUE:
+                restoreKvMetaData(backend, snapshot);
+                return;
+            case PRIORITY_QUEUE:
+                restorePqMetaData(backend, snapshot);
+                return;
+            default:
+                throw new RuntimeException(
+                        "Unsupported state type: "
+                                + snapshot.getBackendStateType()
+                                + ", sate: "
+                                + snapshot.getName());
+        }
+    }
+
+    private static void restoreKvMetaData(
+            ChangelogKeyedStateBackend<?> backend, StateMetaInfoSnapshot snapshot)
+            throws Exception {
+        RegisteredKeyValueStateBackendMetaInfo meta =
+                new RegisteredKeyValueStateBackendMetaInfo(snapshot);
+        // Use regular API to create states in both changelog and the base backends the metadata is
+        // persisted in log before data changes.
+        // An alternative solution to load metadata "natively" by the base backends would require
+        // base state to be always present, i.e. the 1st checkpoint would have to be "full" always.
+        backend.getOrCreateKeyedState(meta.getNamespaceSerializer(), toStateDescriptor(meta));
+    }
+
+    private static StateDescriptor toStateDescriptor(RegisteredKeyValueStateBackendMetaInfo meta) {
+        switch (meta.getStateType()) {
+            case VALUE:
+                return new ValueStateDescriptor(meta.getName(), meta.getStateSerializer());
+            case MAP:
+                MapSerializer mapSerializer = (MapSerializer) meta.getStateSerializer();
+                return new MapStateDescriptor(
+                        meta.getName(),
+                        mapSerializer.getKeySerializer(),
+                        mapSerializer.getValueSerializer());
+            case LIST:
+                return new ListStateDescriptor(
+                        meta.getName(),
+                        ((ListSerializer) meta.getStateSerializer()).getElementSerializer());
+            case AGGREGATING:
+                return new AggregatingStateDescriptor(
+                        meta.getName(), delegateAggregateFunction(), meta.getStateSerializer());
+            case REDUCING:
+                return new ReducingStateDescriptor(
+                        meta.getName(), delegateReduceFunction(), meta.getStateSerializer());
+            default:
+                throw new IllegalArgumentException(meta.getStateType().toString());
+        }
+    }
+
+    private static void restorePqMetaData(
+            ChangelogKeyedStateBackend<?> backend, StateMetaInfoSnapshot snapshot) {
+        RegisteredPriorityQueueStateBackendMetaInfo meta =
+                new RegisteredPriorityQueueStateBackendMetaInfo(snapshot);
+        backend.create(meta.getName(), meta.getElementSerializer());
+    }
+
+    private static StateMetaInfoSnapshot readStateMetaInfoSnapshot(
+            DataInputView in, ClassLoader classLoader) throws IOException {
+        int version = in.readInt();
+        StateMetaInfoReader reader =
+                StateMetaInfoSnapshotReadersWriters.getReader(version, KEYED_STATE);
+        return reader.readStateMetaInfoSnapshot(in, classLoader);
+    }
+
+    private static void applyDataChange(
+            DataInputView in,
+            ChangelogApplierFactory factory,
+            ChangelogKeyedStateBackend<?> backend,
+            StateChangeOperation operation)
+            throws Exception {
+        String name = checkNotNull(in.readUTF());
+        BackendStateType type = BackendStateType.byCode(in.readByte());
+        ChangelogState state = backend.getExistingState(name, type);
+        StateChangeApplier changeApplier = state.getChangeApplier(factory);
+        changeApplier.apply(operation, in);
+    }
+
+    private ChangelogBackendLogApplier() {}
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendRestoreOperation.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+import org.apache.flink.runtime.state.changelog.StateChange;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandle;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
+import org.apache.flink.state.changelog.ChangelogKeyedStateBackend;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.BiFunctionWithException;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Restores {@link ChangelogKeyedStateBackend} from the provided {@link ChangelogStateBackendHandle
+ * handles}.
+ */
+@Internal
+public class ChangelogBackendRestoreOperation {
+    /** Builds base backend for {@link ChangelogKeyedStateBackend} from state. */
+    @FunctionalInterface
+    public interface BaseBackendBuilder<K>
+            extends FunctionWithException<
+                    Collection<KeyedStateHandle>, AbstractKeyedStateBackend<K>, Exception> {}
+
+    /** Builds {@link ChangelogKeyedStateBackend} from the base backend and state. */
+    @FunctionalInterface
+    public interface DeltaBackendBuilder<K>
+            extends BiFunctionWithException<
+                    AbstractKeyedStateBackend<K>,
+                    Collection<ChangelogStateBackendHandle>,
+                    ChangelogKeyedStateBackend<K>,
+                    Exception> {}
+
+    public static <K, T extends StateChangelogHandle> ChangelogKeyedStateBackend<K> restore(
+            StateChangelogHandleReader<T> changelogHandleReader,
+            ClassLoader classLoader,
+            Collection<ChangelogStateBackendHandle> stateHandles,
+            BaseBackendBuilder<K> baseBackendBuilder,
+            DeltaBackendBuilder<K> changelogBackendBuilder)
+            throws Exception {
+        Collection<KeyedStateHandle> baseState = extractBaseState(stateHandles);
+        AbstractKeyedStateBackend<K> baseBackend = baseBackendBuilder.apply(baseState);
+        ChangelogKeyedStateBackend<K> changelogBackend =
+                changelogBackendBuilder.apply(baseBackend, stateHandles);
+
+        for (ChangelogStateBackendHandle handle : stateHandles) {
+            if (handle != null) { // null is empty state (no change)
+                readBackendHandle(changelogBackend, handle, changelogHandleReader, classLoader);
+            }
+        }
+        return changelogBackend;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends StateChangelogHandle> void readBackendHandle(
+            ChangelogKeyedStateBackend<?> backend,
+            ChangelogStateBackendHandle backendHandle,
+            StateChangelogHandleReader<T> changelogHandleReader,
+            ClassLoader classLoader)
+            throws Exception {
+        for (StateChangelogHandle changelogHandle :
+                backendHandle.getNonMaterializedStateHandles()) {
+            try (CloseableIterator<StateChange> changes =
+                    changelogHandleReader.getChanges((T) changelogHandle)) {
+                while (changes.hasNext()) {
+                    ChangelogBackendLogApplier.apply(changes.next(), backend, classLoader);
+                }
+            }
+        }
+    }
+
+    private static Collection<KeyedStateHandle> extractBaseState(
+            Collection<ChangelogStateBackendHandle> stateHandles) {
+        Preconditions.checkNotNull(stateHandles);
+        return stateHandles.stream()
+                .filter(Objects::nonNull)
+                .map(ChangelogStateBackendHandle::getMaterializedStateHandles)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    private ChangelogBackendRestoreOperation() {}
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogBackendRestoreOperation.java
@@ -21,8 +21,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
 import org.apache.flink.runtime.state.changelog.StateChange;
-import org.apache.flink.runtime.state.changelog.StateChangelogHandle;
 import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
 import org.apache.flink.state.changelog.ChangelogKeyedStateBackend;
 import org.apache.flink.util.CloseableIterator;
@@ -55,7 +55,7 @@ public class ChangelogBackendRestoreOperation {
                     ChangelogKeyedStateBackend<K>,
                     Exception> {}
 
-    public static <K, T extends StateChangelogHandle> ChangelogKeyedStateBackend<K> restore(
+    public static <K, T extends ChangelogStateHandle> ChangelogKeyedStateBackend<K> restore(
             StateChangelogHandleReader<T> changelogHandleReader,
             ClassLoader classLoader,
             Collection<ChangelogStateBackendHandle> stateHandles,
@@ -76,13 +76,13 @@ public class ChangelogBackendRestoreOperation {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends StateChangelogHandle> void readBackendHandle(
+    private static <T extends ChangelogStateHandle> void readBackendHandle(
             ChangelogKeyedStateBackend<?> backend,
             ChangelogStateBackendHandle backendHandle,
             StateChangelogHandleReader<T> changelogHandleReader,
             ClassLoader classLoader)
             throws Exception {
-        for (StateChangelogHandle changelogHandle :
+        for (ChangelogStateHandle changelogHandle :
                 backendHandle.getNonMaterializedStateHandles()) {
             try (CloseableIterator<StateChange> changes =
                     changelogHandleReader.getChanges((T) changelogHandle)) {

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/FunctionDelegationHelper.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/FunctionDelegationHelper.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.StateDescriptor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * {@link DelegatingFunction Delegating functions} are used to create metadata on recovery when the
+ * actual function code is not known yet. Once the actual function is known, backend updates the
+ * delegate which starts receiving the calls.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+@Internal
+public class FunctionDelegationHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(FunctionDelegationHelper.class);
+
+    public static <T> ReduceFunction<T> delegateReduceFunction() {
+        return new DelegatingReduceFunction<>();
+    }
+
+    public static <IN, ACC, OUT> AggregateFunction<IN, ACC, OUT> delegateAggregateFunction() {
+        return new DelegatingAggregateFunction<>();
+    }
+
+    private interface DelegatingFunction<F> extends Function {
+        void delegateIfNeeded(F delegated);
+    }
+
+    private final Map<String, DelegatingFunction> delegatingFunctions = new HashMap<>();
+
+    public <T, S extends State, F> void addOrUpdate(StateDescriptor<S, T> stateDescriptor) {
+        F function = tryGetFunction(stateDescriptor);
+        String name = stateDescriptor.getName();
+        if (function instanceof DelegatingFunction) {
+            LOG.debug("add delegate: {}", name);
+            delegatingFunctions.putIfAbsent(name, (DelegatingFunction<?>) function);
+        } else {
+            DelegatingFunction<F> delegating = delegatingFunctions.get(name);
+            if (delegating != null) {
+                LOG.debug("update delegate: {}", name);
+                checkState(function != null, "unable to extract function for state " + name);
+                delegating.delegateIfNeeded(function);
+            }
+        }
+    }
+
+    @Nullable
+    private static <F extends Function> F tryGetFunction(StateDescriptor<?, ?> stateDescriptor) {
+        if (stateDescriptor instanceof ReducingStateDescriptor) {
+            return (F) ((ReducingStateDescriptor) stateDescriptor).getReduceFunction();
+        } else if (stateDescriptor instanceof AggregatingStateDescriptor) {
+            return (F) ((AggregatingStateDescriptor) stateDescriptor).getAggregateFunction();
+        } else {
+            return null;
+        }
+    }
+
+    static class DelegatingAggregateFunction<IN, ACC, OUT>
+            implements AggregateFunction<IN, ACC, OUT>,
+                    DelegatingFunction<AggregateFunction<IN, ACC, OUT>> {
+        private static final long serialVersionUID = 1L;
+
+        @Nullable private AggregateFunction<IN, ACC, OUT> delegated;
+
+        @Override
+        public void delegateIfNeeded(AggregateFunction<IN, ACC, OUT> delegated) {
+            if (this.delegated == null) {
+                this.delegated = checkNotNull(delegated);
+            }
+        }
+
+        @Override
+        public ACC createAccumulator() {
+            checkNotNull(delegated);
+            return delegated.createAccumulator();
+        }
+
+        @Override
+        public ACC add(IN value, ACC accumulator) {
+            checkNotNull(delegated);
+            return delegated.add(value, accumulator);
+        }
+
+        @Override
+        public OUT getResult(ACC accumulator) {
+            checkNotNull(delegated);
+            return delegated.getResult(accumulator);
+        }
+
+        @Override
+        public ACC merge(ACC a, ACC b) {
+            checkNotNull(delegated);
+            return delegated.merge(a, b);
+        }
+    }
+
+    static class DelegatingReduceFunction<T>
+            implements ReduceFunction<T>, DelegatingFunction<ReduceFunction<T>> {
+        private static final long serialVersionUID = 1L;
+
+        @Nullable private ReduceFunction<T> delegated;
+
+        @Override
+        public T reduce(T left, T right) throws Exception {
+            checkNotNull(delegated);
+            return delegated.reduce(left, right);
+        }
+
+        @Override
+        public void delegateIfNeeded(ReduceFunction<T> delegated) {
+            if (this.delegated == null) {
+                this.delegated = checkNotNull(delegated);
+            }
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/KvStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/KvStateChangeApplier.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalMergingState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+abstract class KvStateChangeApplier<K, N> implements StateChangeApplier {
+    private final InternalKeyContext<K> keyContext;
+
+    protected abstract InternalKvState<K, N, ?> getState();
+
+    protected KvStateChangeApplier(InternalKeyContext<K> keyContext) {
+        this.keyContext = keyContext;
+    }
+
+    @Override
+    public void apply(StateChangeOperation operation, DataInputView in) throws Exception {
+        K key = getState().getKeySerializer().deserialize(in);
+        keyContext.setCurrentKey(key);
+        keyContext.setCurrentKeyGroupIndex(
+                KeyGroupRangeAssignment.assignToKeyGroup(key, keyContext.getNumberOfKeyGroups()));
+        getState().setCurrentNamespace(getState().getNamespaceSerializer().deserialize(in));
+        applyInternal(operation, in);
+    }
+
+    protected abstract void applyInternal(StateChangeOperation operation, DataInputView in)
+            throws Exception;
+
+    protected static <K, N, T> void applyMergeNamespaces(
+            InternalMergingState<K, N, T, ?, ?> state, DataInputView in) throws Exception {
+        N target = state.getNamespaceSerializer().deserialize(in);
+        int sourcesSize = in.readInt();
+        Collection<N> sources = new ArrayList<>(sourcesSize);
+        for (int i = 0; i < sourcesSize; i++) {
+            sources.add(state.getNamespaceSerializer().deserialize(in));
+        }
+        state.mergeNamespaces(target, sources);
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ListStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ListStateChangeApplier.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+class ListStateChangeApplier<K, N, T> extends KvStateChangeApplier<K, N> {
+    private final InternalListState<K, N, T> state;
+
+    protected ListStateChangeApplier(
+            InternalKeyContext<K> keyContext, InternalListState<K, N, T> state) {
+        super(keyContext);
+        this.state = state;
+    }
+
+    @Override
+    protected InternalKvState<K, N, ?> getState() {
+        return state;
+    }
+
+    protected void applyInternal(StateChangeOperation operation, DataInputView in)
+            throws Exception {
+        switch (operation) {
+            case ADD:
+                state.addAll(state.getValueSerializer().deserialize(in));
+                break;
+            case ADD_ELEMENT:
+                state.add(
+                        ((ListSerializer<T>) state.getValueSerializer())
+                                .getElementSerializer()
+                                .deserialize(in));
+                break;
+            case SET:
+                state.update(state.getValueSerializer().deserialize(in));
+                break;
+            case SET_INTERNAL:
+                state.updateInternal(state.getValueSerializer().deserialize(in));
+                break;
+            case MERGE_NS:
+                applyMergeNamespaces(state, in);
+                break;
+            case CLEAR:
+                state.clear();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown state change operation: " + operation);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/MapStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/MapStateChangeApplier.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+class MapStateChangeApplier<K, N, UK, UV> extends KvStateChangeApplier<K, N> {
+    private final InternalMapState<K, N, UK, UV> mapState;
+    private final MapSerializer<UK, UV> mapSerializer;
+
+    protected MapStateChangeApplier(
+            InternalMapState<K, N, UK, UV> mapState, InternalKeyContext<K> keyContext) {
+        super(keyContext);
+        this.mapState = mapState;
+        this.mapSerializer = (MapSerializer<UK, UV>) mapState.getValueSerializer();
+    }
+
+    @Override
+    protected InternalKvState<K, N, ?> getState() {
+        return mapState;
+    }
+
+    protected void applyInternal(StateChangeOperation operation, DataInputView in)
+            throws Exception {
+        switch (operation) {
+            case ADD:
+                mapState.putAll(mapSerializer.deserialize(in));
+                break;
+            case ADD_ELEMENT:
+            case ADD_OR_UPDATE_ELEMENT:
+                mapState.put(
+                        mapSerializer.getKeySerializer().deserialize(in),
+                        mapSerializer.getValueSerializer().deserialize(in));
+                break;
+            case REMOVE_ELEMENT:
+                mapState.remove(mapSerializer.getKeySerializer().deserialize(in));
+                break;
+            case CLEAR:
+                mapState.clear();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown state change operation: " + operation);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/PriorityQueueStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/PriorityQueueStateChangeApplier.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+class PriorityQueueStateChangeApplier<T> implements StateChangeApplier {
+    private final KeyGroupedInternalPriorityQueue<T> queue;
+    private final TypeSerializer<T> serializer;
+
+    public PriorityQueueStateChangeApplier(
+            KeyGroupedInternalPriorityQueue<T> queue, TypeSerializer<T> serializer) {
+        this.queue = queue;
+        this.serializer = serializer;
+    }
+
+    @Override
+    public void apply(StateChangeOperation operation, DataInputView in) throws Exception {
+        switch (operation) {
+            case REMOVE_FIRST_ELEMENT:
+                queue.poll();
+                break;
+            case ADD_ELEMENT:
+                int numElements = in.readInt();
+                for (int i = 0; i < numElements; i++) {
+                    queue.add(serializer.deserialize(in));
+                }
+                break;
+            case REMOVE_ELEMENT:
+                queue.remove(serializer.deserialize(in));
+                break;
+            default:
+                throw new UnsupportedOperationException(operation.name());
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ReducingStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ReducingStateChangeApplier.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalReducingState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+class ReducingStateChangeApplier<K, N, T> extends KvStateChangeApplier<K, N> {
+    private final InternalReducingState<K, N, T> state;
+
+    protected ReducingStateChangeApplier(
+            InternalKeyContext<K> keyContext, InternalReducingState<K, N, T> state) {
+        super(keyContext);
+        this.state = state;
+    }
+
+    @Override
+    protected InternalKvState<K, N, ?> getState() {
+        return state;
+    }
+
+    protected void applyInternal(StateChangeOperation operation, DataInputView in)
+            throws Exception {
+        switch (operation) {
+            case SET:
+            case SET_INTERNAL:
+                state.updateInternal(state.getValueSerializer().deserialize(in));
+                break;
+            case CLEAR:
+                state.clear();
+                break;
+            case MERGE_NS:
+                applyMergeNamespaces(state, in);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown state change operation: " + operation);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/StateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/StateChangeApplier.java
@@ -15,35 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.changelog;
+package org.apache.flink.state.changelog.restore;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.util.Preconditions;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.state.changelog.StateChangeOperation;
 
-/** Change of state of a keyed operator. Used for generic incremental checkpoints. */
+/** Applies state data change to some state. */
 @Internal
-public class StateChange {
-
-    private final int keyGroup;
-    private final byte[] change;
-
-    public StateChange(int keyGroup, byte[] change) {
-        // todo: enable check in FLINK-23035
-        // Preconditions.checkArgument(keyGroup >= 0);
-        this.keyGroup = keyGroup;
-        this.change = Preconditions.checkNotNull(change);
-    }
-
-    @Override
-    public String toString() {
-        return String.format("keyGroup=%d, dataSize=%d", keyGroup, change.length);
-    }
-
-    public int getKeyGroup() {
-        return keyGroup;
-    }
-
-    public byte[] getChange() {
-        return change;
-    }
+public interface StateChangeApplier {
+    void apply(StateChangeOperation operation, DataInputView in) throws Exception;
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ValueStateChangeApplier.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ValueStateChangeApplier.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog.restore;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.runtime.state.heap.InternalKeyContext;
+import org.apache.flink.runtime.state.internal.InternalKvState;
+import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.state.changelog.StateChangeOperation;
+
+class ValueStateChangeApplier<K, N, T> extends KvStateChangeApplier<K, N> {
+    private final InternalValueState<K, N, T> state;
+
+    protected ValueStateChangeApplier(
+            InternalKeyContext<K> keyContext, InternalValueState<K, N, T> state) {
+        super(keyContext);
+        this.state = state;
+    }
+
+    @Override
+    protected InternalKvState<K, N, ?> getState() {
+        return state;
+    }
+
+    protected void applyInternal(StateChangeOperation operation, DataInputView in)
+            throws Exception {
+        switch (operation) {
+            case SET:
+                state.update(state.getValueSerializer().deserialize(in));
+                break;
+            case CLEAR:
+                state.clear();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown state change operation: " + operation);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogListStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogListStateTest.java
@@ -21,6 +21,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -202,7 +204,10 @@ public class ChangelogListStateTest {
 
     private static ChangelogListState createState(List<String> data, TestChangeLoggerKv logger) {
         ChangelogListState state =
-                new ChangelogListState<>(new TestingInternalListState(data), logger);
+                new ChangelogListState<>(
+                        new TestingInternalListState(data),
+                        logger,
+                        new InternalKeyContextImpl<>(KeyGroupRange.EMPTY_KEY_GROUP_RANGE, 0));
         state.setCurrentNamespace("ns0");
         return state;
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMapStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMapStateTest.java
@@ -21,6 +21,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -246,7 +248,10 @@ public class ChangelogMapStateTest {
     private static ChangelogMapState createState(
             Map<String, String> data, TestChangeLoggerKv logger) {
         ChangelogMapState state =
-                new ChangelogMapState<>(new TestingInternalMapState(data), logger);
+                new ChangelogMapState<>(
+                        new TestingInternalMapState(data),
+                        logger,
+                        new InternalKeyContextImpl<>(KeyGroupRange.EMPTY_KEY_GROUP_RANGE, 0));
         state.setCurrentNamespace("ns0");
         return state;
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
@@ -21,14 +21,13 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
-import org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
 
 import static org.apache.flink.api.common.state.StateDescriptor.Type.VALUE;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.MERGE_NS;
+import static org.apache.flink.state.changelog.StateChangeOperation.MERGE_NS;
 
 /** {@link KvStateChangeLoggerImpl} test. */
 public class KvStateChangeLoggerImplTest extends StateChangeLoggerTestBase<String> {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
@@ -21,12 +21,11 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
-import org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation;
 
 import java.io.IOException;
 import java.util.Optional;
 
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.REMOVE_FIRST_ELEMENT;
+import static org.apache.flink.state.changelog.StateChangeOperation.REMOVE_FIRST_ELEMENT;
 
 /** {@link PriorityQueueStateChangeLoggerImpl} test. */
 public class PriorityQueueStateChangeLoggerImplTest extends StateChangeLoggerTestBase<Void> {

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -109,6 +109,11 @@ abstract class StateChangeLoggerTestBase<Namespace> {
         }
 
         @Override
+        public SequenceNumber initialSequenceNumber() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public SequenceNumber lastAppendedSequenceNumber() {
             throw new UnsupportedOperationException();
         }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
-import org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation;
 
 import org.junit.Test;
 
@@ -33,7 +32,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.state.changelog.AbstractStateChangeLogger.COMMON_KEY_GROUP;
-import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.METADATA;
+import static org.apache.flink.state.changelog.StateChangeOperation.METADATA;
 import static org.junit.Assert.assertEquals;
 
 abstract class StateChangeLoggerTestBase<Namespace> {


### PR DESCRIPTION
Depends on:
- #15200 (writing data)
- #16035 (writing metadata)
-  #15339 (for testing)
-  #16050 (for testing) 
 
Must be rebased before merging. 
Only the last 5 commits are relevant.

## What is the purpose of the change

Add support for checkpointing and recovery using changelog to `ChangelogStateBackend`.
Currently, changelog is written (with #15200) but not used, neither in snapshot nor
during recovery - the underlying backend's snapshot is used.

State materialization will be implemented in FLINK-21357 (for now, the underlying
backend is not snapshotted and the changelog keeps ever growing).

Design doc: https://docs.google.com/document/d/10c6hZsOVxzUjeCLPSDpKGyZOYHi73yd92lCqRs1CyUE/edit?usp=sharing

## Verifying this change

- Existing unit tests which extend `StateBackendTestBase` are used (which test recovery after #16050).
- Integration tests should use `ChangelogStateBackend` after FLINK-21448

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
