### PR TITLE
[FLINK-22154][table-planner-blink] Fix bug where PushFilterIntoTableSourceScanRule fails to deal with IN expressions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
@@ -31,6 +31,8 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilder;
 
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
+
 import scala.Tuple2;
 
 /**
@@ -119,7 +121,9 @@ public class PushFilterInCalcIntoTableSourceScanRule extends PushFilterIntoSourc
             RexNode remainingCondition =
                     createRemainingCondition(
                             relBuilder, result.getRemainingFilters(), unconvertedPredicates);
-            programBuilder.addCondition(remainingCondition);
+            RexNode simplifiedRemainingCondition =
+                    FlinkRexUtil.simplify(relBuilder.getRexBuilder(), remainingCondition);
+            programBuilder.addCondition(simplifiedRemainingCondition);
         }
 
         RexProgram program = programBuilder.getProgram();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Calc;
@@ -30,8 +31,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.tools.RelBuilder;
-
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 
 import scala.Tuple2;
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
+
 import scala.Tuple2;
 
 /**
@@ -108,7 +110,13 @@ public class PushFilterIntoTableSourceScanRule extends PushFilterIntoSourceScanR
             RexNode remainingCondition =
                     createRemainingCondition(
                             relBuilder, result.getRemainingFilters(), unconvertedPredicates);
-            Filter newFilter = filter.copy(filter.getTraitSet(), newScan, remainingCondition);
+            RexNode simplifiedRemainingCondition = FlinkRexUtil.simplify(
+                    relBuilder.getRexBuilder(),
+                    remainingCondition);
+            Filter newFilter = filter.copy(
+                    filter.getTraitSet(),
+                    newScan,
+                    simplifiedRemainingCondition);
             call.transformTo(newFilter);
         }
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -21,14 +21,13 @@ package org.apache.flink.table.planner.plan.rules.logical;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
-
-import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 
 import scala.Tuple2;
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -109,13 +109,10 @@ public class PushFilterIntoTableSourceScanRule extends PushFilterIntoSourceScanR
             RexNode remainingCondition =
                     createRemainingCondition(
                             relBuilder, result.getRemainingFilters(), unconvertedPredicates);
-            RexNode simplifiedRemainingCondition = FlinkRexUtil.simplify(
-                    relBuilder.getRexBuilder(),
-                    remainingCondition);
-            Filter newFilter = filter.copy(
-                    filter.getTraitSet(),
-                    newScan,
-                    simplifiedRemainingCondition);
+            RexNode simplifiedRemainingCondition =
+                    FlinkRexUtil.simplify(relBuilder.getRexBuilder(), remainingCondition);
+            Filter newFilter =
+                    filter.copy(filter.getTraitSet(), newScan, simplifiedRemainingCondition);
             call.transformTo(newFilter);
         }
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
@@ -117,4 +117,12 @@ public abstract class PushFilterIntoTableSourceScanRuleTestBase extends TableTes
                         + "OR\n"
                         + "TIMESTAMPADD(YEAR, 2, b) >= a");
     }
+
+    @Test
+    public void testCannotPushDownIn() {
+        // this test is to avoid filter push down rules throwing exceptions
+        // when dealing with IN expressions, this is because Filter in calcite
+        // requires its condition to be "flat"
+        util.verifyRelPlan("SELECT * FROM MyTable WHERE name IN ('Alice', 'Bob', 'Dave')");
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -71,6 +71,24 @@ FlinkLogicalCalc(select=[name, id, amount, +(amount, 1) AS virtualField, price],
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCannotPushDownIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE name IN ('Alice', 'Bob', 'Dave')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(=($0, _UTF-16LE'Alice'), =($0, _UTF-16LE'Bob'), =($0, _UTF-16LE'Dave'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[name, id, amount, price], where=[SEARCH(name, Sarg[_UTF-16LE'Alice':VARCHAR(5) CHARACTER SET "UTF-16LE", _UTF-16LE'Bob':VARCHAR(5) CHARACTER SET "UTF-16LE", _UTF-16LE'Dave':VARCHAR(5) CHARACTER SET "UTF-16LE"]:VARCHAR(5) CHARACTER SET "UTF-16LE")])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[]]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCannotPushDownWithVirtualColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -75,6 +75,25 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCannotPushDownIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE name IN ('Alice', 'Bob', 'Dave')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(=($0, _UTF-16LE'Alice'), =($0, _UTF-16LE'Bob'), =($0, _UTF-16LE'Dave'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[SEARCH($0, Sarg[_UTF-16LE'Alice':VARCHAR(5) CHARACTER SET "UTF-16LE", _UTF-16LE'Bob':VARCHAR(5) CHARACTER SET "UTF-16LE", _UTF-16LE'Dave':VARCHAR(5) CHARACTER SET "UTF-16LE"]:VARCHAR(5) CHARACTER SET "UTF-16LE")])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[]]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCannotPushDownWithVirtualColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -75,6 +75,25 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], virtualField=[$3], price=[$4])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCannotPushDownIn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE name IN ('Alice', 'Bob', 'Dave')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[OR(=($0, _UTF-16LE'Alice'), =($0, _UTF-16LE'Bob'), =($0, _UTF-16LE'Dave'))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
++- LogicalFilter(condition=[SEARCH($0, Sarg[_UTF-16LE'Alice':VARCHAR(5) CHARACTER SET "UTF-16LE", _UTF-16LE'Bob':VARCHAR(5) CHARACTER SET "UTF-16LE", _UTF-16LE'Dave':VARCHAR(5) CHARACTER SET "UTF-16LE"]:VARCHAR(5) CHARACTER SET "UTF-16LE")])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCannotPushDownWithVirtualColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM VirtualTable WHERE price > 10]]>


### PR DESCRIPTION
## What is the purpose of the change

`PushFilterIntoTableSourceScanRule` will throw exception when dealing with `IN` expressions. This is because `Filter` in calcite requires its condition to be "flat" so we should first simplify the conditions before constructing a filter in the rule.

This PR fixes this issue.

## Brief change log

 - Fix bug where PushFilterIntoTableSourceScanRule fails to deal with IN expressions

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
