### PR TITLE
[FLINK-22167][table-planner] Partial insert not works when complex fields reorder

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -267,15 +267,22 @@ object PreValidateReWriter {
     SqlStdOperatorTable.VALUES.createCall(values.getParserPosition, fixedNodes)
   }
 
+  /**
+   * Reorder sourceList to targetPosition. For example:
+   * - sourceList(f0, f1, f2).
+   * - targetPosition(1, 2, 0).
+   * - Output(f1, f2, f0).
+   *
+   * @param sourceList input fields.
+   * @param targetPosition reorder mapping.
+   * @return reorder fields.
+   */
   private def reorder(
       sourceList: util.ArrayList[SqlNode],
       targetPosition: util.List[Int]): util.ArrayList[SqlNode] = {
-    val targetList = new Array[SqlNode](sourceList.size())
-    0 until sourceList.size() foreach {
-      idx => targetList(idx) = sourceList.get(targetPosition.get(idx))
-    }
-    new util.ArrayList[SqlNode](targetList.toList)
+    new util.ArrayList[SqlNode](targetPosition.map(sourceList.get))
   }
+
   /**
     * Derives a physical row-type for INSERT and UPDATE operations.
     *

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -272,7 +272,7 @@ object PreValidateReWriter {
       targetPosition: util.List[Int]): util.ArrayList[SqlNode] = {
     val targetList = new Array[SqlNode](sourceList.size())
     0 until sourceList.size() foreach {
-      idx => targetList(targetPosition.get(idx)) = sourceList.get(idx)
+      idx => targetList(idx) = sourceList.get(targetPosition.get(idx))
     }
     new util.ArrayList[SqlNode](targetList.toList)
   }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/common/PartialInsertTest.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testPartialInsertWithComplexReorder[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink (b,e,a,g,f,c,d) SELECT b,e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
+   +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
++- Calc(select=[a, b, c, d, e, 123:BIGINT AS f, 456 AS g])
+   +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      +- Exchange(distribution=[hash[a, b, c, d, e]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertWithComplexReorderAndComputedColumn[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
++- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
+   +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
++- Sort(orderBy=[c ASC, d ASC])
+   +- Calc(select=[a, c, d, e, 123:BIGINT AS f, 456 AS g])
+      +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+         +- Exchange(distribution=[hash[a, b, c, d, e]])
+            +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertWithComplexReorder[isBatch: true]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sink (b,e,a,g,f,c,d) SELECT b,e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
++- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
+   +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c, d, e, f, g])
++- Calc(select=[a, b, c, d, e, 123:BIGINT AS f, 456 AS g])
+   +- HashAggregate(isMerge=[true], groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      +- Exchange(distribution=[hash[a, b, c, d, e]])
+         +- LocalHashAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartialInsertWithComplexReorderAndComputedColumn[isBatch: false]">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO partitioned_sink (e,a,g,f,c,d) SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
++- LogicalProject(a=[$0], c=[$2], d=[$3], e=[$4], f=[123:BIGINT], g=[456])
+   +- LogicalAggregate(group=[{0, 1, 2, 3, 4}])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.partitioned_sink], fields=[a, c, d, e, f, g])
++- Calc(select=[a, c, d, e, 123:BIGINT AS f, 456 AS g])
+   +- GroupAggregate(groupBy=[a, b, c, d, e], select=[a, b, c, d, e])
+      +- Exchange(distribution=[hash[a, b, c, d, e]])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d, e)]]], fields=[a, b, c, d, e])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/PartialInsertTest.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.common
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api._
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(classOf[Parameterized])
+class PartialInsertTest(isBatch: Boolean) extends TableTestBase {
+
+  private val util = if (isBatch) batchTestUtil() else streamTestUtil()
+  util.addTableSource[(Int, String, String, String, Double)]("MyTable", 'a, 'b, 'c, 'd, 'e)
+  util.tableEnv.executeSql(
+    s"""
+       |create table sink (
+       |  `a` INT,
+       |  `b` STRING,
+       |  `c` STRING,
+       |  `d` STRING,
+       |  `e` DOUBLE,
+       |  `f` BIGINT,
+       |  `g` INT
+       |) with (
+       |  'connector' = 'values',
+       |  'sink-insert-only' = 'false'
+       |)
+       |""".stripMargin)
+  util.tableEnv.executeSql(
+    s"""
+       |create table partitioned_sink (
+       |  `a` INT,
+       |  `b` AS `a` + 1,
+       |  `c` STRING,
+       |  `d` STRING,
+       |  `e` DOUBLE,
+       |  `f` BIGINT,
+       |  `g` INT
+       |) PARTITIONED BY (`c`, `d`) with (
+       |  'connector' = 'values',
+       |  'sink-insert-only' = 'false'
+       |)
+       |""".stripMargin)
+
+  @Test
+  def testPartialInsertWithComplexReorder(): Unit = {
+    util.verifyRelPlanInsert("INSERT INTO sink (b,e,a,g,f,c,d) " +
+        "SELECT b,e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e")
+  }
+
+  @Test
+  def testPartialInsertWithComplexReorderAndComputedColumn(): Unit = {
+    util.verifyRelPlanInsert("INSERT INTO partitioned_sink (e,a,g,f,c,d) " +
+        "SELECT e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e")
+  }
+}
+
+object PartialInsertTest {
+  @Parameterized.Parameters(name = "isBatch: {0}")
+  def parameters(): java.util.Collection[Boolean] = {
+    java.util.Arrays.asList(true, false)
+  }
+}


### PR DESCRIPTION

## What is the purpose of the change

```
util.tableEnv.executeSql(
  s"""
     |create table partitioned_sink (
     |  `a` INT,
     |  `b` AS `a` + 1,
     |  `c` STRING,
     |  `d` STRING,
     |  `e` DOUBLE,
     |  `f` BIGINT,
     |  `g` INT
     |) PARTITIONED BY (`c`, `d`) with (
     |  'connector' = 'values',
     |  'sink-insert-only' = 'false'
     |)
     |""".stripMargin)

INSERT INTO sink (b,e,a,g,f,c,d) SELECT b,e,a,456,123,c,d FROM MyTable GROUP BY a,b,c,d,e
```
Not work.

## Brief change log

Fix bug in `PreValidateReWriter`

## Verifying this change

`PartialInsertTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no