### PR TITLE
[FLINK-22106][table-planner-blink] Result type of GeneratedExpression in StringCallGen should be compatible with their definition in FlinkSqlOperatorTable

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -132,9 +132,10 @@ object GenerateUtils {
     */
   def generateStringResultCallIfArgsNotNull(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression])
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType)
       (call: Seq[String] => String): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       args => s"$BINARY_STRING.fromString(${call(args)})"
     }
   }
@@ -146,9 +147,10 @@ object GenerateUtils {
     */
   def generateStringResultCallWithStmtIfArgsNotNull(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression])
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType)
       (call: Seq[String] => (String, String)): GeneratedExpression = {
-    generateCallWithStmtIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    generateCallWithStmtIfArgsNotNull(ctx, returnType, operands) {
       args =>
         val (stmt, result) = call(args)
         (stmt, s"$BINARY_STRING.fromString($result)")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -63,11 +63,11 @@ object StringCallGen {
       case NOT_LIKE =>
         generateNot(ctx, new LikeCallGen().generate(ctx, operands, new BooleanType()))
 
-      case SUBSTR | SUBSTRING => generateSubString(ctx, operands)
+      case SUBSTR | SUBSTRING => generateSubString(ctx, operands, returnType)
 
-      case LEFT => generateLeft(ctx, operands.head, operands(1))
+      case LEFT => generateLeft(ctx, operands.head, operands(1), returnType)
 
-      case RIGHT => generateRight(ctx, operands.head, operands(1))
+      case RIGHT => generateRight(ctx, operands.head, operands(1), returnType)
 
       case CHAR_LENGTH | CHARACTER_LENGTH => generateCharLength(ctx, operands)
 
@@ -75,9 +75,9 @@ object StringCallGen {
 
       case NOT_SIMILAR_TO => generateNot(ctx, generateSimilarTo(ctx, operands))
 
-      case REGEXP_EXTRACT => generateRegexpExtract(ctx, operands)
+      case REGEXP_EXTRACT => generateRegexpExtract(ctx, operands, returnType)
 
-      case REGEXP_REPLACE => generateRegexpReplace(ctx, operands)
+      case REGEXP_REPLACE => generateRegexpReplace(ctx, operands, returnType)
 
       case IS_DECIMAL => generateIsDecimal(ctx, operands)
 
@@ -85,88 +85,88 @@ object StringCallGen {
 
       case IS_ALPHA => generateIsAlpha(ctx, operands)
 
-      case UPPER => generateUpper(ctx, operands)
+      case UPPER => generateUpper(ctx, operands, returnType)
 
-      case LOWER => generateLower(ctx, operands)
+      case LOWER => generateLower(ctx, operands, returnType)
 
-      case INITCAP => generateInitcap(ctx, operands)
+      case INITCAP => generateInitcap(ctx, operands, returnType)
 
       case POSITION => generatePosition(ctx, operands)
 
       case LOCATE => generateLocate(ctx, operands)
 
-      case OVERLAY => generateOverlay(ctx, operands)
+      case OVERLAY => generateOverlay(ctx, operands, returnType)
 
-      case LPAD => generateLpad(ctx, operands)
+      case LPAD => generateLpad(ctx, operands, returnType)
 
-      case RPAD => generateRpad(ctx, operands)
+      case RPAD => generateRpad(ctx, operands, returnType)
 
-      case REPEAT => generateRepeat(ctx, operands)
+      case REPEAT => generateRepeat(ctx, operands, returnType)
 
-      case REVERSE => generateReverse(ctx, operands)
+      case REVERSE => generateReverse(ctx, operands, returnType)
 
-      case REPLACE => generateReplace(ctx, operands)
+      case REPLACE => generateReplace(ctx, operands, returnType)
 
-      case SPLIT_INDEX => generateSplitIndex(ctx, operands)
+      case SPLIT_INDEX => generateSplitIndex(ctx, operands, returnType)
 
       case HASH_CODE if isCharacterString(operands.head.resultType) =>
         generateHashCode(ctx, operands)
 
-      case MD5 => generateMd5(ctx, operands)
+      case MD5 => generateMd5(ctx, operands, returnType)
 
-      case SHA1 => generateSha1(ctx, operands)
+      case SHA1 => generateSha1(ctx, operands, returnType)
 
-      case SHA224 => generateSha224(ctx, operands)
+      case SHA224 => generateSha224(ctx, operands, returnType)
 
-      case SHA256 => generateSha256(ctx, operands)
+      case SHA256 => generateSha256(ctx, operands, returnType)
 
-      case SHA384 => generateSha384(ctx, operands)
+      case SHA384 => generateSha384(ctx, operands, returnType)
 
-      case SHA512 => generateSha512(ctx, operands)
+      case SHA512 => generateSha512(ctx, operands, returnType)
 
-      case SHA2 => generateSha2(ctx, operands)
+      case SHA2 => generateSha2(ctx, operands, returnType)
 
-      case PARSE_URL => generateParserUrl(ctx, operands)
+      case PARSE_URL => generateParserUrl(ctx, operands, returnType)
 
-      case FROM_BASE64 => generateFromBase64(ctx, operands)
+      case FROM_BASE64 => generateFromBase64(ctx, operands, returnType)
 
-      case TO_BASE64 => generateToBase64(ctx, operands)
+      case TO_BASE64 => generateToBase64(ctx, operands, returnType)
 
-      case CHR => generateChr(ctx, operands)
+      case CHR => generateChr(ctx, operands, returnType)
 
       case REGEXP => generateRegExp(ctx, operands)
 
-      case BIN => generateBin(ctx, operands)
+      case BIN => generateBin(ctx, operands, returnType)
 
       case CONCAT_FUNCTION =>
         operands.foreach(requireCharacterString)
-        generateConcat(ctx, operands)
+        generateConcat(ctx, operands, returnType)
 
       case CONCAT_WS =>
         operands.foreach(requireCharacterString)
-        generateConcatWs(ctx, operands)
+        generateConcatWs(ctx, operands, returnType)
 
       case STR_TO_MAP => generateStrToMap(ctx, operands)
 
-      case TRIM => generateTrim(ctx, operands)
+      case TRIM => generateTrim(ctx, operands, returnType)
 
-      case LTRIM => generateTrimLeft(ctx, operands)
+      case LTRIM => generateTrimLeft(ctx, operands, returnType)
 
-      case RTRIM => generateTrimRight(ctx, operands)
+      case RTRIM => generateTrimRight(ctx, operands, returnType)
 
       case CONCAT =>
         val left = operands.head
         val right = operands(1)
         requireCharacterString(left)
-        generateArithmeticConcat(ctx, left, right)
+        generateArithmeticConcat(ctx, left, right, returnType)
 
-      case UUID => generateUuid(ctx, operands)
+      case UUID => generateUuid(ctx, operands, returnType)
 
       case ASCII => generateAscii(ctx, operands.head)
 
-      case ENCODE => generateEncode(ctx, operands.head, operands(1))
+      case ENCODE => generateEncode(ctx, operands.head, operands(1), returnType)
 
-      case DECODE => generateDecode(ctx, operands.head, operands(1))
+      case DECODE => generateDecode(ctx, operands.head, operands(1), returnType)
 
       case INSTR => generateInstr(ctx, operands)
 
@@ -251,16 +251,18 @@ object StringCallGen {
 
   def generateConcat(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNullable(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNullable(ctx, returnType, operands) {
       terms => s"$BINARY_STRING_UTIL.concat(${terms.mkString(", ")})"
     }
   }
 
   def generateConcatWs(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNullable(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNullable(ctx, returnType, operands) {
       terms => s"$BINARY_STRING_UTIL.concatWs(${terms.mkString(", ")})"
     }
   }
@@ -291,8 +293,9 @@ object StringCallGen {
 
   def generateSubString(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"$BINARY_STRING_UTIL.substringSQL(${terms.head}, ${terms.drop(1).mkString(", ")})"
     }
   }
@@ -300,8 +303,9 @@ object StringCallGen {
   def generateLeft(
     ctx: CodeGeneratorContext,
     str: GeneratedExpression,
-    len: GeneratedExpression): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), Seq(str, len)) {
+    len: GeneratedExpression,
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, Seq(str, len)) {
       val emptyString = s"$BINARY_STRING.EMPTY_UTF8"
       terms =>
         s"${terms(1)} <= 0 ? $emptyString :" +
@@ -312,8 +316,9 @@ object StringCallGen {
   def generateRight(
       ctx: CodeGeneratorContext,
       str: GeneratedExpression,
-      len: GeneratedExpression): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), Seq(str, len)) {
+      len: GeneratedExpression,
+      returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, Seq(str, len)) {
       terms =>
         s"""
            |${terms(1)} <= 0 ?
@@ -344,18 +349,20 @@ object StringCallGen {
 
   def generateRegexpExtract(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.regexpExtract(${safeToStringTerms(terms, operands)})"
     }
   }
 
   def generateRegexpReplace(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.regexpReplace(${toStringTerms(terms, operands)})"
     }
   }
@@ -397,25 +404,28 @@ object StringCallGen {
 
   def generateUpper(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"${terms.head}.toUpperCase()"
     }
   }
 
   def generateLower(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"${terms.head}.toLowerCase()"
     }
   }
 
   def generateInitcap(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctions].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.initcap(${terms.head}.toString())"
     }
   }
@@ -453,9 +463,10 @@ object StringCallGen {
 
   def generateOverlay(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.overlay(${toStringTerms(terms, operands)})"
     }
   }
@@ -463,17 +474,19 @@ object StringCallGen {
   def generateArithmeticConcat(
       ctx: CodeGeneratorContext,
       left: GeneratedExpression,
-      right: GeneratedExpression): GeneratedExpression = {
-    generateStringResultCallIfArgsNotNull(ctx, Seq(left, right)) {
+      right: GeneratedExpression,
+      returnType: LogicalType): GeneratedExpression = {
+    generateStringResultCallIfArgsNotNull(ctx, Seq(left, right), returnType) {
       terms => s"${terms.head}.toString() + String.valueOf(${terms(1)})"
     }
   }
 
   def generateLpad(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms =>
         s"$className.lpad(${toStringTerms(terms, operands)})"
     }
@@ -481,9 +494,10 @@ object StringCallGen {
 
   def generateRpad(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms =>
         s"$className.rpad(${toStringTerms(terms, operands)})"
     }
@@ -491,44 +505,49 @@ object StringCallGen {
 
   def generateRepeat(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.repeat(${toStringTerms(terms, operands)})"
     }
   }
 
   def generateReverse(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"$BINARY_STRING_UTIL.reverse(${terms.head})"
     }
   }
 
   def generateReplace(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.replace(${toStringTerms(terms, operands)})"
     }
   }
 
   def generateSplitIndex(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.splitIndex(${toStringTerms(terms, operands)})"
     }
   }
 
   def generateKeyValue(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateCallIfArgsNullable(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    generateCallIfArgsNullable(ctx, returnType, operands) {
       terms => s"$className.keyValue(${terms.mkString(",")})"
     }
   }
@@ -544,21 +563,23 @@ object StringCallGen {
 
   def generateMd5(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression =
-    generateHashInternal(ctx, "MD5", operands)
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression =
+    generateHashInternal(ctx, "MD5", operands, returnType)
 
   def generateHashInternal(
       ctx: CodeGeneratorContext,
       algorithm: String,
-      operands: Seq[GeneratedExpression]): GeneratedExpression = {
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression = {
     val digestTerm = ctx.addReusableMessageDigest(algorithm)
     if (operands.length == 1) {
-      generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+      generateCallIfArgsNotNull(ctx, returnType, operands) {
         terms =>s"$BINARY_STRING_UTIL.hash(${terms.head}, $digestTerm)"
       }
     } else {
       val className = classOf[SqlFunctionUtils].getCanonicalName
-      generateStringResultCallIfArgsNotNull(ctx, operands) {
+      generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
         terms => s"$className.hash($digestTerm, ${toStringTerms(terms, operands)})"
       }
     }
@@ -566,41 +587,47 @@ object StringCallGen {
 
   def generateSha1(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression =
-    generateHashInternal(ctx, "SHA", operands)
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression =
+    generateHashInternal(ctx, "SHA", operands, returnType)
 
   def generateSha224(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression =
-    generateHashInternal(ctx, "SHA-224", operands)
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression =
+    generateHashInternal(ctx, "SHA-224", operands, returnType)
 
   def generateSha256(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression =
-    generateHashInternal(ctx, "SHA-256", operands)
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression =
+    generateHashInternal(ctx, "SHA-256", operands, returnType)
 
   def generateSha384(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression =
-    generateHashInternal(ctx, "SHA-384", operands)
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression =
+    generateHashInternal(ctx, "SHA-384", operands, returnType)
 
   def generateSha512(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression =
-    generateHashInternal(ctx, "SHA-512", operands)
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression =
+    generateHashInternal(ctx, "SHA-512", operands, returnType)
 
   def generateSha2(
       ctx: CodeGeneratorContext,
-      operands: Seq[GeneratedExpression]): GeneratedExpression = {
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
     if (operands.last.literal) {
       val digestTerm = ctx.addReusableSha2MessageDigest(operands.last)
       if (operands.length == 2) {
-        generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+        generateCallIfArgsNotNull(ctx, returnType, operands) {
           terms =>s"$BINARY_STRING_UTIL.hash(${terms.head}, $digestTerm)"
         }
       } else {
-        generateStringResultCallIfArgsNotNull(ctx, operands) {
+        generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
           terms =>
             s"$className.hash($digestTerm," +
                 s"${toStringTerms(terms.dropRight(1), operands.dropRight(1))})"
@@ -608,12 +635,12 @@ object StringCallGen {
       }
     } else {
       if (operands.length == 2) {
-        generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+        generateCallIfArgsNotNull(ctx, returnType, operands) {
           terms =>
             s"""$BINARY_STRING_UTIL.hash(${terms.head}, "SHA-" + ${terms.last})"""
         }
       } else {
-        generateStringResultCallIfArgsNotNull(ctx, operands) {
+        generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
           terms => {
             val strTerms = toStringTerms(terms.dropRight(1), operands.dropRight(1))
             s"""$className.hash("SHA-" + ${terms.last}, $strTerms)"""
@@ -625,36 +652,40 @@ object StringCallGen {
 
   def generateParserUrl(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.parseUrl(${safeToStringTerms(terms, operands)})"
     }
   }
 
   def generateFromBase64(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"$className.fromBase64(${terms.head})"
     }
   }
 
   def generateToBase64(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.toBase64(${terms.head})"
     }
   }
 
   def generateChr(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.chr(${terms.head})"
     }
   }
@@ -670,9 +701,10 @@ object StringCallGen {
 
   def generateJsonValue(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms =>
         s"$className.jsonValue(${safeToStringTerms(terms, operands)})"
     }
@@ -680,16 +712,18 @@ object StringCallGen {
 
   def generateBin(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"Long.toBinaryString(${terms.head})"
     }
   }
 
   def generateTrim(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms =>
         val leading = compareEnum(terms.head, BOTH) || compareEnum(terms.head, LEADING)
         val trailing = compareEnum(terms.head, BOTH) || compareEnum(terms.head, TRAILING)
@@ -700,25 +734,28 @@ object StringCallGen {
 
   def generateTrimLeft(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"$BINARY_STRING_UTIL.trimLeft(${terms.mkString(", ")})"
     }
   }
 
   def generateTrimRight(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
-    generateCallIfArgsNotNull(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
+    generateCallIfArgsNotNull(ctx, returnType, operands) {
       terms => s"$BINARY_STRING_UTIL.trimRight(${terms.mkString(", ")})"
     }
   }
 
   def generateUuid(
     ctx: CodeGeneratorContext,
-    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    operands: Seq[GeneratedExpression],
+    returnType: LogicalType): GeneratedExpression = {
     val className = classOf[SqlFunctionUtils].getCanonicalName
-    generateStringResultCallIfArgsNotNull(ctx, operands) {
+    generateStringResultCallIfArgsNotNull(ctx, operands, returnType) {
       terms => s"$className.uuid(${terms.mkString(",")})"
     }
   }
@@ -742,9 +779,10 @@ object StringCallGen {
   def generateEncode(
       ctx: CodeGeneratorContext,
       str: GeneratedExpression,
-      charset: GeneratedExpression): GeneratedExpression = {
+      charset: GeneratedExpression,
+      returnType: LogicalType): GeneratedExpression = {
     generateCallIfArgsNotNull(
-      ctx, new VarBinaryType(VarBinaryType.MAX_LENGTH), Seq(str, charset)) {
+      ctx, returnType, Seq(str, charset)) {
       terms => s"${terms.head}.toString().getBytes(${terms(1)}.toString())"
     }
   }
@@ -752,8 +790,9 @@ object StringCallGen {
   def generateDecode(
       ctx: CodeGeneratorContext,
       binary: GeneratedExpression,
-      charset: GeneratedExpression): GeneratedExpression = {
-    generateStringResultCallIfArgsNotNull(ctx, Seq(binary, charset)) {
+      charset: GeneratedExpression,
+      returnType: LogicalType): GeneratedExpression = {
+    generateStringResultCallIfArgsNotNull(ctx, Seq(binary, charset), returnType) {
       terms =>
         s"new String(${terms.head}, ${terms(1)}.toString())"
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -4065,8 +4065,8 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testStringFunctionAndExpressionResultType(): Unit = {
     // this test is to check if the `resultType` of the `GeneratedExpression`
-    // of these string functions match their definition in `FlinkSqlOperatorTable`
-    // see FLINK-22106
+    // of these string functions match their definition in `FlinkSqlOperatorTable`,
+    // if not exceptions will be thrown from BridgingFunctionGenUtil#verifyArgumentTypes
 
     val str1 = "CAST('Hello' AS VARCHAR(5))"
     val str2 = "CAST('Hi' AS VARCHAR(2))"

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -4061,4 +4061,72 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "f55=f57",
       "true")
   }
+
+  @Test
+  def testStringFunctionAndExpressionReturnType(): Unit = {
+    val str1 = "CAST('Hello' AS VARCHAR(5))"
+    val str2 = "CAST('Hi' AS VARCHAR(2))"
+    val str3 = "CAST('hello world' AS VARCHAR(11))"
+    val str4 = "CAST(' hello ' AS VARCHAR(7))"
+    val url = "CAST('http://user:pass@host' AS VARCHAR(50))"
+    val base64 = "CAST('aGVsbG8gd29ybGQ=' AS VARCHAR(20))"
+
+    testSqlApi(s"IFNULL(SUBSTR($str1, 2, 3), $str2)", "ell")
+    testSqlApi(s"IFNULL(SUBSTRING($str1, 2, 3), $str2)", "ell")
+    testSqlApi(s"IFNULL(LEFT($str1, 3), $str2)", "Hel")
+    testSqlApi(s"IFNULL(RIGHT($str1, 3), $str2)", "llo")
+    testSqlApi(s"IFNULL(REGEXP_EXTRACT($str1, 'H(.+?)l(.+?)$$', 2), $str2)", "lo")
+    testSqlApi(s"IFNULL(REGEXP_REPLACE($str1, 'e.l', 'EXL'), $str2)", "HEXLo")
+    testSqlApi(s"IFNULL(UPPER($str1), $str2)", "HELLO")
+    testSqlApi(s"IFNULL(LOWER($str1), $str2)", "hello")
+    testSqlApi(s"IFNULL(INITCAP($str3), $str2)", "Hello World")
+    testSqlApi(s"IFNULL(OVERLAY($str1 PLACING $str3 FROM 2 FOR 3), $str2)", "Hhello worldo")
+    testSqlApi(s"IFNULL(LPAD($str1, 7, $str3), $str2)", "heHello")
+    testSqlApi(s"IFNULL(RPAD($str1, 7, $str3), $str2)", "Hellohe")
+    testSqlApi(s"IFNULL(REPEAT($str1, 2), $str2)", "HelloHello")
+    testSqlApi(s"IFNULL(REVERSE($str1), $str2)", "olleH")
+    testSqlApi(s"IFNULL(REPLACE($str3, ' ', '_'), $str2)", "hello_world")
+    testSqlApi(s"IFNULL(SPLIT_INDEX($str3, ' ', 1), $str2)", "world")
+    testSqlApi(s"IFNULL(MD5($str1), $str2)", "8b1a9953c4611296a827abf8c47804d7")
+    testSqlApi(s"IFNULL(SHA1($str1), $str2)", "f7ff9e8b7bb2e09b70935a5d785e0cc5d9d0abf0")
+    testSqlApi(
+      s"IFNULL(SHA224($str1), $str2)",
+      "4149da18aa8bfc2b1e382c6c26556d01a92c261b6436dad5e3be3fcc")
+    testSqlApi(
+      s"IFNULL(SHA256($str1), $str2)",
+      "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969")
+    testSqlApi(
+      s"IFNULL(SHA384($str1), $str2)",
+      "3519fe5ad2c596efe3e276a6f351b8fc0b03db861782490d45" +
+        "f7598ebd0ab5fd5520ed102f38c4a5ec834e98668035fc")
+    testSqlApi(
+      s"IFNULL(SHA512($str1), $str2)",
+      "3615f80c9d293ed7402687f94b22d58e529b8cc7916f8fac7fddf7fbd5af4cf777d" +
+        "3d795a7a00a16bf7e7f3fb9561ee9baae480da9fe7a18769e71886b03f315")
+    testSqlApi(
+      s"IFNULL(SHA2($str1, 256), $str2)",
+      "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969")
+    testSqlApi(s"IFNULL(PARSE_URL($url, 'HOST'), $str2)", "host")
+    testSqlApi(s"IFNULL(FROM_BASE64($base64), $str2)", "hello world")
+    testSqlApi(s"IFNULL(TO_BASE64($str3), $str2)", "aGVsbG8gd29ybGQ=")
+    testSqlApi(s"IFNULL(CHR(65), $str2)", "A")
+    testSqlApi(s"IFNULL(BIN(10), $str2)", "1010")
+    testSqlApi(s"IFNULL(CONCAT($str1, $str2), $str2)", "HelloHi")
+    testSqlApi(s"IFNULL(CONCAT_WS('~', $str1, $str2), $str2)", "Hello~Hi")
+    testSqlApi(s"IFNULL(TRIM($str4), $str2)", "hello")
+    testSqlApi(s"IFNULL(LTRIM($str4), $str2)", "hello ")
+    testSqlApi(s"IFNULL(RTRIM($str4), $str2)", " hello")
+    testSqlApi(s"IFNULL($str1 || $str2, $str2)", "HelloHi")
+    testSqlApi(s"IFNULL(SUBSTRING(UUID(), 9, 1), $str2)", "-")
+    testSqlApi(s"IFNULL(DECODE(ENCODE($str1, 'utf-8'), 'utf-8'), $str2)", "Hello")
+
+    testSqlApi(s"IFNULL(CAST(DATE '2021-04-06' AS VARCHAR(10)), $str2)", "2021-04-06")
+    testSqlApi(s"IFNULL(CAST(TIME '11:05:30' AS VARCHAR(8)), $str2)", "11:05:30")
+    testSqlApi(
+      s"IFNULL(CAST(TIMESTAMP '2021-04-06 11:05:30' AS VARCHAR(19)), $str2)",
+      "2021-04-06 11:05:30")
+    testSqlApi(s"IFNULL(CAST(INTERVAL '2' YEAR AS VARCHAR(20)), $str2)", "+2-00")
+    testSqlApi(s"IFNULL(CAST(INTERVAL '2' DAY AS VARCHAR(20)), $str2)", "+2 00:00:00.000")
+    testSqlApi(s"IFNULL(CAST(f53 AS VARCHAR(100)), $str2)", "hello world")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -4063,7 +4063,11 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
-  def testStringFunctionAndExpressionReturnType(): Unit = {
+  def testStringFunctionAndExpressionResultType(): Unit = {
+    // this test is to check if the `resultType` of the `GeneratedExpression`
+    // of these string functions match their definition in `FlinkSqlOperatorTable`
+    // see FLINK-22106
+
     val str1 = "CAST('Hello' AS VARCHAR(5))"
     val str2 = "CAST('Hi' AS VARCHAR(2))"
     val str3 = "CAST('hello world' AS VARCHAR(11))"


### PR DESCRIPTION
## What is the purpose of the change

Result type of `GeneratedExpression` of most functions in `StringCallGen` is now `VarCharType(VarCharType.MAX_LENGTH)`, which is incompatible with the functions' definitions in `FlinkSqlOperatorTable`. This may cause exceptions when performing `BridgingFunctionGenUtil#verifyArgumentTypes`.

This PR fixes this issue.

## Brief change log

 - Result type of GeneratedExpression in StringCallGen are now compatible with their definition in FlinkSqlOperatorTable

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable