### PR TITLE
[FLINK-22082][planner] Nested projection push down doesn't work for d…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -305,17 +305,23 @@ class RefFieldAccessorVisitor(usedFields: Array[Int]) extends RexVisitorImpl[Uni
   }
 
   override def visitFieldAccess(fieldAccess: RexFieldAccess): Unit = {
-    def internalVisit(fieldAccess: RexFieldAccess): (Int, List[String]) = {
+    def internalVisit(fieldAccess: RexFieldAccess): (Boolean, Int, List[String]) = {
       fieldAccess.getReferenceExpr match {
         case ref: RexInputRef =>
-          (ref.getIndex, List(fieldAccess.getField.getName))
+          (true, ref.getIndex, List(fieldAccess.getField.getName))
         case fac: RexFieldAccess =>
-          val (i, n) = internalVisit(fac)
-          (i, n :+ fieldAccess.getField.getName)
+          val (success, i, n) = internalVisit(fac)
+          (success, i, if (success) n :+ fieldAccess.getField.getName else null)
+        case expr =>
+          expr.accept(this)
+          (false, -1, null)
       }
     }
 
-    val (index, fullName) = internalVisit(fieldAccess)
+    val (success, index, fullName) = internalVisit(fieldAccess)
+    if (!success) {
+      return
+    }
     val outputIndex = order.getOrElse(index, -1)
     val fields: List[List[String]] = projectedFields(outputIndex)
     projectedFields(outputIndex) = fields :+ fullName

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
@@ -141,9 +141,9 @@ public class PushProjectIntoTableSourceScanRuleTest
                         + "  `Timestamp` TIMESTAMP(3),\n"
                         + "  `Result` ROW(\n"
                         + "    `data_arr` ROW(`value` BIGINT) ARRAY,\n"
-                        + "    `data_map` MAP<STRING, ROW<`value` BIGINT>>),\n" +
-                        "  `outer_map` MAP<STRING, STRING>,\n" +
-                        "`outer_array` ARRAY<INT>,\n"
+                        + "    `data_map` MAP<STRING, ROW<`value` BIGINT>>),\n"
+                        + "  `outer_map` MAP<STRING, STRING>,\n"
+                        + "  `outer_array` ARRAY<INT>,\n"
                         + "   WATERMARK FOR `Timestamp` AS `Timestamp`\n"
                         + ") WITH (\n"
                         + " 'connector' = 'values',\n"

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
@@ -141,7 +141,9 @@ public class PushProjectIntoTableSourceScanRuleTest
                         + "  `Timestamp` TIMESTAMP(3),\n"
                         + "  `Result` ROW(\n"
                         + "    `data_arr` ROW(`value` BIGINT) ARRAY,\n"
-                        + "      `data_map` MAP<STRING, ROW<`value` BIGINT>>),\n"
+                        + "    `data_map` MAP<STRING, ROW<`value` BIGINT>>),\n" +
+                        "  `outer_map` MAP<STRING, STRING>,\n" +
+                        "`outer_array` ARRAY<INT>,\n"
                         + "   WATERMARK FOR `Timestamp` AS `Timestamp`\n"
                         + ") WITH (\n"
                         + " 'connector' = 'values',\n"
@@ -235,7 +237,10 @@ public class PushProjectIntoTableSourceScanRuleTest
         util().verifyPlan(
                         "SELECT "
                                 + "`Result`.data_arr[ID].`value`, "
-                                + "`Result`.data_map['item'].`value`"
+                                + "`Result`.data_map['item'].`value`, "
+                                + "`outer_array`[ID], "
+                                + "`outer_array`[1], "
+                                + "`outer_map`['item'] "
                                 + "FROM ItemTable");
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
@@ -40,28 +40,6 @@ Calc(select=[id, deepNested_nested1_name AS nestedName, nested_value AS nestedVa
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testNestProjectWithMetadata">
-    <Resource name="sql">
-      <![CDATA[
-SELECT id,
-       deepNested.nested1 AS nested1,
-       deepNested.nested1.`value` + deepNested.nested2.num + metadata_1 as results
-FROM T
-]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.nested2.num), $2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, T]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[id, deepNested_nested1 AS nested1, +(+(deepNested_nested1.value, deepNested_nested2_num), metadata_1) AS results])
-+- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1]]], fields=[id, deepNested_nested1, deepNested_nested2_num, metadata_1])
-]]>
-    </Resource>
-  </TestCase>
   <TestCase name="testSimpleProject">
     <Resource name="sql">
       <![CDATA[SELECT a, c FROM ProjectableTable]]>
@@ -75,6 +53,28 @@ LogicalProject(a=[$0], c=[$2])
     <Resource name="planAfter">
       <![CDATA[
 TableSourceScan(table=[[default_catalog, default_database, ProjectableTable, project=[a, c]]], fields=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedProjectFieldWithITEM">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  `result`.`data_arr`[`id`].`value`,
+  `result`.`data_map`['item'].`value`
+FROM NestedItemTable
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ITEM(result_data_arr, id).value AS EXPR$0, ITEM(result_data_map, _UTF-16LE'item').value AS EXPR$1])
++- TableSourceScan(table=[[default_catalog, default_database, NestedItemTable, project=[result_data_arr, result_data_map, id]]], fields=[result_data_arr, result_data_map, id])
 ]]>
     </Resource>
   </TestCase>
@@ -95,6 +95,28 @@ HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
 +- Exchange(distribution=[single])
    +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
       +- TableSourceScan(table=[[default_catalog, default_database, ProjectableTable, project=[]]], fields=[])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestProjectWithMetadata">
+    <Resource name="sql">
+      <![CDATA[
+SELECT id,
+       deepNested.nested1 AS nested1,
+       deepNested.nested1.`value` + deepNested.nested2.num + metadata_1 as results
+FROM T
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.nested2.num), $2)])
++- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[id, deepNested_nested1 AS nested1, +(+(deepNested_nested1.value, deepNested_nested2_num), metadata_1) AS results])
++- TableSourceScan(table=[[default_catalog, default_database, T, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1]]], fields=[id, deepNested_nested1, deepNested_nested2_num, metadata_1])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -50,6 +50,23 @@ LogicalProject(a=[$0], c=[$2], d=[+($0, 1)], EXPR$3=[+($1, 1)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNestedProjectFieldAccessWithITEMWithConstantIndex">
+    <Resource name="sql">
+      <![CDATA[SELECT `Result`.`Mid`.data_arr[2].`value`, `Result`.`Mid`.data_arr FROM NestedItemTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.Mid.data_arr, 2).value], data_arr=[$2.Mid.data_arr])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($0, 2).value], data_arr=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable, project=[Result_Mid_data_arr]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testComplicatedNestedProject">
     <Resource name="sql">
       <![CDATA[SELECT id,    deepNested.nested1.name AS nestedName,
@@ -66,25 +83,6 @@ LogicalProject(id=[$0], nestedName=[$1.nested1.name], nestedSum=[+($3..value, $3
       <![CDATA[
 LogicalProject(id=[$0], nestedName=[$1], nestedSum=[+($2, $3)])
 +- LogicalTableScan(table=[[default_catalog, default_database, NestedTable, project=[id, deepNested_nested1_name, deepNestedWith._.value, deepNestedWith._nested_.value]]])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testNestProjectWithUpsertSource">
-    <Resource name="sql">
-      <![CDATA[SELECT id,    deepNested.nested1 AS nested1,
-    deepNested.nested1.`value` + deepNested.nested2.num + metadata_1 as results
-FROM MetadataTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.nested2.num), $2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-LogicalProject(id=[$0], nested1=[$1], results=[+(+($1.value, $2), $3)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1]]])
 ]]>
     </Resource>
   </TestCase>
@@ -110,21 +108,37 @@ LogicalProject(id=[$0], nestedName=[$1], nestedValue=[$4], nestedFlag=[$2], nest
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testProjectWithMapType">
+  <TestCase name="testNestedProjectFieldAccessWithITEM">
     <Resource name="sql">
-      <![CDATA[SELECT id, testMap['e']
-FROM NestedTable]]>
+      <![CDATA[SELECT `Result`.`Mid`.data_arr[ID].`value`, `Result`.`Mid`.data_map['item'].`value` FROM NestedItemTable]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(id=[$0], EXPR$1=[ITEM($5, _UTF-16LE'e')])
-+- LogicalTableScan(table=[[default_catalog, default_database, NestedTable]])
+LogicalProject(EXPR$0=[ITEM($2.Mid.data_arr, $0).value], EXPR$1=[ITEM($2.Mid.data_map, _UTF-16LE'item').value])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(id=[$0], EXPR$1=[ITEM($1, _UTF-16LE'e')])
-+- LogicalTableScan(table=[[default_catalog, default_database, NestedTable, project=[id, testMap]]])
+LogicalProject(EXPR$0=[ITEM($0, $2).value], EXPR$1=[ITEM($1, _UTF-16LE'item').value])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable, project=[Result_Mid_data_arr, Result_Mid_data_map, ID]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedProjectFieldAccessWithITEMContainsTopLevelAccess">
+    <Resource name="sql">
+      <![CDATA[SELECT `Result`.`Mid`.data_arr[2].`value`, `Result`.`Mid`.data_arr[ID].`value`, `Result`.`Mid`.data_map['item'].`value`, `Result`.`Mid` FROM NestedItemTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.Mid.data_arr, 2).value], EXPR$1=[ITEM($2.Mid.data_arr, $0).value], EXPR$2=[ITEM($2.Mid.data_map, _UTF-16LE'item').value], Mid=[$2.Mid])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($0.data_arr, 2).value], EXPR$1=[ITEM($0.data_arr, $1).value], EXPR$2=[ITEM($0.data_map, _UTF-16LE'item').value], Mid=[$0])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable, project=[Result_Mid, ID]]])
 ]]>
     </Resource>
   </TestCase>
@@ -144,6 +158,60 @@ LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.
       <![CDATA[
 LogicalProject(id=[$0], nested1=[$1], results=[+(+($1.value, $2), $3)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestProjectWithUpsertSource">
+    <Resource name="sql">
+      <![CDATA[SELECT id,    deepNested.nested1 AS nested1,
+    deepNested.nested1.`value` + deepNested.nested2.num + metadata_1 as results
+FROM MetadataTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], nested1=[$1.nested1], results=[+(+($1.nested1.value, $1.nested2.num), $2)])
++- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], nested1=[$1], results=[+(+($1.value, $2), $3)])
++- LogicalTableScan(table=[[default_catalog, default_database, MetadataTable, project=[id, deepNested_nested1, deepNested_nested2_num, metadata_1]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectWithMapType">
+    <Resource name="sql">
+      <![CDATA[SELECT id, testMap['e']
+FROM NestedTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(id=[$0], EXPR$1=[ITEM($5, _UTF-16LE'e')])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(id=[$0], EXPR$1=[ITEM($1, _UTF-16LE'e')])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedTable, project=[id, testMap]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectFieldAccessWithITEM">
+    <Resource name="sql">
+      <![CDATA[SELECT `Result`.data_arr[ID].`value`, `Result`.data_map['item'].`value`FROM ItemTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($0.data_arr, $1).value], EXPR$1=[ITEM($0.data_map, _UTF-16LE'item').value])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable, project=[Result, ID]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -200,18 +200,18 @@ LogicalProject(id=[$0], EXPR$1=[ITEM($1, _UTF-16LE'e')])
   </TestCase>
   <TestCase name="testProjectFieldAccessWithITEM">
     <Resource name="sql">
-      <![CDATA[SELECT `Result`.data_arr[ID].`value`, `Result`.data_map['item'].`value`FROM ItemTable]]>
+      <![CDATA[SELECT `Result`.data_arr[ID].`value`, `Result`.data_map['item'].`value`, `outer_array`[ID], `outer_array`[1], `outer_map`['item'] FROM ItemTable]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value])
+LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value], EXPR$2=[ITEM($4, $0)], EXPR$3=[ITEM($4, 1)], EXPR$4=[ITEM($3, _UTF-16LE'item')])
 +- LogicalTableScan(table=[[default_catalog, default_database, ItemTable]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(EXPR$0=[ITEM($0.data_arr, $1).value], EXPR$1=[ITEM($0.data_map, _UTF-16LE'item').value])
-+- LogicalTableScan(table=[[default_catalog, default_database, ItemTable, project=[Result, ID]]])
+LogicalProject(EXPR$0=[ITEM($0.data_arr, $1).value], EXPR$1=[ITEM($0.data_map, _UTF-16LE'item').value], EXPR$2=[ITEM($2, $1)], EXPR$3=[ITEM($2, 1)], EXPR$4=[ITEM($3, _UTF-16LE'item')])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable, project=[Result, ID, outer_array, outer_map]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -40,6 +40,28 @@ Calc(select=[id, deepNested_nested1_name AS nestedName, nested_value AS nestedVa
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNestedProjectWithItem">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  `result`.`data_arr`[`id`].`value`,
+  `result`.`data_map`['item'].`value`
+FROM NestedItemTable
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[ITEM($2.data_arr, $0).value], EXPR$1=[ITEM($2.data_map, _UTF-16LE'item').value])
++- LogicalTableScan(table=[[default_catalog, default_database, NestedItemTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[ITEM(result_data_arr, id).value AS EXPR$0, ITEM(result_data_map, _UTF-16LE'item').value AS EXPR$1])
++- TableSourceScan(table=[[default_catalog, default_database, NestedItemTable, project=[result_data_arr, result_data_map, id]]], fields=[result_data_arr, result_data_map, id])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNestedProjectWithMetadata">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -100,9 +100,10 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     val expected = Array(
       Array(Arrays.asList("amount")),
       Array(Arrays.asList("*")),
-      Array(Arrays.asList("with", "deeper", "entry"), Arrays.asList("with", "deep", "entry")))
+      Array(Arrays.asList("with", "deeper", "entry"), Arrays.asList("with", "deep", "entry")),
+      Array(Arrays.asList("outer"), Arrays.asList("inner", "deep_array")))
 
-    assertThat(usedFields, is(Array(1, 0, 2)))
+    assertThat(usedFields, is(Array(1, 0, 2, 3)))
     assertThat(usedNestedFields, is(expected))
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -70,11 +70,11 @@ class TableSourceITCase extends BatchTestBase {
          |  id BIGINT,
          |  deepNested ROW<
          |     nested1 ROW<name STRING, `value.` INT>,
-         |     `nested2.` ROW<num INT, flag BOOLEAN>
-         |   >,
-         |   nested ROW<name STRING, `value` INT>,
-         |   name STRING,
-         |   lower_name AS LOWER(name)
+         |     `nested2.` ROW<num INT, flag BOOLEAN>>,
+         |  nested ROW<name STRING, `value` INT>,
+         |  name STRING,
+         |  nestedItem ROW<deepArray ROW<`value` INT> ARRAY, deepMap MAP<STRING, INT>>,
+         |  lower_name AS LOWER(name)
          |) WITH (
          |  'connector' = 'values',
          |  'nested-projection-supported' = 'true',
@@ -120,6 +120,16 @@ class TableSourceITCase extends BatchTestBase {
         row(2, "Rob", 20000, false, 2200, "bob"),
         row(3, "Mike", 30000, true, 3300, "liz")
       )
+    )
+  }
+
+  @Test
+  def testNestedProjectWithItem(): Unit = {
+    checkResult(
+      """
+        |SELECT nestedItem.deepArray[nestedItem.deepMap['Monday']] FROM  NestedTable
+        |""".stripMargin,
+      Seq(row(row(1)), row(row(1)), row(row(1)))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -88,15 +88,16 @@ class TableSourceITCase extends StreamingTestBase {
          |  id BIGINT,
          |  deepNested ROW<
          |     nested1 ROW<name STRING, `value.` INT>,
-         |     `nested2.` ROW<num INT, flag BOOLEAN>
-         |   >,
-         |   nested ROW<name STRING, `value` INT>,
-         |   name STRING,
-         |   lower_name AS LOWER(name)
+         |     `nested2.` ROW<num INT, flag BOOLEAN>>,
+         |  nested ROW<name STRING, `value` INT>,
+         |  name STRING,
+         |  nestedItem ROW<deepArray ROW<`value` INT> ARRAY, deepMap MAP<STRING, INT>>,
+         |  lower_name AS LOWER(name)
          |) WITH (
          |  'connector' = 'values',
          |  'nested-projection-supported' = 'true',
-         |  'data-id' = '$nestedTableDataId'
+         |  'data-id' = '$nestedTableDataId',
+         |  'bounded' = 'true'
          |)
          |""".stripMargin
     )
@@ -151,6 +152,22 @@ class TableSourceITCase extends StreamingTestBase {
       "3,Mike,30000,true,3300,liz")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
+
+  @Test
+  def testNestedProjectWithItem(): Unit = {
+    val query =
+      """
+        |SELECT nestedItem.deepArray[nestedItem.deepMap['Monday']] FROM  NestedTable
+        |""".stripMargin
+    val result = tEnv.sqlQuery(query).toAppendStream[Row]
+    val sink = new TestingAppendSink
+    result.addSink(sink)
+    env.execute()
+
+    val expected = Seq("1", "1", "1")
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
+  }
+
 
   @Test
   def testTableSourceWithFilterable(): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -270,6 +270,14 @@ object TestData {
     data
   }
 
+  lazy val arrayRows = Array(
+    Row.of(new JInt(1)),
+    Row.of(new JInt(2)),
+    Row.of(new JInt(3)),
+    Row.of(new JInt(4)))
+
+  lazy val mapRows = map(("Monday", 1), ("Tuesday", 2), ("Wednesday", 3))
+
   lazy val deepNestedRow: Seq[Row] = {
     Seq(
       Row.of(new JLong(1),
@@ -278,21 +286,24 @@ object TestData {
           Row.of(new JInt(1000), new JBool(true))
         ),
         Row.of("Peter", new JInt(10000)),
-        "Mary"),
+        "Mary",
+        Row.of(arrayRows, mapRows)),
       Row.of(new JLong(2),
         Row.of(
           Row.of("Rob", new JInt(200)),
           Row.of(new JInt(2000), new JBool(false))
         ),
         Row.of("Lucy", new JInt(20000)),
-        "Bob"),
+        "Bob",
+        Row.of(arrayRows, mapRows)),
       Row.of(new JLong(3),
         Row.of(
           Row.of("Mike", new JInt(300)),
           Row.of(new JInt(3000), new JBool(true))
         ),
         Row.of("Betty", new JInt(30000)),
-        "Liz"))
+        "Liz",
+        Row.of(arrayRows, mapRows)))
   }
 
   lazy val tupleData5: Seq[(Int, Long, Int, String, Long)] = {


### PR DESCRIPTION
…work for row(array(row))

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix nested projection push down doesn't work for row(array).*

*`RexFieldAccess` has two parts: reference expression and fields. When reference expression has `RexCall`, we just push the projection of the operands of the call to the source rather than push the projection of the result of the call into the source. In this way, we simplify the situation.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test about `NestedProjectionUtils` to verify field access contains MAP or ARRAY*
  - *Added test about `PushProjectIntoTableSourceScanRule` when row has MAP or ARRAY*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
