### PR TITLE
[FLINK-21954][tests] Harden JobMasterQueryableStateTest, JobMasterTest.testRestoringFromSavepoint and .testRequestNextInputSplitWithGlobalFailover

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -1836,7 +1836,17 @@ public class JobMasterTest extends TestLogger {
     private static void registerSlotsRequiredForJobExecution(
             JobMasterGateway jobMasterGateway, JobID jobId, int numSlots)
             throws ExecutionException, InterruptedException {
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setCancelTaskFunction(
+                                executionAttemptId -> {
+                                    jobMasterGateway.updateTaskExecutionState(
+                                            new TaskExecutionState(
+                                                    executionAttemptId, ExecutionState.CANCELED));
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .createTestingTaskExecutorGateway();
         JobMasterTestUtils.registerTaskExecutorAndOfferSlots(
-                rpcService, jobMasterGateway, jobId, numSlots, testingTimeout);
+                rpcService, jobMasterGateway, jobId, numSlots, taskExecutorGateway, testingTimeout);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -673,13 +673,24 @@ public class JobMasterTest extends TestLogger {
             // restore from the savepoint
             jobMaster.start();
 
+            final OneShotLatch taskSubmitLatch = new OneShotLatch();
+
             registerSlotsAtJobMaster(
                     1,
                     jobMaster.getSelfGateway(JobMasterGateway.class),
                     jobGraph.getJobID(),
-                    new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway(),
+                    new TestingTaskExecutorGatewayBuilder()
+                            .setSubmitTaskConsumer(
+                                    (taskDeploymentDescriptor, jobMasterId) -> {
+                                        taskSubmitLatch.trigger();
+                                        return CompletableFuture.completedFuture(Acknowledge.get());
+                                    })
+                            .createTestingTaskExecutorGateway(),
                     new LocalUnresolvedTaskManagerLocation());
 
+            // wait until a task has submitted because this guarantees that the ExecutionGraph has
+            // been created
+            taskSubmitLatch.await();
             final CompletedCheckpoint savepointCheckpoint =
                     completedCheckpointStore.getLatestCheckpoint(false);
 
@@ -1018,13 +1029,16 @@ public class JobMasterTest extends TestLogger {
         final Deadline deadline = Deadline.fromNow(duration);
 
         CommonTestUtils.waitUntilCondition(
-                () ->
-                        getExecutions(jobMasterGateway).stream()
-                                .allMatch(
-                                        execution ->
-                                                execution.getState() == ExecutionState.SCHEDULED
-                                                        || execution.getState()
-                                                                == ExecutionState.DEPLOYING),
+                () -> {
+                    final Collection<AccessExecution> executions = getExecutions(jobMasterGateway);
+                    return !executions.isEmpty()
+                            && executions.stream()
+                                    .allMatch(
+                                            execution ->
+                                                    execution.getState() == ExecutionState.SCHEDULED
+                                                            || execution.getState()
+                                                                    == ExecutionState.DEPLOYING);
+                },
                 deadline);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTestUtils.java
@@ -21,18 +21,13 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
-import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -45,19 +40,9 @@ public class JobMasterTestUtils {
             JobMasterGateway jobMasterGateway,
             JobID jobId,
             int numSlots,
+            TaskExecutorGateway taskExecutorGateway,
             Time testingTimeout)
             throws ExecutionException, InterruptedException {
-
-        final TaskExecutorGateway taskExecutorGateway =
-                new TestingTaskExecutorGatewayBuilder()
-                        .setCancelTaskFunction(
-                                executionAttemptId -> {
-                                    jobMasterGateway.updateTaskExecutionState(
-                                            new TaskExecutionState(
-                                                    executionAttemptId, ExecutionState.CANCELED));
-                                    return CompletableFuture.completedFuture(Acknowledge.get());
-                                })
-                        .createTestingTaskExecutorGateway();
 
         final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation =
                 new LocalUnresolvedTaskManagerLocation();


### PR DESCRIPTION
This commit fixes the test instabilities `JobMasterQueryableStateTest.*`, `JobMasterTest.testRestoringFromSavepoint` and `JobMasterTest.testRequestNextInputSplitWithGlobalFailover` which were introduced because of FLINK-21602 which makes the `ExecutionGraph` creation asynchronous. Due to this change, we now have to wait until a task is submitted in order to ensure that the `ExecutionGraph` has been created.