### PR TITLE
[FLINK-22105][tests] Fix checkpoint id in testForceAlignedCheckpointResultingInPriorityEvents

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -180,6 +180,7 @@ public class SubtaskCheckpointCoordinatorTest {
 
     @Test
     public void testForceAlignedCheckpointResultingInPriorityEvents() throws Exception {
+        final long checkpointId = 42L;
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
 
         SubtaskCheckpointCoordinator coordinator =
@@ -202,10 +203,10 @@ public class SubtaskCheckpointCoordinatorTest {
                         coordinator
                                 .getChannelStateWriter()
                                 .addOutputData(
-                                        0,
+                                        checkpointId,
                                         new ResultSubpartitionInfo(0, 0),
                                         0,
-                                        BufferBuilderTestUtils.buildSomeBuffer(1337));
+                                        BufferBuilderTestUtils.buildSomeBuffer(500));
                     }
                 };
 
@@ -213,7 +214,7 @@ public class SubtaskCheckpointCoordinatorTest {
                 CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault())
                         .withUnalignedUnsupported();
         coordinator.checkpointState(
-                new CheckpointMetaData(42, 0),
+                new CheckpointMetaData(checkpointId, 0),
                 forcedAlignedOptions,
                 new CheckpointMetricsBuilder(),
                 operatorChain,


### PR DESCRIPTION
## What is the purpose of the change

1. Don't finish output channel state write in `testForceAlignedCheckpointResultingInPriorityEvents` as `FORCE_ALIGNED` checkpoint shouldn't have any channel state persisted.
1. Close SubtaskCheckpointCoordinator in tests to reveal any async failures occurring when writing channel state.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
