### PR TITLE
[FLINK-22184][client] Shutdown client outside of netty thread

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -92,7 +92,7 @@ public class AbstractSessionClusterExecutor<
                                                     clusterClientProvider,
                                                     jobID,
                                                     userCodeClassloader))
-                    .whenComplete((ignored1, ignored2) -> clusterClient.close());
+                    .whenCompleteAsync((ignored1, ignored2) -> clusterClient.close());
         }
     }
 }


### PR DESCRIPTION
If the future returned by `clusterClient.submitJob()` fails, then this failure is executed by a netty thread. This then causes `.whenComplete((ignored1, ignored2) -> clusterClient.close())` to also be run in the netty thread, which causes the shutdown to fail because netty can't be shutdown since a thread is still active.