### PR TITLE
[FLINK-22015][table-planner-blink] Exclude IS NULL from SEARCH operators

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -71,9 +71,10 @@ import static org.apache.calcite.rex.RexUnknownAs.UNKNOWN;
  * <p>Copied to fix Calcite 1.26 bugs, should be removed for the next Calcite upgrade.
  *
  * <p>Changes (line numbers are from the original RexSimplify file):
+ *
  * <ol>
- *     <li>CALCITE-4364 & FLINK-19811: Line 1307, Line 1764, Line 2638 ~ Line 2656.
- *     <li>CALCITE-4446 & FLINK-22015: Line 2542 ~ Line 2548, Line 2614 ~ Line 2619.
+ *   <li>CALCITE-4364 & FLINK-19811: Line 1307, Line 1764, Line 2638 ~ Line 2656.
+ *   <li>CALCITE-4446 & FLINK-22015: Line 2542 ~ Line 2548, Line 2614 ~ Line 2619.
  * </ol>
  */
 public class RexSimplify {
@@ -2673,9 +2674,9 @@ public class RexSimplify {
                             ((RexCall) e).operands.get(1),
                             e.getKind(),
                             newTerms);
-                // CHANGED: we remove IS_NULL here
-                // because SEARCH operator in Calcite 1.26 handles UNKNOWNs incorrectly
-                // see CALCITE-4446
+                    // CHANGED: we remove IS_NULL here
+                    // because SEARCH operator in Calcite 1.26 handles UNKNOWNs incorrectly
+                    // see CALCITE-4446
                 default:
                     return false;
             }
@@ -2741,9 +2742,9 @@ public class RexSimplify {
                     final Sarg sarg = literal.getValueAs(Sarg.class);
                     b.addSarg(sarg, negate, literal.getType());
                     return true;
-                // CHANGED: we remove IS_NULL here
-                // because SEARCH operator in Calcite 1.26 handles UNKNOWNs incorrectly
-                // see CALCITE-4446
+                    // CHANGED: we remove IS_NULL here
+                    // because SEARCH operator in Calcite 1.26 handles UNKNOWNs incorrectly
+                    // see CALCITE-4446
                 default:
                     throw new AssertionError("unexpected " + kind);
             }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -68,9 +68,13 @@ import static org.apache.calcite.rex.RexUnknownAs.UNKNOWN;
 /**
  * Context required to simplify a row-expression.
  *
- * <p>Copied to fix CALCITE-4364, should be removed for the next Calcite upgrade.
+ * <p>Copied to fix Calcite 1.26 bugs, should be removed for the next Calcite upgrade.
  *
- * <p>Changes: Line 1307, Line 1764, Line 2638 ~ Line 2656.
+ * <p>Changes (line numbers are from the original RexSimplify file):
+ * <ol>
+ *     <li>CALCITE-4364 & FLINK-19811: Line 1307, Line 1764, Line 2638 ~ Line 2656.
+ *     <li>CALCITE-4446 & FLINK-22015: Line 2542 ~ Line 2548, Line 2614 ~ Line 2619.
+ * </ol>
  */
 public class RexSimplify {
     private final boolean paranoid;
@@ -2669,13 +2673,9 @@ public class RexSimplify {
                             ((RexCall) e).operands.get(1),
                             e.getKind(),
                             newTerms);
-                case IS_NULL:
-                    if (negate) {
-                        return false;
-                    }
-                    final RexNode arg = ((RexCall) e).operands.get(0);
-                    return accept1(
-                            arg, e.getKind(), rexBuilder.makeNullLiteral(arg.getType()), newTerms);
+                // CHANGED: we remove IS_NULL here
+                // because SEARCH operator in Calcite 1.26 handles UNKNOWNs incorrectly
+                // see CALCITE-4446
                 default:
                     return false;
             }
@@ -2741,12 +2741,9 @@ public class RexSimplify {
                     final Sarg sarg = literal.getValueAs(Sarg.class);
                     b.addSarg(sarg, negate, literal.getType());
                     return true;
-                case IS_NULL:
-                    if (negate) {
-                        throw new AssertionError("negate is not supported for IS_NULL");
-                    }
-                    b.containsNull = true;
-                    return true;
+                // CHANGED: we remove IS_NULL here
+                // because SEARCH operator in Calcite 1.26 handles UNKNOWNs incorrectly
+                // see CALCITE-4446
                 default:
                     throw new AssertionError("unexpected " + kind);
             }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
@@ -214,6 +214,24 @@ Calc(select=[MAP(a, c) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testOrWithIsNullPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(=($0, 1), =($0, 10), IS NULL($0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c], where=[(a IS NULL OR SEARCH(a, Sarg[1L:BIGINT, 10L:BIGINT]:BIGINT))])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNotIn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx']]>
@@ -267,20 +285,37 @@ Calc(select=[a, c])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOrWithIsNull">
+  <TestCase name="testProjectAndFilter">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL]]>
+      <![CDATA[SELECT a, b + 1 FROM MyTable WHERE b > 2]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
-+- LogicalFilter(condition=[OR(=($0, 1), =($0, 10), IS NULL($0))])
+LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
++- LogicalFilter(condition=[>($1, 2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c], where=[(a IS NULL OR SEARCH(a, Sarg[1L:BIGINT, 10L:BIGINT]:BIGINT))])
+Calc(select=[a, (b + 1) AS EXPR$1], where=[(b > 2)])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOrWithIsNullInIf">
+    <Resource name="sql">
+      <![CDATA[SELECT IF(c = '' OR c IS NULL, 'a', 'b') FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[IF(OR(=($2, _UTF-16LE''), IS NULL($2)), _UTF-16LE'a', _UTF-16LE'b')])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[IF(((c = _UTF-16LE'':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") OR c IS NULL), _UTF-16LE'a', _UTF-16LE'b') AS EXPR$0])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -314,24 +349,6 @@ LogicalProject(EXPR$0=[MAP($1, 30, 10, $0)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[MAP(b, 30, 10, a) AS EXPR$0])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectAndFilter">
-    <Resource name="sql">
-      <![CDATA[SELECT a, b + 1 FROM MyTable WHERE b > 2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
-+- LogicalFilter(condition=[>($1, 2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, (b + 1) AS EXPR$1], where=[(b > 2)])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
@@ -267,6 +267,24 @@ Calc(select=[a, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testOrWithIsNull">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(=($0, 1), =($0, 10), IS NULL($0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c], where=[(a IS NULL OR SEARCH(a, Sarg[1L:BIGINT, 10L:BIGINT]:BIGINT))])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPojoType">
     <Resource name="sql">
       <![CDATA[SELECT a FROM MyTable4]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
@@ -268,6 +268,24 @@ Calc(select=[a, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testOrWithIsNull">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(=($0, 1), =($0, 10), IS NULL($0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c], where=[(a IS NULL OR SEARCH(a, Sarg[1L:BIGINT, 10L:BIGINT]:BIGINT))])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPojoType">
     <Resource name="sql">
       <![CDATA[SELECT a FROM MyTable4]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
@@ -215,6 +215,24 @@ Calc(select=[MAP(a, c) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testOrWithIsNullPredicate">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[OR(=($0, 1), =($0, 10), IS NULL($0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c], where=[(a IS NULL OR SEARCH(a, Sarg[1L:BIGINT, 10L:BIGINT]:BIGINT))])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNotIn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx']]>
@@ -268,20 +286,37 @@ Calc(select=[a, c])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testOrWithIsNull">
+  <TestCase name="testProjectAndFilter">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL]]>
+      <![CDATA[SELECT a, b + 1 FROM MyTable WHERE b > 2]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2])
-+- LogicalFilter(condition=[OR(=($0, 1), =($0, 10), IS NULL($0))])
+LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
++- LogicalFilter(condition=[>($1, 2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, b, c], where=[(a IS NULL OR SEARCH(a, Sarg[1L:BIGINT, 10L:BIGINT]:BIGINT))])
+Calc(select=[a, (b + 1) AS EXPR$1], where=[(b > 2)])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOrWithIsNullInIf">
+    <Resource name="sql">
+      <![CDATA[SELECT IF(c = '' OR c IS NULL, 'a', 'b') FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[IF(OR(=($2, _UTF-16LE''), IS NULL($2)), _UTF-16LE'a', _UTF-16LE'b')])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[IF(((c = _UTF-16LE'':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") OR c IS NULL), _UTF-16LE'a', _UTF-16LE'b') AS EXPR$0])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>
@@ -315,24 +350,6 @@ LogicalProject(EXPR$0=[MAP($1, 30, 10, $0)])
     <Resource name="optimized exec plan">
       <![CDATA[
 Calc(select=[MAP(b, 30, 10, a) AS EXPR$0])
-+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testProjectAndFilter">
-    <Resource name="sql">
-      <![CDATA[SELECT a, b + 1 FROM MyTable WHERE b > 2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], EXPR$1=[+($1, 1)])
-+- LogicalFilter(condition=[>($1, 2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, (b + 1) AS EXPR$1], where=[(b > 2)])
 +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
@@ -163,7 +163,12 @@ class CalcTest extends TableTestBase {
   }
 
   @Test
-  def testOrWithIsNull(): Unit = {
+  def testOrWithIsNullPredicate(): Unit = {
     util.verifyExecPlan("SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL")
+  }
+
+  @Test
+  def testOrWithIsNullInIf(): Unit = {
+    util.verifyExecPlan("SELECT IF(c = '' OR c IS NULL, 'a', 'b') FROM MyTable")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
@@ -161,4 +161,9 @@ class CalcTest extends TableTestBase {
   def testCollationDeriveOnCalc(): Unit = {
     util.verifyExecPlan("SELECT CAST(a AS INT), CAST(b AS VARCHAR) FROM (VALUES (3, 'c')) T(a,b)")
   }
+
+  @Test
+  def testOrWithIsNull(): Unit = {
+    util.verifyExecPlan("SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
@@ -162,7 +162,12 @@ class CalcTest extends TableTestBase {
   }
 
   @Test
-  def testOrWithIsNull(): Unit = {
+  def testOrWithIsNullPredicate(): Unit = {
     util.verifyExecPlan("SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL")
+  }
+
+  @Test
+  def testOrWithIsNullInIf(): Unit = {
+    util.verifyExecPlan("SELECT IF(c = '' OR c IS NULL, 'a', 'b') FROM MyTable")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
@@ -161,4 +161,8 @@ class CalcTest extends TableTestBase {
       "WHERE (a, b, c) = ('foo', 12, TIMESTAMP '1984-07-12 14:34:24')")
   }
 
+  @Test
+  def testOrWithIsNull(): Unit = {
+    util.verifyExecPlan("SELECT * FROM MyTable WHERE a = 1 OR a = 10 OR a IS NULL")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1443,4 +1443,18 @@ class CalcITCase extends BatchTestBase {
         row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 09:59:59")),
         row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 10:00:00"))))
   }
+
+  @Test
+  def testOrWithIsNull(): Unit = {
+    checkResult(
+      """
+        |SELECT * FROM NullTable3 AS T
+        |WHERE T.a = 1 OR T.a = 3 OR T.a IS NULL
+        |""".stripMargin,
+      Seq(
+        row(1, 1L, "Hi"),
+        row(3, 2L, "Hello world"),
+        row(null, 999L, "NullTuple"),
+        row(null, 999L, "NullTuple")))
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -1445,7 +1445,7 @@ class CalcITCase extends BatchTestBase {
   }
 
   @Test
-  def testOrWithIsNull(): Unit = {
+  def testOrWithIsNullPredicate(): Unit = {
     checkResult(
       """
         |SELECT * FROM NullTable3 AS T
@@ -1456,5 +1456,25 @@ class CalcITCase extends BatchTestBase {
         row(3, 2L, "Hello world"),
         row(null, 999L, "NullTuple"),
         row(null, 999L, "NullTuple")))
+  }
+
+  @Test
+  def testOrWithIsNullInIf(): Unit = {
+    val data = Seq(
+      row("", "N"),
+      row("X", "Y"),
+      row(null, "Y"))
+    registerCollection(
+      "MyTable", data, new RowTypeInfo(STRING_TYPE_INFO, STRING_TYPE_INFO), "a, b")
+
+    checkResult(
+      "SELECT IF(a = '', 'a', 'b') FROM MyTable",
+      Seq(row('a'), row('b'), row('b')))
+    checkResult(
+      "SELECT IF(a IS NULL, 'a', 'b') FROM MyTable",
+      Seq(row('b'), row('b'), row('a')))
+    checkResult(
+      "SELECT IF(a = '' OR a IS NULL, 'a', 'b') FROM MyTable",
+      Seq(row('a'), row('b'), row('a')))
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

In Calcite 1.26, expressions like `a = 1 OR a IS NULL` will be simplified to `SEARCH(a, [1, NULL])`. This is incorrect because searching for NULL is always false (this is a bug, fixed in CALCITE-4446).

This PR exclude `IS NULL` from `SEARCH` operators to solve this issue.

## Brief change log

 - Exclude IS NULL from SEARCH operators

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
