### PR TITLE
[BP-1.11][FLINK-21609][tests] Remove usage of LocalCollectionOutpuFormat from SimpleRecoveryITCaseBase

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureRateRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureRateRestartBackoffTimeStrategy.java
@@ -92,7 +92,7 @@ public class FailureRateRestartBackoffTimeStrategy implements RestartBackoffTime
     }
 
     private boolean isFailureTimestampsQueueFull() {
-        return failureTimestamps.size() >= maxFailuresPerInterval;
+        return failureTimestamps.size() > maxFailuresPerInterval;
     }
 
     private String generateStrategyString() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureRateRestartBackoffTimeStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureRateRestartBackoffTimeStrategyTest.java
@@ -45,8 +45,8 @@ public class FailureRateRestartBackoffTimeStrategyTest extends TestLogger {
                 new FailureRateRestartBackoffTimeStrategy(clock, 1, intervalMS, 0);
 
         for (int failuresLeft = numFailures; failuresLeft > 0; failuresLeft--) {
-            assertTrue(restartStrategy.canRestart());
             restartStrategy.notifyFailure(failure);
+            assertTrue(restartStrategy.canRestart());
             clock.advanceTime(intervalMS + 1, TimeUnit.MILLISECONDS);
         }
 
@@ -63,10 +63,11 @@ public class FailureRateRestartBackoffTimeStrategyTest extends TestLogger {
                         new ManualClock(), numFailures, intervalMS, 0);
 
         for (int failuresLeft = numFailures; failuresLeft > 0; failuresLeft--) {
-            assertTrue(restartStrategy.canRestart());
             restartStrategy.notifyFailure(failure);
+            assertTrue(restartStrategy.canRestart());
         }
 
+        restartStrategy.notifyFailure(failure);
         assertFalse(restartStrategy.canRestart());
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -43,7 +43,7 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
         Configuration config = new Configuration();
         config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
         config.setInteger(
-                RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 1);
+                RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 3);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL,
                 Duration.ofSeconds(1));

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
@@ -42,7 +42,7 @@ public class SimpleRecoveryFixedDelayRestartStrategyITBase extends SimpleRecover
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
         config.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
-        config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+        config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 3);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofMillis(100));
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -39,7 +40,7 @@ import static org.junit.Assert.fail;
  * should restart them to verify job completion.
  */
 @SuppressWarnings("serial")
-public abstract class SimpleRecoveryITCaseBase {
+public abstract class SimpleRecoveryITCaseBase extends TestLogger {
 
     @ClassRule
     public static final MiniClusterWithClientResource MINI_CLUSTER_WITH_CLIENT_RESOURCE =

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -23,7 +23,10 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.List;
@@ -37,6 +40,14 @@ import static org.junit.Assert.fail;
  */
 @SuppressWarnings("serial")
 public abstract class SimpleRecoveryITCaseBase {
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER_WITH_CLIENT_RESOURCE =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(4)
+                            .setNumberSlotsPerTaskManager(1)
+                            .build());
 
     @Test
     public void testFailedRunThenSuccessfulRun() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryITCaseBase.java
@@ -134,7 +134,6 @@ public abstract class SimpleRecoveryITCaseBase {
             ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 
             env.setParallelism(4);
-            env.setRestartStrategy(RestartStrategies.fixedDelayRestart(5, 100));
 
             List<Long> resultCollection =
                     env.generateSequence(1, 10)


### PR DESCRIPTION
Backport of #15389  to `release-1.11`.