### PR TITLE
[FLINK-20761][hive] Escape the location path when creating input splits

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.io.CheckpointableInputFormat;
 import org.apache.flink.api.common.io.LocatableInputSplitAssigner;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.api.java.hadoop.common.HadoopInputFormatCommonBase;
-import org.apache.flink.connectors.hive.FlinkHiveException;
+import org.apache.flink.connectors.hive.HiveSourceFileEnumerator;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.JobConfWrapper;
 import org.apache.flink.core.io.InputSplitAssigner;
@@ -39,9 +39,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
-import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.util.ReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +52,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.hadoop.mapreduce.lib.input.FileInputFormat.INPUT_DIR;
 
 /**
  * The HiveTableInputFormat are inspired by the HCatInputFormat and HadoopInputFormatBase. It's used
@@ -324,32 +322,9 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
         List<HiveTableInputSplit> hiveSplits = new ArrayList<>();
         int splitNum = 0;
         for (HiveTablePartition partition : partitions) {
-            StorageDescriptor sd = partition.getStorageDescriptor();
-            Path inputPath = new Path(sd.getLocation());
-            FileSystem fs = inputPath.getFileSystem(jobConf);
-            // it's possible a partition exists in metastore but the data has been removed
-            if (!fs.exists(inputPath)) {
-                continue;
-            }
-            InputFormat format;
-            try {
-                format =
-                        (InputFormat)
-                                Class.forName(
-                                                sd.getInputFormat(),
-                                                true,
-                                                Thread.currentThread().getContextClassLoader())
-                                        .newInstance();
-            } catch (Exception e) {
-                throw new FlinkHiveException("Unable to instantiate the hadoop input format", e);
-            }
-            ReflectionUtils.setConf(format, jobConf);
-            jobConf.set(INPUT_DIR, sd.getLocation());
-            // TODO: we should consider how to calculate the splits according to minNumSplits in the
-            // future.
-            org.apache.hadoop.mapred.InputSplit[] splitArray =
-                    format.getSplits(jobConf, minNumSplits);
-            for (org.apache.hadoop.mapred.InputSplit inputSplit : splitArray) {
+            for (InputSplit inputSplit :
+                    HiveSourceFileEnumerator.createMRSplits(
+                            minNumSplits, partition.getStorageDescriptor(), jobConf)) {
                 hiveSplits.add(new HiveTableInputSplit(splitNum++, inputSplit, jobConf, partition));
             }
         }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -469,11 +469,17 @@ public class TableEnvHiveConnectorITCase {
                     String.format(
                             "alter table tbl2 add partition (p='a') location '%s'",
                             location.getAbsolutePath()));
-            tableEnv.executeSql("insert into tbl2 partition (p='a') values (1),(2)");
+            tableEnv.executeSql("insert into tbl2 partition (p='a') values (1),(2)").await();
             results =
                     CollectionUtil.iteratorToList(
                             tableEnv.executeSql("select * from tbl2").collect());
             assertEquals("[+I[1, a], +I[2, a]]", results.toString());
+
+            tableEnv.executeSql("insert into tbl2 partition (p) values (3,'b ,')").await();
+            results =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql("select * from tbl2 where p='b ,'").collect());
+            assertEquals("[+I[3, b ,]]", results.toString());
         } finally {
             if (location != null) {
                 IOUtils.deleteFileQuietly(location.toPath());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.IOUtils;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -40,8 +41,11 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -66,6 +70,8 @@ public class TableEnvHiveConnectorITCase {
                 HiveMetastoreClientFactory.create(
                         hiveCatalog.getHiveConf(), HiveShimLoader.getHiveVersion());
     }
+
+    @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Test
     public void testDefaultPartitionName() throws Exception {
@@ -439,6 +445,41 @@ public class TableEnvHiveConnectorITCase {
         } finally {
             tableEnv.executeSql("drop table src");
             tableEnv.executeSql("drop table dest");
+        }
+    }
+
+    @Test
+    public void testLocationWithComma() throws Exception {
+        TableEnvironment tableEnv = getTableEnvWithHiveCatalog();
+        File location = tempFolder.newFolder(",tbl1,location,");
+        try {
+            // test table location
+            tableEnv.executeSql(
+                    String.format(
+                            "create table tbl1 (x int) location '%s'", location.getAbsolutePath()));
+            tableEnv.executeSql("insert into tbl1 values (1),(2)").await();
+            List<Row> results =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql("select * from tbl1").collect());
+            assertEquals("[+I[1], +I[2]]", results.toString());
+            // test partition location
+            tableEnv.executeSql("create table tbl2 (x int) partitioned by (p string)");
+            location = tempFolder.newFolder(",");
+            tableEnv.executeSql(
+                    String.format(
+                            "alter table tbl2 add partition (p='a') location '%s'",
+                            location.getAbsolutePath()));
+            tableEnv.executeSql("insert into tbl2 partition (p='a') values (1),(2)");
+            results =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql("select * from tbl2").collect());
+            assertEquals("[+I[1, a], +I[2, a]]", results.toString());
+        } finally {
+            if (location != null) {
+                IOUtils.deleteFileQuietly(location.toPath());
+            }
+            tableEnv.executeSql("drop table if exists tbl1");
+            tableEnv.executeSql("drop table if exists tbl2");
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the issue that we can't read hive table/partition whose location contains comma character


## Brief change log

  - Escape the location path before creating input splits for hive table
  - Add test case


## Verifying this change

Added test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
