### PR TITLE
[FLINK-22084][runtime] Use a consistent default max parallelism in the Adaptive Scheduler

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerComputeReactiveModeVertexParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerComputeReactiveModeVertexParallelismTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.util.TestLogger;
@@ -32,9 +33,6 @@ import java.util.Collections;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
 import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.UPPER_BOUND_MAX_PARALLELISM;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assume.assumeThat;
 
 /** Test vertex parallelism configuration for the {@link AdaptiveScheduler} in Reactive mode. */
 @RunWith(Parameterized.class)
@@ -82,15 +80,12 @@ public class AdaptiveSchedulerComputeReactiveModeVertexParallelismTest extends T
 
     @Test
     public void testCreateStoreWithoutAdjustedParallelism() {
-        assumeThat(
-                "max parallelism must be set",
-                maxParallelism,
-                is(not(JobVertex.MAX_PARALLELISM_DEFAULT)));
-
         JobVertex jobVertex = createNoOpVertex("test", parallelism, maxParallelism);
         VertexParallelismStore store =
                 AdaptiveScheduler.computeReactiveModeVertexParallelismStore(
-                        Collections.singleton(jobVertex), false);
+                        Collections.singleton(jobVertex),
+                        SchedulerBase::getDefaultMaxParallelism,
+                        false);
 
         VertexParallelismInformation info = store.getParallelismInfo(jobVertex.getID());
 
@@ -108,7 +103,9 @@ public class AdaptiveSchedulerComputeReactiveModeVertexParallelismTest extends T
         JobVertex jobVertex = createNoOpVertex("test", parallelism, maxParallelism);
         VertexParallelismStore store =
                 AdaptiveScheduler.computeReactiveModeVertexParallelismStore(
-                        Collections.singleton(jobVertex), true);
+                        Collections.singleton(jobVertex),
+                        SchedulerBase::getDefaultMaxParallelism,
+                        true);
 
         VertexParallelismInformation info = store.getParallelismInfo(jobVertex.getID());
 


### PR DESCRIPTION
# What is the purpose of the change

Ensure that the same max parallelism value is used as the default in the Adaptive Scheduler between submissions, even as the job scales in and out. Previously, the default was used as if it were specified by the user in the JobGraph, making it impossible to rescale from a configured maxP to the default.

The solution of passing a defaulting function is not the prettiest, but is easy enough to follow and can be removed once  the overall flow of parallelism-from-state is improved.

Closes FLINK-22084

Signed-off-by: austin ce <austin.cawley@gmail.com>

## Brief change log

- Allow passing a function, used to compute the default max parallelism value for a vertex,
to the `SchedulerBase#computeVertexParallelismStore` method 

## Verifying this change

This change added tests and can be verified as follows:

- Ran the `RescalingITCase` with adaptive scheduling enabled locally
- Added `AdaptiveSchedulerTest#testConsistentMaxParallelism` to ensure rescaling jobs
use the same default max parallelism

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
