### PR TITLE
[FLINK-21850][docs] Improve config descriptions of sort-merge blocking shuffle and remove outdated document

### DIFF
--- a/docs/content.zh/docs/deployment/memory/mem_tuning.md
+++ b/docs/content.zh/docs/deployment/memory/mem_tuning.md
@@ -87,20 +87,3 @@ Flink 批处理算子使用[托管内存]({{< ref "docs/deployment/memory/mem_se
 因此 Flink 会在不超过其配置限额的前提下，尽可能分配更多的[托管内存]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory)。
 Flink 明确知道可以使用的内存大小，因此可以有效避免 `OutOfMemoryError` 的发生。
 当[托管内存]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory)不足时，Flink 会优雅地将数据落盘。
-
-## SortMerge数据Shuffle内存配置
-
-对于SortMerge数据Shuffle，每个ResultPartition需要的网络缓冲区（Buffer）数目是由[taskmanager.network.sort-
-shuffle.min-buffers]({{< ref "docs/deployment/config" >}}#taskmanager-network-sort-shuffle-min-buffers)这个配置决定的。它的
-默认值是64，是比较小的。虽然64个网络Buffer已经可以支持任意规模的并发，但性能可能不是最好的。对于大并发的作业，通
-过增大这个配置值，可以提高落盘数据的压缩率并且减少网络小包的数量，从而有利于提高Shuffle性能。为了增大这个配置值，
-你可能需要通过调整[taskmanager.memory.network.fraction]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-fraction)，
-[taskmanager.memory.network.min]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-min)和[taskmanager.memory
-.network.max]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-max)这三个参数来增大总的网络内存大小从而避免出现
-`insufficient number of network buffers`错误。
-
-除了网络内存，SortMerge数据Shuffle还需要使用一些JVM Direct Memory来进行Shuffle数据的写出与读取。所以，为了使
-用SortMerge数据Shuffle你可能还需要通过增大这个配置值[taskmanager.memory.task.off-heap.size
-]({{< ref "docs/deployment/config" >}}#taskmanager-memory-task-off-heap-size)来为其来预留一些JVM Direct Memory。如果在你开启
-SortMerge数据Shuffle之后出现了Direct Memory OOM的错误，你只需要继续加大上面的配置值来预留更多的Direct Memory
-直到不再发生Direct Memory OOM的错误为止。

--- a/docs/content/docs/deployment/memory/mem_tuning.md
+++ b/docs/content/docs/deployment/memory/mem_tuning.md
@@ -89,23 +89,3 @@ on the performance of your applications. Flink will attempt to allocate and use 
 as configured for batch jobs but not go beyond its limits. This prevents `OutOfMemoryError`'s because Flink knows precisely
 how much memory it has to leverage. If the [managed memory]({{< ref "docs/deployment/memory/mem_setup_tm" >}}#managed-memory) is not sufficient,
 Flink will gracefully spill to disk.
-
-## Configure memory for sort-merge blocking shuffle
-
-The number of required network buffers per sort-merge blocking result partition is controlled by 
-[taskmanager.network.sort-shuffle.min-buffers]({{< ref "docs/deployment/config" >}}#taskmanager-network-sort-shuffle-min-buffers)
-and the default value is 64 which is quite small. Though it can work for arbitrary parallelism, the 
-performance may not be the best. For large scale jobs, it is suggested to increase this config value 
-to improve compression ratio and reduce small network packets which is good for performance. To increase 
-this value, you may also need to increase the size of total network memory by adjusting the config 
-values of [taskmanager.memory.network.fraction]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-fraction),
-[taskmanager.memory.network.min]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-min) and [taskmanager.
-memory.network.max]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-max) to avoid `insufficient number of 
-network buffers` error.
-
-Except for network memory, the sort-merge blocking shuffle implementation also uses some unmanaged 
-direct memory for shuffle data writing and reading. So to use sort-merge blocking shuffle, you may 
-need to reserve some direct memory for it by increasing the config value of [taskmanager.memory.task
-.off-heap.size]({{< ref "docs/deployment/config" >}}#taskmanager-memory-task-off-heap-size). If direct memory OOM error 
-occurs after you enable the sort-merge blocking shuffle, you can just give more direct memory until 
-the OOM error disappears.

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -12,7 +12,7 @@
             <td><h5>taskmanager.network.blocking-shuffle.compression.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when data compression ratio is high. Currently, shuffle data compression is an experimental feature and the config option can be changed in the future.</td>
+            <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when compression ratio is high.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.blocking-shuffle.type</h5></td>
@@ -108,13 +108,13 @@
             <td><h5>taskmanager.network.sort-shuffle.min-buffers</h5></td>
             <td style="word-wrap: break-word;">64</td>
             <td>Integer</td>
-            <td>Minimum number of network buffers required per sort-merge blocking result partition. For large scale batch jobs, it is suggested to increase this config value to improve compression ratio and reduce small network packets. Note: to increase this config value, you may also need to increase the size of total network memory to avoid "insufficient number of network buffers" error.</td>
+            <td>Minimum number of network buffers required per sort-merge blocking result partition. For production usage, it is suggested to increase this config value to at least 2048 (64M memory if the default 32K memory segment size is used) to improve the data compression ratio and reduce the small network packets. Usually, several hundreds of megabytes memory is enough for large scale batch jobs. Note: you may also need to increase the size of total network memory to avoid the 'insufficient number of network buffers' error if you are increasing this config value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.sort-shuffle.min-parallelism</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
-            <td>Parallelism threshold to switch between sort-merge blocking shuffle and the default hash-based blocking shuffle, which means for small parallelism, hash-based blocking shuffle will be used and for large parallelism, sort-merge blocking shuffle will be used. Note: sort-merge blocking shuffle uses unmanaged direct memory for shuffle data writing and reading so just increase the size of direct memory if direct memory OOM error occurs.</td>
+            <td>Parallelism threshold to switch between sort-merge blocking shuffle and the default hash-based blocking shuffle, which means for batch jobs of small parallelism, the hash-based blocking shuffle will be used and for batch jobs of large parallelism, the sort-merge one will be used. Note: For production usage, if sort-merge blocking shuffle is enabled, you may also need to enable data compression by setting 'taskmanager.network.blocking-shuffle.compression.enabled' to true and tune 'taskmanager.network.sort-shuffle.min-buffers' and 'taskmanager.memory.framework.off-heap.batch-shuffle.size' for better performance.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>taskmanager.network.blocking-shuffle.compression.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when data compression ratio is high. Currently, shuffle data compression is an experimental feature and the config option can be changed in the future.</td>
+            <td>Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when compression ratio is high.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.blocking-shuffle.type</h5></td>
@@ -126,13 +126,13 @@
             <td><h5>taskmanager.network.sort-shuffle.min-buffers</h5></td>
             <td style="word-wrap: break-word;">64</td>
             <td>Integer</td>
-            <td>Minimum number of network buffers required per sort-merge blocking result partition. For large scale batch jobs, it is suggested to increase this config value to improve compression ratio and reduce small network packets. Note: to increase this config value, you may also need to increase the size of total network memory to avoid "insufficient number of network buffers" error.</td>
+            <td>Minimum number of network buffers required per sort-merge blocking result partition. For production usage, it is suggested to increase this config value to at least 2048 (64M memory if the default 32K memory segment size is used) to improve the data compression ratio and reduce the small network packets. Usually, several hundreds of megabytes memory is enough for large scale batch jobs. Note: you may also need to increase the size of total network memory to avoid the 'insufficient number of network buffers' error if you are increasing this config value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.sort-shuffle.min-parallelism</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>
-            <td>Parallelism threshold to switch between sort-merge blocking shuffle and the default hash-based blocking shuffle, which means for small parallelism, hash-based blocking shuffle will be used and for large parallelism, sort-merge blocking shuffle will be used. Note: sort-merge blocking shuffle uses unmanaged direct memory for shuffle data writing and reading so just increase the size of direct memory if direct memory OOM error occurs.</td>
+            <td>Parallelism threshold to switch between sort-merge blocking shuffle and the default hash-based blocking shuffle, which means for batch jobs of small parallelism, the hash-based blocking shuffle will be used and for batch jobs of large parallelism, the sort-merge one will be used. Note: For production usage, if sort-merge blocking shuffle is enabled, you may also need to enable data compression by setting 'taskmanager.network.blocking-shuffle.compression.enabled' to true and tune 'taskmanager.network.sort-shuffle.min-buffers' and 'taskmanager.memory.framework.off-heap.batch-shuffle.size' for better performance.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -71,19 +71,18 @@ public class NettyShuffleEnvironmentOptions {
      * mode.
      *
      * <p>Note: Data is compressed per buffer and compression can incur extra CPU overhead so it is
-     * more effective for IO bounded scenario when data compression ratio is high. Currently,
-     * shuffle data compression is an experimental feature and the config option can be changed in
-     * the future.
+     * more effective for IO bounded scenario when data compression ratio is high.
      */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Boolean> BLOCKING_SHUFFLE_COMPRESSION_ENABLED =
             key("taskmanager.network.blocking-shuffle.compression.enabled")
                     .defaultValue(false)
                     .withDescription(
-                            "Boolean flag indicating whether the shuffle data will be compressed for blocking shuffle"
-                                    + " mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is"
-                                    + " more effective for IO bounded scenario when data compression ratio is high. Currently, shuffle data "
-                                    + "compression is an experimental feature and the config option can be changed in the future.");
+                            "Boolean flag indicating whether the shuffle data will be compressed "
+                                    + "for blocking shuffle mode. Note that data is compressed per "
+                                    + "buffer and compression can incur extra CPU overhead, so it "
+                                    + "is more effective for IO bounded scenario when compression "
+                                    + "ratio is high.");
 
     /** The codec to be used when compressing shuffle data. */
     @Documentation.ExcludeFromDocumentation("Currently, LZ4 is the only legal option.")
@@ -192,10 +191,15 @@ public class NettyShuffleEnvironmentOptions {
                     .defaultValue(64)
                     .withDescription(
                             "Minimum number of network buffers required per sort-merge blocking "
-                                    + "result partition. For large scale batch jobs, it is suggested to increase this"
-                                    + " config value to improve compression ratio and reduce small network packets. "
-                                    + "Note: to increase this config value, you may also need to increase the size of "
-                                    + "total network memory to avoid \"insufficient number of network buffers\" error.");
+                                    + "result partition. For production usage, it is suggested to "
+                                    + "increase this config value to at least 2048 (64M memory if "
+                                    + "the default 32K memory segment size is used) to improve the "
+                                    + "data compression ratio and reduce the small network packets."
+                                    + " Usually, several hundreds of megabytes memory is enough for"
+                                    + " large scale batch jobs. Note: you may also need to increase"
+                                    + " the size of total network memory to avoid the 'insufficient"
+                                    + " number of network buffers' error if you are increasing this"
+                                    + " config value.");
 
     /**
      * Parallelism threshold to switch between sort-merge based blocking shuffle and the default
@@ -207,12 +211,22 @@ public class NettyShuffleEnvironmentOptions {
                     .intType()
                     .defaultValue(Integer.MAX_VALUE)
                     .withDescription(
-                            "Parallelism threshold to switch between sort-merge blocking shuffle "
-                                    + "and the default hash-based blocking shuffle, which means for small parallelism,"
-                                    + " hash-based blocking shuffle will be used and for large parallelism, sort-merge"
-                                    + " blocking shuffle will be used. Note: sort-merge blocking shuffle uses unmanaged"
-                                    + " direct memory for shuffle data writing and reading so just increase the size of"
-                                    + " direct memory if direct memory OOM error occurs.");
+                            String.format(
+                                    "Parallelism threshold to switch between sort-merge blocking "
+                                            + "shuffle and the default hash-based blocking shuffle,"
+                                            + " which means for batch jobs of small parallelism, "
+                                            + "the hash-based blocking shuffle will be used and for"
+                                            + " batch jobs of large parallelism, the sort-merge one"
+                                            + " will be used. Note: For production usage, if sort-"
+                                            + "merge blocking shuffle is enabled, you may also need"
+                                            + " to enable data compression by setting '%s' to true "
+                                            + "and tune '%s' and '%s' for better performance.",
+                                    BLOCKING_SHUFFLE_COMPRESSION_ENABLED.key(),
+                                    NETWORK_SORT_SHUFFLE_MIN_BUFFERS.key(),
+                                    // raw string key is used here to avoid interdependence, a test
+                                    // is implemented to guard that when the target key is modified,
+                                    // this raw value must be changed correspondingly
+                                    "taskmanager.memory.framework.off-heap.batch-shuffle.size"));
 
     /** Number of max buffers can be used for each output subparition. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.description.Formatter;
+import org.apache.flink.configuration.description.HtmlFormatter;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.util.TestLogger;
 
@@ -32,6 +35,7 @@ import java.net.InetAddress;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /** Unit test for {@link NettyShuffleEnvironmentConfiguration}. */
 public class NettyShuffleEnvironmentConfigurationTest extends TestLogger {
@@ -75,5 +79,26 @@ public class NettyShuffleEnvironmentConfigurationTest extends TestLogger {
         assertEquals(networkConfig.partitionRequestMaxBackoff(), 200);
         assertEquals(networkConfig.networkBuffersPerChannel(), 10);
         assertEquals(networkConfig.floatingNetworkBuffersPerGate(), 100);
+    }
+
+    /** Verifies the correlation of sort-merge blocking shuffle config options. */
+    @Test
+    public void testSortMergeShuffleConfigOptionsCorrelation() {
+        Formatter formatter = new HtmlFormatter();
+        ConfigOption<Integer> configOption =
+                NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM;
+        String description = formatter.format(configOption.description());
+
+        String configKey =
+                getConfigKey(NettyShuffleEnvironmentOptions.BLOCKING_SHUFFLE_COMPRESSION_ENABLED);
+        assertTrue(description.contains(configKey));
+        configKey = getConfigKey(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
+        assertTrue(description.contains(configKey));
+        configKey = getConfigKey(TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY);
+        assertTrue(description.contains(configKey));
+    }
+
+    private static String getConfigKey(ConfigOption<?> configOption) {
+        return "'" + configOption.key() + "'";
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Improve config descriptions of sort-merge blocking shuffle and remove outdated document.


## Brief change log

  - Improve config descriptions of sort-merge blocking shuffle and remove outdated document.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
