### PR TITLE
[FLINK-22052][python] Add FLIP-142 public classes to python API

### DIFF
--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -101,6 +101,8 @@ __all__ = [
     'SourceFunction',
     'StateBackend',
     'MapFunction',
+    'HashMapStateBackend',
+    'EmbeddedRocksDBStateBackend',
     'MemoryStateBackend',
     'FsStateBackend',
     'RocksDBStateBackend',

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -75,7 +75,11 @@ from pyflink.datastream.functions import (MapFunction, CoMapFunction, FlatMapFun
                                           SinkFunction)
 from pyflink.datastream.state_backend import (StateBackend, MemoryStateBackend, FsStateBackend,
                                               RocksDBStateBackend, CustomStateBackend,
-                                              PredefinedOptions)
+                                              PredefinedOptions, HashMapStateBackend,
+                                              EmbeddedRocksDBStateBackend)
+from pyflink.datastream.checkpoint_storage import (CheckpointStorage, JobManagerCheckpointStorage,
+                                                   FileSystemCheckpointStorage,
+                                                   CustomCheckpointStorage)
 from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.datastream.time_characteristic import TimeCharacteristic
 from pyflink.datastream.time_domain import TimeDomain
@@ -108,6 +112,10 @@ __all__ = [
     'RocksDBStateBackend',
     'CustomStateBackend',
     'PredefinedOptions',
+    'CheckpointStorage',
+    'JobManagerCheckpointStorage',
+    'FileSystemCheckpointStorage',
+    'CustomCheckpointStorage',
     'ExternalizedCheckpointCleanup',
     'TimeCharacteristic',
     'TimeDomain',

--- a/flink-python/pyflink/datastream/checkpoint_storage.py
+++ b/flink-python/pyflink/datastream/checkpoint_storage.py
@@ -1,0 +1,363 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from abc import ABCMeta
+
+from py4j.java_gateway import get_java_class
+from typing import Optional
+
+from pyflink.java_gateway import get_gateway
+
+__all__ = [
+    'CheckpointStorage',
+    'JobManagerCheckpointStorage',
+    'FileSystemCheckpointStorage',
+    'CustomCheckpointStorage']
+
+
+def _from_j_checkpoint_storage(j_checkpoint_storage):
+    if j_checkpoint_storage is None:
+        return None
+    gateway = get_gateway()
+    JCheckpointStorage = gateway.jvm.org.apache.flink.runtime.state.CheckpointStorage
+    JJobManagerCheckpointStorage = gateway.jvm.org.apache.flink.runtime.state.storage \
+        .JobManagerCheckpointStorage
+    JFileSystemCheckpointStorage = gateway.jvm.org.apache.flink.runtime.state.storage \
+        .FileSystemCheckpointStorage
+
+    j_clz = j_checkpoint_storage.getClass()
+
+    if not get_java_class(JCheckpointStorage).isAssignableFrom(j_clz):
+        raise TypeError("%s is not an instance of CheckpointStorage." % j_checkpoint_storage)
+
+    if get_java_class(JJobManagerCheckpointStorage).isAssignableFrom(j_clz):
+        return JobManagerCheckpointStorage(j_jobmanager_checkpoint_storage=j_checkpoint_storage)
+    elif get_java_class(JFileSystemCheckpointStorage).isAssignableFrom(j_clz):
+        return FileSystemCheckpointStorage(j_filesystem_checkpoint_storage=j_checkpoint_storage)
+    else:
+        return CustomCheckpointStorage(j_checkpoint_storage)
+
+
+class CheckpointStorage(object, metaclass=ABCMeta):
+    """
+    Checkpoint storage defines how :class:`StateBackend`'s store their state for fault-tolerance
+    in streaming applications. Various implementations store their checkpoints in different fashions
+    and have different requirements and availability guarantees.
+
+    For example, :class:`JobManagerCheckpointStorage` stores checkpoints in the memory of the
+    `JobManager`. It is lightweight and without additional dependencies but is not scalable
+    and only supports small state sizes. This checkpoints storage policy is convenient for local
+    testing and development.
+
+    :class:`FileSystemCheckpointStorage` stores checkpoints in a filesystem. For systems like HDFS
+    NFS drives, S3, and GCS, this storage policy supports large state size, in the magnitude of many
+    terabytes while providing a highly available foundation for streaming applications. This
+    checkpoint storage policy is recommended for most production deployments.
+
+    **Raw Bytes Storage**
+
+    The `CheckpointStorage` creates services for raw bytes storage.
+
+    The raw bytes storage (through the CheckpointStreamFactory) is the fundamental service that
+    simply stores bytes in a fault tolerant fashion. This service is used by the JobManager to
+    store checkpoint and recovery metadata and is typically also used by the keyed- and operator-
+    state backends to store checkpoint state.
+
+    **Serializability**
+
+    Implementations need to be serializable(`java.io.Serializable`), because they are distributed
+    across parallel processes (for distributed execution) together with the streaming application
+    code.
+
+    Because of that `CheckpointStorage` implementations are meant to be like _factories_ that create
+    the proper state stores that provide access to the persistent layer. That way, the storage
+    policy can be very lightweight (contain only configurations) which makes it easier to be
+    serializable.
+
+    **Thread Safety**
+
+    Checkpoint storage implementations have to be thread-safe. Multiple threads may be creating
+    streams concurrently.
+    """
+
+    def __init__(self, j_checkpoint_storage):
+        self._j_checkpoint_storage = j_checkpoint_storage
+
+
+class JobManagerCheckpointStorage(CheckpointStorage):
+    """
+    The `CheckpointStorage` checkpoints state directly to the JobManager's memory (hence the
+    name), but savepoints will be persisted to a file system.
+
+    This checkpoint storage is primarily for experimentation, quick local setups, or for streaming
+    applications that have very small state: Because it requires checkpoints to go through the
+    JobManager's memory, larger state will occupy larger portions of the JobManager's main memory,
+    reducing operational stability. For any other setup, the `FileSystemCheckpointStorage`
+    should be used. The `FileSystemCheckpointStorage` but checkpoints state directly to files
+    rather than to the JobManager's memory, thus supporting larger state sizes and more highly
+    available recovery.
+
+    **State Size Considerations**
+
+    State checkpointing with this checkpoint storage is subject to the following conditions:
+
+    - Each individual state must not exceed the configured maximum state size
+      (see :func:`get_max_state_size`.
+
+    - All state from one task (i.e., the sum of all operator states and keyed states from all
+      chained operators of the task) must not exceed what the RPC system supports, which is
+      be default < 10 MB. That limit can be configured up, but that is typically not advised.
+
+    - The sum of all states in the application times all retained checkpoints must comfortably
+      fit into the JobManager's JVM heap space.
+
+    **Persistence Guarantees**
+
+    For the use cases where the state sizes can be handled by this storage, it does
+    guarantee persistence for savepoints, externalized checkpoints (of configured), and checkpoints
+    (when high-availability is configured).
+
+        **Configuration**
+
+    As for all checkpoint storage, this type can either be configured within the application (by
+    creating the storage with the respective constructor parameters and setting it on the execution
+    environment) or by specifying it in the Flink configuration.
+
+    If the storage was specified in the application, it may pick up additional configuration
+    parameters from the Flink configuration. For example, if the backend if configured in the
+    application without a default savepoint directory, it will pick up a default savepoint
+    directory specified in the Flink configuration of the running job/cluster. That behavior is
+    implemented via the :func:`configure` method.
+    """
+
+    # The default maximal size that the snapshotted memory state may have (5 MiBytes).
+    DEFAULT_MAX_STATE_SIZE = 5 * 1024 * 1024
+
+    def __init__(self,
+                 checkpoint_path=None,
+                 max_state_size=None,
+                 j_jobmanager_checkpoint_storage=None):
+        """
+        Creates a new JobManagerCheckpointStorage, setting optionally the paths to persist
+        checkpoint metadata to, as well as configuring state thresholds.
+
+        WARNING: Increasing the size of this value beyond the default value
+        (:data:`DEFAULT_MAX_STATE_SIZE`) should be done with care.
+        The checkpointed state needs to be send to the JobManager via limited size RPC messages,
+        and there and the JobManager needs to be able to hold all aggregated state in its memory.
+
+        Example:
+        ::
+            >>> checkpoint_storage = JobManagerCheckpointStorage()
+
+        :param checkpoint_path: The path to write checkpoint metadata to. If none, the value from
+                                the runtime configuration will be used.
+        :param max_state_size: The maximal size of the serialized state. If none, the
+                               :data:`DEFAULT_MAX_STATE_SIZE` will be used.
+        :param j_jobmanager_checkpoint_storage: For internal use, please keep none.
+        """
+        if j_jobmanager_checkpoint_storage is None:
+            gateway = get_gateway()
+            JJobManagerCheckpointStorage = gateway.jvm.org.apache.flink.runtime.state.storage\
+                .JobManagerCheckpointStorage
+            JPath = gateway.jvm.org.apache.flink.core.fs.Path
+
+            if checkpoint_path is not None:
+                checkpoint_path = JPath(checkpoint_path)
+            if max_state_size is None:
+                max_state_size = JJobManagerCheckpointStorage.DEFAULT_MAX_STATE_SIZE
+            j_jobmanager_checkpoint_storage = JJobManagerCheckpointStorage(checkpoint_path,
+                                                                           max_state_size)
+
+        super(JobManagerCheckpointStorage, self).__init__(j_jobmanager_checkpoint_storage)
+
+    def get_checkpoint_path(self) -> Optional[str]:
+        """
+        Gets the base directory where all the checkpoints are stored.
+        The job-specific checkpoint directory is created inside this directory.
+
+        :return: The base directory for checkpoints.
+        """
+        j_path = self._j_checkpoint_storage.getCheckpointPath()
+        if j_path is None:
+            return None
+        else:
+            return j_path.toString()
+
+    def get_max_state_size(self) -> int:
+        """
+        Gets the maximum size that an individual state can have, as configured in the
+        constructor. By default :data:`DEFAULT_MAX_STATE_SIZE` will be used.
+        """
+        return self._j_checkpoint_storage.getMaxStateSize()
+
+    def get_savepoint_path(self) -> Optional[str]:
+        """
+        Gets the base directory where all the savepoints are stored.
+        The job-specific savepoint directory is created inside this directory.
+
+        :return: The base directory for savepoints.
+        """
+
+        j_path = self._j_checkpoint_storage.getSavepointPath()
+        if j_path is None:
+            return None
+        else:
+            return j_path.toString()
+
+    def __str__(self):
+        return self._j_checkpoint_storage.toString()
+
+
+class FileSystemCheckpointStorage(CheckpointStorage):
+    """
+    `FileSystemCheckpointStorage` checkpoints state as files to a filesystem.
+
+    Each checkpoint will store all its files in a subdirectory that includes the
+    checkpoints number, such as `hdfs://namenode:port/flink-checkpoints/chk-17/`.
+
+    **State Size Considerations**
+
+    This checkpoint storage stores small state chunks directly with the metadata, to avoid creating
+    many small files. The threshold for that is configurable. When increasing this threshold, the
+    size of the checkpoint metadata increases. The checkpoint metadata of all retained completed
+    checkpoints needs to fit into the JobManager's heap memory. This is typically not a problem,
+    unless the threashold `get_min_file_size_threshold` is increased significantly.
+
+    **Persistence Guarantees**
+
+    Checkpoints from this checkpoint storage are as persistent and available as the filesystem
+    that it is written to. If the file system is a persistent distributed file system, this
+    checkpoint storage supports highly available setups. The backend additionally supports
+    savepoints and externalized checkpoints.
+
+    **Configuration**
+
+    As for all checkpoint storage policies, this backend can either be configured within the
+    application (by creating the storage with the respective constructor parameters and setting
+    it on the execution environment) or by specifying it in the Flink configuration.
+
+    If the checkpoint storage was specified in the application, it may pick up additional
+    configuration parameters from the Flink configuration. For example, if the storage is configured
+    in the application without a default savepoint directory, it will pick up a default savepoint
+    directory specified in the Flink configuration of the running job/cluster.
+    """
+
+    # Maximum size of state that is stored with the metadata, rather than in files (1 MiByte).
+    MAX_FILE_STATE_THRESHOLD = 1024 * 1024
+
+    def __init__(self,
+                 checkpoint_path=None,
+                 file_state_size_threshold=None,
+                 write_buffer_size=-1,
+                 j_filesystem_checkpoint_storage=None):
+        """
+        Creates a new FileSystemCheckpointStorage, setting the paths for the checkpoint data
+        in a file system.
+
+        All file systems for the file system scheme in the URI (e.g., `file://`, `hdfs://`, or
+        `s3://`) must be accessible via `FileSystem#get`.
+
+        For a Job targeting HDFS, this means that the URI must either specify the authority (host
+        and port), of the Hadoop configuration that describes that information must be in the
+        classpath.
+
+        Example:
+        ::
+            >>> checkpoint_storage = FileSystemCheckpointStorage("hdfs://checkpoints")
+
+        :param checkpoint_path: The path to write checkpoint metadata to. If none, the value from
+                                the runtime configuration will be used.
+        :param file_state_size_threshold: State below this size will be stored as part of the
+                                        metadata, rather than in files. If -1, the value configured
+                                        in the runtime configuration will be used, or the default
+                                        value (1KB) if nothing is configured.
+        :param write_buffer_size: Write buffer size used to serialize state. If -1, the value
+                                    configured in the runtime configuration will be used, or the
+                                    default value (4KB) if nothing is configured.
+        :param j_filesystem_checkpoint_storage: For internal use, please keep none.
+        """
+        if j_filesystem_checkpoint_storage is None:
+            gateway = get_gateway()
+            JFileSystemCheckpointStorage = gateway.jvm.org.apache.flink.runtime.state.storage\
+                .FileSystemCheckpointStorage
+            JPath = gateway.jvm.org.apache.flink.core.fs.Path
+
+            if checkpoint_path is None:
+                raise ValueError("checkpoint_path must not be None")
+            else:
+                checkpoint_path = JPath(checkpoint_path)
+
+            if file_state_size_threshold is None:
+                file_state_size_threshold = -1
+
+            j_filesystem_checkpoint_storage = JFileSystemCheckpointStorage(
+                checkpoint_path,
+                file_state_size_threshold,
+                write_buffer_size)
+
+        super(FileSystemCheckpointStorage, self).__init__(j_filesystem_checkpoint_storage)
+
+    def get_checkpoint_path(self) -> str:
+        """
+        Gets the base directory where all the checkpoints are stored.
+        The job-specific checkpoint directory is created inside this directory.
+
+        :return: The base directory for checkpoints.
+        """
+        return self._j_checkpoint_storage.getCheckpointPath().toString()
+
+    def get_savepoint_path(self) -> Optional[str]:
+        """
+        Gets the base directory where all the savepoints are stored.
+        The job-specific savepoint directory is created inside this directory.
+
+        :return: The base directory for savepoints.
+        """
+
+        j_path = self._j_checkpoint_storage.getSavepointPath()
+        if j_path is None:
+            return None
+        else:
+            return j_path.toString()
+
+    def get_min_file_size_threshold(self) -> int:
+        """
+        Gets the threshold below which state is stored as part of the metadata, rather than in
+        file. This threshold ensures the backend does not create a large amount of small files,
+        where potentially the file pointers are larget than the state itself.
+        """
+        return self._j_checkpoint_storage.getMinFileSizeThreshold()
+
+    def get_write_buffer_size(self) -> int:
+        """
+        Gets the write buffer size for created checkpoint streams.
+        """
+        return self._j_checkpoint_storage.getWriteBufferSize()
+
+    def __str__(self):
+        return self._j_checkpoint_storage.toString()
+
+
+class CustomCheckpointStorage(CheckpointStorage):
+    """
+    A wrapper of customized java checkpoint storage created from the provided `StateBackendFactory`.
+    """
+
+    def __init__(self, j_custom_checkpoint_storage):
+        super(CustomCheckpointStorage, self).__init__(j_custom_checkpoint_storage)

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -27,6 +27,8 @@ from pyflink.util.java_utils import load_java_class
 
 __all__ = [
     'StateBackend',
+    'HashMapStateBackend',
+    'EmbeddedRocksDBStateBackend',
     'MemoryStateBackend',
     'FsStateBackend',
     'RocksDBStateBackend',
@@ -39,6 +41,9 @@ def _from_j_state_backend(j_state_backend):
         return None
     gateway = get_gateway()
     JStateBackend = gateway.jvm.org.apache.flink.runtime.state.StateBackend
+    JHashMapStateBackend = gateway.jvm.org.apache.flink.runtime.state.hashmap.HashMapStateBackend
+    JEmbeddedRocksDBStateBackend = gateway.jvm.org.apache.flink.contrib.streaming.state.\
+        EmbeddedRocksDBStateBackend
     JMemoryStateBackend = gateway.jvm.org.apache.flink.runtime.state.memory.MemoryStateBackend
     JFsStateBackend = gateway.jvm.org.apache.flink.runtime.state.filesystem.FsStateBackend
     JRocksDBStateBackend = gateway.jvm.org.apache.flink.contrib.streaming.state.RocksDBStateBackend
@@ -47,7 +52,11 @@ def _from_j_state_backend(j_state_backend):
     if not get_java_class(JStateBackend).isAssignableFrom(j_clz):
         raise TypeError("The input %s is not an instance of StateBackend." % j_state_backend)
 
-    if get_java_class(JMemoryStateBackend).isAssignableFrom(j_state_backend.getClass()):
+    if get_java_class(JHashMapStateBackend).isAssignableFrom(j_state_backend.getClass()):
+        return HashMapStateBackend(j_hashmap_state_backend=j_state_backend.getClass())
+    elif get_java_class(JEmbeddedRocksDBStateBackend).isAssignableFrom(j_state_backend.getClass()):
+        return EmbeddedRocksDBStateBackend(j_embedded_rocks_db_state_backend=j_state_backend)
+    elif get_java_class(JMemoryStateBackend).isAssignableFrom(j_state_backend.getClass()):
         return MemoryStateBackend(j_memory_state_backend=j_state_backend)
     elif get_java_class(JFsStateBackend).isAssignableFrom(j_state_backend.getClass()):
         return FsStateBackend(j_fs_state_backend=j_state_backend)
@@ -59,33 +68,27 @@ def _from_j_state_backend(j_state_backend):
 
 class StateBackend(object, metaclass=ABCMeta):
     """
-    A **State Backend** defines how the state of a streaming application is stored and
-    checkpointed. Different State Backends store their state in different fashions, and use
-    different data structures to hold the state of a running application.
+    A **State Backend** defines how the state of a streaming application is stored locally within
+    the cluster. Different state backends store their state in different fashions, and use different
+    data structures to hold the state of running applications.
 
-    For example, the :class:`MemoryStateBackend` keeps working state in the memory of the
-    TaskManager and stores checkpoints in the memory of the JobManager. The backend is
-    lightweight and without additional dependencies, but not highly available and supports only
-    small state.
+    For example, the :class:`HashMapStateBackend` keeps working state in the memory of the
+    TaskManager. The backend is lightweight and without additional dependencies.
 
-    The :class:`FsStateBackend` keeps working state in the memory of the TaskManager and stores
-    state checkpoints in a filesystem(typically a replicated highly-available filesystem,
+    The :class:`EmbeddedRocksDBStateBackend` keeps working state in the memory of the TaskManager
+    and stores state checkpoints in a filesystem(typically a replicated highly-available filesystem,
     like `HDFS <https://hadoop.apache.org/>`_, `Ceph <https://ceph.com/>`_,
     `S3 <https://aws.amazon.com/documentation/s3/>`_, `GCS <https://cloud.google.com/storage/>`_,
     etc).
 
-    The :class:`RocksDBStateBackend` stores working state in `RocksDB <http://rocksdb.org/>`_,
-    and checkpoints the state by default to a filesystem (similar to the :class:`FsStateBackend`).
+    The :class:`EmbeddedRocksDBStateBackend` stores working state in an embedded
+    `RocksDB <http://rocksdb.org/>`_, instance and is able to scale working state to many
+    terrabytes in size, only limited by available disk space across all task amangers.
 
     **Raw Bytes Storage and Backends**
 
     The :class:`StateBackend` creates services for *raw bytes storage* and for *keyed state*
     and *operator state*.
-
-    The *raw bytes storage* (through the `org.apache.flink.runtime.state.CheckpointStreamFactory`)
-    is the fundamental service that simply stores bytes in a fault tolerant fashion. This service
-    is used by the JobManager to store checkpoint and recovery metadata and is typically also used
-    by the keyed- and operator state backends to store checkpointed state.
 
     The `org.apache.flink.runtime.state.AbstractKeyedStateBackend and
     `org.apache.flink.runtime.state.OperatorStateBackend` created by this state backend define how
@@ -116,8 +119,278 @@ class StateBackend(object, metaclass=ABCMeta):
         self._j_state_backend = j_state_backend
 
 
+class HashMapStateBackend(StateBackend):
+    """
+    This state backend holds the working state in the memory (JVM heap) of the TaskManagers
+    and checkpoints based on the configured CheckpointStorage.
+
+    **State Size Considerations**
+
+    Working state is kept on the TaskManager heap. If a TaskManager executes multiple
+    tasks concurrently (if the TaskManager has multiple slots, or if slot-sharing is used)
+    then the aggregate state of all tasks needs to fit into that TaskManager's memory.
+
+    **Configuration**
+
+    As for all state backends, this backend can either be configured within the application (by
+    creating the backend with the respective constructor parameters and setting it on the execution
+    environment) or by specifying it in the Flink configuration.
+
+    If the state backend was specified in the application, it may pick up additional configuration
+    parameters from the Flink configuration. For example, if the backend if configured in the
+    application without a default savepoint directory, it will pick up a default savepoint
+    directory specified in the Flink configuration of the running job/cluster. That behavior is
+    implemented via the :func:`configure` method.
+    """
+
+    def __init__(self, j_hashmap_state_backend=None):
+        """
+        Creates a new MemoryStateBackend, setting optionally the paths to persist checkpoint
+        metadata and savepoints to, as well as configuring state thresholds and asynchronous
+        operations.
+
+        WARNING: Increasing the size of this value beyond the default value
+        (:data:`DEFAULT_MAX_STATE_SIZE`) should be done with care.
+        The checkpointed state needs to be send to the JobManager via limited size RPC messages,
+        and there and the JobManager needs to be able to hold all aggregated state in its memory.
+
+        Example:
+        ::
+            >>> state_backend = HashMapStateBackend()
+
+        :param j_hashmap_state_backend: For internal use, please keep none.
+        """
+        if j_hashmap_state_backend is None:
+            gateway = get_gateway()
+            JHashMapStateBackend = gateway.jvm.org.apache.flink.runtime.state.hashmap\
+                .HashMapStateBackend
+
+            j_hashmap_state_backend = JHashMapStateBackend()
+
+        super(HashMapStateBackend, self).__init__(j_hashmap_state_backend)
+
+    def __str__(self):
+        return self._j_state_backend.toString()
+
+
+class EmbeddedRocksDBStateBackend(StateBackend):
+    """
+    A State Backend that stores its state in an embedded ``RocksDB`` instance. This state backend
+    can store very large state that exceeds memory and spills to local disk.
+
+    All key/value state (including windows) is stored in the key/value index of RocksDB.
+    For persistence against loss of machines, please configure a CheckpointStorage instance
+    for the Job.
+
+    The behavior of the RocksDB instances can be parametrized by setting RocksDB Options
+    using the methods :func:`set_predefined_options` and :func:`set_options`.
+    """
+
+    def __init__(self,
+                 enable_incremental_checkpointing=None,
+                 j_embedded_rocks_db_state_backend=None):
+        """
+        Creates a new :class:`EmbeddedRocksDBStateBackend` for storing local state.
+
+        Example:
+        ::
+
+            >>> state_backend = EmbeddedRocksDBStateBackend()
+
+        :param enable_incremental_checkpointing: True if incremental checkpointing is enabled.
+        :param j_embedded_rocks_db_state_backend: For internal use, please keep none.
+        """
+        if j_embedded_rocks_db_state_backend is None:
+            gateway = get_gateway()
+            JTernaryBoolean = gateway.jvm.org.apache.flink.util.TernaryBoolean
+            JEmbeddedRocksDBStateBackend = gateway.jvm.org.apache.flink.contrib.streaming.state \
+                .EmbeddedRocksDBStateBackend
+
+            if enable_incremental_checkpointing not in (None, True, False):
+                raise TypeError("Unsupported input for 'enable_incremental_checkpointing': %s, "
+                                "the value of the parameter should be None or"
+                                "True or False.")
+
+            if enable_incremental_checkpointing is None:
+                j_enable_incremental_checkpointing = JTernaryBoolean.UNDEFINED
+            elif enable_incremental_checkpointing is True:
+                j_enable_incremental_checkpointing = JTernaryBoolean.TRUE
+            else:
+                j_enable_incremental_checkpointing = JTernaryBoolean.FALSE
+
+            j_embedded_rocks_db_state_backend = \
+                JEmbeddedRocksDBStateBackend(j_enable_incremental_checkpointing)
+
+        super(EmbeddedRocksDBStateBackend, self).__init__(j_embedded_rocks_db_state_backend)
+
+    def set_db_storage_paths(self, *paths: str):
+        """
+        Sets the directories in which the local RocksDB database puts its files (like SST and
+        metadata files). These directories do not need to be persistent, they can be ephemeral,
+        meaning that they are lost on a machine failure, because state in RocksDB is persisted
+        in checkpoints.
+
+        If nothing is configured, these directories default to the TaskManager's local
+        temporary file directories.
+
+        Each distinct state will be stored in one path, but when the state backend creates
+        multiple states, they will store their files on different paths.
+
+        Passing ``None`` to this function restores the default behavior, where the configured
+        temp directories will be used.
+
+        :param paths: The paths across which the local RocksDB database files will be spread. this
+                      parameter is optional.
+        """
+        if len(paths) < 1:
+            self._j_state_backend.setDbStoragePath(None)
+        else:
+            gateway = get_gateway()
+            j_path_array = gateway.new_array(gateway.jvm.String, len(paths))
+            for i in range(0, len(paths)):
+                j_path_array[i] = paths[i]
+            self._j_state_backend.setDbStoragePaths(j_path_array)
+
+    def get_db_storage_paths(self) -> List[str]:
+        """
+        Gets the configured local DB storage paths, or null, if none were configured.
+
+        Under these directories on the TaskManager, RocksDB stores its SST files and
+        metadata files. These directories do not need to be persistent, they can be ephermeral,
+        meaning that they are lost on a machine failure, because state in RocksDB is persisted
+        in checkpoints.
+
+        If nothing is configured, these directories default to the TaskManager's local
+        temporary file directories.
+
+        :return: The list of configured local DB storage paths.
+        """
+        return list(self._j_state_backend.getDbStoragePaths())
+
+    def is_incremental_checkpoints_enabled(self) -> bool:
+        """
+        Gets whether incremental checkpoints are enabled for this state backend.
+
+        :return: True if incremental checkpoints are enabled, false otherwise.
+        """
+        return self._j_state_backend.isIncrementalCheckpointsEnabled()
+
+    def set_predefined_options(self, options: 'PredefinedOptions'):
+        """
+        Sets the predefined options for RocksDB.
+
+        If user-configured options within ``RocksDBConfigurableOptions`` is set (through
+        flink-conf.yaml) or a user-defined options factory is set (via :func:`setOptions`),
+        then the options from the factory are applied on top of the here specified
+        predefined options and customized options.
+
+        Example:
+        ::
+
+            >>> state_backend.set_predefined_options(PredefinedOptions.SPINNING_DISK_OPTIMIZED)
+
+        :param options: The options to set (must not be null), see :class:`PredefinedOptions`.
+        """
+        self._j_state_backend\
+            .setPredefinedOptions(options._to_j_predefined_options())
+
+    def get_predefined_options(self) -> 'PredefinedOptions':
+        """
+        Gets the current predefined options for RocksDB.
+        The default options (if nothing was set via :func:`setPredefinedOptions`)
+        are :data:`PredefinedOptions.DEFAULT`.
+
+        If user-configured options within ``RocksDBConfigurableOptions`` is set (through
+        flink-conf.yaml) or a user-defined options factory is set (via :func:`setOptions`),
+        then the options from the factory are applied on top of the predefined and customized
+        options.
+
+        .. seealso:: :func:`set_predefined_options`
+
+        :return: Current predefined options.
+        """
+        j_predefined_options = self._j_state_backend.getPredefinedOptions()
+        return PredefinedOptions._from_j_predefined_options(j_predefined_options)
+
+    def set_options(self, options_factory_class_name: str):
+        """
+        Sets ``org.rocksdb.Options`` for the RocksDB instances.
+        Because the options are not serializable and hold native code references,
+        they must be specified through a factory.
+
+        The options created by the factory here are applied on top of the pre-defined
+        options profile selected via :func:`set_predefined_options`.
+        If the pre-defined options profile is the default (:data:`PredefinedOptions.DEFAULT`),
+        then the factory fully controls the RocksDB options.
+
+        :param options_factory_class_name: The fully-qualified class name of the options
+                                           factory in Java that lazily creates the RocksDB options.
+                                           The options factory must have a default constructor.
+        """
+        gateway = get_gateway()
+        JOptionsFactory = gateway.jvm.org.apache.flink.contrib.streaming.state.RocksDBOptionsFactory
+        j_options_factory_clz = load_java_class(options_factory_class_name)
+        if not get_java_class(JOptionsFactory).isAssignableFrom(j_options_factory_clz):
+            raise ValueError("The input class does not implement RocksDBOptionsFactory.")
+        self._j_state_backend\
+            .setRocksDBOptions(j_options_factory_clz.newInstance())
+
+    def get_options(self) -> Optional[str]:
+        """
+        Gets the fully-qualified class name of the options factory in Java that lazily creates
+        the RocksDB options.
+
+        :return: The fully-qualified class name of the options factory in Java.
+        """
+        j_options_factory = self._j_state_backend.getRocksDBOptions()
+        if j_options_factory is not None:
+            return j_options_factory.getClass().getName()
+        else:
+            return None
+
+    def get_number_of_transfer_threads(self) -> int:
+        """
+        Gets the number of threads used to transfer files while snapshotting/restoring.
+
+        :return: The number of threads used to transfer files while snapshotting/restoring.
+        """
+        return self._j_state_backend.getNumberOfTransferThreads()
+
+    def set_number_of_transfer_threads(self, number_of_transfering_threads: int):
+        """
+        Sets the number of threads used to transfer files while snapshotting/restoring.
+
+        :param number_of_transfering_threads: The number of threads used to transfer files while
+                                              snapshotting/restoring.
+        """
+        self._j_state_backend\
+            .setNumberOfTransferThreads(number_of_transfering_threads)
+
+    def __str__(self):
+        return self._j_state_backend.toString()
+
+
 class MemoryStateBackend(StateBackend):
     """
+    **IMPORTANT** `MemoryStateBackend` is deprecated in favor of `HashMapStateBackend` and
+    `JobManagerCheckpointStorage`. This change does not affect the runtime characteristics of your
+    Jobs and is simply an API change to help better communicate the ways Flink separates local state
+    storage from fault tolerance. Jobs can be upgraded without loss of state. If configuring
+    your state backend via the `StreamExecutionEnvironment` please make the following changes.
+
+    ::
+
+        >> env.set_state_backend(HashMapStateBackend())
+        >> env.get_checkpoint_config().set_checkpoint_storage(JobManagerCheckpointStorage())
+
+    If you are configuring your state backend via the `flink-conf.yaml` please make the following
+    changes.
+
+    ```
+    state.backend: hashmap
+    state.checkpoint-storage: jobmanager
+    ```
+
     This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
     The state backend checkpoints state directly to the JobManager's memory (hence the backend's
     name), but the checkpoints will be persisted to a file system for high-availability setups and
@@ -250,6 +523,21 @@ class MemoryStateBackend(StateBackend):
 
 class FsStateBackend(StateBackend):
     """
+    **IMPORTANT** `FsStateBackend is deprecated in favor of `HashMapStateBackend` and
+    `FileSystemCheckpointStorage`. This change does not affect the runtime characteristics
+    of your Jobs and is simply an API change to help better communicate the ways Flink separates
+    local state storage from fault tolerance. Jobs can be upgraded without loss of state. If
+    configuring your state backend via the `StreamExecutionEnvironment` please make the following
+    changes.
+
+    ::
+
+        >> env.set_state_backend(HashMapStateBackend())
+        >> env.get_checkpoint_config().set_checkpoint_storage("hdfs://checkpoints")
+
+    If you are configuring your state backend via the `flink-conf.yaml` please set your state
+    backend type to `hashmap`.
+
     This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
     The state backend checkpoints state as files to a file system (hence the backend's name).
 
@@ -417,6 +705,20 @@ class FsStateBackend(StateBackend):
 
 class RocksDBStateBackend(StateBackend):
     """
+    **IMPORTANT** `RocksDBStateBackend` is deprecated in favor of `EmbeddedRocksDBStateBackend`
+    and `FileSystemCheckpointStorage`. This change does not affect the runtime characteristics of
+    your Jobs and is simply an API change to help better communicate the ways Flink separates
+    local state storage from fault tolerance. Jobs can be upgraded without loss of state. If
+    configuring your state backend via the `StreamExecutionEnvironment` please make the following
+    changes.
+
+    ::
+
+        >> env.set_state_backend(EmbeddedRocksDBStateBackend())
+        >> env.get_checkpoint_config().set_checkpoint_storage("hdfs://checkpoints")
+
+    If you are configuring your state backend via the `flink-conf.yaml` no changes are required.
+
     A State Backend that stores its state in ``RocksDB``. This state backend can
     store very large state that exceeds memory and spills to disk.
 

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -293,7 +293,7 @@ class StreamExecutionEnvironment(object):
         Example:
         ::
 
-            >>> env.set_state_backend(RocksDBStateBackend("file://var/checkpoints/"))
+            >>> env.set_state_backend(EmbeddedRocksDBStateBackend())
 
         :param state_backend: The :class:`StateBackend`.
         :return: This object.
@@ -352,6 +352,32 @@ class StreamExecutionEnvironment(object):
         """
         j_ternary_boolean = self._j_stream_execution_environment.isChangelogStateBackendEnabled()
         return j_ternary_boolean.getAsBoolean()
+
+    def set_default_savepoint_directory(self, directory: str) -> 'StreamExecutionEnvironment':
+        """
+        Sets the default savepoint directory, where savepoints will be written to if none
+        is explicitly provided when triggered.
+
+        Example:
+        ::
+
+            >>> env.set_default_savepoint_directory("hdfs://savepoints")
+
+        :param directory The savepoint directory
+        :return: This object.
+        """
+        self._j_stream_execution_environment.setDefaultSavepointDirectory(directory)
+        return self
+
+    def get_default_savepoint_directory(self) -> Optional[str]:
+        """
+        Gets the default savepoint directory for this Job.
+        """
+        j_path = self._j_stream_execution_environment.getDefaultSavepointDirectory()
+        if j_path is None:
+            return None
+        else:
+            return j_path.toString()
 
     def set_restart_strategy(self, restart_strategy_configuration: RestartStrategyConfiguration):
         """

--- a/flink-python/pyflink/datastream/tests/test_check_point_config.py
+++ b/flink-python/pyflink/datastream/tests/test_check_point_config.py
@@ -157,3 +157,14 @@ class CheckpointConfigTests(PyFlinkTestCase):
 
         self.checkpoint_config.set_alignment_timeout(Duration.of_minutes(1))
         self.assertEqual(self.checkpoint_config.get_alignment_timeout(), Duration.of_minutes(1))
+
+    def test_get_set_checkpoint_storage(self):
+
+        self.assertIsNone(self.checkpoint_config.get_checkpoint_storage(),
+                          "Default checkpoint storage should be None")
+
+        self.checkpoint_config.set_checkpoint_storage_dir("file://var/checkpoints/")
+
+        self.assertEqual(self.checkpoint_config.get_checkpoint_storage().get_checkpoint_path(),
+                         "file://var/checkpoints",
+                         "Wrong checkpoints directory")

--- a/flink-python/pyflink/datastream/tests/test_checkpoint_storage.py
+++ b/flink-python/pyflink/datastream/tests/test_checkpoint_storage.py
@@ -1,0 +1,82 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.datastream.checkpoint_storage import (JobManagerCheckpointStorage,
+                                                   FileSystemCheckpointStorage)
+
+from pyflink.java_gateway import get_gateway
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class JobManagerCheckpointStorageTests(PyFlinkTestCase):
+
+    def test_constant(self):
+        gateway = get_gateway()
+        JJobManagerCheckpointStorage = gateway.jvm.org.apache.flink.runtime.state.storage \
+            .JobManagerCheckpointStorage
+
+        self.assertEqual(JobManagerCheckpointStorage.DEFAULT_MAX_STATE_SIZE,
+                         JJobManagerCheckpointStorage.DEFAULT_MAX_STATE_SIZE)
+
+    def test_create_jobmanager_checkpoint_storage(self):
+
+        self.assertIsNotNone(JobManagerCheckpointStorage())
+
+        self.assertIsNotNone(JobManagerCheckpointStorage("file://var/checkpoints/"))
+
+        self.assertIsNotNone(JobManagerCheckpointStorage(
+            "file://var/checkpoints/", 10000000))
+
+    def test_get_max_state_size(self):
+
+        checkpoint_storage = JobManagerCheckpointStorage()
+
+        self.assertEqual(checkpoint_storage.get_max_state_size(),
+                         JobManagerCheckpointStorage.DEFAULT_MAX_STATE_SIZE)
+
+        checkpoint_storage = JobManagerCheckpointStorage(max_state_size=50000)
+
+        self.assertEqual(checkpoint_storage.get_max_state_size(), 50000)
+
+
+class FileSystemCheckpointStorageTests(PyFlinkTestCase):
+
+    def test_create_fs_checkpoint_storage(self):
+
+        self.assertIsNotNone(FileSystemCheckpointStorage("file://var/checkpoints/"))
+
+        self.assertIsNotNone(FileSystemCheckpointStorage("file://var/checkpoints/", 2048))
+
+        self.assertIsNotNone(FileSystemCheckpointStorage(
+            "file://var/checkpoints/", 2048, 4096))
+
+    def test_get_min_file_size_threshold(self):
+
+        checkpoint_storage = FileSystemCheckpointStorage("file://var/checkpoints/")
+
+        self.assertEqual(checkpoint_storage.get_min_file_size_threshold(), 20480)
+
+        checkpoint_storage = FileSystemCheckpointStorage("file://var/checkpoints/",
+                                                         file_state_size_threshold=2048)
+
+        self.assertEqual(checkpoint_storage.get_min_file_size_threshold(), 2048)
+
+    def test_get_checkpoint_path(self):
+
+        checkpoint_storage = FileSystemCheckpointStorage("file://var/checkpoints/")
+
+        self.assertEqual(checkpoint_storage.get_checkpoint_path(), "file://var/checkpoints")

--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -17,7 +17,8 @@
 ################################################################################
 from pyflink.datastream.state_backend import (_from_j_state_backend, CustomStateBackend,
                                               MemoryStateBackend, FsStateBackend,
-                                              RocksDBStateBackend, PredefinedOptions)
+                                              RocksDBStateBackend, PredefinedOptions,
+                                              EmbeddedRocksDBStateBackend)
 from pyflink.java_gateway import get_gateway
 from pyflink.pyflink_gateway_server import on_windows
 from pyflink.testing.test_case_utils import PyFlinkTestCase
@@ -94,6 +95,85 @@ class FsStateBackendTests(PyFlinkTestCase):
         state_backend = FsStateBackend("file://var/checkpoints/")
 
         self.assertEqual(state_backend.get_checkpoint_path(), "file://var/checkpoints")
+
+
+class EmbeddedRocksDBStateBackendTests(PyFlinkTestCase):
+
+    def test_create_rocks_db_state_backend(self):
+
+        self.assertIsNotNone(EmbeddedRocksDBStateBackend())
+
+        self.assertIsNotNone(EmbeddedRocksDBStateBackend(True))
+
+        self.assertIsNotNone(EmbeddedRocksDBStateBackend(False))
+
+    def test_get_set_db_storage_paths(self):
+        if on_windows():
+            storage_path = ["file:/C:/var/db_storage_dir1/",
+                            "file:/C:/var/db_storage_dir2/",
+                            "file:/C:/var/db_storage_dir3/"]
+            expected = ["C:\\var\\db_storage_dir1",
+                        "C:\\var\\db_storage_dir2",
+                        "C:\\var\\db_storage_dir3"]
+        else:
+            storage_path = ["file://var/db_storage_dir1/",
+                            "file://var/db_storage_dir2/",
+                            "file://var/db_storage_dir3/"]
+            expected = ["/db_storage_dir1",
+                        "/db_storage_dir2",
+                        "/db_storage_dir3"]
+
+        state_backend = EmbeddedRocksDBStateBackend()
+        state_backend.set_db_storage_paths(*storage_path)
+        self.assertEqual(state_backend.get_db_storage_paths(), expected)
+
+    def test_get_set_predefined_options(self):
+
+        state_backend = EmbeddedRocksDBStateBackend()
+
+        self.assertEqual(state_backend.get_predefined_options(), PredefinedOptions.DEFAULT)
+
+        state_backend.set_predefined_options(PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM)
+
+        self.assertEqual(state_backend.get_predefined_options(),
+                         PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM)
+
+        state_backend.set_predefined_options(PredefinedOptions.SPINNING_DISK_OPTIMIZED)
+
+        self.assertEqual(state_backend.get_predefined_options(),
+                         PredefinedOptions.SPINNING_DISK_OPTIMIZED)
+
+        state_backend.set_predefined_options(PredefinedOptions.FLASH_SSD_OPTIMIZED)
+
+        self.assertEqual(state_backend.get_predefined_options(),
+                         PredefinedOptions.FLASH_SSD_OPTIMIZED)
+
+        state_backend.set_predefined_options(PredefinedOptions.DEFAULT)
+
+        self.assertEqual(state_backend.get_predefined_options(), PredefinedOptions.DEFAULT)
+
+    def test_get_set_options(self):
+
+        state_backend = EmbeddedRocksDBStateBackend()
+
+        self.assertIsNone(state_backend.get_options())
+
+        state_backend.set_options(
+            "org.apache.flink.contrib.streaming.state.DefaultConfigurableOptionsFactory")
+
+        self.assertEqual(state_backend.get_options(),
+                         "org.apache.flink.contrib.streaming.state."
+                         "DefaultConfigurableOptionsFactory")
+
+    def test_get_set_number_of_transfering_threads(self):
+
+        state_backend = EmbeddedRocksDBStateBackend()
+
+        self.assertEqual(state_backend.get_number_of_transfering_threads(), 1)
+
+        state_backend.set_number_of_transfering_threads(4)
+
+        self.assertEqual(state_backend.get_number_of_transfering_threads(), 4)
 
 
 class RocksDBStateBackendTests(PyFlinkTestCase):

--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -165,15 +165,15 @@ class EmbeddedRocksDBStateBackendTests(PyFlinkTestCase):
                          "org.apache.flink.contrib.streaming.state."
                          "DefaultConfigurableOptionsFactory")
 
-    def test_get_set_number_of_transfering_threads(self):
+    def test_get_set_number_of_transfer_threads(self):
 
         state_backend = EmbeddedRocksDBStateBackend()
 
-        self.assertEqual(state_backend.get_number_of_transfering_threads(), 1)
+        self.assertEqual(state_backend.get_number_of_transfer_threads(), 4)
 
-        state_backend.set_number_of_transfering_threads(4)
+        state_backend.set_number_of_transfer_threads(8)
 
-        self.assertEqual(state_backend.get_number_of_transfering_threads(), 4)
+        self.assertEqual(state_backend.get_number_of_transfer_threads(), 8)
 
 
 class RocksDBStateBackendTests(PyFlinkTestCase):

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -48,8 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
-                'clearJobListeners', 'getJobListeners', "fromSequence",
-                'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory'}
+                'clearJobListeners', 'getJobListeners', "fromSequence"}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is the purpose of the change

This adds the new public APIs from FLIP-142 to the Python DataStream API. It is based on top of #15429  so only the last 3 commits are relevant. 

## Brief change log

96aa09c Add new state backend classes and sync updated JavaDoc

7193a21 Add new checkpoint storage classes 

57c27b5 Add new methods to StreamExecutionEnvironment

## Verifying this change

Added new Python Unit Tests.  Note to the reviewer, I had some issues running the python tests locally. I will monitor the CI to ensure everything passes. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no /** don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
