### PR TITLE
[FLINK-16947][Azure] Use latest docker image for CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-98ad098
+    image: rmetzger/flink-ci:ubuntu-amd64-7ac4e28
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-98ad098
+    image: rmetzger/flink-ci:ubuntu-amd64-7ac4e28
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
This is the change in the docker image: https://github.com/rmetzger/flink-ci/commit/7ac4e285d89c306092d685be5fe1a0ca7d059e07
Essentially, we are using an official release of wagon-http again.