### PR TITLE
[FLINK-22097][sql-client] CliResultView should wait RefreshThread exi…

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
@@ -228,12 +228,10 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
     @Override
     protected void cleanUp() {
         stopRetrieval(true);
-        synchronized (refreshThread) {
-            try {
-                refreshThread.join();
-            } catch (InterruptedException ex) {
-                // ignore
-            }
+        try {
+            refreshThread.join();
+        } catch (InterruptedException ex) {
+            // ignore
         }
     }
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliResultView.java
@@ -228,6 +228,13 @@ public abstract class CliResultView<O extends Enum<O>> extends CliView<O, Void> 
     @Override
     protected void cleanUp() {
         stopRetrieval(true);
+        synchronized (refreshThread) {
+            try {
+                refreshThread.join();
+            } catch (InterruptedException ex) {
+                // ignore
+            }
+        }
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -94,7 +94,6 @@ public class CliResultViewTest {
                         false,
                         true);
 
-        Thread resultViewRunner = null;
         try (CliClient cli =
                 new CliClient(
                         TerminalUtils.createDummyTerminal(),
@@ -102,10 +101,11 @@ public class CliResultViewTest {
                         executor,
                         File.createTempFile("history", "tmp").toPath(),
                         null)) {
-            resultViewRunner = new Thread(new TestingCliResultView(cli, descriptor, isTableMode));
+            Thread resultViewRunner =
+                    new Thread(new TestingCliResultView(cli, descriptor, isTableMode));
             resultViewRunner.start();
 
-            if (resultViewRunner != null && !resultViewRunner.isInterrupted()) {
+            if (!resultViewRunner.isInterrupted()) {
                 resultViewRunner.interrupt();
             }
             // close the client until view exit


### PR DESCRIPTION
…ts before exits

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*The failed test is mainly to test the view thread has the ability to exit gracefully when users(main thread) interrupt the view thread.*

*We have 3 threads in the test: main thread, view thread and refresh thread.*

*The main thread has the resource Terminal and uses the the resource to create the view thread. When the view thread starts, it set the interrupt flag on the view thread and close the Terminal until view thread exits*

- *When view thread start, it start the refresh thread and monitors the user input. In the test, it only monitors interrput signal.*
- *When get the signal, it mark the flag isRunning of the refresh thread false and notify the refresh thread.*
- *The refresh thread is used to fetch the data from the remote periodically and display the results on Terminal. When exits, the refresh thread will invoke the `Executor.cancelQuery` and count down the cancellation.*

*The reason why we can NPE is because when view thread exits, it only notifies the refresh thread instead of waiting for the refresh thread exits. It's possible*

1. *the view thread notifies the refresh thread*
2. *the refresh thread wakes up and prepares to display the result on the terminal*
3. *the view thread exits*
4. *the main thread finds the view thread exit and closes the resource*
5. *the refresh thread gets NPE*
6. *the main thread find the cancellation is not as same as the expected*

*Therefore, we should request the view thread wait for the refresh thread exit.*

*To reproduce the bug, we can request the refresh thread sleep 1 seconds before display.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
