### PR TITLE
[BP-1.12][FLINK-22006][k8s] Support to configure max concurrent requests for fabric8 Kubernetes client via JAVA opts or envs

### DIFF
--- a/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/deployment/resource-providers/native_kubernetes.md
@@ -163,6 +163,17 @@ $ echo 'stop' | ./bin/kubernetes-session.sh \
 
 The Kubernetes-specific configuration options are listed on the [configuration page]({% link deployment/config.md %}#kubernetes).
 
+Flink uses [Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client) to communicate with Kubernetes APIServer to create/delete Kubernetes resources(e.g. Deployment, Pod, ConfigMap, Service, etc.), as well as watch the Pods and ConfigMaps.
+Except for the above Flink config options, some [expert options](https://github.com/fabric8io/kubernetes-client#configuring-the-client) of Fabric8 Kubernetes client could be configured via system properties or environment variables.
+
+For example, users could use the following Flink config options to set the concurrent max requests, which allows running more jobs in a session cluster when [Kubernetes HA Services]({% link deployment/ha/kubernetes_ha.md %}) are used.
+Please note that, each Flink job will consume `3` concurrent requests.
+
+```yaml
+containerized.master.env.KUBERNETES_MAX_CONCURRENT_REQUESTS: 200
+env.java.opts.jobmanager: "-Dkubernetes.max.concurrent.requests=200"
+```
+
 ### Accessing Flink's Web UI
 
 Flink's Web UI and REST endpoint can be exposed in several ways via the [kubernetes.rest-service.exposed.type]({% link deployment/config.md %}#kubernetes-rest-service-exposed-type) configuration option.

--- a/docs/deployment/resource-providers/native_kubernetes.zh.md
+++ b/docs/deployment/resource-providers/native_kubernetes.zh.md
@@ -163,6 +163,18 @@ $ echo 'stop' | ./bin/kubernetes-session.sh \
 
 The Kubernetes-specific configuration options are listed on the [configuration page]({% link deployment/config.zh.md %}#kubernetes).
 
+
+Flink uses [Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client) to communicate with Kubernetes APIServer to create/delete Kubernetes resources(e.g. Deployment, Pod, ConfigMap, Service, etc.), as well as watch the Pods and ConfigMaps.
+Except for the above Flink config options, some [expert options](https://github.com/fabric8io/kubernetes-client#configuring-the-client) of Fabric8 Kubernetes client could be configured via system properties or environment variables.
+
+For example, users could use the following Flink config options to set the concurrent max requests, which allows running more jobs in a session cluster when [Kubernetes HA Services]({% link deployment/ha/kubernetes_ha.zh.md %}) are used.
+Please note that, each Flink job will consume `3` concurrent requests.
+
+```yaml
+containerized.master.env.KUBERNETES_MAX_CONCURRENT_REQUESTS: 200
+env.java.opts.jobmanager: "-Dkubernetes.max.concurrent.requests=200"
+```
+
 ### Accessing Flink's Web UI
 
 Flink's Web UI and REST endpoint can be exposed in several ways via the [kubernetes.rest-service.exposed.type]({% link deployment/config.zh.md %}#kubernetes-rest-service-exposed-type) configuration option.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.kubeclient;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
@@ -27,6 +28,7 @@ import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,11 +94,30 @@ public class FlinkKubeClientFactory {
         LOG.debug("Setting namespace of Kubernetes client to {}", namespace);
         config.setNamespace(namespace);
 
+        // This could be removed after we bump the fabric8 Kubernetes client version to 4.13.0+ or
+        // use the a shared connection for all ConfigMap watches. See FLINK-22006 for more
+        // information.
+        trySetMaxConcurrentRequest(config);
+
         final NamespacedKubernetesClient client = new DefaultKubernetesClient(config);
         final int poolSize =
                 flinkConfig.get(KubernetesConfigOptions.KUBERNETES_CLIENT_IO_EXECUTOR_POOL_SIZE);
         return new Fabric8FlinkKubeClient(
                 flinkConfig, client, createThreadPoolForAsyncIO(poolSize, useCase));
+    }
+
+    @VisibleForTesting
+    static void trySetMaxConcurrentRequest(Config config) {
+        final String configuredMaxConcurrentRequests =
+                Utils.getSystemPropertyOrEnvVar(
+                        Config.KUBERNETES_MAX_CONCURRENT_REQUESTS,
+                        String.valueOf(Config.DEFAULT_MAX_CONCURRENT_REQUESTS));
+        if (configuredMaxConcurrentRequests != null) {
+            LOG.debug(
+                    "Setting max concurrent requests of Kubernetes client to {}",
+                    configuredMaxConcurrentRequests);
+            config.setMaxConcurrentRequests(Integer.parseInt(configuredMaxConcurrentRequests));
+        }
     }
 
     private static ExecutorService createThreadPoolForAsyncIO(int poolSize, String useCase) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient;
+
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.util.TestLogger;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for {@link FlinkKubeClientFactory}. */
+public class FlinkKubeClientFactoryTest extends TestLogger {
+
+    @Test
+    public void testTrySetMaxConcurrentRequestViaJavaSystemProperty() {
+        System.setProperty(Config.KUBERNETES_MAX_CONCURRENT_REQUESTS, "100");
+        testTrySetMaxConcurrentRequest(100);
+        System.getProperties().remove(Config.KUBERNETES_MAX_CONCURRENT_REQUESTS);
+    }
+
+    @Test
+    public void testTrySetMaxConcurrentRequestViaEnvVar() {
+        final Map<String, String> currentEnv = System.getenv();
+        final String envKey = "KUBERNETES_MAX_CONCURRENT_REQUESTS";
+        final Map<String, String> envMap = new HashMap<>();
+        envMap.put(envKey, "200");
+        CommonTestUtils.setEnv(envMap, true);
+        testTrySetMaxConcurrentRequest(200);
+        CommonTestUtils.setEnv(currentEnv);
+    }
+
+    private void testTrySetMaxConcurrentRequest(int expectedValue) {
+        final Config config = new ConfigBuilder().build();
+        FlinkKubeClientFactory.trySetMaxConcurrentRequest(config);
+        assertThat(config.getMaxConcurrentRequests(), is(expectedValue));
+    }
+}


### PR DESCRIPTION
Backport of #15480 to `release-1.12`.