### PR TITLE
[FLINK-21817][connector/kafka] Remove split assignment tracking from Kafka enumerator

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -170,7 +170,7 @@ public class KafkaSource<OUT>
                 stoppingOffsetsInitializer,
                 props,
                 enumContext,
-                checkpoint.getCurrentAssignment());
+                checkpoint.assignedPartitions());
     }
 
     @Override

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
@@ -18,20 +18,19 @@
 
 package org.apache.flink.connector.kafka.source.enumerator;
 
-import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.kafka.common.TopicPartition;
 
-import java.util.Map;
 import java.util.Set;
 
 /** The state of Kafka source enumerator. */
 public class KafkaSourceEnumState {
-    private final Map<Integer, Set<KafkaPartitionSplit>> currentAssignment;
+    private final Set<TopicPartition> assignedPartitions;
 
-    KafkaSourceEnumState(Map<Integer, Set<KafkaPartitionSplit>> currentAssignment) {
-        this.currentAssignment = currentAssignment;
+    KafkaSourceEnumState(Set<TopicPartition> assignedPartitions) {
+        this.assignedPartitions = assignedPartitions;
     }
 
-    public Map<Integer, Set<KafkaPartitionSplit>> getCurrentAssignment() {
-        return currentAssignment;
+    public Set<TopicPartition> assignedPartitions() {
+        return assignedPartitions;
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -255,7 +255,7 @@ public class KafkaEnumeratorTest {
     public void testWorkWithPreexistingAssignments() throws Throwable {
         final MockSplitEnumeratorContext<KafkaPartitionSplit> context1 =
                 new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        Map<Integer, Set<KafkaPartitionSplit>> preexistingAssignments;
+        Set<TopicPartition> preexistingAssignments;
         try (KafkaSourceEnumerator enumerator =
                 createEnumerator(context1, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
             startEnumeratorAndRegisterReaders(context1, enumerator);
@@ -299,7 +299,7 @@ public class KafkaEnumeratorTest {
                         context,
                         ENABLE_PERIODIC_PARTITION_DISCOVERY,
                         PRE_EXISTING_TOPICS,
-                        Collections.emptyMap(),
+                        Collections.emptySet(),
                         properties)) {
             enumerator.start();
 
@@ -322,6 +322,30 @@ public class KafkaEnumeratorTest {
                     (long) defaultTimeoutMs,
                     Whitebox.getInternalState(consumer, "requestTimeoutMs"));
         }
+    }
+
+    @Test
+    public void testSnapshotState() throws Throwable {
+        final MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+
+        final KafkaSourceEnumerator enumerator = createEnumerator(context, false);
+        enumerator.start();
+
+        // No reader is registered, so the state should be empty
+        final KafkaSourceEnumState state1 = enumerator.snapshotState();
+        assertTrue(state1.assignedPartitions().isEmpty());
+
+        registerReader(context, enumerator, READER0);
+        registerReader(context, enumerator, READER1);
+        context.runNextOneTimeCallable();
+
+        // The state should contain splits assigned to READER0 and READER1
+        final KafkaSourceEnumState state2 = enumerator.snapshotState();
+        verifySplitAssignmentWithPartitions(
+                getExpectedAssignments(
+                        new HashSet<>(Arrays.asList(READER0, READER1)), PRE_EXISTING_TOPICS),
+                state2.assignedPartitions());
     }
 
     // -------------- some common startup sequence ---------------
@@ -370,7 +394,7 @@ public class KafkaEnumeratorTest {
                 enumContext,
                 enablePeriodicPartitionDiscovery,
                 topics,
-                Collections.emptyMap(),
+                Collections.emptySet(),
                 new Properties());
     }
 
@@ -382,7 +406,7 @@ public class KafkaEnumeratorTest {
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             boolean enablePeriodicPartitionDiscovery,
             Collection<String> topicsToSubscribe,
-            Map<Integer, Set<KafkaPartitionSplit>> currentAssignments,
+            Set<TopicPartition> assignedPartitions,
             Properties overrideProperties) {
         // Use a TopicPatternSubscriber so that no exception if a subscribed topic hasn't been
         // created yet.
@@ -408,7 +432,7 @@ public class KafkaEnumeratorTest {
                 stoppingOffsetsInitializer,
                 props,
                 enumContext,
-                currentAssignments);
+                assignedPartitions);
     }
 
     // ---------------------
@@ -475,11 +499,21 @@ public class KafkaEnumeratorTest {
         return expectedAssignments;
     }
 
-    private Map<Integer, Set<KafkaPartitionSplit>> asEnumState(
-            Map<Integer, List<KafkaPartitionSplit>> assignments) {
-        Map<Integer, Set<KafkaPartitionSplit>> enumState = new HashMap<>();
+    private void verifySplitAssignmentWithPartitions(
+            Map<Integer, Set<TopicPartition>> expectedAssignment,
+            Set<TopicPartition> actualTopicPartitions) {
+        final Set<TopicPartition> allTopicPartitionsFromAssignment = new HashSet<>();
+        expectedAssignment.forEach(
+                (reader, topicPartitions) ->
+                        allTopicPartitionsFromAssignment.addAll(topicPartitions));
+        assertEquals(allTopicPartitionsFromAssignment, actualTopicPartitions);
+    }
+
+    private Set<TopicPartition> asEnumState(Map<Integer, List<KafkaPartitionSplit>> assignments) {
+        Set<TopicPartition> enumState = new HashSet<>();
         assignments.forEach(
-                (reader, assignment) -> enumState.put(reader, new HashSet<>(assignment)));
+                (reader, assignment) ->
+                        assignment.forEach(split -> enumState.add(split.getTopicPartition())));
         return enumState;
     }
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.connector.base.source.utils.SerdeUtils;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitSerializer;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link KafkaSourceEnumStateSerializer}. */
+public class KafkaSourceEnumStateSerializerTest {
+
+    private static final int NUM_READERS = 10;
+    private static final String TOPIC_PREFIX = "topic-";
+    private static final int NUM_PARTITIONS_PER_TOPIC = 10;
+    private static final long STARTING_OFFSET = KafkaPartitionSplit.EARLIEST_OFFSET;
+
+    @Test
+    public void testEnumStateSerde() throws IOException {
+        final KafkaSourceEnumState state = new KafkaSourceEnumState(constructTopicPartitions());
+        final KafkaSourceEnumStateSerializer serializer = new KafkaSourceEnumStateSerializer();
+
+        final byte[] bytes = serializer.serialize(state);
+
+        final KafkaSourceEnumState restoredState =
+                serializer.deserialize(serializer.getVersion(), bytes);
+
+        assertEquals(state.assignedPartitions(), restoredState.assignedPartitions());
+    }
+
+    @Test
+    public void testBackwardCompatibility() throws IOException {
+
+        final Set<TopicPartition> topicPartitions = constructTopicPartitions();
+        final Map<Integer, Set<KafkaPartitionSplit>> splitAssignments =
+                toSplitAssignments(topicPartitions);
+
+        // Create bytes in the way of KafkaEnumStateSerializer version 0 doing serialization
+        final byte[] bytes =
+                SerdeUtils.serializeSplitAssignments(
+                        splitAssignments, new KafkaPartitionSplitSerializer());
+
+        // Deserialize above bytes with KafkaEnumStateSerializer version 1 to check backward
+        // compatibility
+        final KafkaSourceEnumState kafkaSourceEnumState =
+                new KafkaSourceEnumStateSerializer().deserialize(0, bytes);
+
+        assertEquals(topicPartitions, kafkaSourceEnumState.assignedPartitions());
+    }
+
+    private Set<TopicPartition> constructTopicPartitions() {
+        // Create topic partitions for readers.
+        // Reader i will be assigned with NUM_PARTITIONS_PER_TOPIC splits, with topic name
+        // "topic-{i}" and
+        // NUM_PARTITIONS_PER_TOPIC partitions.
+        // Totally NUM_READERS * NUM_PARTITIONS_PER_TOPIC partitions will be created.
+        Set<TopicPartition> topicPartitions = new HashSet<>();
+        for (int readerId = 0; readerId < NUM_READERS; readerId++) {
+            for (int partition = 0; partition < NUM_PARTITIONS_PER_TOPIC; partition++) {
+                topicPartitions.add(new TopicPartition(TOPIC_PREFIX + readerId, partition));
+            }
+        }
+        return topicPartitions;
+    }
+
+    private Map<Integer, Set<KafkaPartitionSplit>> toSplitAssignments(
+            Collection<TopicPartition> topicPartitions) {
+        // Assign splits to readers according to topic name. For example, topic "topic-5" will be
+        // assigned to reader with ID=5
+        Map<Integer, Set<KafkaPartitionSplit>> splitAssignments = new HashMap<>();
+        topicPartitions.forEach(
+                (tp) ->
+                        splitAssignments
+                                .computeIfAbsent(
+                                        Integer.valueOf(
+                                                tp.topic().substring(TOPIC_PREFIX.length())),
+                                        HashSet::new)
+                                .add(new KafkaPartitionSplit(tp, STARTING_OFFSET)));
+        return splitAssignments;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -92,7 +92,7 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
 
     /**
      * Invoke the callable and handover the return value to the handler which will be executed by
-     * the source coordinator. When this method is invoked multiple times, The <code>Coallble</code>
+     * the source coordinator. When this method is invoked multiple times, The <code>Callable</code>
      * s may be executed in a thread pool concurrently.
      *
      * <p>It is important to make sure that the callable does not modify any shared state,


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes reader id to split assignment mapping from state, and change the logic of worker coordinator thread to avoid double-bookkeeping discovered partitions in ```KafkaSourceEnumerator```.


## Brief change log

*(for example:)*
  - Change ```KafkaSourceEnumState``` and its serializer to store assigned partitions instead of split assignments, since split assignments might change after job failover.
  - Change the logic of worker thread and coordinator thread. Worker thread fetches all topic information from Kafka cluster, and coordinator thread checks if there's any partition changes. This solves potential inconsistency between two sets of discovered partitions kept separately by worker and coordinator thread.

## Verifying this change
This change added tests and can be verified as follows:

  - Added test for the new serializer of ```KafkaSourceEnumState```. Backward compatibility is also tested.
  - Logic of worker and coordinator thread has been tested by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
