### PR TITLE
[FLINK-21879][tests] Harden ActiveResourceManagerTest.testWorkerRegistrationTimeoutNotCountingAllocationTime

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -66,6 +66,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 /** Tests for {@link ActiveResourceManager}. */
 public class ActiveResourceManagerTest extends TestLogger {
@@ -782,11 +783,19 @@ public class ActiveResourceManagerTest extends TestLogger {
                                 fail();
                             }
 
+                            final long start = System.nanoTime();
+
                             runInMainThread(() -> requestResourceFuture.complete(tmResourceId));
 
                             // worker registered, verify not released due to timeout
                             CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
                                     registerTaskExecutor(tmResourceId);
+
+                            final long registrationTime = (System.nanoTime() - start) / 1_000_000;
+
+                            assumeTrue(
+                                    "The registration must not take longer than the start worker timeout. If it does, then this indicates a very slow machine.",
+                                    registrationTime < TESTING_START_WORKER_TIMEOUT_MS);
                             assertThat(
                                     registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
                                     instanceOf(RegistrationResponse.Success.class));


### PR DESCRIPTION
Hardens the ActiveResourceManagerTest.testWorkerRegistrationTimeoutNotCountingAllocationTime by introducing
the assumption that the registration is faster than the start worker timeout.