### PR TITLE
[FLINK-16947][Azure] Attempt to fix the "Entry has not been leased fr…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-f009d96
+    image: rmetzger/flink-ci:ubuntu-amd64-7ac4e28
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -38,7 +38,7 @@ resources:
   containers:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
-    image: rmetzger/flink-ci:ubuntu-amd64-f009d96
+    image: rmetzger/flink-ci:ubuntu-amd64-7ac4e28
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
@@ -135,7 +135,7 @@ stages:
           container: flink-build-container
           jdk: jdk11
       - job: docs_404_check # run on a MSFT provided machine
-        pool: 
+        pool:
           vmImage: 'ubuntu-16.04'
         steps:
         - task: UseRubyVersion@0


### PR DESCRIPTION
This is the change to the docker image https://github.com/rmetzger/flink-ci/commit/7ac4e285d89c306092d685be5fe1a0ca7d059e07
We've had deployed the updated http wagon version on master for quite a while, and it seemed to have improved the situation a lot. This is a backport of the latest docker image for release-1.12.