### PR TITLE
[FLINK-22120] Remove duplicate code in generated code for map get

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1836,7 +1836,14 @@ object ScalarOperatorGens {
 
     val mapTerm = map.resultTerm
 
-    val equal = generateEquals(ctx, key, GeneratedExpression(tmpKey, NEVER_NULL, NO_CODE, keyType))
+    val equal = generateEquals(
+      ctx,
+      // We have to create a new GeneratedExpression from `key`, but erase the code of it.
+      // Otherwise, the code of `key` will be called twice in `accessCode`, which may lead to
+      // exceptions such as 'Redefinition of local variable'.
+      GeneratedExpression(key.resultTerm, key.nullTerm, NO_CODE, key.resultType, key.literalValue),
+      GeneratedExpression(tmpKey, NEVER_NULL, NO_CODE, keyType)
+    )
     val code =
       s"""
          |if ($mapTerm instanceof $BINARY_MAP) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
@@ -45,6 +45,7 @@ class MapTypeTest extends MapTypeTestBase {
     testSqlApi("f2['b']", "13")
     testSqlApi("f3[1]", "null")
     testSqlApi("f3[12]", "a")
+    testSqlApi("f2[f3[12]]", "12")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixed a bug that there is duplicate code in generated code for map get, an it may lead to some exceptions such as  'Redefinition of local variable'.

## Brief change log
remove the duplicate code in generated code for map get.


## Verifying this change
This change added tests and can be verified as follows:
- org.apache.flink.table.planner.runtime.stream.sql.CalcITCase#testMapGet


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
