### PR TITLE
[FLINK-22076][python] Split the global test into multiple module tests

### DIFF
--- a/flink-python/dev/integration_test.sh
+++ b/flink-python/dev/integration_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+function test_module() {
+    module="$FLINK_PYTHON_DIR/pyflink/$1"
+    echo "test module $module"
+    pytest --durations=20 ${module}
+    if [[ $? -ne 0 ]]; then
+        echo "test module $module failed"
+        exit 1
+    fi
+}
+
+# CURRENT_DIR is "flink/flink-python/dev/"
+CURRENT_DIR="$(cd "$( dirname "$0" )" && pwd)"
+
+# FLINK_PYTHON_DIR is "flink/flink-python"
+FLINK_PYTHON_DIR=$(dirname "$CURRENT_DIR")
+
+# test common module
+test_module "common"
+
+# test dataset module
+test_module "dataset"
+
+# test datastream module
+test_module "datastream"
+
+# test fn_execution module
+test_module "fn_execution"
+
+# test metrics module
+test_module "metrics"
+
+# test table module
+test_module "table"

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -36,10 +36,10 @@ deps =
 commands =
     python --version
     # python test
-    pytest --durations=20
+    bash ./dev/integration_test.sh
     python setup.py build_ext --inplace --force
     # cython test
-    pytest --durations=20
+    bash ./dev/integration_test.sh
     bash ./dev/run_pip_test.sh
 # Replace the default installation command with a custom retry installation script, because on high-speed
 # networks, downloading a package may raise a ConnectionResetError: [Errno 104] Peer reset connection.


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will split the global test into multiple module tests to solve the memory shortage caused by too many python processes in the background*


## Brief change log

  - *Split the global test into multiple module tests*

## Verifying this change

This change added tests and can be verified as follows:

 - *Original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
