### PR TITLE
[FLINK-22006][k8s] Support to configure max concurrent requests for fabric8 Kubernetes client via JAVA opts or envs

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
@@ -166,6 +166,17 @@ $ echo 'stop' | ./bin/kubernetes-session.sh \
 
 The Kubernetes-specific configuration options are listed on the [configuration page]({{< ref "docs/deployment/config" >}}#kubernetes).
 
+Flink uses [Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client) to communicate with Kubernetes APIServer to create/delete Kubernetes resources(e.g. Deployment, Pod, ConfigMap, Service, etc.), as well as watch the Pods and ConfigMaps.
+Except for the above Flink config options, some [expert options](https://github.com/fabric8io/kubernetes-client#configuring-the-client) of Fabric8 Kubernetes client could be configured via system properties or environment variables.
+
+For example, users could use the following Flink config options to set the concurrent max requests, which allows running more jobs in a session cluster when [Kubernetes HA Services]({{< ref "docs/deployment/ha/kubernetes_ha" >}}) are used.
+Please note that, each Flink job will consume `3` concurrent requests.
+
+```yaml
+containerized.master.env.KUBERNETES_MAX_CONCURRENT_REQUESTS: 200
+env.java.opts.jobmanager: "-Dkubernetes.max.concurrent.requests=200"
+```
+
 ### Accessing Flink's Web UI
 
 Flink's Web UI and REST endpoint can be exposed in several ways via the [kubernetes.rest-service.exposed.type]({{< ref "docs/deployment/config" >}}#kubernetes-rest-service-exposed-type) configuration option.

--- a/docs/content/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/native_kubernetes.md
@@ -166,6 +166,17 @@ $ echo 'stop' | ./bin/kubernetes-session.sh \
 
 The Kubernetes-specific configuration options are listed on the [configuration page]({{< ref "docs/deployment/config" >}}#kubernetes).
 
+Flink uses [Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client) to communicate with Kubernetes APIServer to create/delete Kubernetes resources(e.g. Deployment, Pod, ConfigMap, Service, etc.), as well as watch the Pods and ConfigMaps.
+Except for the above Flink config options, some [expert options](https://github.com/fabric8io/kubernetes-client#configuring-the-client) of Fabric8 Kubernetes client could be configured via system properties or environment variables.
+
+For example, users could use the following Flink config options to set the concurrent max requests, which allows running more jobs in a session cluster when [Kubernetes HA Services]({{< ref "docs/deployment/ha/kubernetes_ha" >}}) are used.
+Please note that, each Flink job will consume `3` concurrent requests.
+
+```yaml
+containerized.master.env.KUBERNETES_MAX_CONCURRENT_REQUESTS: 200
+env.java.opts.jobmanager: "-Dkubernetes.max.concurrent.requests=200"
+```
+
 ### Accessing Flink's Web UI
 
 Flink's Web UI and REST endpoint can be exposed in several ways via the [kubernetes.rest-service.exposed.type]({{< ref "docs/deployment/config" >}}#kubernetes-rest-service-exposed-type) configuration option.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.kubeclient;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
@@ -27,6 +28,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,11 +94,30 @@ public class FlinkKubeClientFactory {
         LOG.debug("Setting namespace of Kubernetes client to {}", namespace);
         config.setNamespace(namespace);
 
+        // This could be removed after we bump the fabric8 Kubernetes client version to 4.13.0+ or
+        // use the a shared connection for all ConfigMap watches. See FLINK-22006 for more
+        // information.
+        trySetMaxConcurrentRequest(config);
+
         final NamespacedKubernetesClient client = new DefaultKubernetesClient(config);
         final int poolSize =
                 flinkConfig.get(KubernetesConfigOptions.KUBERNETES_CLIENT_IO_EXECUTOR_POOL_SIZE);
         return new Fabric8FlinkKubeClient(
                 flinkConfig, client, createThreadPoolForAsyncIO(poolSize, useCase));
+    }
+
+    @VisibleForTesting
+    static void trySetMaxConcurrentRequest(Config config) {
+        final String configuredMaxConcurrentRequests =
+                Utils.getSystemPropertyOrEnvVar(
+                        Config.KUBERNETES_MAX_CONCURRENT_REQUESTS,
+                        String.valueOf(Config.DEFAULT_MAX_CONCURRENT_REQUESTS));
+        if (configuredMaxConcurrentRequests != null) {
+            LOG.debug(
+                    "Setting max concurrent requests of Kubernetes client to {}",
+                    configuredMaxConcurrentRequests);
+            config.setMaxConcurrentRequests(Integer.parseInt(configuredMaxConcurrentRequests));
+        }
     }
 
     private static ExecutorService createThreadPoolForAsyncIO(int poolSize, String useCase) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.TestLogger;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link FlinkKubeClientFactory}. */
+public class FlinkKubeClientFactoryTest extends TestLogger {
+
+    @Test
+    public void testTrySetMaxConcurrentRequestViaJavaSystemProperty() {
+        System.setProperty(Config.KUBERNETES_MAX_CONCURRENT_REQUESTS, "100");
+        testTrySetMaxConcurrentRequest(100);
+        System.getProperties().remove(Config.KUBERNETES_MAX_CONCURRENT_REQUESTS);
+    }
+
+    @Test
+    public void testTrySetMaxConcurrentRequestViaEnvVar() {
+        final Map<String, String> currentEnv = System.getenv();
+        final String envKey = "KUBERNETES_MAX_CONCURRENT_REQUESTS";
+        final Map<String, String> envMap = new HashMap<>();
+        envMap.put(envKey, "200");
+        CommonTestUtils.setEnv(envMap, true);
+        testTrySetMaxConcurrentRequest(200);
+        CommonTestUtils.setEnv(currentEnv);
+    }
+
+    private void testTrySetMaxConcurrentRequest(int expectedValue) {
+        final Config config = new ConfigBuilder().build();
+        FlinkKubeClientFactory.trySetMaxConcurrentRequest(config);
+        assertThat(config.getMaxConcurrentRequests(), is(expectedValue));
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Flink now could only run 20 jobs or less in a K8s session(native and standalone) when K8s HA enabled.
The root cause is fabric8 Kubernetes client has configured the MaxRequests of `OkHttpClient#Dispatcher`[1] to 64[2], which means we could not create more than 64 watchers in the JobManager pod.

Normally, it could be configured in Flink via env or java opts. Unfortunately, the fabric8 Kubernetes client version 4.9.2 has a bug[3], which causes the max concurrent requests could not be set via system properties.

This PR is a temporary fix before we bumping the fabric8 Kubernetes version to 4.13.0+ or change the behavior how we watch the leader ConfigMaps.

After this commit, users could use any one in the following Flink config options to set the concurrent max requests, which allows to run more jobs in a session cluster. Please note that, each Flink job will consume 3 concurrent requests.
* `containerized.master.env.KUBERNETES_MAX_CONCURRENT_REQUESTS: 200`
* `env.java.opts.jobmanager: "-Dkubernetes.max.concurrent.requests=200"`

1. https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/HttpClientUtils.java#L166
2. https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java#L135
3. https://github.com/fabric8io/kubernetes-client/issues/2531


## Brief change log

* Support to configure max concurrent requests for fabric8 Kubernetes client via JAVA opts or envs


## Verifying this change

* Add two unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
