### PR TITLE
[FLINK-22172][python] Fix the bug of shared resource among Python Operators of the same slot is not released

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -294,10 +294,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
 
         try {
             if (sharedResources != null) {
-                if (sharedResources.getResourceHandle().release()) {
-                    // release sharedResources iff there are no more Python operators sharing it
-                    sharedResources.close();
-                }
+                sharedResources.close();
             } else {
                 // if sharedResources is not null, the close of environmentManager will be managed
                 // in sharedResources,

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/PythonSharedResources.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/PythonSharedResources.java
@@ -44,14 +44,10 @@ public final class PythonSharedResources implements AutoCloseable {
     /** Keep track of the PythonEnvironmentManagers of the Python operators in one slot. */
     private final List<PythonEnvironmentManager> environmentManagers;
 
-    /** Keep track of the number of Python operators sharing this Python resource. */
-    private int refCnt;
-
     PythonSharedResources(JobBundleFactory jobBundleFactory, Environment environment) {
         this.jobBundleFactory = jobBundleFactory;
         this.environment = environment;
         this.environmentManagers = new ArrayList<>();
-        this.refCnt = 0;
     }
 
     JobBundleFactory getJobBundleFactory() {
@@ -64,16 +60,6 @@ public final class PythonSharedResources implements AutoCloseable {
 
     void addPythonEnvironmentManager(PythonEnvironmentManager environmentManager) {
         environmentManagers.add(environmentManager);
-        refCnt++;
-    }
-
-    /**
-     * Release a Python operator which shares this Python resource. Returns true if there are no
-     * more Python operators sharing this Python resource.
-     */
-    boolean release() {
-        refCnt--;
-        return refCnt == 0;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of shared resource among Python Operators of the same slot is not released*

## Brief change log

  - *Remove the logic of reference count in `PythonSharedResources` since this part has been implemented in `SharedResources`*

## Verifying this change

- *Original Tests and watch the number of python processes in background*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
