### PR TITLE
[FLINK-21829][Hive Connect]Fix to throw exception when custom hadoop conf path does not exist or there is no conf file

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -103,6 +103,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -223,6 +224,16 @@ public class HiveCatalog extends AbstractCatalog {
             }
         } else {
             hadoopConf = getHadoopConfiguration(hadoopConfDir);
+            if (hadoopConf == null) {
+                String possiableUsedConfFiles =
+                        "core-site.xml | hdfs-site.xml | yarn-site.xml | mapred-site.xml";
+                throw new CatalogException(
+                        "Failed to load the hadoop conf from specified path:" + hadoopConfDir,
+                        new FileNotFoundException(
+                                "Please check the path none of the conf files ("
+                                        + possiableUsedConfFiles
+                                        + ") exist in the folder."));
+            }
         }
         if (hadoopConf == null) {
             hadoopConf = new Configuration();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -454,25 +454,33 @@ public class HiveTableUtil {
      */
     public static Configuration getHadoopConfiguration(String hadoopConfDir) {
         if (new File(hadoopConfDir).exists()) {
-            Configuration hadoopConfiguration = new Configuration();
+            List<File> possiableConfFiles = new ArrayList<File>();
             File coreSite = new File(hadoopConfDir, "core-site.xml");
             if (coreSite.exists()) {
-                hadoopConfiguration.addResource(new Path(coreSite.getAbsolutePath()));
+                possiableConfFiles.add(coreSite);
             }
             File hdfsSite = new File(hadoopConfDir, "hdfs-site.xml");
             if (hdfsSite.exists()) {
-                hadoopConfiguration.addResource(new Path(hdfsSite.getAbsolutePath()));
+                possiableConfFiles.add(hdfsSite);
             }
             File yarnSite = new File(hadoopConfDir, "yarn-site.xml");
             if (yarnSite.exists()) {
-                hadoopConfiguration.addResource(new Path(yarnSite.getAbsolutePath()));
+                possiableConfFiles.add(yarnSite);
             }
             // Add mapred-site.xml. We need to read configurations like compression codec.
             File mapredSite = new File(hadoopConfDir, "mapred-site.xml");
             if (mapredSite.exists()) {
-                hadoopConfiguration.addResource(new Path(mapredSite.getAbsolutePath()));
+                possiableConfFiles.add(mapredSite);
             }
-            return hadoopConfiguration;
+            if (possiableConfFiles.isEmpty()) {
+                return null;
+            } else {
+                Configuration hadoopConfiguration = new Configuration();
+                for (File confFile : possiableConfFiles) {
+                    hadoopConfiguration.addResource(new Path(confFile.getAbsolutePath()));
+                }
+                return hadoopConfiguration;
+            }
         }
         return null;
     }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactoryTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -106,6 +107,30 @@ public class HiveCatalogFactoryTest extends TestLogger {
 
         checkEquals(expectedCatalog, (HiveCatalog) actualCatalog);
         assertEquals(mapredVal, ((HiveCatalog) actualCatalog).getHiveConf().get(mapredKey));
+    }
+
+    @Test
+    public void testCreateHiveCatalogWithIllegalHadoopConfDir() throws IOException {
+        final String catalogName = "mycatalog";
+
+        final String hadoopConfDir = tempFolder.newFolder().getAbsolutePath();
+
+        try {
+            final Map<String, String> options = new HashMap<>();
+            options.put(
+                    CommonCatalogOptions.CATALOG_TYPE.key(), HiveCatalogFactoryOptions.IDENTIFIER);
+            options.put(HiveCatalogFactoryOptions.HIVE_CONF_DIR.key(), CONF_DIR.getPath());
+            options.put(HiveCatalogFactoryOptions.HADOOP_CONF_DIR.key(), hadoopConfDir);
+
+            final Catalog actualCatalog =
+                    FactoryUtil.createCatalog(
+                            catalogName,
+                            options,
+                            null,
+                            Thread.currentThread().getContextClassLoader());
+            Assert.fail();
+        } catch (ValidationException e) {
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
There is no prompt when the the path to hadoop conf configured is wrong unintentional.
It is better to  load hadoop conf from possiable  hadoop path when the path is wrong.

[PR ahead](https://github.com/apache/flink/pull/15274)