### PR TITLE
[hotfix] Remove unnecessary rollbackPreparedFromCheckpoint from JdbcXaSinkFunction.snapshot

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
@@ -46,7 +46,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.connector.jdbc.xa.JdbcXaSinkFunctionState.of;
 
@@ -236,7 +235,6 @@ public class JdbcXaSinkFunction<T> extends AbstractRichFunction
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         LOG.debug("snapshot state, checkpointId={}", context.getCheckpointId());
-        rollbackPreparedFromCheckpoint(context.getCheckpointId());
         prepareCurrentTx(context.getCheckpointId());
         beginTx(context.getCheckpointId() + 1);
         stateHandler.store(of(preparedXids, hangingXids));
@@ -318,26 +316,6 @@ public class JdbcXaSinkFunction<T> extends AbstractRichFunction
                                     options.getMaxCommitAttempts())
                             .getForRetry());
         }
-    }
-
-    private void rollbackPreparedFromCheckpoint(long fromCheckpointInclusive) {
-        Tuple2<List<CheckpointAndXid>, List<CheckpointAndXid>> splittedXids =
-                split(preparedXids, fromCheckpointInclusive, false);
-        if (splittedXids.f1.isEmpty()) {
-            return;
-        }
-        preparedXids = splittedXids.f0;
-        LOG.warn(
-                "state snapshots have already been taken for checkpoint >= {}, rolling back {} transactions",
-                fromCheckpointInclusive,
-                splittedXids.f1.size());
-        xaGroupOps
-                .failOrRollback(
-                        splittedXids.f1.stream()
-                                .map(CheckpointAndXid::getXid)
-                                .collect(Collectors.toList()))
-                .getForRetry()
-                .forEach(hangingXids::offerFirst);
     }
 
     private Tuple2<List<CheckpointAndXid>, List<CheckpointAndXid>> split(


### PR DESCRIPTION
At the point of snapshotting, there is not possible any prepared xas with trans id > the current checkpoint id

hence 
`rollbackPreparedFromCheckpoint` will always check and return;

remove this method in this hotfix.