### PR TITLE
[FLINK-22187][docs] Remove description of sync checkpoint mode of HashMapStateBackend

### DIFF
--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -53,12 +53,6 @@ If nothing else is configured, the system will use the HashMapStateBackend.
 The *HashMapStateBackend* holds data internally as objects on the Java heap. Key/value state and window operators hold hash tables
 that store the values, triggers, etc.
 
-The HashMapStateBackend uses *asynchronous snapshots by default* to avoid blocking the processing pipeline while writing state checkpoints. To disable this feature, users can instantiate a HashMapStateBackend with the corresponding boolean flag in the constructor set to `false`, e.g.:
-
-```java
-new HashMapStateBackend(false);
-```
-
 The HashMapStateBackend is encouraged for:
 
   - Jobs with large state, long windows, large key/value states.


### PR DESCRIPTION
## What is the purpose of the change

Remove description of sync checkpoint mode of HashMapStateBackend as the constructor has been removed.



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
