### PR TITLE
[FLINK-21386][datastream] Postpone FromElementsFunction serialization to respect later type customization

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1096,12 +1096,7 @@ public class StreamExecutionEnvironment {
         // must not have null elements and mixed elements
         FromElementsFunction.checkCollection(data, typeInfo.getTypeClass());
 
-        SourceFunction<OUT> function;
-        try {
-            function = new FromElementsFunction<>(typeInfo.createSerializer(getConfig()), data);
-        } catch (IOException e) {
-            throw new RuntimeException(e.getMessage(), e);
-        }
+        SourceFunction<OUT> function = new FromElementsFunction<>(data);
         return addSource(function, "Collection Source", typeInfo, Boundedness.BOUNDED)
                 .setParallelism(1);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -143,7 +143,9 @@ public class FromElementsFunction<T>
      */
     @Override
     public void setOutputType(TypeInformation<T> outTypeInfo, ExecutionConfig executionConfig) {
-        Preconditions.checkState(elements != null, "elements lost during serialization");
+        Preconditions.checkState(
+                elements != null,
+                "The output type should've been specified before shipping the graph to the cluster");
         checkIterable(elements, outTypeInfo.getTypeClass());
         TypeSerializer<T> newSerializer = outTypeInfo.createSerializer(executionConfig);
         if (Objects.equals(serializer, newSerializer)) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -18,8 +18,11 @@
 package org.apache.flink.streaming.api.functions.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.memory.DataInputView;
@@ -28,37 +31,44 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
+import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A stream source function that returns a sequence of elements.
  *
- * <p>Upon construction, this source function serializes the elements using Flink's type
- * information. That way, any object transport using Java serialization will not be affected by the
- * serializability of the elements.
+ * <p>This source function serializes the elements using Flink's type information. That way, any
+ * object transport using Java serialization will not be affected by the serializability of the
+ * elements.
  *
  * <p><b>NOTE:</b> This source has a parallelism of 1.
  *
  * @param <T> The type of elements returned by this function.
  */
 @PublicEvolving
-public class FromElementsFunction<T> implements SourceFunction<T>, CheckpointedFunction {
+public class FromElementsFunction<T>
+        implements SourceFunction<T>, CheckpointedFunction, OutputTypeConfigurable<T> {
 
     private static final long serialVersionUID = 1L;
 
     /** The (de)serializer to be used for the data elements. */
-    private final TypeSerializer<T> serializer;
+    private @Nullable TypeSerializer<T> serializer;
 
     /** The actual data elements, in serialized form. */
-    private final byte[] elementsSerialized;
+    private byte[] elementsSerialized;
 
     /** The number of serialized elements. */
     private final int numElements;
@@ -72,30 +82,79 @@ public class FromElementsFunction<T> implements SourceFunction<T>, CheckpointedF
     /** Flag to make the source cancelable. */
     private volatile boolean isRunning = true;
 
+    private final transient Iterable<T> elements;
+
     private transient ListState<Integer> checkpointedState;
 
+    @SafeVarargs
     public FromElementsFunction(TypeSerializer<T> serializer, T... elements) throws IOException {
         this(serializer, Arrays.asList(elements));
     }
 
     public FromElementsFunction(TypeSerializer<T> serializer, Iterable<T> elements)
             throws IOException {
+        this.serializer = Preconditions.checkNotNull(serializer);
+        this.elements = elements;
+        this.numElements =
+                elements instanceof Collection
+                        ? ((Collection<T>) elements).size()
+                        : (int) IterableUtils.toStream(elements).count();
+        serializeElements();
+    }
+
+    @SafeVarargs
+    public FromElementsFunction(T... elements) {
+        this(Arrays.asList(elements));
+    }
+
+    public FromElementsFunction(Iterable<T> elements) {
+        this.serializer = null;
+        this.elements = elements;
+        this.numElements =
+                elements instanceof Collection
+                        ? ((Collection<T>) elements).size()
+                        : (int) IterableUtils.toStream(elements).count();
+        checkIterable(elements, Object.class);
+    }
+
+    @VisibleForTesting
+    @Nullable
+    public TypeSerializer<T> getSerializer() {
+        return serializer;
+    }
+
+    private void serializeElements() throws IOException {
+        Preconditions.checkState(serializer != null, "serializer not set");
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputViewStreamWrapper wrapper = new DataOutputViewStreamWrapper(baos);
-
-        int count = 0;
         try {
             for (T element : elements) {
                 serializer.serialize(element, wrapper);
-                count++;
             }
         } catch (Exception e) {
             throw new IOException("Serializing the source elements failed: " + e.getMessage(), e);
         }
-
-        this.serializer = serializer;
         this.elementsSerialized = baos.toByteArray();
-        this.numElements = count;
+    }
+
+    /**
+     * Set element type and re-serialize element if required. Should only be called before
+     * serialization/deserialization of this function.
+     */
+    @Override
+    public void setOutputType(TypeInformation<T> outTypeInfo, ExecutionConfig executionConfig) {
+        Preconditions.checkState(elements != null, "elements lost during serialization");
+        checkIterable(elements, outTypeInfo.getTypeClass());
+        TypeSerializer<T> newSerializer = outTypeInfo.createSerializer(executionConfig);
+        if (Objects.equals(serializer, newSerializer)) {
+            return;
+        }
+        serializer = newSerializer;
+        try {
+            serializeElements();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
     }
 
     @Override
@@ -127,6 +186,7 @@ public class FromElementsFunction<T> implements SourceFunction<T>, CheckpointedF
 
     @Override
     public void run(SourceContext<T> ctx) throws Exception {
+        Preconditions.checkState(serializer != null, "serializer not configured");
         ByteArrayInputStream bais = new ByteArrayInputStream(elementsSerialized);
         final DataInputView input = new DataInputViewStreamWrapper(bais);
 
@@ -222,6 +282,10 @@ public class FromElementsFunction<T> implements SourceFunction<T>, CheckpointedF
      * @param <OUT> The generic type of the collection to be checked.
      */
     public static <OUT> void checkCollection(Collection<OUT> elements, Class<OUT> viewedAs) {
+        checkIterable(elements, viewedAs);
+    }
+
+    private static <OUT> void checkIterable(Iterable<OUT> elements, Class<?> viewedAs) {
         for (OUT elem : elements) {
             if (elem == null) {
                 throw new IllegalArgumentException("The collection contains a null element");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -219,10 +219,10 @@ public class StreamGraphGeneratorTest extends TestLogger {
 
         DataStream<Integer> source = env.fromElements(1, 10);
 
-        NoOpUdfOperator<Integer> udfOperator = new NoOpUdfOperator(function);
+        NoOpUdfOperator<Integer> udfOperator = new NoOpUdfOperator<>(function);
 
         source.transform("no-op udf operator", BasicTypeInfo.INT_TYPE_INFO, udfOperator)
-                .addSink(new DiscardingSink());
+                .addSink(new DiscardingSink<>());
 
         env.getStreamGraph();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -40,6 +41,7 @@ import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
@@ -207,6 +209,25 @@ public class StreamGraphGeneratorTest extends TestLogger {
         assertTrue(
                 graph.getStreamNode(shuffleOperator.getId()).getOutEdges().get(0).getPartitioner()
                         instanceof ShufflePartitioner);
+    }
+
+    @Test
+    public void testOutputTypeConfigurationWithUdfStreamOperator() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        OutputTypeConfigurableFunction<Integer> function = new OutputTypeConfigurableFunction<>();
+
+        DataStream<Integer> source = env.fromElements(1, 10);
+
+        NoOpUdfOperator<Integer> udfOperator = new NoOpUdfOperator(function);
+
+        source.transform("no-op udf operator", BasicTypeInfo.INT_TYPE_INFO, udfOperator)
+                .addSink(new DiscardingSink());
+
+        env.getStreamGraph();
+
+        assertTrue(udfOperator instanceof AbstractUdfStreamOperator);
+        assertEquals(BasicTypeInfo.INT_TYPE_INFO, function.getTypeInformation());
     }
 
     /**
@@ -632,6 +653,32 @@ public class StreamGraphGeneratorTest extends TestLogger {
                                 StreamGraphGenerator.DEFAULT_SLOT_SHARING_GROUP)
                         .get(),
                 equalTo(resourceProfile3));
+    }
+
+    private static class OutputTypeConfigurableFunction<T>
+            implements OutputTypeConfigurable<T>, Function {
+        private TypeInformation<T> typeInformation;
+
+        public TypeInformation<T> getTypeInformation() {
+            return typeInformation;
+        }
+
+        @Override
+        public void setOutputType(TypeInformation<T> outTypeInfo, ExecutionConfig executionConfig) {
+            typeInformation = outTypeInfo;
+        }
+    }
+
+    static class NoOpUdfOperator<T> extends AbstractUdfStreamOperator<T, Function>
+            implements OneInputStreamOperator<T, T> {
+        NoOpUdfOperator(Function function) {
+            super(function);
+        }
+
+        @Override
+        public void processElement(StreamRecord<T> element) throws Exception {
+            output.collect(element);
+        }
     }
 
     static class OutputTypeConfigurableOperationWithTwoInputs


### PR DESCRIPTION
## What is the purpose of the change
Respect type customization(eg. `SingleOutputStreamOperator.returns`) for `FromElementsFunction`.

## Brief change log
* Add test to assert that `AbstractUdfStreamOperator` redirects `OutputTypeConfigurable` to function
* Postpone `FromElementsFunction` serialization to respect later type customization

## Verifying this change

This change added tests and can be verified as follows:
* `StreamGraphGeneratorTesttestOutputTypeConfigurationWithUdfStreamOperator`
* `FromElementsFunctionTest`
* Existing tests that using `FromElementsFunction` directly or indirectly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes**)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## **WARNING: possible breaking change**
Previously, `FromElementsFunction` serializes elements eagerly. After this pr, it serializes elements lazily. Any code which depend on previous behavior may break. Depends on perspective, this might be treated as a breaking change. Following are possible affected apis:
* `StreamExecutionEnvironment.fromElements(OUT... data)`
* `StreamExecutionEnvironment.fromElements(Class<OUT> type, OUT... data)`
* `StreamExecutionEnvironment.fromCollection(Collection<OUT> data)`
* `StreamExecutionEnvironment.fromCollection(Collection<OUT> data, TypeInformation<OUT> typeInfo)`