### PR TITLE
[FLINK-22143][table runtime] fix less lines than requested returned by LimitableBulk…

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/LimitableBulkFormat.java
@@ -122,8 +122,13 @@ public class LimitableBulkFormat<T, SplitT extends FileSourceSplit>
                 if (reachLimit()) {
                     return null;
                 }
-                numRead.incrementAndGet();
-                return iterator.next();
+
+                RecordAndPosition<T> ret = iterator.next();
+                if (ret != null) {
+                    numRead.incrementAndGet();
+                }
+
+                return ret;
             }
 
             @Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/LimitableBulkFormatTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/LimitableBulkFormatTest.java
@@ -19,9 +19,11 @@
 package org.apache.flink.table.filesystem;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.impl.StreamFormatAdapter;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.connector.file.src.reader.TextLineFormat;
 import org.apache.flink.connector.file.src.util.Utils;
 import org.apache.flink.core.fs.Path;
@@ -64,5 +66,37 @@ public class LimitableBulkFormatTest {
         AtomicInteger i = new AtomicInteger(0);
         Utils.forEachRemaining(reader, s -> i.incrementAndGet());
         Assert.assertEquals(22, i.get());
+    }
+
+    @Test
+    public void testLimitOverBatches() throws IOException {
+        // prepare file
+        File file = TEMP_FOLDER.newFile();
+        file.createNewFile();
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 10000; i++) {
+            builder.append(i).append("\n");
+        }
+        FileUtils.writeFileUtf8(file, builder.toString());
+
+        // set limit
+        Long limit = 2048L;
+
+        // configuration for small batches
+        Configuration conf = new Configuration();
+        conf.set(StreamFormat.FETCH_IO_SIZE, MemorySize.parse("4k"));
+
+        // read
+        BulkFormat<String, FileSourceSplit> format =
+                LimitableBulkFormat.create(new StreamFormatAdapter<>(new TextLineFormat()), limit);
+
+        BulkFormat.Reader<String> reader =
+                format.createReader(
+                        conf, new FileSourceSplit("id", new Path(file.toURI()), 0, file.length()));
+
+        // check
+        AtomicInteger i = new AtomicInteger(0);
+        Utils.forEachRemaining(reader, s -> i.incrementAndGet());
+        Assert.assertEquals(limit.intValue(), i.get());
     }
 }


### PR DESCRIPTION
…Format

## What is the purpose of the change

* fix less lines than requested returned by LimitableBulkFormat under certain conditions


## Brief change log

  - check null or not on result of `next()` before increase `numRead`

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
