### PR TITLE
[FLINK-22081][core] handle entropy injection metadata path in pluggable HadoopS3FileSystem

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/PluginFileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/PluginFileSystemFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.core.fs;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TemporaryClassLoaderContext;
+import org.apache.flink.util.WrappingProxy;
 
 import java.io.IOException;
 import java.net.URI;
@@ -67,7 +68,8 @@ public class PluginFileSystemFactory implements FileSystemFactory {
         return String.format("Plugin %s", inner.getClass().getName());
     }
 
-    static class ClassLoaderFixingFileSystem extends FileSystem {
+    static class ClassLoaderFixingFileSystem extends FileSystem
+            implements WrappingProxy<FileSystem> {
         private final FileSystem inner;
         private final ClassLoader loader;
 
@@ -190,7 +192,8 @@ public class PluginFileSystemFactory implements FileSystemFactory {
             }
         }
 
-        public FileSystem getInner() {
+        @Override
+        public FileSystem getWrappedDelegate() {
             return inner;
         }
     }

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -169,7 +169,7 @@ public class EntropyInjectorTest {
     }
 
     @Test
-    public void testClassLoaderFixingFs() throws Exception {
+    public void testClassLoaderFixingFsWithSafeyNet() throws Exception {
         final String entropyKey = "__ekey__";
         final String entropyValue = "abc";
 
@@ -192,6 +192,26 @@ public class EntropyInjectorTest {
         } finally {
             FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
         }
+    }
+
+    @Test
+    public void testClassLoaderFixingFsWithoutSafeyNet() throws Exception {
+        final String entropyKey = "__ekey__";
+        final String entropyValue = "abc";
+
+        final File folder = TMP_FOLDER.newFolder();
+
+        final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
+        final Path pathWithEntropy = new Path(Path.fromLocalFile(folder), entropyValue + "/path/");
+
+        PluginFileSystemFactory pluginFsFactory =
+                PluginFileSystemFactory.of(new TestFileSystemFactory(entropyKey, entropyValue));
+        FileSystem testFs = pluginFsFactory.create(URI.create("test"));
+
+        OutputStreamAndPath streamAndPath =
+                EntropyInjector.createEntropyAware(testFs, path, WriteMode.NO_OVERWRITE);
+
+        assertEquals(pathWithEntropy, streamAndPath.path());
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

entropy injection suppose to filter entropy marker in plug able s3 filesystem, instead, job manager incorrectly view s3 filesystem as non entropy fs because of nested file system types difference from task manager. 

The goal of this fix is to accommodate both job manager as well as task manager on entropy marker parsing with pluggable filesystem ans make metadata path consistent with 1.9 and earlier.

http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/Flink-job-cannot-find-recover-path-after-using-entropy-injection-for-s3-file-systems-tp49527p49656.html


## Brief change log

refactor EntropyInjectingFileSystem getEntropyFs if else logic able to handle pluggable filesystem.
adding test coverage on job manager entropy marker handling

## Verifying this change

run test job on  yarn cluster, verify job manager generate checkpoint path without entropy marker
 
## Does this pull request potentially affect one of the following parts:

this is backward compatible change, adding handling to checkpoint path not covered previously.

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
