### PR TITLE
[FLINK-21240][jdbc] Fix JDBC row converter doesn't support external LocalDateTime type

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/AbstractJdbcRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/AbstractJdbcRowConverter.java
@@ -42,6 +42,7 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -167,7 +168,10 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
                 return val -> (int) (((Time) val).toLocalTime().toNanoOfDay() / 1_000_000L);
             case TIMESTAMP_WITH_TIME_ZONE:
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return val -> TimestampData.fromTimestamp((Timestamp) val);
+                return val ->
+                        val instanceof LocalDateTime
+                                ? TimestampData.fromLocalDateTime((LocalDateTime) val)
+                                : TimestampData.fromTimestamp((Timestamp) val);
             case CHAR:
             case VARCHAR:
                 return val -> StringData.fromString((String) val);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/AbstractJdbcRowConverterTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/AbstractJdbcRowConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.internal;
+
+import org.apache.flink.connector.jdbc.internal.converter.AbstractJdbcRowConverter;
+import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.ResultSet;
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link AbstractJdbcRowConverter}. */
+public class AbstractJdbcRowConverterTest {
+
+    @Test
+    public void testTimestampType() throws Exception {
+        RowType rowType = RowType.of(new IntType(), new TimestampType(3));
+        JdbcRowConverter rowConverter =
+                new AbstractJdbcRowConverter(rowType) {
+
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public String converterName() {
+                        return "test";
+                    }
+                };
+
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        Mockito.when(resultSet.getObject(1)).thenReturn(123);
+        Mockito.when(resultSet.getObject(2))
+                .thenReturn(LocalDateTime.parse("2021-04-07T00:00:05.999"));
+        RowData res = rowConverter.toInternal(resultSet);
+
+        assertEquals(123, res.getInt(0));
+        assertEquals(
+                LocalDateTime.parse("2021-04-07T00:00:05.999"),
+                res.getTimestamp(1, 3).toLocalDateTime());
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/converter/AbstractJdbcRowConverterTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/converter/AbstractJdbcRowConverterTest.java
@@ -16,10 +16,8 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.jdbc.internal;
+package org.apache.flink.connector.jdbc.internal.converter;
 
-import org.apache.flink.connector.jdbc.internal.converter.AbstractJdbcRowConverter;
-import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
@@ -37,7 +35,7 @@ import static org.junit.Assert.assertEquals;
 public class AbstractJdbcRowConverterTest {
 
     @Test
-    public void testTimestampType() throws Exception {
+    public void testExternalLocalDateTimeToTimestamp() throws Exception {
         RowType rowType = RowType.of(new IntType(), new TimestampType(3));
         JdbcRowConverter rowConverter =
                 new AbstractJdbcRowConverter(rowType) {


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix the JDBC row converter didn't consider external `LocalDateTime type`

## Brief change log

  -  Add external `LocalDateTime` type support in `AbstractJdbcRowConverter`

## Verifying this change

- Add unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
