### PR TITLE
[FLINK-22021][table-planner-blink] Fix exception when PushFilterIntoLegacyTableSourceScanRule is faced with INTERVAL types

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.annotation.VisibleForTesting
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, FunctionLookup, UnresolvedIdentifier}
+import org.apache.flink.table.data.conversion.{DayTimeIntervalDurationConverter, YearMonthIntervalPeriodConverter}
 import org.apache.flink.table.data.util.DataFormatConverters.{LocalDateConverter, LocalTimeConverter}
 import org.apache.flink.table.expressions.ApiExpressionUtils._
 import org.apache.flink.table.expressions._
@@ -30,6 +31,7 @@ import org.apache.flink.table.planner.utils.Logging
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.YearMonthIntervalType
 import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
 import org.apache.flink.util.Preconditions
 
@@ -407,6 +409,16 @@ class RexNodeToExpressionConverter(
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val v = literal.getValueAs(classOf[TimestampString])
         toLocalDateTime(v).atZone(timeZone.toZoneId).toInstant
+
+      case INTERVAL_DAY_TIME =>
+        val v = literal.getValueAs(classOf[java.lang.Long])
+        DayTimeIntervalDurationConverter.INSTANCE.toExternal(v)
+
+      case INTERVAL_YEAR_MONTH =>
+        val v = literal.getValueAs(classOf[java.lang.Integer])
+        YearMonthIntervalPeriodConverter
+          .create(literalType.asInstanceOf[YearMonthIntervalType])
+          .toExternal(v)
 
       case TINYINT =>
         // convert from BigDecimal to Byte

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -209,6 +209,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWithInterval">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MTable
+WHERE
+  TIMESTAMPADD(HOUR, 5, a) >= b
+  OR
+  TIMESTAMPADD(YEAR, 2, b) >= a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL DAY TO SECOND, 5)), $1), >=(+($1, *(12:INTERVAL YEAR TO MONTH, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[]]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialPushDown2">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR price > 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -209,6 +209,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWithInterval">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MTable
+WHERE
+  TIMESTAMPADD(HOUR, 5, a) >= b
+  OR
+  TIMESTAMPADD(YEAR, 2, b) >= a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialPushDown2">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR price > 10]]>

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
@@ -28,6 +28,8 @@ import java.time.Duration;
 public class DayTimeIntervalDurationConverter
         implements DataStructureConverter<Long, java.time.Duration> {
 
+    public static DayTimeIntervalDurationConverter INSTANCE = new DayTimeIntervalDurationConverter();
+
     private static final long serialVersionUID = 1L;
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
@@ -28,7 +28,8 @@ import java.time.Duration;
 public class DayTimeIntervalDurationConverter
         implements DataStructureConverter<Long, java.time.Duration> {
 
-    public static final DayTimeIntervalDurationConverter INSTANCE = new DayTimeIntervalDurationConverter();
+    public static final DayTimeIntervalDurationConverter INSTANCE =
+            new DayTimeIntervalDurationConverter();
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
@@ -28,7 +28,7 @@ import java.time.Duration;
 public class DayTimeIntervalDurationConverter
         implements DataStructureConverter<Long, java.time.Duration> {
 
-    public static DayTimeIntervalDurationConverter INSTANCE = new DayTimeIntervalDurationConverter();
+    public static final DayTimeIntervalDurationConverter INSTANCE = new DayTimeIntervalDurationConverter();
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/YearMonthIntervalPeriodConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/YearMonthIntervalPeriodConverter.java
@@ -58,8 +58,10 @@ public class YearMonthIntervalPeriodConverter
     // --------------------------------------------------------------------------------------------
 
     public static YearMonthIntervalPeriodConverter create(DataType dataType) {
-        final YearMonthIntervalType intervalType =
-                (YearMonthIntervalType) dataType.getLogicalType();
+        return create((YearMonthIntervalType) dataType.getLogicalType());
+    }
+
+    public static YearMonthIntervalPeriodConverter create(YearMonthIntervalType intervalType) {
         return new YearMonthIntervalPeriodConverter(
                 createPeriodConstructor(intervalType.getResolution()));
     }


### PR DESCRIPTION
## What is the purpose of the change

`PushFilterIntoLegacyTableSourceScanRule` will throw exception when faced with `INTERVAL` types, no matter it can be pushed down or not.

This PR fixes this issue.

## Brief change log

 - Fix exception when PushFilterIntoLegacyTableSourceScanRule is faced with INTERVAL types

## Verifying this change

This change can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
