### PR TITLE
[FLINK-21969][python] Invoke finish bundle method before emitting the max timestamp watermark in PythonTimestampsAndWatermarksOperator

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonTimestampsAndWatermarksOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/PythonTimestampsAndWatermarksOperator.java
@@ -173,8 +173,10 @@ public class PythonTimestampsAndWatermarksOperator<IN>
     }
 
     @Override
-    public void processWatermark(org.apache.flink.streaming.api.watermark.Watermark mark) {
+    public void processWatermark(org.apache.flink.streaming.api.watermark.Watermark mark)
+            throws Exception {
         if (mark.getTimestamp() == Long.MAX_VALUE) {
+            invokeFinishBundle();
             watermarkOutput.emitWatermark(Watermark.MAX_WATERMARK);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

*This pull cherry-picks the patches reviewed in #15401.*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
