### PR TITLE
[FLINK-22070][python] Support FileSink in PyFlink DataStream API

### DIFF
--- a/flink-python/pyflink/common/serialization.py
+++ b/flink-python/pyflink/common/serialization.py
@@ -15,14 +15,13 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from py4j.java_gateway import java_import, JavaObject
+from py4j.java_gateway import java_import
 from pyflink.common import typeinfo
 from pyflink.common.typeinfo import TypeInformation
 
 from pyflink.util.java_utils import load_java_class
 
 from pyflink.java_gateway import get_gateway
-from typing import Union
 
 
 class SerializationSchema(object):
@@ -371,26 +370,19 @@ class AvroRowSerializationSchema(SerializationSchema):
 
 class Encoder(object):
     """
-    A `Encoder` is used by the streaming file sink to perform the actual writing
-    of the incoming elements to the files in a bucket.
+    Encoder is used by the file sink to perform the actual writing of the
+    incoming elements to the files in a bucket.
     """
 
-    def __init__(self, j_encoder: Union[str, JavaObject]):
-        if isinstance(j_encoder, str):
-            j_encoder_class = get_gateway().jvm.__getattr__(j_encoder)
-            j_encoder = j_encoder_class()
-        self.j_encoder = j_encoder
+    def __init__(self, j_encoder):
+        self._j_encoder = j_encoder
 
-    def get_java_encoder(self):
-        return self.j_encoder
-
-
-class SimpleStringEncoder(Encoder):
-    """
-    A simple `Encoder` that uses `toString()` on the input elements and
-    writes them to the output bucket file separated by newline.
-    """
-    def __init__(self, charset_name: str = "UTF-8"):
-        j_encoder = get_gateway().\
-            jvm.org.apache.flink.api.common.serialization.SimpleStringEncoder(charset_name)
-        super(SimpleStringEncoder, self).__init__(j_encoder)
+    @staticmethod
+    def simple_string_encoder(charset_name: str = "UTF-8") -> 'Encoder':
+        """
+        A simple Encoder that uses toString() on the input elements and writes them to
+        the output bucket file separated by newline.
+        """
+        j_encoder = get_gateway().jvm.org.apache.flink.api.common.serialization.\
+            SimpleStringEncoder(charset_name)
+        return Encoder(j_encoder)

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -25,6 +25,7 @@ from pyflink.datastream.window import TimeWindowSerializer, CountWindowSerialize
     Trigger, WindowOperationDescriptor
 from pyflink.common.typeinfo import RowTypeInfo, Types, TypeInformation, _from_java_type
 from pyflink.common.watermark_strategy import WatermarkStrategy
+from pyflink.datastream.connectors import Sink
 from pyflink.datastream.functions import _get_python_env, FlatMapFunctionWrapper, FlatMapFunction, \
     MapFunction, MapFunctionWrapper, Function, FunctionWrapper, SinkFunction, FilterFunction, \
     FilterFunctionWrapper, KeySelectorFunctionWrapper, KeySelector, ReduceFunction, \
@@ -617,6 +618,18 @@ class DataStream(object):
         :return: The closed DataStream.
         """
         return DataStreamSink(self._j_data_stream.addSink(sink_func.get_java_function()))
+
+    def sink_to(self, sink: Sink) -> 'DataStreamSink':
+        """
+        Adds the given sink to this DataStream. Only streams with sinks added will be
+        executed once the
+        :func:`~pyflink.datastream.stream_execution_environment.StreamExecutionEnvironment.execute`
+        method is called.
+
+        :param sink: The user defined sink.
+        :return: The closed DataStream.
+        """
+        return DataStreamSink(self._j_data_stream.sinkTo(sink.get_java_function()))
 
     def execute_and_collect(self, job_execution_name: str = None, limit: int = None) \
             -> Union['CloseableIterator', list]:

--- a/flink-python/pyflink/datastream/tests/test_connectors.py
+++ b/flink-python/pyflink/datastream/tests/test_connectors.py
@@ -18,13 +18,13 @@
 
 from pyflink.common import typeinfo, Duration
 from pyflink.common.serialization import JsonRowDeserializationSchema, \
-    JsonRowSerializationSchema, SimpleStringEncoder
+    JsonRowSerializationSchema, Encoder
 from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.datastream.connectors import FlinkKafkaConsumer, FlinkKafkaProducer, JdbcSink, \
-    JdbcConnectionOptions, JdbcExecutionOptions, StreamingFileSink, DefaultRollingPolicy, \
+    JdbcConnectionOptions, JdbcExecutionOptions, StreamingFileSink, \
     OutputFileConfig, FileSource, StreamFormat, FileEnumeratorProvider, FileSplitAssignerProvider, \
-    NumberSequenceSource
+    NumberSequenceSource, RollingPolicy, FileSink, BucketAssigner
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.testing.test_case_utils import PyFlinkTestCase, _load_specific_flink_module_jars, \
@@ -154,6 +154,7 @@ class ConnectorTests(PyFlinkTestCase):
         self.env = StreamExecutionEnvironment.get_execution_environment()
         self.test_sink = DataStreamTestSinkFunction()
         _load_specific_flink_module_jars('/flink-connectors/flink-connector-files')
+        _load_specific_flink_module_jars('/flink-connectors/flink-connector-sink-common')
 
     def tearDown(self) -> None:
         self.test_sink.clear()
@@ -165,11 +166,12 @@ class ConnectorTests(PyFlinkTestCase):
         ds.map(
             lambda a: a[0],
             Types.STRING()).add_sink(
-            StreamingFileSink.for_row_format(self.tempdir, SimpleStringEncoder())
+            StreamingFileSink.for_row_format(self.tempdir, Encoder.simple_string_encoder())
                 .with_rolling_policy(
-                    DefaultRollingPolicy.builder().with_rollover_interval(15 * 60 * 1000)
-                .with_inactivity_interval(5 * 60 * 1000)
-                .with_max_part_size(1024 * 1024 * 1024).build())
+                    RollingPolicy.default_rolling_policy(
+                        part_size=1024 * 1024 * 1024,
+                        rollover_interval=15 * 60 * 1000,
+                        inactivity_interval=5 * 60 * 1000))
                 .with_output_file_config(
                     OutputFileConfig.OutputFileConfigBuilder()
                     .with_part_prefix("prefix")
@@ -215,6 +217,53 @@ class ConnectorTests(PyFlinkTestCase):
         self.assertEqual(len(input_paths), len(paths))
         self.assertEqual(str(input_paths[0]), paths[0])
         self.assertEqual(str(input_paths[1]), paths[1])
+
+    def test_file_sink(self):
+        base_path = "/tmp/1.txt"
+        encoder = Encoder.simple_string_encoder()
+        file_sink_builder = FileSink.for_row_format(base_path, encoder)
+        file_sink = file_sink_builder\
+            .with_bucket_check_interval(1000) \
+            .with_bucket_assigner(BucketAssigner.base_path_bucket_assigner()) \
+            .with_rolling_policy(RollingPolicy.on_checkpoint_rolling_policy()) \
+            .with_output_file_config(
+                OutputFileConfig.builder().with_part_prefix("pre").with_part_suffix("suf").build())\
+            .build()
+
+        buckets_builder_field = \
+            load_java_class("org.apache.flink.connector.file.sink.FileSink"). \
+            getDeclaredField("bucketsBuilder")
+        buckets_builder_field.setAccessible(True)
+        buckets_builder = buckets_builder_field.get(file_sink.get_java_function())
+
+        self.assertEqual("DefaultRowFormatBuilder", buckets_builder.getClass().getSimpleName())
+
+        row_format_builder_clz = load_java_class(
+            "org.apache.flink.connector.file.sink.FileSink$RowFormatBuilder")
+        encoder_field = row_format_builder_clz.getDeclaredField("encoder")
+        encoder_field.setAccessible(True)
+        self.assertEqual("SimpleStringEncoder",
+                         encoder_field.get(buckets_builder).getClass().getSimpleName())
+
+        interval_field = row_format_builder_clz.getDeclaredField("bucketCheckInterval")
+        interval_field.setAccessible(True)
+        self.assertEqual(1000, interval_field.get(buckets_builder))
+
+        bucket_assigner_field = row_format_builder_clz.getDeclaredField("bucketAssigner")
+        bucket_assigner_field.setAccessible(True)
+        self.assertEqual("BasePathBucketAssigner",
+                         bucket_assigner_field.get(buckets_builder).getClass().getSimpleName())
+
+        rolling_policy_field = row_format_builder_clz.getDeclaredField("rollingPolicy")
+        rolling_policy_field.setAccessible(True)
+        self.assertEqual("OnCheckpointRollingPolicy",
+                         rolling_policy_field.get(buckets_builder).getClass().getSimpleName())
+
+        output_file_config_field = row_format_builder_clz.getDeclaredField("outputFileConfig")
+        output_file_config_field.setAccessible(True)
+        output_file_config = output_file_config_field.get(buckets_builder)
+        self.assertEqual("pre", output_file_config.getPartPrefix())
+        self.assertEqual("suf", output_file_config.getPartSuffix())
 
     def test_seq_source(self):
         seq_source = NumberSequenceSource(1, 10)

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -46,7 +46,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'getNumberOfExecutionRetries', 'getStreamGraph', 'fromParallelCollection',
                 'readFileStream', 'isForceCheckpointing', 'readFile', 'clean',
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
-                'socketTextStream', 'initializeContextEnvironment', 'readTextFile', 'addSource',
+                'socketTextStream', 'initializeContextEnvironment', 'readTextFile',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
                 'clearJobListeners', 'getJobListeners', "fromSequence",
                 'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory'}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add support of FileSink in PyFlink DataStream API*


## Brief change log

  - *Introduce FileSink in PyFlink DataStream API*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_file_sink*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will add documentation in a separate PR)
