### PR TITLE
[FLINK-22061][file connector] Fix DEFAULT_NON_SPLITTABLE_FILE_ENUMERATOR to point to NonSplittingRecursiveEnumerator

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
 import org.apache.flink.connector.file.src.assigners.LocalityAwareSplitAssigner;
 import org.apache.flink.connector.file.src.enumerate.BlockSplittingRecursiveEnumerator;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
+import org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumerator;
 import org.apache.flink.connector.file.src.impl.FileRecordFormatAdapter;
 import org.apache.flink.connector.file.src.impl.StreamFormatAdapter;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
@@ -119,7 +120,7 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit> 
      * with '.' or '_').
      */
     public static final FileEnumerator.Provider DEFAULT_NON_SPLITTABLE_FILE_ENUMERATOR =
-            BlockSplittingRecursiveEnumerator::new;
+            NonSplittingRecursiveEnumerator::new;
 
     // ------------------------------------------------------------------------
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix DEFAULT_NON_SPLITTABLE_FILE_ENUMERATOR to point it to NonSplittingRecursiveEnumerator instead of BlockSplittingRecursiveEnumerator*


## Brief change log

  - *Update DEFAULT_NON_SPLITTABLE_FILE_ENUMERATOR to point to NonSplittingRecursiveEnumerator*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
