### PR TITLE
[FLINK-22020][table-planner-blink] Add org.reflections to include list of maven shade plugin

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
+++ b/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
@@ -64,6 +64,9 @@ function checkCodeDependencies {
       grep -v "^\s*\-> org.apiguardian.api" |\
       grep -v "^\s*\-> org.apache.commons.io.input" |\
       grep -v "^\s*\-> com.ibm.icu" |\
+      `# org.reflections dependencies` \
+      grep -v "^\s*\-> org.apache.commons.vfs2" |\
+      grep -v "^\s*\-> org.dom4j" |\
       grep -v "^\s*\-> net.minidev.json" > $CONTENTS_FILE
   if [[ `cat $CONTENTS_FILE | wc -l` -eq '0' ]]; then
       echo "Success: There are no unwanted dependencies in the ${JAR} jar."

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -381,6 +381,8 @@ under the License.
 
 									<!-- Tools to unify display format for different languages -->
 									<include>com.ibm.icu:icu4j</include>
+
+									<include>org.reflections:reflections</include>
 								</includes>
 							</artifactSet>
 							<relocations>

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -29,3 +29,8 @@ This project bundles the following dependencies under the ICU license.
 See bundled license files for details
 
 - com.ibm.icu:icu4j:67.1
+
+This project bundles the following dependencies under the WTFPL license.
+See bundled license files for details
+
+- org.reflections:reflections:0.9.10

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/licenses/LICENSE.reflections
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/licenses/LICENSE.reflections
@@ -1,0 +1,13 @@
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.


### PR DESCRIPTION
## What is the purpose of the change
this is a hotfix adding org.reflections:reflections to include list of maven shade plugin just like how we treat com.ibm.icu:icu4j


## Brief change log
Add org.reflections to include list of maven shade plugin


## Verifying this change

This change added tests and can be verified as follows:

  - *Manually verified the change by generate a json plan by TableEnvironmentInternal#getJsonPlan and then explain the plan json by TableEnvironmentInternal#explainJsonPlan.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)