### PR TITLE
[FLINK-22138][table] Allow casting between row and structured type

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -75,6 +75,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.types.extraction.ExtractionUtils.validateStructuredClass;
@@ -733,6 +734,19 @@ public final class DataTypes {
     }
 
     /**
+     * Data type of a sequence of fields.
+     *
+     * <p>This is shortcut for {@link #ROW(Field...)} where the field names will be generated using
+     * {@code f0, f1, f2, ...}.
+     */
+    public static DataType ROW(DataType... fieldDataTypes) {
+        return ROW(
+                IntStream.range(0, fieldDataTypes.length)
+                        .mapToObj(idx -> FIELD("f" + idx, fieldDataTypes[idx]))
+                        .toArray(Field[]::new));
+    }
+
+    /**
      * Data type of a row type with no fields. It only exists for completeness.
      *
      * @see #ROW(Field...)
@@ -783,6 +797,19 @@ public final class DataTypes {
                                     .toArray(Field[]::new);
                     return ROW(fieldsArray);
                 });
+    }
+
+    /**
+     * Data type of a sequence of fields.
+     *
+     * <p>This is shortcut for {@link #ROW(AbstractField...)} where the field names will be
+     * generated using {@code f0, f1, f2, ...}.
+     */
+    public static UnresolvedDataType ROW(AbstractDataType<?>... fieldDataTypes) {
+        return ROW(
+                IntStream.range(0, fieldDataTypes.length)
+                        .mapToObj(idx -> FIELD("f" + idx, fieldDataTypes[idx]))
+                        .toArray(AbstractField[]::new));
     }
 
     /**

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -217,6 +217,9 @@ public class DataTypesTest {
                                                 new RowType.RowField("field1", new CharType(2)),
                                                 new RowType.RowField("field2", new BooleanType()))))
                         .expectConversionClass(Row.class),
+                TestSpec.forDataType(ROW(DataTypes.INT(), DataTypes.FLOAT()))
+                        .expectResolvedDataType(
+                                DataTypes.ROW(FIELD("f0", INT()), FIELD("f1", FLOAT()))),
                 TestSpec.forDataType(NULL())
                         .expectLogicalType(new NullType())
                         .expectConversionClass(Object.class),
@@ -267,6 +270,8 @@ public class DataTypesTest {
                         .expectUnresolvedString("[ROW<field1 [CHAR(2)], field2 BOOLEAN>]")
                         .expectResolvedDataType(
                                 ROW(FIELD("field1", CHAR(2)), FIELD("field2", BOOLEAN()))),
+                TestSpec.forUnresolvedDataType(ROW(DataTypes.of("CHAR(2)"), BOOLEAN()))
+                        .expectResolvedDataType(ROW(FIELD("f0", CHAR(2)), FIELD("f1", BOOLEAN()))),
                 TestSpec.forUnresolvedDataType(
                                 ARRAY(
                                         ROW(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastAvoidanceTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastAvoidanceTest.java
@@ -228,7 +228,29 @@ public class LogicalTypeCastAvoidanceTest {
                         createDistinctType("Money", new DecimalType(10, 2)),
                         createDistinctType("Money2", new DecimalType(10, 2)),
                         true
-                    }
+                    },
+
+                    // row and structure type
+                    {
+                        RowType.of(new IntType(), new VarCharType()),
+                        createUserType("User2", new IntType(), new VarCharType()),
+                        true
+                    },
+                    {
+                        RowType.of(new BigIntType(), new VarCharType()),
+                        createUserType("User2", new IntType(), new VarCharType()),
+                        false
+                    },
+                    {
+                        createUserType("User2", new IntType(), new VarCharType()),
+                        RowType.of(new IntType(), new VarCharType()),
+                        true
+                    },
+                    {
+                        createUserType("User2", new IntType(), new VarCharType()),
+                        RowType.of(new BigIntType(), new VarCharType()),
+                        false
+                    },
                 });
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types;
 
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -31,7 +32,10 @@ import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
@@ -158,7 +162,8 @@ public class LogicalTypeCastsTest {
                         false,
                         false
                     },
-                    // test implicit cast between timestamp type and timestamp_ltz type
+
+                    // timestamp type and timestamp_ltz type
                     {new TimestampType(9), new TimestampType(9), true, true},
                     {new LocalZonedTimestampType(9), new LocalZonedTimestampType(9), true, true},
                     {new TimestampType(3), new LocalZonedTimestampType(3), true, true},
@@ -169,18 +174,48 @@ public class LogicalTypeCastsTest {
                     {new LocalZonedTimestampType(false, 3), new TimestampType(6), true, true},
                     {new TimestampType(6), new LocalZonedTimestampType(3), true, true},
                     {new LocalZonedTimestampType(6), new TimestampType(3), true, true},
+
+                    // row and structured type
                     {
                         new RowType(
                                 Arrays.asList(
                                         new RowField("f1", new TimestampType()),
-                                        new RowField("f2", new LocalZonedTimestampType()),
-                                        new RowField("f3", new IntType()))),
+                                        new RowField("f2", new IntType()))),
+                        StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"))
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute("f2", new IntType())))
+                                .build(),
+                        true,
+                        true
+                    },
+                    {
                         new RowType(
                                 Arrays.asList(
-                                        new RowField("f1", new LocalZonedTimestampType()),
-                                        new RowField("f2", new TimestampType()),
-                                        new RowField("f3", new IntType()))),
+                                        new RowField("f1", new TimestampType()),
+                                        new RowField("f2", new IntType()))),
+                        StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"))
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute("diff", new IntType())))
+                                .build(),
                         true,
+                        true
+                    },
+                    {
+                        new RowType(
+                                Arrays.asList(
+                                        new RowField("f1", new TimestampType()),
+                                        new RowField("f2", new IntType()))),
+                        StructuredType.newBuilder(ObjectIdentifier.of("cat", "db", "User"))
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute("diff", new TinyIntType())))
+                                .build(),
+                        false,
                         true
                     },
                 });

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypesTest.java
@@ -657,7 +657,11 @@ public class LogicalTypesTest {
 
         testInvalidStringSerializability(structuredType);
 
-        testStringSummary(structuredType, "*" + User.class.getName() + "*");
+        testStringSummary(
+                structuredType,
+                String.format(
+                        "*%s<`name` VARCHAR(1) '...', `setting` INT, `timestamp` TIMESTAMP(6)>*",
+                        User.class.getName()));
 
         testConversions(
                 structuredType,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/StructuredRelDataType.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/schema/StructuredRelDataType.java
@@ -48,6 +48,10 @@ import java.util.stream.Collectors;
 @Internal
 public final class StructuredRelDataType extends ObjectSqlType {
 
+    private static final String IDENTIFIER_FORMAT = "*%s*";
+
+    private static final String DIGEST_FORMAT = "*%s(%s)* %s";
+
     private final StructuredType structuredType;
 
     private StructuredRelDataType(StructuredType structuredType, List<RelDataTypeField> fields) {
@@ -107,17 +111,21 @@ public final class StructuredRelDataType extends ObjectSqlType {
             if (structuredType.getObjectIdentifier().isPresent()) {
                 sb.append(structuredType.asSerializableString());
             }
-            // in case of inline structured type we are using a temporary identifier
+            // in case of inline structured types we are using a temporary digest
             // that includes both the implementation class plus its children for cases with classes
             // that use generics
             else {
-                sb.append(structuredType.asSummaryString());
-                sb.append("(");
                 sb.append(
-                        fieldList.stream()
-                                .map(field -> field.getType().getFullTypeString())
-                                .collect(Collectors.joining(", ")));
-                sb.append(")");
+                        String.format(
+                                DIGEST_FORMAT,
+                                structuredType
+                                        .getImplementationClass()
+                                        .map(Class::getName)
+                                        .orElseThrow(IllegalStateException::new),
+                                fieldList.stream()
+                                        .map(field -> field.getType().getFullTypeString())
+                                        .collect(Collectors.joining(", ")),
+                                structuredType.isNullable() ? "" : " NOT NULL"));
             }
         } else {
             sb.append(structuredType.asSummaryString());
@@ -138,7 +146,13 @@ public final class StructuredRelDataType extends ObjectSqlType {
                 .orElseGet(
                         () ->
                                 new SqlIdentifier(
-                                        structuredType.asSummaryString(), SqlParserPos.ZERO));
+                                        String.format(
+                                                IDENTIFIER_FORMAT,
+                                                structuredType
+                                                        .getImplementationClass()
+                                                        .map(Class::getName)
+                                                        .orElseThrow(IllegalStateException::new)),
+                                        SqlParserPos.ZERO));
     }
 
     private static RelDataTypeComparability createRelDataTypeComparability(

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/ViewsExpandingTest.xml
@@ -58,7 +58,7 @@ LogicalProject(f0=[$0], f1=[$1])
 +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
    :- LogicalProject(f0=[AS($0, _UTF-16LE'f0')])
    :  +- LogicalValues(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
-   +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[*org.apache.flink.table.planner.utils.SimpleUser* NOT NULL])
+   +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[*org.apache.flink.table.planner.utils.SimpleUser<`name` STRING, `age` INT NOT NULL>* NOT NULL])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -157,7 +157,7 @@ LogicalProject(f0=[$0], f1=[$1])
 +- LogicalCorrelate(correlation=[$cor1], joinType=[inner], requiredColumns=[{0}])
    :- LogicalProject(f0=[AS($0, _UTF-16LE'f0')])
    :  +- LogicalValues(tuples=[[{ _UTF-16LE'danny#21' }, { _UTF-16LE'julian#55' }, { _UTF-16LE'fabian#30' }]])
-   +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[*org.apache.flink.table.planner.utils.SimpleUser* NOT NULL])
+   +- LogicalTableFunctionScan(invocation=[myFunc($cor1.f0)], rowType=[*org.apache.flink.table.planner.utils.SimpleUser<`name` STRING, `age` INT NOT NULL>* NOT NULL])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
@@ -43,7 +43,7 @@ FROM MyTable, LATERAL TABLE(func1(c)) AS T
 LogicalProject(a=[$0], b=[$1], c=[$2], f0=[$3], f1=[$4], f2=[$5], f3=[$6], f4=[$7], f5=[$8], f6=[$9], f7=[$10], f8=[$11], f9=[$12], f10=[$13], f11=[$14])
 +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-   +- LogicalTableFunctionScan(invocation=[func1($cor0.c)], rowType=[*org.apache.flink.api.java.tuple.Tuple12* NOT NULL])
+   +- LogicalTableFunctionScan(invocation=[func1($cor0.c)], rowType=[*org.apache.flink.api.java.tuple.Tuple12<`f0` STRING, `f1` STRING, `f2` STRING, `f3` STRING, `f4` STRING, `f5` STRING, `f6` INT, `f7` INT, `f8` INT, `f9` INT, `f10` INT, `f11` INT>* NOT NULL])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">


### PR DESCRIPTION
## What is the purpose of the change

This enables a flexible use of row and structured types. It reduces friction in the edge cases such as functions, `toDataStream` and `collect`.

## Brief change log

See commit messages.

## Verifying this change

This change added tests and can be verified as follows:
- `LogicalTypeCastsTest`
- `CastFunctionITCase`
- 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
