### PR TITLE
[FLINK-22157][table-planner-blink] Fix join & select a portion of composite primary key will cause ArrayIndexOutOfBoundsException

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
@@ -399,6 +399,30 @@ Calc(select=[a1, a2, b1, b2], changelogMode=[I,UB,UA])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinAndSelectOnPartialCompositePrimaryKey">
+    <Resource name="sql">
+      <![CDATA[SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalJoin(condition=[=($0, $3)], joinType=[left])
+   :- LogicalTableScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a1, a2, a3)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a1])
++- Join(joinType=[LeftOuterJoin], where=[(a1 = pk1)], select=[a1, pk1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3])
+   +- Exchange(distribution=[hash[pk1]])
+      +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[pk1]]], fields=[pk1])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinWithSort">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -57,6 +57,20 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUniqueKeysOnProjectedTableScanWithPartialCompositePrimaryKey(): Unit = {
+    val table = relBuilder
+      .getRelOptSchema
+      .asInstanceOf[CalciteCatalogReader]
+      .getTable(Seq("projected_table_source_table_with_partial_pk"))
+      .asInstanceOf[TableSourceTable]
+    val tableSourceScan = new StreamPhysicalTableSourceScan(
+      cluster,
+      streamPhysicalTraits,
+      table)
+    assertNull(mq.getUniqueKeys(tableSourceScan))
+  }
+
+  @Test
   def testGetUniqueKeysOnValues(): Unit = {
     assertNull(mq.getUniqueKeys(logicalValues))
     assertNull(mq.getUniqueKeys(emptyValues))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.scala
@@ -284,4 +284,19 @@ class JoinTest extends TableTestBase {
   def testRightOuterJoinEquiAndNonEquiPred(): Unit = {
     util.verifyExecPlan("SELECT b, y FROM t RIGHT OUTER JOIN s ON a = z AND b < x")
   }
+
+  @Test
+  def testJoinAndSelectOnPartialCompositePrimaryKey(): Unit = {
+    util.tableEnv.executeSql(
+      """
+        |CREATE TABLE tableWithCompositePk (
+        |  pk1 INT,
+        |  pk2 BIGINT,
+        |  PRIMARY KEY (pk1, pk2) NOT ENFORCED
+        |) WITH (
+        |  'connector'='values'
+        |)
+        |""".stripMargin)
+    util.verifyExecPlan("SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

`FlinkRelMdUniqueKeys#getTableUniqueKeys` currently does not consider the case when projections are pushed down and cause only a part of the composite primary key to be selected.

This PR fixes this issue.

## Brief change log

 - Fix join & select a portion of composite primary key will cause ArrayIndexOutOfBoundsException

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
