### PR TITLE
[FLINK-22022][table-planner-blink] Reduce the ExecNode scan scope to improve performance when converting json plan to ExecNodeGraph

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataHandlerConsistencyTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataHandlerConsistencyTest.scala
@@ -28,10 +28,8 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.reflections.Reflections
-import org.reflections.util.{ClasspathHelper, ConfigurationBuilder}
 
-import java.lang.reflect.{Method, Modifier}
+import java.lang.reflect.Method
 import java.util
 
 import scala.collection.JavaConversions._


### PR DESCRIPTION


## What is the purpose of the change

*Reduce the ExecNode scan scope to improve performance when converting json plan to ExecNodeGraph*


## Brief change log

  - *Change the scan package from `org.apache.flink` to `org.apache.flink.table.planner.plan.nodes.exec` in ExecNodeGraphJsonPlanGenerator*
  - *Do some code clean up*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
