### PR TITLE
[FLINK-20230][table] FileSystemOutputFormat should delete file using FileSystemFactory

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOutputFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOutputFormat.java
@@ -27,7 +27,6 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
 import org.apache.flink.table.api.TableException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
@@ -93,7 +92,10 @@ public class FileSystemOutputFormat<T> implements OutputFormat<T>, FinalizeOnMas
         } catch (Exception e) {
             throw new TableException("Exception in finalizeGlobal", e);
         } finally {
-            new File(tmpPath.getPath()).delete();
+            try {
+                fsFactory.create(tmpPath.toUri()).delete(tmpPath, true);
+            } catch (IOException ignore) {
+            }
         }
     }
 


### PR DESCRIPTION

## What is the purpose of the change

Fix INSERT INTO EMPTY VALUES, THROW FileNotFoundException

## Brief change log

FileSystemOutputFormat use local File.delete is wrong. It should use FileSystemFactory to delete file.

## Verifying this change

Manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no