### PR TITLE
[hotfix][ui] Remove unrelated UI backpressure console logs

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/dagre/node.component.ts
@@ -58,7 +58,6 @@ export class NodeComponent {
     this.parallelism = value.parallelism;
     this.lowWatermark = value.lowWatermark;
     if (this.isValid(value.backPressuredPercentage)) {
-        console.log(value.backPressuredPercentage)
         this.backPressuredPercentage = value.backPressuredPercentage
     }
     if (this.isValid(value.busyPercentage)) {


### PR DESCRIPTION
This seems to have been accidentally left over during the development. It unnecessarily pollutes the browser logs - values are being constantly printed to the console when the DAG is opened.