### PR TITLE
[FLINK-22050][runtime] Don't release StreamTask network resources from TaskCanceller

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.FlinkException;
@@ -303,4 +304,12 @@ public abstract class AbstractInvokable {
      *     failure/recovery.
      */
     public void restore() throws Exception {}
+
+    /**
+     * @return true if blocking input such as {@link InputGate#getNext()} is used (as opposed to
+     *     {@link InputGate#pollNext()}. To be removed together with the DataSet API.
+     */
+    public boolean isUsingNonBlockingInput() {
+        return false;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1390,4 +1390,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             suspendedDefaultAction.resume();
         }
     }
+
+    @Override
+    public boolean isUsingNonBlockingInput() {
+        return true;
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

```
Don't release StreamTask network resources from TaskCanceller
Concurrent release could lead to race conditions.
```

## Verifying this change

The race condition is already covered by `UnalignedCheckpointITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
