### PR TITLE
[FLINK-22058][python] Support FLIP-27 based NumberSequenceSource connector in PyFlink DataStream API

### DIFF
--- a/flink-python/pyflink/datastream/connectors.py
+++ b/flink-python/pyflink/datastream/connectors.py
@@ -29,6 +29,7 @@ from pyflink.util.java_utils import load_java_class, to_jarray
 from py4j.java_gateway import java_import, JavaObject
 
 __all__ = [
+    'DefaultRollingPolicy',
     'FileEnumeratorProvider',
     'FileSource',
     'FileSourceBuilder',
@@ -38,12 +39,12 @@ __all__ = [
     'JdbcSink',
     'JdbcConnectionOptions',
     'JdbcExecutionOptions',
+    'NumberSequenceSource',
+    'OutputFileConfig',
     'RollingPolicy',
-    'DefaultRollingPolicy',
     'Source',
     'StreamFormat',
-    'StreamingFileSink',
-    'OutputFileConfig']
+    'StreamingFileSink']
 
 
 class FlinkKafkaConsumerBase(SourceFunction, abc.ABC):
@@ -922,3 +923,28 @@ class FileSource(Source):
         j_paths = to_jarray(JPath, [JPath(p) for p in paths])
         return FileSourceBuilder(
             JFileSource.forRecordStreamFormat(stream_format._j_stream_format, j_paths))
+
+
+class NumberSequenceSource(Source):
+    """
+    A data source that produces a sequence of numbers (longs). This source is useful for testing and
+    for cases that just need a stream of N events of any kind.
+
+    The source splits the sequence into as many parallel sub-sequences as there are parallel
+    source readers. Each sub-sequence will be produced in order. Consequently, if the parallelism is
+    limited to one, this will produce one sequence in order.
+
+    This source is always bounded. For very long sequences (for example over the entire domain of
+    long integer values), user may want to consider executing the application in a streaming manner,
+    because, despite the fact that the produced stream is bounded, the end bound is pretty far away.
+    """
+
+    def __init__(self, start, end):
+        """
+        Creates a new NumberSequenceSource that produces parallel sequences covering the
+        range start to end (both boundaries are inclusive).
+        """
+        JNumberSequenceSource = get_gateway().jvm.org.apache.flink.api.connector.source.lib.\
+            NumberSequenceSource
+        j_seq_source = JNumberSequenceSource(start, end)
+        super(NumberSequenceSource, self).__init__(source=j_seq_source)

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -153,6 +153,10 @@ class ConnectorTests(PyFlinkTestCase):
     def setUp(self) -> None:
         self.env = StreamExecutionEnvironment.get_execution_environment()
         self.test_sink = DataStreamTestSinkFunction()
+        _load_specific_flink_module_jars('/flink-connectors/flink-connector-files')
+
+    def tearDown(self) -> None:
+        self.test_sink.clear()
 
     def test_stream_file_sink(self):
         self.env.set_parallelism(2)
@@ -189,17 +193,6 @@ class ConnectorTests(PyFlinkTestCase):
         expected.sort()
         self.assertEqual(expected, results)
 
-    def tearDown(self) -> None:
-        self.test_sink.clear()
-
-
-class FlinkFileSourceTest(PyFlinkTestCase):
-
-    def setUp(self):
-        self.env = StreamExecutionEnvironment.get_execution_environment()
-        self._cxt_clz_loader = get_gateway().jvm.Thread.currentThread().getContextClassLoader()
-        _load_specific_flink_module_jars('/flink-connectors/flink-connector-files')
-
     def test_file_source(self):
         stream_format = StreamFormat.text_line_format()
         paths = ["/tmp/1.txt", "/tmp/2.txt"]
@@ -223,10 +216,7 @@ class FlinkFileSourceTest(PyFlinkTestCase):
         self.assertEqual(str(input_paths[0]), paths[0])
         self.assertEqual(str(input_paths[1]), paths[1])
 
-
-class NumberSequenceSourceTest(PyFlinkTestCase):
-
-    def test_file_source(self):
+    def test_seq_source(self):
         seq_source = NumberSequenceSource(1, 10)
 
         seq_source_clz = load_java_class(

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -23,7 +23,8 @@ from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.datastream.connectors import FlinkKafkaConsumer, FlinkKafkaProducer, JdbcSink, \
     JdbcConnectionOptions, JdbcExecutionOptions, StreamingFileSink, DefaultRollingPolicy, \
-    OutputFileConfig, FileSource, StreamFormat, FileEnumeratorProvider, FileSplitAssignerProvider
+    OutputFileConfig, FileSource, StreamFormat, FileEnumeratorProvider, FileSplitAssignerProvider, \
+    NumberSequenceSource
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase, _load_specific_flink_module_jars, \
@@ -221,3 +222,19 @@ class FlinkFileSourceTest(PyFlinkTestCase):
         self.assertEqual(len(input_paths), len(paths))
         self.assertEqual(str(input_paths[0]), paths[0])
         self.assertEqual(str(input_paths[1]), paths[1])
+
+
+class NumberSequenceSourceTest(PyFlinkTestCase):
+
+    def test_file_source(self):
+        seq_source = NumberSequenceSource(1, 10)
+
+        seq_source_clz = load_java_class(
+            "org.apache.flink.api.connector.source.lib.NumberSequenceSource")
+        from_field = seq_source_clz.getDeclaredField("from")
+        from_field.setAccessible(True)
+        self.assertEqual(1, from_field.get(seq_source.get_java_function()))
+
+        to_field = seq_source_clz.getDeclaredField("to")
+        to_field.setAccessible(True)
+        self.assertEqual(10, to_field.get(seq_source.get_java_function()))


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support of FLIP-27 based NumberSequenceSource connector in PyFlink DataStream API*

## Brief change log

  - *Introduce NumberSequenceSource in PyFlink DataStream API*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_seq_source*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will add documentation in a separate PR)
