### PR TITLE
[FLINK-22121][table-planner-blink] FlinkLogicalRankRuleBase now check if name of rankNumberType already exists in the input

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/RowTypeUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/RowTypeUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.typeutils;
+
+import java.util.List;
+
+/**
+ * Utils for deriving row types of {@link org.apache.calcite.rel.RelNode}s.
+ */
+public class RowTypeUtils {
+
+    public static String getUniqueName(String nameToChange, List<String> namesToCheck) {
+        if (namesToCheck.contains(nameToChange)) {
+            int suffix = 0;
+            while (namesToCheck.contains(nameToChange + "_" + suffix)) {
+                suffix++;
+            }
+            return nameToChange + "_" + suffix;
+        } else {
+            return nameToChange;
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/RowTypeUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/typeutils/RowTypeUtils.java
@@ -18,22 +18,32 @@
 
 package org.apache.flink.table.planner.typeutils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-/**
- * Utils for deriving row types of {@link org.apache.calcite.rel.RelNode}s.
- */
+/** Utils for deriving row types of {@link org.apache.calcite.rel.RelNode}s. */
 public class RowTypeUtils {
 
-    public static String getUniqueName(String nameToChange, List<String> namesToCheck) {
-        if (namesToCheck.contains(nameToChange)) {
-            int suffix = 0;
-            while (namesToCheck.contains(nameToChange + "_" + suffix)) {
-                suffix++;
+    public static String getUniqueName(String oldName, List<String> checklist) {
+        return getUniqueName(Collections.singletonList(oldName), checklist).get(0);
+    }
+
+    public static List<String> getUniqueName(List<String> oldNames, List<String> checklist) {
+        List<String> result = new ArrayList<>();
+        for (String oldName : oldNames) {
+            if (checklist.contains(oldName) || result.contains(oldName)) {
+                int suffix = -1;
+                String changedName;
+                do {
+                    suffix++;
+                    changedName = oldName + "_" + suffix;
+                } while (checklist.contains(changedName) || result.contains(changedName));
+                result.add(changedName);
+            } else {
+                result.add(oldName);
             }
-            return nameToChange + "_" + suffix;
-        } else {
-            return nameToChange;
         }
+        return result;
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Rank.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Rank.scala
@@ -21,12 +21,12 @@ package org.apache.flink.table.planner.plan.nodes.calcite
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.utils._
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankRange, RankType, VariableRankRange}
-
 import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
-import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField}
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField, RelDataTypeFieldImpl}
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelCollation, RelNode, RelWriter, SingleRel}
 import org.apache.calcite.util.{ImmutableBitSet, NumberUtil}
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
 
 import scala.collection.JavaConversions._
 
@@ -92,11 +92,22 @@ abstract class Rank(
     if (!outputRankNumber) {
       return input.getRowType
     }
+
     // output row type = input row type + rank number type
     val typeFactory = cluster.getRexBuilder.getTypeFactory
     val typeBuilder = typeFactory.builder()
     input.getRowType.getFieldList.foreach(typeBuilder.add)
-    typeBuilder.add(rankNumberType)
+
+    // this is to avoid rank number name be the same with some input column name
+    val newRankNumberName =
+      RowTypeUtils.getUniqueName(rankNumberType.getName, input.getRowType.getFieldNames)
+    if (newRankNumberName == rankNumberType.getName) {
+      typeBuilder.add(rankNumberType)
+    } else {
+      typeBuilder.add(new RelDataTypeFieldImpl(
+        newRankNumberName, rankNumberType.getIndex, rankNumberType.getType))
+    }
+
     typeBuilder.build()
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalOverAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalOverAggregateRule.scala
@@ -26,7 +26,6 @@ import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalOverAggrega
 import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalOverAggregate, BatchPhysicalOverAggregateBase, BatchPhysicalPythonOverAggregate}
 import org.apache.flink.table.planner.plan.utils.PythonUtil.isPythonAggregate
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, OverAggregateUtil, SortUtil}
-
 import org.apache.calcite.plan.RelOptRule._
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel._
@@ -34,6 +33,7 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Window.Group
 import org.apache.calcite.rel.core.{AggregateCall, Window}
 import org.apache.calcite.tools.ValidationException
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -190,7 +190,8 @@ class BatchPhysicalOverAggregateRule
     val inputNameList = inputType.getFieldNames
     val inputTypeList = inputType.getFieldList.asScala.map(field => field.getType)
 
-    val aggNames = aggCalls.map(_.getName)
+    // we should avoid duplicated names with input column names
+    val aggNames = aggCalls.map(c => RowTypeUtils.getUniqueName(c.getName, inputNameList))
     val aggTypes = aggCalls.map(_.getType)
 
     val typeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalOverAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalOverAggregateRule.scala
@@ -26,6 +26,8 @@ import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalOverAggrega
 import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalOverAggregate, BatchPhysicalOverAggregateBase, BatchPhysicalPythonOverAggregate}
 import org.apache.flink.table.planner.plan.utils.PythonUtil.isPythonAggregate
 import org.apache.flink.table.planner.plan.utils.{AggregateUtil, OverAggregateUtil, SortUtil}
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
+
 import org.apache.calcite.plan.RelOptRule._
 import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rel._
@@ -33,7 +35,6 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Window.Group
 import org.apache.calcite.rel.core.{AggregateCall, Window}
 import org.apache.calcite.tools.ValidationException
-import org.apache.flink.table.planner.typeutils.RowTypeUtils
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -191,7 +192,7 @@ class BatchPhysicalOverAggregateRule
     val inputTypeList = inputType.getFieldList.asScala.map(field => field.getType)
 
     // we should avoid duplicated names with input column names
-    val aggNames = aggCalls.map(c => RowTypeUtils.getUniqueName(c.getName, inputNameList))
+    val aggNames = RowTypeUtils.getUniqueName(aggCalls.map(_.getName), inputNameList)
     val aggTypes = aggCalls.map(_.getType)
 
     val typeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
@@ -23,16 +23,15 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-/**
- * Tests for {@link RowTypeUtils}.
- */
+/** Tests for {@link RowTypeUtils}. */
 public class RowTypeUtilsTest {
 
     @Test
     public void testGetUniqueName() {
         Assert.assertEquals(
                 Arrays.asList("Dave", "Evan"),
-                RowTypeUtils.getUniqueName(Arrays.asList("Dave", "Evan"), Arrays.asList("Alice", "Bob")));
+                RowTypeUtils.getUniqueName(
+                        Arrays.asList("Dave", "Evan"), Arrays.asList("Alice", "Bob")));
         Assert.assertEquals(
                 Arrays.asList("Bob_0", "Bob_1", "Dave", "Alice_0"),
                 RowTypeUtils.getUniqueName(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.typeutils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Tests for {@link RowTypeUtils}.
+ */
+public class RowTypeUtilsTest {
+
+    @Test
+    public void testGetUniqueName() {
+        Assert.assertEquals(
+                Arrays.asList("Dave", "Evan"),
+                RowTypeUtils.getUniqueName(Arrays.asList("Dave", "Evan"), Arrays.asList("Alice", "Bob")));
+        Assert.assertEquals(
+                Arrays.asList("Bob_0", "Bob_1", "Dave", "Alice_0"),
+                RowTypeUtils.getUniqueName(
+                        Arrays.asList("Bob", "Bob", "Dave", "Alice"),
+                        Arrays.asList("Alice", "Bob")));
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RankTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RankTest.xml
@@ -245,4 +245,42 @@ Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=9], partitionBy=[], orderB
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testRankWithAnotherRankAsInput">
+    <Resource name="sql">
+      <![CDATA[
+SELECT CAST(rna AS INT) AS rn1, CAST(rnb AS INT) AS rn2 FROM (
+  SELECT *, row_number() over (partition by a order by b desc) AS rnb
+  FROM (
+    SELECT *, row_number() over (partition by a, c order by b desc) AS rna
+    FROM MyTable
+  )
+  WHERE rna <= 100
+)
+WHERE rnb <= 200
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(rn1=[CAST($3):INTEGER NOT NULL], rn2=[CAST($4):INTEGER NOT NULL])
++- LogicalFilter(condition=[<=($4, 200)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], rna=[$3], rnb=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
+      +- LogicalFilter(condition=[<=($3, 100)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], rna=[ROW_NUMBER() OVER (PARTITION BY $0, $2 ORDER BY $1 DESC NULLS LAST)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[CAST(rna) AS rn1, CAST(w0$o0) AS rn2], where=[(w0$o0 <= 200)])
++- OverAggregate(partitionBy=[a], orderBy=[b DESC], window#0=[ROW_NUMBER(*) AS w0$o0_0 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, w0$o0, w0$o0_0])
+   +- Sort(orderBy=[a ASC, b DESC])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, c, w0$o0], where=[(w0$o0 <= 100)])
+            +- OverAggregate(partitionBy=[a, c], orderBy=[b DESC], window#0=[ROW_NUMBER(*) AS w0$o0 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, w0$o0])
+               +- Sort(orderBy=[a ASC, c ASC, b DESC])
+                  +- Exchange(distribution=[hash[a, c]])
+                     +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/RemoveRedundantLocalRankRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/RemoveRedundantLocalRankRuleTest.xml
@@ -100,7 +100,7 @@ LogicalProject(a=[$0], b=[$1], rk=[$2], rk1=[$3])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=5], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0, w0$o0])
+Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=5], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0, w0$o0_0])
 +- Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=5], partitionBy=[a], orderBy=[b ASC], global=[true], select=[a, b, w0$o0])
    +- Sort(orderBy=[a ASC, b ASC])
       +- Exchange(distribution=[hash[a]])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -119,8 +119,8 @@ LogicalProject(a=[$0], b=[$1], count_c=[$2], rank_num=[$3])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Calc(select=[a, b, count_c, w0$o0], changelogMode=[I,UA,D])
-+- Rank(strategy=[UpdateFastStrategy[0,1]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=10], partitionBy=[], orderBy=[count_c DESC], select=[a, b, count_c, w0$o0, w0$o0], changelogMode=[I,UA,D])
+Calc(select=[a, b, count_c, w0$o0_0 AS w0$o0], changelogMode=[I,UA,D])
++- Rank(strategy=[UpdateFastStrategy[0,1]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=10], partitionBy=[], orderBy=[count_c DESC], select=[a, b, count_c, w0$o0, w0$o0_0], changelogMode=[I,UA,D])
    +- Exchange(distribution=[single], changelogMode=[I,UA,D])
       +- Rank(strategy=[UpdateFastStrategy[0,1]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=10], partitionBy=[a], orderBy=[count_c DESC], select=[a, b, count_c, w0$o0], changelogMode=[I,UA,D])
          +- Exchange(distribution=[hash[a]], changelogMode=[I,UA])
@@ -183,6 +183,42 @@ Calc(select=[a, rk, b, c])
    +- Exchange(distribution=[hash[a]])
       +- Calc(select=[a, b, c])
          +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRankWithAnotherRankAsInput">
+    <Resource name="sql">
+      <![CDATA[
+SELECT CAST(rna AS INT) AS rn1, CAST(rnb AS INT) AS rn2 FROM (
+  SELECT *, row_number() over (partition by a order by b desc) AS rnb
+  FROM (
+    SELECT *, row_number() over (partition by a, c order by b desc) AS rna
+    FROM MyTable
+  )
+  WHERE rna <= 100
+)
+WHERE rnb <= 200
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(rn1=[CAST($5):INTEGER NOT NULL], rn2=[CAST($6):INTEGER NOT NULL])
++- LogicalFilter(condition=[<=($6, 200)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rna=[$5], rnb=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
+      +- LogicalFilter(condition=[<=($5, 100)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], rna=[ROW_NUMBER() OVER (PARTITION BY $0, $2 ORDER BY $1 DESC NULLS LAST)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[CAST(w0$o0) AS rn1, CAST(w0$o0_0) AS rn2])
++- Rank(strategy=[UpdateFastStrategy[0,2,3]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=200], partitionBy=[a], orderBy=[b DESC], select=[a, b, c, w0$o0, w0$o0_0])
+   +- Exchange(distribution=[hash[a]])
+      +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a, c], orderBy=[b DESC], select=[a, b, c, w0$o0])
+         +- Exchange(distribution=[hash[a, c]])
+            +- Calc(select=[a, b, c])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/RankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/RankTest.scala
@@ -201,4 +201,21 @@ class RankTest extends TableTestBase {
     util.verifyExecPlanInsert("insert into sink select name, eat, cnt\n"
       + "from view2 where row_num <= 3")
   }
+
+  @Test
+  def testRankWithAnotherRankAsInput(): Unit = {
+    val sql =
+      """
+        |SELECT CAST(rna AS INT) AS rn1, CAST(rnb AS INT) AS rn2 FROM (
+        |  SELECT *, row_number() over (partition by a order by b desc) AS rnb
+        |  FROM (
+        |    SELECT *, row_number() over (partition by a, c order by b desc) AS rna
+        |    FROM MyTable
+        |  )
+        |  WHERE rna <= 100
+        |)
+        |WHERE rnb <= 200
+        |""".stripMargin
+    util.verifyExecPlan(sql)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
@@ -688,5 +688,22 @@ class RankTest extends TableTestBase {
     util.verifyExecPlan(query)
   }
 
+  @Test
+  def testRankWithAnotherRankAsInput(): Unit = {
+    val sql =
+      """
+        |SELECT CAST(rna AS INT) AS rn1, CAST(rnb AS INT) AS rn2 FROM (
+        |  SELECT *, row_number() over (partition by a order by b desc) AS rnb
+        |  FROM (
+        |    SELECT *, row_number() over (partition by a, c order by b desc) AS rna
+        |    FROM MyTable
+        |  )
+        |  WHERE rna <= 100
+        |)
+        |WHERE rnb <= 200
+        |""".stripMargin
+    util.verifyExecPlan(sql)
+  }
+
   // TODO add tests about multi-sinks and udf
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently names of rank fields are all `w0$o0`, so if the input of a `Rank` is another `Rank` some exception will occur. To solve this, we should check if name of rank field has occurred in the input in `FlinkLogicalRankRuleBase`.

## Brief change log

- FlinkLogicalRankRuleBase now check if name of rankNumberType already exists in the input

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
