### PR TITLE
[BP-1.11][FLINK-22014][ha] Make sure that AbstractHaServices delete first the HA data before deleting blobs on closeAndCleanupAllData

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -233,19 +233,26 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 
         Throwable exception = null;
 
-        try {
-            blobStoreService.closeAndCleanupAllData();
-        } catch (Throwable t) {
-            exception = t;
-        }
+        boolean deletedHAData = false;
 
         try {
             cleanupZooKeeperPaths();
-        } catch (Throwable t) {
-            exception = ExceptionUtils.firstOrSuppressed(t, exception);
+            deletedHAData = true;
+        } catch (Exception e) {
+            exception = e;
         }
 
         internalClose();
+
+        try {
+            if (deletedHAData) {
+                blobStoreService.closeAndCleanupAllData();
+            } else {
+                blobStoreService.close();
+            }
+        } catch (Throwable t) {
+            exception = ExceptionUtils.firstOrSuppressed(t, exception);
+        }
 
         if (exception != null) {
             ExceptionUtils.rethrowException(


### PR DESCRIPTION
Backport of #15468 to `release-1.11`.