### PR TITLE
[FLINK-22087] CheckpointPlanCalculator should abort checkpoint if tasks is in canceling/canceled and so on

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -147,9 +147,8 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
      */
     private void checkTasksStarted(List<Execution> toTrigger) throws CheckpointException {
         for (Execution execution : toTrigger) {
-            if (execution.getState() == ExecutionState.CREATED
-                    || execution.getState() == ExecutionState.SCHEDULED
-                    || execution.getState() == ExecutionState.DEPLOYING) {
+            if (!(execution.getState() == ExecutionState.RUNNING
+                    || execution.getState() == ExecutionState.FINISHED)) {
 
                 throw new CheckpointException(
                         String.format(


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug that when tasks are canceling/canceled, the checkpoint trigger could still be successful. 


## Brief change log

- 9e67c92183a98e1ab2e3465f9516ec9dafd6c453 fixes the bug


## Verifying this change

This change added tests and can be verified via added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
