### PR TITLE
[FLINK-22003][checkpointing] Prevent checkpoint from starting if any Source isn't running

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointPlanCalculator.java
@@ -147,11 +147,7 @@ public class DefaultCheckpointPlanCalculator implements CheckpointPlanCalculator
      */
     private void checkTasksStarted(List<Execution> toTrigger) throws CheckpointException {
         for (Execution execution : toTrigger) {
-            if (execution.getState() == ExecutionState.CREATED
-                    || execution.getState() == ExecutionState.RECOVERING
-                    || execution.getState() == ExecutionState.SCHEDULED
-                    || execution.getState() == ExecutionState.DEPLOYING) {
-
+            if (execution.getState() != ExecutionState.RUNNING) {
                 throw new CheckpointException(
                         String.format(
                                 "Checkpoint triggering task %s of job %s has not being executed at the moment. "

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -744,8 +744,7 @@ public class DefaultSchedulerTest extends TestLogger {
                                 .getAllExecutionVertices());
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
-        scheduler.updateTaskExecutionState(
-                new TaskExecutionState(attemptId, ExecutionState.RUNNING));
+        transitionToRunning(scheduler, attemptId);
 
         final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
 
@@ -775,8 +774,7 @@ public class DefaultSchedulerTest extends TestLogger {
                                 .getAllExecutionVertices());
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
-        scheduler.updateTaskExecutionState(
-                new TaskExecutionState(attemptId, ExecutionState.RUNNING));
+        transitionToRunning(scheduler, attemptId);
 
         final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
 
@@ -814,8 +812,7 @@ public class DefaultSchedulerTest extends TestLogger {
                                 .getAllExecutionVertices());
         final ExecutionAttemptID attemptId =
                 onlyExecutionVertex.getCurrentExecutionAttempt().getAttemptId();
-        scheduler.updateTaskExecutionState(
-                new TaskExecutionState(attemptId, ExecutionState.RUNNING));
+        transitionToRunning(scheduler, attemptId);
 
         final CheckpointCoordinator checkpointCoordinator = getCheckpointCoordinator(scheduler);
 
@@ -1325,5 +1322,14 @@ public class DefaultSchedulerTest extends TestLogger {
                     checkpointTriggeredLatch.countDown();
                 });
         return checkpointTriggeredLatch;
+    }
+
+    private void transitionToRunning(DefaultScheduler scheduler, ExecutionAttemptID attemptId) {
+        Preconditions.checkState(
+                scheduler.updateTaskExecutionState(
+                        new TaskExecutionState(attemptId, ExecutionState.RECOVERING)));
+        Preconditions.checkState(
+                scheduler.updateTaskExecutionState(
+                        new TaskExecutionState(attemptId, ExecutionState.RUNNING)));
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -264,7 +264,8 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                         // prevent test from timing out in case when a failover happens concurrently
                         // with triggering a checkpoint (some execution status can change right
                         // after triggering)
-                        .setCheckpointTimeout(Duration.ofMinutes(1))
+                        .setCheckpointTimeout(Duration.ofSeconds(30))
+                        .setTolerableCheckpointFailures(3)
                         .setAlignmentTimeout(timeout);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -47,6 +47,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -260,6 +261,10 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                         .setChannelTypes(channelType)
                         .setExpectedFailures(5)
                         .setFailuresAfterSourceFinishes(1)
+                        // prevent test from timing out in case when a failover happens concurrently
+                        // with triggering a checkpoint (some execution status can change right
+                        // after triggering)
+                        .setCheckpointTimeout(Duration.ofMinutes(1))
                         .setAlignmentTimeout(timeout);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -669,6 +669,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         @Nullable private File restoreCheckpoint;
         private boolean generateCheckpoint = false;
         int expectedFailures = 0;
+        int tolerableCheckpointFailures = 0;
         private final DagCreator dagCreator;
         private int alignmentTimeout = 0;
         private Duration checkpointTimeout = CHECKPOINTING_TIMEOUT.defaultValue();
@@ -719,10 +720,17 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             return this;
         }
 
+        public UnalignedSettings setTolerableCheckpointFailures(int tolerableCheckpointFailures) {
+            this.tolerableCheckpointFailures = tolerableCheckpointFailures;
+            return this;
+        }
+
         public void configure(StreamExecutionEnvironment env) {
             env.enableCheckpointing(Math.max(100L, parallelism * 50L));
             env.getCheckpointConfig().setAlignmentTimeout(alignmentTimeout);
             env.getCheckpointConfig().setCheckpointTimeout(checkpointTimeout.toMillis());
+            env.getCheckpointConfig()
+                    .setTolerableCheckpointFailureNumber(tolerableCheckpointFailures);
             env.setParallelism(parallelism);
             env.setRestartStrategy(
                     RestartStrategies.fixedDelayRestart(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -99,6 +99,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterables.getOnlyElement;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_TIMEOUT;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.fail;
 
@@ -670,6 +671,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         int expectedFailures = 0;
         private final DagCreator dagCreator;
         private int alignmentTimeout = 0;
+        private Duration checkpointTimeout = CHECKPOINTING_TIMEOUT.defaultValue();
         private int failuresAfterSourceFinishes = 0;
         private ChannelType channelType = ChannelType.MIXED;
 
@@ -697,6 +699,11 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             return this;
         }
 
+        public UnalignedSettings setCheckpointTimeout(Duration checkpointTimeout) {
+            this.checkpointTimeout = checkpointTimeout;
+            return this;
+        }
+
         public UnalignedSettings setAlignmentTimeout(int alignmentTimeout) {
             this.alignmentTimeout = alignmentTimeout;
             return this;
@@ -715,6 +722,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         public void configure(StreamExecutionEnvironment env) {
             env.enableCheckpointing(Math.max(100L, parallelism * 50L));
             env.getCheckpointConfig().setAlignmentTimeout(alignmentTimeout);
+            env.getCheckpointConfig().setCheckpointTimeout(checkpointTimeout.toMillis());
             env.setParallelism(parallelism);
             env.setRestartStrategy(
                     RestartStrategies.fixedDelayRestart(


### PR DESCRIPTION
## What is the purpose of the change

Don't start checkpoint if there is any source task not in RUNNING state.
Currently, only (`CREATED`, `RECOVERING`, `SCHEDULED`, `DEPLOYING`) source 
states are disallowed explicitly (in addition to finished).
If source is e.g. `CANCELLING` then such checkpoint will timeout in the best case.

## Verifying this change
- added `DefaultCheckpointPlanCalculatorTest.testCheckpointNotStartedIfSourceCancelled` unit test
- the issue is already covered by `UnalignedCheckpointITCase` on integration level

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
