### PR TITLE
[FLINK-22147][connector/kafka] Refactor partition discovery logic in Kafka source enumerator

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriber.java
@@ -41,36 +41,12 @@ import java.util.regex.Pattern;
 public interface KafkaSubscriber extends Serializable {
 
     /**
-     * Get the partitions changes compared to the current partition assignment.
+     * Get a set of subscribed {@link TopicPartition}s.
      *
-     * <p>Although Kafka partitions can only expand and will not shrink, the partitions may still
-     * disappear when the topic is deleted.
-     *
-     * @param adminClient The admin client used to retrieve partition information.
-     * @param currentAssignment the partitions that are currently assigned to the source readers.
-     * @return The partition changes compared with the currently assigned partitions.
+     * @param adminClient The admin client used to retrieve subscribed topic partitions.
+     * @return A set of subscribed {@link TopicPartition}s
      */
-    PartitionChange getPartitionChanges(
-            AdminClient adminClient, Set<TopicPartition> currentAssignment);
-
-    /** A container class to hold the newly added partitions and removed partitions. */
-    class PartitionChange {
-        private final Set<TopicPartition> newPartitions;
-        private final Set<TopicPartition> removedPartitions;
-
-        PartitionChange(Set<TopicPartition> newPartitions, Set<TopicPartition> removedPartitions) {
-            this.newPartitions = newPartitions;
-            this.removedPartitions = removedPartitions;
-        }
-
-        public Set<TopicPartition> getNewPartitions() {
-            return newPartitions;
-        }
-
-        public Set<TopicPartition> getRemovedPartitions() {
-            return removedPartitions;
-        }
-    }
+    Set<TopicPartition> getSubscribedTopicPartitions(AdminClient adminClient);
 
     // ----------------- factory methods --------------
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
@@ -30,8 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.maybeLog;
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.updatePartitionChanges;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getTopicMetadata;
 
 /**
  * A subscriber to a fixed list of topics. The subscribed topics must hav existed in the Kafka
@@ -47,25 +46,18 @@ class TopicListSubscriber implements KafkaSubscriber {
     }
 
     @Override
-    public PartitionChange getPartitionChanges(
-            AdminClient adminClient, Set<TopicPartition> currentAssignment) {
-        Set<TopicPartition> newPartitions = new HashSet<>();
-        Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
+    public Set<TopicPartition> getSubscribedTopicPartitions(AdminClient adminClient) {
+        LOG.debug("Fetching descriptions for topics: {}", topics);
+        final Map<String, TopicDescription> topicMetadata =
+                getTopicMetadata(adminClient, new HashSet<>(topics));
 
-        Map<String, TopicDescription> topicMetadata;
-        try {
-            topicMetadata = adminClient.describeTopics(topics).all().get();
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to get topic metadata.", e);
+        Set<TopicPartition> subscribedPartitions = new HashSet<>();
+        for (TopicDescription topic : topicMetadata.values()) {
+            for (TopicPartitionInfo partition : topic.partitions()) {
+                subscribedPartitions.add(new TopicPartition(topic.name(), partition.partition()));
+            }
         }
-        topics.forEach(
-                topic -> {
-                    List<TopicPartitionInfo> partitions = topicMetadata.get(topic).partitions();
-                    if (partitions != null) {
-                        updatePartitionChanges(topic, newPartitions, removedPartitions, partitions);
-                    }
-                });
-        maybeLog(newPartitions, removedPartitions, LOG);
-        return new PartitionChange(newPartitions, removedPartitions);
+
+        return subscribedPartitions;
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.kafka.source.enumerator.subscriber;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,9 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getTopicMetadata;
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.maybeLog;
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.updatePartitionChanges;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getAllTopicMetadata;
 
 /** A subscriber to a topic pattern. */
 class TopicPatternSubscriber implements KafkaSubscriber {
@@ -44,23 +43,23 @@ class TopicPatternSubscriber implements KafkaSubscriber {
     }
 
     @Override
-    public PartitionChange getPartitionChanges(
-            AdminClient adminClient, Set<TopicPartition> currentAssignment) {
-        Set<TopicPartition> newPartitions = new HashSet<>();
-        Set<TopicPartition> removedPartitions = new HashSet<>(currentAssignment);
+    public Set<TopicPartition> getSubscribedTopicPartitions(AdminClient adminClient) {
+        LOG.debug("Fetching descriptions for all topics on Kafka cluster");
+        final Map<String, TopicDescription> allTopicMetadata = getAllTopicMetadata(adminClient);
 
-        Map<String, TopicDescription> topicMetadata = getTopicMetadata(adminClient);
-        for (Map.Entry<String, TopicDescription> topicEntry : topicMetadata.entrySet()) {
-            String topic = topicEntry.getKey();
-            if (topicPattern.matcher(topic).matches()) {
-                updatePartitionChanges(
-                        topic,
-                        newPartitions,
-                        removedPartitions,
-                        topicEntry.getValue().partitions());
-            }
-        }
-        maybeLog(newPartitions, removedPartitions, LOG);
-        return new PartitionChange(newPartitions, removedPartitions);
+        Set<TopicPartition> subscribedTopicPartitions = new HashSet<>();
+
+        allTopicMetadata.forEach(
+                (topicName, topicDescription) -> {
+                    if (topicPattern.matcher(topicName).matches()) {
+                        for (TopicPartitionInfo partition : topicDescription.partitions()) {
+                            subscribedTopicPartitions.add(
+                                    new TopicPartition(
+                                            topicDescription.name(), partition.partition()));
+                        }
+                    }
+                });
+
+        return subscribedTopicPartitions;
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -87,11 +87,11 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testStartWithDiscoverPartitionsOnce() {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+    public void testStartWithDiscoverPartitionsOnce() throws Exception {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             // Start the enumerator and it should schedule a one time task to discover and assign
             // partitions.
@@ -105,11 +105,11 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testStartWithPeriodicPartitionDiscovery() {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+    public void testStartWithPeriodicPartitionDiscovery() throws Exception {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             // Start the enumerator and it should schedule a one time task to discover and assign
             // partitions.
@@ -124,10 +124,10 @@ public class KafkaEnumeratorTest {
 
     @Test
     public void testDiscoverPartitionsTriggersAssignments() throws Throwable {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             // Start the enumerator and it should schedule a one time task to discover and assign
             // partitions.
@@ -149,10 +149,10 @@ public class KafkaEnumeratorTest {
 
     @Test
     public void testReaderRegistrationTriggersAssignments() throws Throwable {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             // Start the enumerator and it should schedule a one time task to discover and assign
             // partitions.
@@ -172,9 +172,9 @@ public class KafkaEnumeratorTest {
 
     @Test(timeout = 30000L)
     public void testDiscoverPartitionsPeriodically() throws Throwable {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
                         createEnumerator(
                                 context,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY,
@@ -226,10 +226,10 @@ public class KafkaEnumeratorTest {
 
     @Test
     public void testAddSplitsBack() throws Throwable {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             startEnumeratorAndRegisterReaders(context, enumerator);
 
@@ -252,25 +252,25 @@ public class KafkaEnumeratorTest {
 
     @Test
     public void testWorkWithPreexistingAssignments() throws Throwable {
-        final MockSplitEnumeratorContext<KafkaPartitionSplit> context1 =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
         Set<TopicPartition> preexistingAssignments;
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context1, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context1 =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context1, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
             startEnumeratorAndRegisterReaders(context1, enumerator);
             preexistingAssignments =
                     asEnumState(context1.getSplitsAssignmentSequence().get(0).assignment());
         }
 
-        final MockSplitEnumeratorContext<KafkaPartitionSplit> context2 =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(
-                        context2,
-                        ENABLE_PERIODIC_PARTITION_DISCOVERY,
-                        PRE_EXISTING_TOPICS,
-                        preexistingAssignments,
-                        new Properties())) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context2 =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context2,
+                                ENABLE_PERIODIC_PARTITION_DISCOVERY,
+                                PRE_EXISTING_TOPICS,
+                                preexistingAssignments,
+                                new Properties())) {
             enumerator.start();
             runPeriodicPartitionDiscovery(context2);
 
@@ -284,22 +284,22 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testKafkaClientProperties() {
-        MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+    public void testKafkaClientProperties() throws Exception {
         Properties properties = new Properties();
         String clientIdPrefix = "test-prefix";
         Integer defaultTimeoutMs = 99999;
         properties.setProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key(), clientIdPrefix);
         properties.setProperty(
                 ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(defaultTimeoutMs));
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(
-                        context,
-                        ENABLE_PERIODIC_PARTITION_DISCOVERY,
-                        PRE_EXISTING_TOPICS,
-                        Collections.emptySet(),
-                        properties)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context,
+                                ENABLE_PERIODIC_PARTITION_DISCOVERY,
+                                PRE_EXISTING_TOPICS,
+                                Collections.emptySet(),
+                                properties)) {
             enumerator.start();
 
             AdminClient adminClient =
@@ -325,10 +325,9 @@ public class KafkaEnumeratorTest {
 
     @Test
     public void testSnapshotState() throws Throwable {
-        final MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-
-        try (KafkaSourceEnumerator enumerator = createEnumerator(context, false)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator = createEnumerator(context, false)) {
             enumerator.start();
 
             // No reader is registered, so the state should be empty
@@ -350,11 +349,10 @@ public class KafkaEnumeratorTest {
 
     @Test
     public void testPartitionChangeChecking() throws Throwable {
-        final MockSplitEnumeratorContext<KafkaPartitionSplit> context =
-                new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
-
-        try (KafkaSourceEnumerator enumerator =
-                createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
             enumerator.start();
             runOneTimePartitionDiscovery(context);
             registerReader(context, enumerator, READER0);

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
@@ -19,9 +19,11 @@
 package org.apache.flink.connector.kafka.source.enumerator.subscriber;
 
 import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -34,16 +36,14 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link KafkaSubscriber}. */
 public class KafkaSubscriberTest {
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "pattern-topic";
-    private static final TopicPartition assignedPartition1 = new TopicPartition(TOPIC1, 2);
-    private static final TopicPartition assignedPartition2 = new TopicPartition(TOPIC2, 2);
-    private static final TopicPartition removedPartition = new TopicPartition("removed", 0);
-    private static final Set<TopicPartition> currentAssignment =
-            new HashSet<>(Arrays.asList(assignedPartition1, assignedPartition2, removedPartition));
+    private static final TopicPartition NON_EXISTING_TOPIC = new TopicPartition("removed", 0);
     private static AdminClient adminClient;
 
     @BeforeClass
@@ -65,34 +65,44 @@ public class KafkaSubscriberTest {
         List<String> topics = Arrays.asList(TOPIC1, TOPIC2);
         KafkaSubscriber subscriber =
                 KafkaSubscriber.getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2));
-        KafkaSubscriber.PartitionChange change =
-                subscriber.getPartitionChanges(adminClient, currentAssignment);
-        Set<TopicPartition> expectedNewPartitions =
+        final Set<TopicPartition> subscribedPartitions =
+                subscriber.getSubscribedTopicPartitions(adminClient);
+
+        final Set<TopicPartition> expectedSubscribedPartitions =
                 new HashSet<>(KafkaSourceTestEnv.getPartitionsForTopics(topics));
-        expectedNewPartitions.remove(assignedPartition1);
-        expectedNewPartitions.remove(assignedPartition2);
-        assertEquals(expectedNewPartitions, change.getNewPartitions());
-        assertEquals(Collections.singleton(removedPartition), change.getRemovedPartitions());
+
+        assertEquals(expectedSubscribedPartitions, subscribedPartitions);
+    }
+
+    @Test
+    public void testNonExistingTopic() {
+        final KafkaSubscriber subscriber =
+                KafkaSubscriber.getTopicListSubscriber(
+                        Collections.singletonList(NON_EXISTING_TOPIC.topic()));
+
+        Throwable t =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> subscriber.getSubscribedTopicPartitions(adminClient));
+
+        assertTrue(
+                "Exception should be caused by UnknownTopicOrPartitionException",
+                ExceptionUtils.findThrowable(t, UnknownTopicOrPartitionException.class)
+                        .isPresent());
     }
 
     @Test
     public void testTopicPatternSubscriber() {
         KafkaSubscriber subscriber =
                 KafkaSubscriber.getTopicPatternSubscriber(Pattern.compile("pattern.*"));
-        KafkaSubscriber.PartitionChange change =
-                subscriber.getPartitionChanges(adminClient, currentAssignment);
+        final Set<TopicPartition> subscribedPartitions =
+                subscriber.getSubscribedTopicPartitions(adminClient);
 
-        Set<TopicPartition> expectedNewPartitions = new HashSet<>();
-        for (int i = 0; i < KafkaSourceTestEnv.NUM_PARTITIONS; i++) {
-            if (i != assignedPartition2.partition()) {
-                expectedNewPartitions.add(new TopicPartition(TOPIC2, i));
-            }
-        }
-        Set<TopicPartition> expectedRemovedPartitions =
-                new HashSet<>(Arrays.asList(assignedPartition1, removedPartition));
+        final Set<TopicPartition> expectedSubscribedPartitions =
+                new HashSet<>(
+                        KafkaSourceTestEnv.getPartitionsForTopics(Collections.singleton(TOPIC2)));
 
-        assertEquals(expectedNewPartitions, change.getNewPartitions());
-        assertEquals(expectedRemovedPartitions, change.getRemovedPartitions());
+        assertEquals(expectedSubscribedPartitions, subscribedPartitions);
     }
 
     @Test
@@ -103,13 +113,28 @@ public class KafkaSubscriberTest {
         partitions.remove(new TopicPartition(TOPIC1, 1));
 
         KafkaSubscriber subscriber = KafkaSubscriber.getPartitionSetSubscriber(partitions);
-        KafkaSubscriber.PartitionChange change =
-                subscriber.getPartitionChanges(adminClient, currentAssignment);
 
-        Set<TopicPartition> expectedNewPartitions = new HashSet<>(partitions);
-        expectedNewPartitions.remove(assignedPartition1);
-        expectedNewPartitions.remove(assignedPartition2);
-        assertEquals(expectedNewPartitions, change.getNewPartitions());
-        assertEquals(Collections.singleton(removedPartition), change.getRemovedPartitions());
+        final Set<TopicPartition> subscribedPartitions =
+                subscriber.getSubscribedTopicPartitions(adminClient);
+
+        assertEquals(partitions, subscribedPartitions);
+    }
+
+    @Test
+    public void testNonExistingPartition() {
+        TopicPartition nonExistingPartition = new TopicPartition(TOPIC1, Integer.MAX_VALUE);
+        final KafkaSubscriber subscriber =
+                KafkaSubscriber.getPartitionSetSubscriber(
+                        Collections.singleton(nonExistingPartition));
+
+        Throwable t =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> subscriber.getSubscribedTopicPartitions(adminClient));
+
+        assertEquals(
+                String.format(
+                        "Partition '%s' does not exist on Kafka brokers", nonExistingPartition),
+                t.getMessage());
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
@@ -27,6 +27,8 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.util.ThrowableCatchingRunnable;
 
+import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +49,7 @@ import java.util.function.BiConsumer;
 
 /** A mock class for {@link SplitEnumeratorContext}. */
 public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
-        implements SplitEnumeratorContext<SplitT> {
+        implements SplitEnumeratorContext<SplitT>, AutoCloseable {
     private final Map<Integer, List<SourceEvent>> sentSourceEvent;
     private final ConcurrentMap<Integer, ReaderInfo> registeredReaders;
     private final List<SplitsAssignment<SplitT>> splitsAssignmentSequence;
@@ -185,8 +187,10 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
         mainExecutor.execute(runnable);
     }
 
-    public void close() {
+    public void close() throws Exception {
         stoppedAcceptAsyncCalls.set(true);
+        workerExecutor.shutdownNow();
+        mainExecutor.shutdownNow();
     }
 
     // ------------ helper method to manipulate the context -------------
@@ -271,7 +275,7 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
         }
 
         @Override
-        public Thread newThread(Runnable r) {
+        public Thread newThread(@Nonnull Runnable r) {
             if (t != null) {
                 throw new IllegalStateException(
                         "Should never happen. This factory should only be used by a "


### PR DESCRIPTION
## What is the purpose of the change

- This pull request refactors the logic of partition discovery in ```KafkaSourceEnumerator```, and changes the interface ```KafkaSubscriber``` to separate topic description fetching and discover partition changes into two methods. 


## Brief change log

- Rework the logic of partition discovery. Currently the flow of partition discovery is:
1. The worker thread fetches descriptions of subscribed topics/partitions, then hands over to coordinator thread
2. The coordinator thread filters out already discovered partitions (pending + assigned partitions), then invokes worker thread with callAsync to fetch offsets for new partitions 
3. The worker thread fetches offsets and creates splits for new partitions, then hands over new splits to coordinator thread
4. The coordinator thread marks these splits as pending and try to make assignment. 

- Add new method ```getSubscribedTopicDescriptions(AdminClient)``` in ```KafkaSubscriber``` for fetching subscribed topic descriptions
- Change method ```getPartitionChanges(AdminClient, Set)``` to ```getPartitionChanges(Map, Set)``` in ```KafkaSubscriber``` for coordinator thread to discover partition changes

## Verifying this change

This change is already covered by existing tests of the Kafka Source. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
