### PR TITLE
[FLINK-22077] Fix incorrect way to create cross-region ConsumedPartitionGroups in PipelinedRegionSchedulingStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -93,29 +93,39 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     }
 
     private void initCrossRegionConsumedPartitionGroups() {
-        Set<ConsumedPartitionGroup> visitedPartitionGroups =
-                Collections.newSetFromMap(new IdentityHashMap<>());
+        final Map<ConsumedPartitionGroup, Set<SchedulingPipelinedRegion>>
+                producerRegionsByConsumedPartitionGroup = new IdentityHashMap<>();
 
         for (SchedulingPipelinedRegion pipelinedRegion :
                 schedulingTopology.getAllPipelinedRegions()) {
             for (ConsumedPartitionGroup consumedPartitionGroup :
                     pipelinedRegion.getAllBlockingConsumedPartitionGroups()) {
-                if (!visitedPartitionGroups.contains(consumedPartitionGroup)) {
-                    visitedPartitionGroups.add(consumedPartitionGroup);
+                producerRegionsByConsumedPartitionGroup.computeIfAbsent(
+                        consumedPartitionGroup, this::getProducerRegionsForConsumedPartitionGroup);
+            }
+        }
 
-                    SchedulingPipelinedRegion producerRegion = null;
-                    for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
-                        SchedulingPipelinedRegion region = getProducerRegion(partitionId);
-                        if (producerRegion == null) {
-                            producerRegion = region;
-                        } else if (producerRegion != region) {
-                            crossRegionConsumedPartitionGroups.add(consumedPartitionGroup);
-                            break;
-                        }
-                    }
+        for (SchedulingPipelinedRegion pipelinedRegion :
+                schedulingTopology.getAllPipelinedRegions()) {
+            for (ConsumedPartitionGroup consumedPartitionGroup :
+                    pipelinedRegion.getAllBlockingConsumedPartitionGroups()) {
+                final Set<SchedulingPipelinedRegion> producerRegions =
+                        producerRegionsByConsumedPartitionGroup.get(consumedPartitionGroup);
+                if (producerRegions.size() > 1 && producerRegions.contains(pipelinedRegion)) {
+                    crossRegionConsumedPartitionGroups.add(consumedPartitionGroup);
                 }
             }
         }
+    }
+
+    private Set<SchedulingPipelinedRegion> getProducerRegionsForConsumedPartitionGroup(
+            ConsumedPartitionGroup consumedPartitionGroup) {
+        final Set<SchedulingPipelinedRegion> producerRegions =
+                Collections.newSetFromMap(new IdentityHashMap<>());
+        for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+            producerRegions.add(getProducerRegion(partitionId));
+        }
+        return producerRegions;
     }
 
     private SchedulingPipelinedRegion getProducerRegion(IntermediateResultPartitionID partitionId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
@@ -320,6 +321,11 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
             IntermediateResultPartitionID partitionId, SchedulingPipelinedRegion pipelinedRegion) {
         return !pipelinedRegion.contains(
                 schedulingTopology.getResultPartition(partitionId).getProducer().getId());
+    }
+
+    @VisibleForTesting
+    Set<ConsumedPartitionGroup> getCrossRegionConsumedPartitionGroups() {
+        return Collections.unmodifiableSet(crossRegionConsumedPartitionGroups);
     }
 
     /** The factory for creating {@link PipelinedRegionSchedulingStrategy}. */


### PR DESCRIPTION
## What is the purpose of the change

*This change fixes the incorrect way to calculate cross-region ConsumedPartitionGroups in PipelinedRegionSchedulingStrategy in FLINK-21330. It slows down the procedure of onExecutionStateChange, makes the complexity increase from O(N) to O(N^2). Also the semantic of cross-region is totally wrong.*

*To correctly calculate the cross-region ConsumedPartitionGroups, we can just calculate the producer regions for all ConsumedPartitionGroups, and then iterate all the regions and its ConsumedPartitionGroups. If the ConsumedPartitionGroup has two or more producer regions, and the regions contains the current region, it is a cross-region ConsumedPartitionGroup.*

*For more details, please check FLINK-22077*


## Brief change log

  - *Fix the incorrect way to create cross-region ConsumedPartitionGroups in PipelinedRegionSchedulingStrategy*

## Verifying this change

*This change is verified by existing tests in PipelinedRegionSchedulingStrategyTest. `testSchedulingTopologyWithCrossRegionConsumedPartitionGroups` tests the case with cross-region ConsumedPartitionGroups illustrated in FLINK-22017. Also we test this change in end-to-end tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
