### PR TITLE
[FLINK-22037][benchmark] Remove the redundant blocking queue from DeployingTasksBenchmarkBase

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
@@ -18,20 +18,16 @@
 
 package org.apache.flink.runtime.scheduler.benchmark.deploying;
 
-import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
@@ -41,7 +37,6 @@ public class DeployingTasksBenchmarkBase {
 
     List<JobVertex> jobVertices;
     ExecutionGraph executionGraph;
-    BlockingQueue<TaskDeploymentDescriptor> taskDeploymentDescriptors;
 
     public void createAndSetupExecutionGraph(JobConfiguration jobConfiguration) throws Exception {
 
@@ -49,14 +44,7 @@ public class DeployingTasksBenchmarkBase {
 
         executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
 
-        taskDeploymentDescriptors = new ArrayBlockingQueue<>(jobConfiguration.getParallelism() * 2);
-
-        final SimpleAckingTaskManagerGateway taskManagerGateway =
-                new SimpleAckingTaskManagerGateway();
-        taskManagerGateway.setSubmitConsumer(taskDeploymentDescriptors::offer);
-
-        final TestingLogicalSlotBuilder slotBuilder =
-                new TestingLogicalSlotBuilder().setTaskManagerGateway(taskManagerGateway);
+        final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
 
         for (ExecutionJobVertex ejv : executionGraph.getVerticesTopologically()) {
             for (ExecutionVertex ev : ejv.getTaskVertices()) {


### PR DESCRIPTION
## What is the purpose of the change

*We find that the BlockingQueue that used to preserve `TaskDeploymentDescriptor`s which are never used later. Since a `TaskDeploymentDescriptor` would cost massive heap memory, it may introduce unnecessary garbage collection and make the result of benchmarks related to deployment unstable. Therefore, we think it's better to remove the redundant blocking queue in `DeployingTasksBenchmarkBase`.*

*For more details please check FLINK-22037.*


## Brief change log

  - *Remove the redundant `BlockingQueue` from `DeployingTasksBenchmarkBase`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
