### PR TITLE
[BP-1.12][FLINK-21833][table-runtime-blink] Fix state of TemporalRowTimeJoinOperator increase unlimitedly even state ttl is enabled

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.join.temporal;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
@@ -209,6 +210,7 @@ public class TemporalRowTimeJoinOperator extends BaseTwoInputStreamOperatorWithS
                 registerProcessingCleanupTimer();
             } else {
                 cleanupLastTimer();
+                nextLeftIndex.clear();
             }
         }
     }
@@ -301,6 +303,8 @@ public class TemporalRowTimeJoinOperator extends BaseTwoInputStreamOperatorWithS
     public void cleanupState(long time) {
         leftState.clear();
         rightState.clear();
+        nextLeftIndex.clear();
+        registeredTimer.clear();
     }
 
     private int firstIndexToKeep(long timerTimestamp, List<RowData> rightRowsSorted) {
@@ -425,5 +429,15 @@ public class TemporalRowTimeJoinOperator extends BaseTwoInputStreamOperatorWithS
             long o2Time = o2.getLong(timeAttribute);
             return Long.compare(o1Time, o2Time);
         }
+    }
+
+    @VisibleForTesting
+    static String getNextLeftIndexStateName() {
+        return NEXT_LEFT_INDEX_STATE_NAME;
+    }
+
+    @VisibleForTesting
+    static String getRegisteredTimerStateName() {
+        return REGISTERED_TIMER_STATE_NAME;
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperatorTest.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.table.runtime.operators.join.temporal;
 
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -166,6 +169,23 @@ public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTes
         expectedOutput.add(new Watermark(15));
 
         assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        Assert.assertNull(
+                joinOperator
+                        .getKeyedStateStore()
+                        .getState(
+                                new ValueStateDescriptor<>(
+                                        TemporalRowTimeJoinOperator.getNextLeftIndexStateName(),
+                                        Types.LONG))
+                        .value());
+        Assert.assertNull(
+                joinOperator
+                        .getKeyedStateStore()
+                        .getState(
+                                new ValueStateDescriptor<>(
+                                        TemporalRowTimeJoinOperator.getRegisteredTimerStateName(),
+                                        Types.LONG))
+                        .value());
+
         testHarness.close();
     }
 


### PR DESCRIPTION
This is a cherry pick back to release-1.12 branch.