### PR TITLE
[FLINK-22151][table] Implement type inference for agg functions

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
@@ -309,5 +309,10 @@ public class HiveSimpleUDFTest {
         public Optional<DataType> getOutputDataType() {
             return Optional.empty();
         }
+
+        @Override
+        public boolean isGroupedAggregation() {
+            return false;
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -267,7 +267,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                         isStreamingMode);
 
         catalogManager.initSchemaResolver(
-                isStreamingMode, operationTreeBuilder.expressionResolverBuilder());
+                isStreamingMode, operationTreeBuilder.getResolverBuilder());
     }
 
     public static TableEnvironmentImpl create(Configuration configuration) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -119,6 +119,8 @@ public class ExpressionResolver {
 
     private final Map<Expression, LocalOverWindow> localOverWindows;
 
+    private final boolean isGroupedAggregation;
+
     private ExpressionResolver(
             TableConfig config,
             TableReferenceLookup tableLookup,
@@ -127,7 +129,8 @@ public class ExpressionResolver {
             SqlExpressionResolver sqlExpressionResolver,
             FieldReferenceLookup fieldLookup,
             List<OverWindow> localOverWindows,
-            List<LocalReferenceExpression> localReferences) {
+            List<LocalReferenceExpression> localReferences,
+            boolean isGroupedAggregation) {
         this.config = Preconditions.checkNotNull(config).getConfiguration();
         this.tableLookup = Preconditions.checkNotNull(tableLookup);
         this.fieldLookup = Preconditions.checkNotNull(fieldLookup);
@@ -147,6 +150,7 @@ public class ExpressionResolver {
                                         },
                                         LinkedHashMap::new));
         this.localOverWindows = prepareOverWindows(localOverWindows);
+        this.isGroupedAggregation = isGroupedAggregation;
     }
 
     /**
@@ -323,6 +327,11 @@ public class ExpressionResolver {
         public Optional<LocalOverWindow> getOverWindow(Expression alias) {
             return Optional.ofNullable(localOverWindows.get(alias));
         }
+
+        @Override
+        public boolean isGroupedAggregation() {
+            return isGroupedAggregation;
+        }
     }
 
     private LocalOverWindow resolveOverWindow(OverWindow overWindow) {
@@ -434,6 +443,7 @@ public class ExpressionResolver {
         private final SqlExpressionResolver sqlExpressionResolver;
         private List<OverWindow> logicalOverWindows = new ArrayList<>();
         private List<LocalReferenceExpression> localReferences = new ArrayList<>();
+        private boolean isGroupedAggregation;
 
         private ExpressionResolverBuilder(
                 QueryOperation[] queryOperations,
@@ -461,6 +471,11 @@ public class ExpressionResolver {
             return this;
         }
 
+        public ExpressionResolverBuilder withGroupedAggregation(boolean isGroupedAggregation) {
+            this.isGroupedAggregation = isGroupedAggregation;
+            return this;
+        }
+
         public ExpressionResolver build() {
             return new ExpressionResolver(
                     config,
@@ -470,7 +485,8 @@ public class ExpressionResolver {
                     sqlExpressionResolver,
                     new FieldReferenceLookup(queryOperations),
                     logicalOverWindows,
-                    localReferences);
+                    localReferences,
+                    isGroupedAggregation);
         }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
@@ -133,7 +133,9 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
                                                                 definition,
                                                                 inference,
                                                                 argCount,
-                                                                currentPos))
+                                                                currentPos,
+                                                                resolutionContext
+                                                                        .isGroupedAggregation()))
                                         .orElse(null));
                 resolvedArgs.addAll(unresolvedCall.getChildren().get(i).accept(childResolver));
             }
@@ -225,7 +227,8 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
                                     resolutionContext.typeFactory(),
                                     name,
                                     unresolvedCall.getFunctionDefinition(),
-                                    resolvedArgs),
+                                    resolvedArgs,
+                                    resolutionContext.isGroupedAggregation()),
                             surroundingInfo);
 
             final List<ResolvedExpression> adaptedArguments =
@@ -324,15 +327,19 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 
         private final List<ResolvedExpression> resolvedArgs;
 
+        private final boolean isGroupedAggregation;
+
         public TableApiCallContext(
                 DataTypeFactory typeFactory,
                 String name,
                 FunctionDefinition definition,
-                List<ResolvedExpression> resolvedArgs) {
+                List<ResolvedExpression> resolvedArgs,
+                boolean isGroupedAggregation) {
             this.typeFactory = typeFactory;
             this.name = name;
             this.definition = definition;
             this.resolvedArgs = resolvedArgs;
+            this.isGroupedAggregation = isGroupedAggregation;
         }
 
         @Override
@@ -396,6 +403,11 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
         @Override
         public Optional<DataType> getOutputDataType() {
             return Optional.empty();
+        }
+
+        @Override
+        public boolean isGroupedAggregation() {
+            return isGroupedAggregation;
         }
 
         private ResolvedExpression getArgument(int pos) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
@@ -89,5 +89,8 @@ public interface ResolverRule {
 
         /** Access to available local over windows. */
         Optional<LocalOverWindow> getOverWindow(Expression alias);
+
+        /** Whether the expression is evaluated for a grouped aggregation. */
+        boolean isGroupedAggregation();
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.StructuredType.StructuredComparision;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 import org.apache.flink.util.Preconditions;
 
 import java.lang.reflect.Field;
@@ -295,70 +296,89 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("avg")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                     .build();
 
     public static final BuiltInFunctionDefinition COUNT =
             BuiltInFunctionDefinition.newBuilder()
                     .name("count")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(ANY)) // COUNT(*) is not supported yet
+                    .outputTypeStrategy(explicit(DataTypes.BIGINT().notNull()))
                     .build();
 
     public static final BuiltInFunctionDefinition MAX =
             BuiltInFunctionDefinition.newBuilder()
                     .name("max")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(
+                            comparable(ConstantArgumentCount.of(1), StructuredComparision.FULL))
+                    .outputTypeStrategy(TypeStrategies.aggArg0(t -> t, false))
                     .build();
 
     public static final BuiltInFunctionDefinition MIN =
             BuiltInFunctionDefinition.newBuilder()
                     .name("min")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(
+                            comparable(ConstantArgumentCount.of(1), StructuredComparision.FULL))
+                    .outputTypeStrategy(TypeStrategies.aggArg0(t -> t, false))
                     .build();
 
     public static final BuiltInFunctionDefinition SUM =
             BuiltInFunctionDefinition.newBuilder()
                     .name("sum")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findSumAggType, false))
                     .build();
 
     public static final BuiltInFunctionDefinition SUM0 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("sum0")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findSumAggType, null))
                     .build();
 
     public static final BuiltInFunctionDefinition STDDEV_POP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("stddevPop")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                     .build();
 
     public static final BuiltInFunctionDefinition STDDEV_SAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("stddevSamp")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                     .build();
 
     public static final BuiltInFunctionDefinition VAR_POP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("varPop")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                     .build();
 
     public static final BuiltInFunctionDefinition VAR_SAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("varSamp")
                     .kind(AGGREGATE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
+                    .outputTypeStrategy(
+                            TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                     .build();
 
     public static final BuiltInFunctionDefinition COLLECT =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContext.java
@@ -92,4 +92,13 @@ public interface CallContext {
     default ValidationException newValidationError(String message, Object... args) {
         return new ValidationException(String.format(message, args));
     }
+
+    /**
+     * Returns whether the function call happens as part of an aggregation that defines grouping
+     * columns.
+     *
+     * <p>E.g. {@code SELECT COUNT(*) FROM t} is not a grouped aggregation but {@code SELECT
+     * COUNT(*) FROM t GROUP BY k} is.
+     */
+    boolean isGroupedAggregation();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -168,8 +168,8 @@ public final class InputTypeStrategies {
     }
 
     /**
-     * Strategy that checks all types are comparable with each other. Requires at least two
-     * arguments.
+     * Strategy that checks all types are comparable with each other. Requires at least one
+     * argument.
      */
     public static InputTypeStrategy comparable(
             ConstantArgumentCount argumentCount, StructuredComparision requiredComparision) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -224,17 +224,21 @@ public final class TypeInferenceUtil {
 
         private final int innerCallPosition;
 
+        private final boolean isGroupedAggregation;
+
         public SurroundingInfo(
                 String name,
                 FunctionDefinition functionDefinition,
                 TypeInference typeInference,
                 int argumentCount,
-                int innerCallPosition) {
+                int innerCallPosition,
+                boolean isGroupedAggregation) {
             this.name = name;
             this.functionDefinition = functionDefinition;
             this.typeInference = typeInference;
             this.argumentCount = argumentCount;
             this.innerCallPosition = innerCallPosition;
+            this.isGroupedAggregation = isGroupedAggregation;
         }
 
         private Optional<DataType> inferOutputType(DataTypeFactory typeFactory) {
@@ -249,7 +253,12 @@ public final class TypeInferenceUtil {
             // for "takes_string(this_function(NULL))" simulate "takes_string(NULL)"
             // for retrieving the output type of "this_function(NULL)"
             final CallContext callContext =
-                    new UnknownCallContext(typeFactory, name, functionDefinition, argumentCount);
+                    new UnknownCallContext(
+                            typeFactory,
+                            name,
+                            functionDefinition,
+                            argumentCount,
+                            isGroupedAggregation);
 
             // We might not be able to infer the input types at this moment, if the surrounding
             // function

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SubsequenceInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SubsequenceInputTypeStrategy.java
@@ -191,6 +191,11 @@ public final class SubsequenceInputTypeStrategy implements InputTypeStrategy {
         public Optional<DataType> getOutputDataType() {
             return originalCallContext.getOutputDataType();
         }
+
+        @Override
+        public boolean isGroupedAggregation() {
+            return originalCallContext.isGroupedAggregation();
+        }
     }
 
     /** A Builder for {@link SubsequenceInputTypeStrategy}. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/utils/AdaptedCallContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/utils/AdaptedCallContext.java
@@ -106,6 +106,11 @@ public final class AdaptedCallContext implements CallContext {
         return Optional.ofNullable(outputDataType);
     }
 
+    @Override
+    public boolean isGroupedAggregation() {
+        return originalContext.isGroupedAggregation();
+    }
+
     private boolean isCasted(int pos) {
         final LogicalType originalType =
                 originalContext.getArgumentDataTypes().get(pos).getLogicalType();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/utils/UnknownCallContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/utils/UnknownCallContext.java
@@ -43,11 +43,14 @@ public final class UnknownCallContext implements CallContext {
 
     private final List<DataType> argumentDataTypes;
 
+    private final boolean isGroupedAggregation;
+
     public UnknownCallContext(
             DataTypeFactory typeFactory,
             String name,
             FunctionDefinition functionDefinition,
-            int argumentCount) {
+            int argumentCount,
+            boolean isGroupedAggregation) {
         this.typeFactory = typeFactory;
         this.name = name;
         this.functionDefinition = functionDefinition;
@@ -63,6 +66,7 @@ public final class UnknownCallContext implements CallContext {
                         return argumentCount;
                     }
                 };
+        this.isGroupedAggregation = isGroupedAggregation;
     }
 
     @Override
@@ -103,5 +107,10 @@ public final class UnknownCallContext implements CallContext {
     @Override
     public Optional<DataType> getOutputDataType() {
         return Optional.empty();
+    }
+
+    @Override
+    public boolean isGroupedAggregation() {
+        return isGroupedAggregation;
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
@@ -119,8 +119,14 @@ public final class ValueDataTypeConverter {
     }
 
     private static DataType convertToDecimalType(BigDecimal decimal) {
+        final int precision = decimal.precision();
+        final int scale = decimal.scale();
         // let underlying layers check if precision and scale are supported
-        return DataTypes.DECIMAL(decimal.precision(), decimal.scale());
+        if (scale < 0) {
+            // negative scale is not supported, normalize it
+            return DataTypes.DECIMAL(precision - scale, 0);
+        }
+        return DataTypes.DECIMAL(precision, scale);
     }
 
     private static DataType convertToTimeType(java.time.LocalTime time) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
@@ -62,6 +62,7 @@ public class ValueDataTypeConverterTest {
                     {new byte[0], new AtomicDataType(BinaryType.ofEmptyLiteral())},
                     {BigDecimal.ZERO, DataTypes.DECIMAL(1, 0)},
                     {new BigDecimal("12.123"), DataTypes.DECIMAL(5, 3)},
+                    {new BigDecimal("1E+36"), DataTypes.DECIMAL(37, 0)},
                     {12, DataTypes.INT()},
                     {LocalTime.of(13, 24, 25, 1000), DataTypes.TIME(6)},
                     {LocalTime.of(13, 24, 25, 0), DataTypes.TIME(0)},

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTestBase.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTestBase.java
@@ -118,7 +118,12 @@ public abstract class InputTypeStrategiesTestBase {
                             .build();
             surroundingInfo =
                     new TypeInferenceUtil.SurroundingInfo(
-                            "f_outer", functionDefinitionMock, outerTypeInference, 1, 0);
+                            "f_outer",
+                            functionDefinitionMock,
+                            outerTypeInference,
+                            1,
+                            0,
+                            callContextMock.isGroupedAggregation);
         } else {
             surroundingInfo = null;
         }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/utils/CallContextMock.java
@@ -45,6 +45,8 @@ public class CallContextMock implements CallContext {
 
     public Optional<DataType> outputDataType;
 
+    public boolean isGroupedAggregation;
+
     @Override
     public DataTypeFactory getDataTypeFactory() {
         return typeFactory;
@@ -85,5 +87,10 @@ public class CallContextMock implements CallContext {
     @Override
     public Optional<DataType> getOutputDataType() {
         return outputDataType;
+    }
+
+    @Override
+    public boolean isGroupedAggregation() {
+        return isGroupedAggregation;
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/AvgAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/AvgAggFunction.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
-import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
 import java.math.BigDecimal;
 
@@ -205,13 +205,13 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
 
         @Override
         public DataType getResultType() {
-            DecimalType t = FlinkTypeSystem.inferAggAvgType(type.getScale());
+            DecimalType t = (DecimalType) LogicalTypeMerging.findAvgAggType(type);
             return DataTypes.DECIMAL(t.getPrecision(), t.getScale());
         }
 
         @Override
         public DataType getSumType() {
-            DecimalType t = FlinkTypeSystem.inferAggSumType(type.getScale());
+            DecimalType t = (DecimalType) LogicalTypeMerging.findSumAggType(type);
             return DataTypes.DECIMAL(t.getPrecision(), t.getScale());
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumAggFunction.java
@@ -22,9 +22,9 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
-import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
@@ -149,7 +149,7 @@ public abstract class IncrSumAggFunction extends DeclarativeAggregateFunction {
 
         @Override
         public DataType getResultType() {
-            DecimalType sumType = FlinkTypeSystem.inferAggSumType(decimalType.getScale());
+            DecimalType sumType = (DecimalType) LogicalTypeMerging.findSumAggType(decimalType);
             return DataTypes.DECIMAL(sumType.getPrecision(), sumType.getScale());
         }
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/IncrSumWithRetractAggFunction.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
-import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.equalTo;
@@ -197,7 +197,7 @@ public abstract class IncrSumWithRetractAggFunction extends DeclarativeAggregate
 
         @Override
         public DataType getResultType() {
-            DecimalType sumType = FlinkTypeSystem.inferAggSumType(decimalType.getScale());
+            DecimalType sumType = (DecimalType) LogicalTypeMerging.findSumAggType(decimalType);
             return DataTypes.DECIMAL(sumType.getPrecision(), sumType.getScale());
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Sum0AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Sum0AggFunction.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
-import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
 import java.math.BigDecimal;
 
@@ -166,7 +166,7 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
 
         @Override
         public DataType getResultType() {
-            DecimalType sumType = FlinkTypeSystem.inferAggSumType(decimalType.getScale());
+            DecimalType sumType = (DecimalType) LogicalTypeMerging.findSumAggType(decimalType);
             return DataTypes.DECIMAL(sumType.getPrecision(), sumType.getScale());
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumAggFunction.java
@@ -22,9 +22,9 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
-import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
@@ -146,7 +146,7 @@ public abstract class SumAggFunction extends DeclarativeAggregateFunction {
 
         @Override
         public DataType getResultType() {
-            DecimalType sumType = FlinkTypeSystem.inferAggSumType(decimalType.getScale());
+            DecimalType sumType = (DecimalType) LogicalTypeMerging.findSumAggType(decimalType);
             return DataTypes.DECIMAL(sumType.getPrecision(), sumType.getScale());
         }
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/SumWithRetractAggFunction.java
@@ -21,9 +21,9 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
-import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.equalTo;
@@ -189,7 +189,7 @@ public abstract class SumWithRetractAggFunction extends DeclarativeAggregateFunc
 
         @Override
         public DataType getResultType() {
-            DecimalType sumType = FlinkTypeSystem.inferAggSumType(decimalType.getScale());
+            DecimalType sumType = (DecimalType) LogicalTypeMerging.findSumAggType(decimalType);
             return DataTypes.DECIMAL(sumType.getPrecision(), sumType.getScale());
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
@@ -42,11 +42,17 @@ public abstract class AbstractSqlCallContext implements CallContext {
 
     private final String name;
 
+    private final boolean isGroupedAggregation;
+
     protected AbstractSqlCallContext(
-            DataTypeFactory dataTypeFactory, FunctionDefinition definition, String name) {
+            DataTypeFactory dataTypeFactory,
+            FunctionDefinition definition,
+            String name,
+            boolean isGroupedAggregation) {
         this.dataTypeFactory = dataTypeFactory;
         this.definition = definition;
         this.name = name;
+        this.isGroupedAggregation = isGroupedAggregation;
     }
 
     @Override
@@ -62,6 +68,11 @@ public abstract class AbstractSqlCallContext implements CallContext {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean isGroupedAggregation() {
+        return isGroupedAggregation;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
@@ -57,7 +57,11 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
             FunctionDefinition definition,
             SqlCallBinding binding,
             @Nullable RelDataType outputType) {
-        super(dataTypeFactory, definition, binding.getOperator().getNameAsId().toString());
+        super(
+                dataTypeFactory,
+                definition,
+                binding.getOperator().getNameAsId().toString(),
+                binding.getGroupCount() > 0);
 
         this.adaptedArguments = binding.operands(); // reorders the operands
         this.argumentDataTypes =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/LookupCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/LookupCallContext.java
@@ -57,7 +57,7 @@ public class LookupCallContext extends AbstractSqlCallContext {
             Map<Integer, LookupKey> lookupKeys,
             int[] lookupKeyOrder,
             LogicalType lookupType) {
-        super(dataTypeFactory, function, function.functionIdentifier());
+        super(dataTypeFactory, function, function.functionIdentifier(), false);
         this.lookupKeys = lookupKeys;
         this.lookupKeyOrder = lookupKeyOrder;
         this.argumentDataTypes =

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
@@ -52,7 +52,11 @@ public final class OperatorBindingCallContext extends AbstractSqlCallContext {
             FunctionDefinition definition,
             SqlOperatorBinding binding,
             RelDataType returnRelDataType) {
-        super(dataTypeFactory, definition, binding.getOperator().getNameAsId().toString());
+        super(
+                dataTypeFactory,
+                definition,
+                binding.getOperator().getNameAsId().toString(),
+                binding.getGroupCount() > 0);
 
         this.binding = binding;
         this.argumentDataTypes =

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -150,46 +150,6 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.size == 1)
             DistinctAgg(args.head)
 
-          case AVG =>
-            assert(args.size == 1)
-            Avg(args.head)
-
-          case COUNT =>
-            assert(args.size == 1)
-            Count(args.head)
-
-          case MAX =>
-            assert(args.size == 1)
-            Max(args.head)
-
-          case MIN =>
-            assert(args.size == 1)
-            Min(args.head)
-
-          case SUM =>
-            assert(args.size == 1)
-            Sum(args.head)
-
-          case SUM0 =>
-            assert(args.size == 1)
-            Sum0(args.head)
-
-          case STDDEV_POP =>
-            assert(args.size == 1)
-            StddevPop(args.head)
-
-          case STDDEV_SAMP =>
-            assert(args.size == 1)
-            StddevSamp(args.head)
-
-          case VAR_POP =>
-            assert(args.size == 1)
-            VarPop(args.head)
-
-          case VAR_SAMP =>
-            assert(args.size == 1)
-            VarSamp(args.head)
-
           case COLLECT =>
             assert(args.size == 1)
             Collect(args.head)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/aggregations.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/aggregations.scala
@@ -73,72 +73,6 @@ case class DistinctAgg(child: PlannerExpression) extends Aggregation {
   override private[flink] def children = Seq(child)
 }
 
-case class Sum(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"sum($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveSumType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "sum")
-}
-
-case class Sum0(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"sum0($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveSumType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "sum0")
-}
-
-case class Min(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"min($child)"
-
-  override private[flink] def resultType = child.resultType
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertOrderableExpr(child.resultType, "min")
-}
-
-case class Max(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"max($child)"
-
-  override private[flink] def resultType = child.resultType
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertOrderableExpr(child.resultType, "max")
-}
-
-case class Count(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"count($child)"
-
-  override private[flink] def resultType = BasicTypeInfo.LONG_TYPE_INFO
-}
-
-case class Avg(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"avg($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveAvgAggType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "avg")
-}
-
 /**
   * Returns a multiset aggregates.
   */
@@ -150,58 +84,6 @@ case class Collect(child: PlannerExpression) extends Aggregation  {
     MultisetTypeInfo.getInfoFor(child.resultType)
 
   override def toString: String = s"collect($child)"
-}
-
-case class StddevPop(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"stddev_pop($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveAvgAggType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "stddev_pop")
-}
-
-case class StddevSamp(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"stddev_samp($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveAvgAggType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "stddev_samp")
-}
-
-case class VarPop(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"var_pop($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveAvgAggType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "var_pop")
-}
-
-case class VarSamp(child: PlannerExpression) extends Aggregation {
-  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
-  override def toString = s"var_samp($child)"
-
-  override private[flink] def resultType = {
-    fromLogicalTypeToTypeInfo(FlinkTypeSystem.deriveAvgAggType(
-      fromTypeInfoToLogicalType(child.resultType)))
-  }
-
-  override private[flink] def validateInput() =
-    TypeInfoCheckUtils.assertNumericExpr(child.resultType, "var_samp")
 }
 
 /**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging
 
 import junit.framework.TestCase.{assertFalse, assertTrue}
 import org.junit.{Assert, Test}
@@ -90,9 +91,12 @@ class FlinkTypeFactoryTest {
   }
 
   @Test def testDecimalInferType(): Unit = {
-    Assert.assertEquals(new DecimalType(7, 0), FlinkTypeSystem.inferIntDivType(5, 2, 4))
-    Assert.assertEquals(new DecimalType(38, 5), FlinkTypeSystem.inferAggSumType(5))
-    Assert.assertEquals(new DecimalType(false, 38, 6), FlinkTypeSystem.inferAggAvgType(5))
+    Assert.assertEquals(
+      new DecimalType(38, 5),
+      LogicalTypeMerging.findSumAggType(new DecimalType(10, 5)))
+    Assert.assertEquals(
+      new DecimalType(38, 6),
+      LogicalTypeMerging.findAvgAggType(new DecimalType(10, 5)))
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/DecimalITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/DecimalITCase.scala
@@ -18,21 +18,21 @@
 
 package org.apache.flink.table.planner.runtime.batch.table
 
-import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.DataTypes.{BIGINT, DECIMAL, DOUBLE, INT}
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
-import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase}
-import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.runtime.types.PlannerTypeUtils.isInteroperable
-import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromLogicalTypeToTypeInfo
-import org.apache.flink.table.types.logical.{DecimalType, LogicalType}
+import org.apache.flink.table.types.DataType
 import org.apache.flink.types.Row
 
+import org.junit.Assert.assertEquals
 import org.junit.{Assert, Test}
 
 import java.math.{BigDecimal => JBigDecimal}
 
+import scala.collection.JavaConverters._
 import scala.collection.Seq
 
 /**
@@ -42,31 +42,29 @@ import scala.collection.Seq
 class DecimalITCase extends BatchTestBase {
 
   private def checkQuery(
-      sourceColTypes: Seq[LogicalType],
+      sourceColTypes: Seq[DataType],
       sourceRows: Seq[Row],
       tableTransfer: Table => Table,
-      expectedColTypes: Seq[LogicalType],
+      expectedColTypes: Seq[DataType],
       expectedRows: Seq[Row],
       isSorted: Boolean = false): Unit = {
-    val rowTypeInfo = new RowTypeInfo(sourceColTypes.toArray.map(fromLogicalTypeToTypeInfo): _*)
-    val fieldNames = rowTypeInfo.getFieldNames.mkString(",")
-    val t = BatchTableEnvUtil.fromCollection(tEnv, sourceRows, rowTypeInfo, fieldNames)
+    val t = tEnv.fromValues(DataTypes.ROW(sourceColTypes: _*), sourceRows: _*)
 
     // check result schema
     val resultTable = tableTransfer(t)
-    val ts2 = resultTable.getSchema.getFieldDataTypes.map(fromDataTypeToLogicalType)
+    val ts2 = resultTable.getResolvedSchema.getColumnDataTypes.asScala
     Assert.assertEquals(expectedColTypes.length, ts2.length)
 
-    Assert.assertTrue(expectedColTypes.zip(ts2).forall {
-      case (t1, t2) => isInteroperable(t1, t2)
-    })
+    expectedColTypes.zip(ts2).foreach {
+      case (t1, t2) => assertEquals(t1, t2)
+    }
 
     def prepareResult(isSorted: Boolean, seq: Seq[Row]) = {
       if (!isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
     }
 
     val resultRows = executeQuery(resultTable)
-    Assert.assertEquals(
+    assertEquals(
       prepareResult(isSorted, expectedRows),
       prepareResult(isSorted, resultRows))
   }
@@ -92,18 +90,6 @@ class DecimalITCase extends BatchTestBase {
       throw new AssertionError("Overflow exception expected, but not thrown.", ex)
     }
   }
-
-  private def DECIMAL = (p: Int, s: Int) => new DecimalType(p, s)
-
-  private def BOOL = DataTypes.BOOLEAN.getLogicalType
-
-  private def INT = DataTypes.INT.getLogicalType
-
-  private def LONG = DataTypes.BIGINT.getLogicalType
-
-  private def DOUBLE = DataTypes.DOUBLE.getLogicalType
-
-  private def STRING = DataTypes.STRING.getLogicalType
 
   // d"xxx" => new BigDecimal("xxx")
   // d"xxx$yy" => new BigDecimal("xxx").setScale(yy)
@@ -190,8 +176,8 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(6, 3)),
       (10 to 90).map(i => row(java.math.BigDecimal.valueOf(i))),
-      table => table.select('f0.min, 'f0.max, 'f0.count ),
-      Seq(DECIMAL(6, 3), DECIMAL(6, 3), LONG),
+      table => table.select('f0.min, 'f0.max, 'f0.count),
+      Seq(DECIMAL(6, 3), DECIMAL(6, 3), BIGINT.notNull()),
       s1r(d"10.000", d"90.000", 81L))
   }
 
@@ -204,7 +190,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('a === 'f0).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
   }
 
@@ -217,7 +203,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('a === 'f1).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
   }
 
@@ -230,7 +216,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('b === 'f0).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
 
   }
@@ -244,7 +230,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('a === 'f2).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
   }
 
@@ -257,7 +243,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('c === 'f0).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
   }
 
@@ -270,7 +256,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('a === 'f3).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
   }
 
@@ -282,7 +268,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
       table => table.as("a", "b", "c", "d").join(table).where('a === 'f3).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       s1r(1L))
   }
 
@@ -292,7 +278,7 @@ class DecimalITCase extends BatchTestBase {
       Seq(DECIMAL(8, 2)),
       Seq(row(d"1"), row(d"3"), row(d"1.0"), row(d"2")),
       table => table.groupBy('f0).select(1.count),
-      Seq(LONG),
+      Seq(BIGINT.notNull()),
       Seq(row(2L), row(1L), row(1L)))
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/AvgAggFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/AvgAggFunction.scala
@@ -25,6 +25,8 @@ import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo
 import org.apache.flink.table.types.logical.DecimalType
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findAvgAggType
 
 import java.lang.{Iterable => JIterable}
 import java.math.{BigDecimal, BigInteger, MathContext}
@@ -327,10 +329,10 @@ class DecimalAvgAggFunction(argType: DecimalType)
   }
 
   def getSumType: DecimalType =
-    FlinkTypeSystem.inferAggSumType(argType.getScale)
+    LogicalTypeMerging.findSumAggType(argType).asInstanceOf[DecimalType]
 
   override def getResultType: BigDecimalTypeInfo = {
-    val t = FlinkTypeSystem.inferAggAvgType(argType.getScale)
+    val t = LogicalTypeMerging.findAvgAggType(argType).asInstanceOf[DecimalType]
     new BigDecimalTypeInfo(t.getPrecision, t.getScale)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -142,7 +142,7 @@ abstract class TableEnvImpl(
 
   catalogManager.initSchemaResolver(
     isStreamingMode,
-    operationTreeBuilder.expressionResolverBuilder())
+    operationTreeBuilder.getResolverBuilder())
 
   def getConfig: TableConfig = config
 


### PR DESCRIPTION
## What is the purpose of the change

Ports the most important agg functions of the Table API to the new type system and removes the legacy planner expressions for those. Table API functions now behave exactly like SQL functions.

## Brief change log

See commit messages.

The following functions have been updated: avg, sum, sum0, count, min, max, stddevPop/Samp, varPop/Samp

## Verifying this change

This change is already covered by existing tests, such as `DecimalITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
