### PR TITLE
[FLINK-17803][table] Should throw a readable exception when group by Map type

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -259,7 +259,7 @@ object CodeGenUtils {
     case TIMESTAMP_WITH_TIME_ZONE | ARRAY | MULTISET | MAP =>
       throw new UnsupportedOperationException(
         s"Unsupported type($t) to generate hash code," +
-            s" the type($t) is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL field.")
+            s" the type($t) is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL/UNION field.")
     case INTERVAL_DAY_TIME => s"${className[JLong]}.hashCode($term)"
     case ROW | STRUCTURED_TYPE =>
       val fieldCount = getFieldCount(t)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -257,7 +257,9 @@ object CodeGenUtils {
     case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
       s"$term.hashCode()"
     case TIMESTAMP_WITH_TIME_ZONE | ARRAY | MULTISET | MAP =>
-      throw new UnsupportedOperationException("Unsupported type: " + t)
+      throw new UnsupportedOperationException(
+        s"Unsupported type($t) to generate hash code," +
+            s" the type($t) is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL field.")
     case INTERVAL_DAY_TIME => s"${className[JLong]}.hashCode($term)"
     case ROW | STRUCTURED_TYPE =>
       val fieldCount = getFieldCount(t)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalAggregate.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.logical
 
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.plan.PartialFinalType
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.utils.AggregateUtil
@@ -30,7 +31,8 @@ import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.logical.LogicalAggregate
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.sql.SqlKind
-import org.apache.calcite.util.ImmutableBitSet
+import org.apache.calcite.sql.`type`.SqlTypeName
+import org.apache.calcite.util.{ImmutableBitSet, Litmus}
 
 import java.util
 import java.util.Collections
@@ -159,6 +161,12 @@ object FlinkLogicalAggregate {
       aggCalls: util.List[AggregateCall]): FlinkLogicalAggregate = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSetOf(FlinkConventions.LOGICAL).simplify()
+    groupSets.flatMap(_.asList())
+        .map(input.getRowType.getFieldList.get(_))
+        .map(_.getType.getSqlTypeName).foreach {
+      case SqlTypeName.MAP | SqlTypeName.MULTISET | SqlTypeName.ARRAY =>
+        Litmus.THROW.fail("Collection type is not supported as a GROUP BY field.")
+    }
     new FlinkLogicalAggregate(cluster, traitSet, input, groupSet, groupSets, aggCalls)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalAggregate.scala
@@ -30,8 +30,7 @@ import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.logical.LogicalAggregate
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.sql.SqlKind
-import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.calcite.util.{ImmutableBitSet, Litmus}
+import org.apache.calcite.util.ImmutableBitSet
 
 import java.util
 import java.util.Collections
@@ -160,12 +159,6 @@ object FlinkLogicalAggregate {
       aggCalls: util.List[AggregateCall]): FlinkLogicalAggregate = {
     val cluster = input.getCluster
     val traitSet = cluster.traitSetOf(FlinkConventions.LOGICAL).simplify()
-    groupSets.flatMap(_.asList())
-        .map(input.getRowType.getFieldList.get(_))
-        .map(_.getType.getSqlTypeName).foreach {
-      case SqlTypeName.MAP | SqlTypeName.MULTISET | SqlTypeName.ARRAY =>
-        Litmus.THROW.fail("Collection type is not supported as a GROUP BY field.")
-    }
     new FlinkLogicalAggregate(cluster, traitSet, input, groupSet, groupSets, aggCalls)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalAggregate.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.plan.nodes.logical
 
-import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.plan.PartialFinalType
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.utils.AggregateUtil

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -801,7 +801,7 @@ class CalcITCase extends BatchTestBase {
 
   @Test
   def testMapTypeGroupBy(): Unit = {
-    _expectedEx.expectMessage("is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL field")
+    _expectedEx.expectMessage("is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL/UNION field")
     checkResult(
       "SELECT COUNT(*) FROM SmallTable3 GROUP BY MAP[1, 'Hello', 2, 'Hi']",
       Seq()

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -45,6 +45,7 @@ import org.apache.flink.types.Row
 
 import org.junit.Assert.assertEquals
 import org.junit._
+import org.junit.rules.ExpectedException
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
@@ -54,6 +55,11 @@ import java.util
 import scala.collection.Seq
 
 class CalcITCase extends BatchTestBase {
+
+  var _expectedEx: ExpectedException = ExpectedException.none
+
+  @Rule
+  def expectedEx: ExpectedException = _expectedEx
 
   @Before
   override def before(): Unit = {
@@ -790,6 +796,15 @@ class CalcITCase extends BatchTestBase {
         row("{2=Hello}"),
         row("{3=Hello world}")
       )
+    )
+  }
+
+  @Test
+  def testMapTypeGroupBy(): Unit = {
+    _expectedEx.expectMessage("Collection type is not supported as a GROUP BY field")
+    checkResult(
+      "SELECT COUNT(*) FROM SmallTable3 GROUP BY MAP[1, 'Hello', 2, 'Hi']",
+      Seq()
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -801,7 +801,7 @@ class CalcITCase extends BatchTestBase {
 
   @Test
   def testMapTypeGroupBy(): Unit = {
-    _expectedEx.expectMessage("Collection type is not supported as a GROUP BY field")
+    _expectedEx.expectMessage("is not supported as a GROUP_BY/PARTITION_BY/JOIN_EQUAL field")
     checkResult(
       "SELECT COUNT(*) FROM SmallTable3 GROUP BY MAP[1, 'Hello', 2, 'Hi']",
       Seq()


### PR DESCRIPTION

## What is the purpose of the change

Should throw a readable exception when group by Map type.

## Brief change log

Throws "Collection type is not supported as a GROUP BY field." in `FlinkLogicalAggregate`.


## Verifying this change

`CalcITCase.testMapTypeGroupBy`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no