### PR TITLE
[FLINK-22127][network] Enrich error message of read buffer request timeout to tell the user how to solve the problem when using sort-merge blocking shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
@@ -163,7 +164,11 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             }
 
             if (numRequestedBuffers <= 0) {
-                throw new TimeoutException("Buffer request timeout.");
+                throw new TimeoutException(
+                        String.format(
+                                "Buffer request timeout, this means there is a fierce contention of"
+                                        + " the batch shuffle read memory, please increase '%s'.",
+                                TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key()));
             }
         } catch (Throwable throwable) {
             // fail all pending subpartition readers immediately if any exception occurs


### PR DESCRIPTION
## What is the purpose of the change

Enrich error message of read buffer request timeout to tell the user how to solve the problem when using sort-merge blocking shuffle.


## Brief change log

  - Enrich error message of read buffer request timeout to tell the user how to solve the problem when using sort-merge blocking shuffle.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
