### PR TITLE
[FLINK-6417] Glob support for FileInputFormat

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -235,7 +236,12 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 
     protected FileInputFormat(Path filePath) {
         if (filePath != null) {
-            setFilePath(filePath);
+            // support glob
+            setFilePath(filePath.getParent());
+            setFilesFilter(
+                    new GlobFilePathFilter(
+                            Collections.singletonList(filePath.getPath()),
+                            Collections.emptyList()));
         }
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.testutils.TestFileUtils;
@@ -197,6 +198,14 @@ public class FileInputFormatTest {
         Configuration conf = new Configuration();
         conf.setString("input.file.path", filePath);
         format.configure(conf);
+    }
+
+    @Test
+    public void testGlobs() throws IOException {
+        String globed = "/path/to/temp*file";
+        String file = "/path/to/temporaryfile";
+        final DummyFileInputFormat fileInputFormat = new DummyFileInputFormat(new Path(globed));
+        Assert.assertTrue(fileInputFormat.acceptFile(new DummyFileStatus(new Path(file))));
     }
 
     // ------------------------------------------------------------------------
@@ -849,8 +858,58 @@ public class FileInputFormatTest {
         }
     }
 
+    private static class DummyFileStatus implements FileStatus {
+
+        private final Path filePath;
+
+        public DummyFileStatus(Path filePath) {
+            this.filePath = filePath;
+        }
+
+        @Override
+        public long getLen() {
+            return 0;
+        }
+
+        @Override
+        public long getBlockSize() {
+            return 0;
+        }
+
+        @Override
+        public short getReplication() {
+            return 0;
+        }
+
+        @Override
+        public long getModificationTime() {
+            return 0;
+        }
+
+        @Override
+        public long getAccessTime() {
+            return 0;
+        }
+
+        @Override
+        public boolean isDir() {
+            return false;
+        }
+
+        @Override
+        public Path getPath() {
+            return filePath;
+        }
+    }
+
     private class DummyFileInputFormat extends FileInputFormat<IntValue> {
         private static final long serialVersionUID = 1L;
+
+        private DummyFileInputFormat() {}
+
+        private DummyFileInputFormat(Path filePath) {
+            super(filePath);
+        }
 
         @Override
         public boolean reachedEnd() throws IOException {


### PR DESCRIPTION

## What is the purpose of the change

Add support for glob (* in file name) for FileInputFormat so that it could profit for DataSet, SQL and Table API.


## Brief change log

Leverage existing GlobFilePathFilter to support globs without user configuration. 

Sure, the user could call _FileInputFormat#setFileFilter()_ but it should not have to. The glob should be supported with no required configuration. 

And also, for some APIs (SQL for example) the FileInputFormat is used under the woods but it is not part of the public API so the user cannot configure it. So he cannot use globs when using this API. Supporting globs at the FileInputFormat level allows to have glob support for all the APIs that rely on it.

## Verifying this change

This change added tests and can be verified as follows:
FileInputFormatTest#testGlobs()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? the ticket says new feature, but I would have qualified it as a bug as glob support is to be expected from every file access in big data environments IMHO. 
