### PR TITLE
[FLINK-21996][coordination] - Part one: Tests and adjusted threading model

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/NumberSequenceSource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/NumberSequenceSource.java
@@ -40,6 +40,7 @@ import org.apache.flink.util.NumberSequenceIterator;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -81,6 +82,18 @@ public class NumberSequenceSource
         this.to = to;
     }
 
+    public long getFrom() {
+        return from;
+    }
+
+    public long getTo() {
+        return to;
+    }
+
+    // ------------------------------------------------------------------------
+    //  source methods
+    // ------------------------------------------------------------------------
+
     @Override
     public TypeInformation<Long> getProducedType() {
         return Types.LONG;
@@ -100,19 +113,8 @@ public class NumberSequenceSource
     public SplitEnumerator<NumberSequenceSplit, Collection<NumberSequenceSplit>> createEnumerator(
             final SplitEnumeratorContext<NumberSequenceSplit> enumContext) {
 
-        final NumberSequenceIterator[] subSequences =
-                new NumberSequenceIterator(from, to).split(enumContext.currentParallelism());
-        final ArrayList<NumberSequenceSplit> splits = new ArrayList<>(subSequences.length);
-
-        int splitId = 1;
-        for (NumberSequenceIterator seq : subSequences) {
-            if (seq.hasNext()) {
-                splits.add(
-                        new NumberSequenceSplit(
-                                String.valueOf(splitId++), seq.getCurrent(), seq.getTo()));
-            }
-        }
-
+        final List<NumberSequenceSplit> splits =
+                splitNumberRange(from, to, enumContext.currentParallelism());
         return new IteratorSourceEnumerator<>(enumContext, splits);
     }
 
@@ -132,6 +134,23 @@ public class NumberSequenceSource
     public SimpleVersionedSerializer<Collection<NumberSequenceSplit>>
             getEnumeratorCheckpointSerializer() {
         return new CheckpointSerializer();
+    }
+
+    protected List<NumberSequenceSplit> splitNumberRange(long from, long to, int numSplits) {
+        final NumberSequenceIterator[] subSequences =
+                new NumberSequenceIterator(from, to).split(numSplits);
+        final ArrayList<NumberSequenceSplit> splits = new ArrayList<>(subSequences.length);
+
+        int splitId = 1;
+        for (NumberSequenceIterator seq : subSequences) {
+            if (seq.hasNext()) {
+                splits.add(
+                        new NumberSequenceSplit(
+                                String.valueOf(splitId++), seq.getCurrent(), seq.getTo()));
+            }
+        }
+
+        return splits;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/lib/NumberSequenceSourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/lib/NumberSequenceSourceTest.java
@@ -66,7 +66,11 @@ public class NumberSequenceSourceTest {
 
                 // re-create and restore
                 reader = createReader();
-                reader.addSplits(splits);
+                if (splits.isEmpty()) {
+                    reader.notifyNoMoreSplits();
+                } else {
+                    reader.addSplits(splits);
+                }
             }
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -595,6 +595,21 @@ public class FutureUtils {
     }
 
     // ------------------------------------------------------------------------
+    //  Delayed completion
+    // ------------------------------------------------------------------------
+
+    /**
+     * Asynchronously completes the future after a certain delay.
+     *
+     * @param future The future to complete.
+     * @param success The element to complete the future with.
+     * @param delay The delay after which the future should be completed.
+     */
+    public static <T> void completeDelayed(CompletableFuture<T> future, T success, Duration delay) {
+        Delayer.delay(() -> future.complete(success), delay.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    // ------------------------------------------------------------------------
     //  Future actions
     // ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -202,8 +202,7 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
          * target TaskManager. The future is completed exceptionally if the event cannot be sent.
          * That includes situations where the target task is not running.
          */
-        CompletableFuture<Acknowledge> sendEvent(OperatorEvent evt, int targetSubtask)
-                throws TaskNotRunningException;
+        CompletableFuture<Acknowledge> sendEvent(OperatorEvent evt, int targetSubtask);
 
         /**
          * Fails the job and trigger a global failover operation.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.OperatorCoordinatorCheckpointContext;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -464,7 +465,12 @@ public class OperatorCoordinatorHolder
                 throw new FlinkRuntimeException("Cannot serialize operator event", e);
             }
 
-            return eventValve.sendEvent(serializedEvent, targetSubtask);
+            try {
+                return eventValve.sendEvent(serializedEvent, targetSubtask);
+            } catch (Throwable t) {
+                ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+                return FutureUtils.completedExceptionally(t);
+            }
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.OperatorCoordinatorCheckpointContext;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -69,9 +68,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * <ul>
  *   <li>Events pass through a special channel, the {@link OperatorEventValve}. If we are not
  *       currently triggering a checkpoint, then events simply pass through.
- *   <li>Atomically, with the completion of the checkpoint future for the coordinator, this operator
- *       operator event valve is closed. Events coming after that are held back (buffered), because
- *       they belong to the epoch after the checkpoint.
+ *   <li>With the completion of the checkpoint future for the coordinator, this operator event valve
+ *       is closed. Events coming after that are held back (buffered), because they belong to the
+ *       epoch after the checkpoint.
  *   <li>Once all coordinators in the job have completed the checkpoint, the barriers to the sources
  *       are injected. After that (see {@link #afterSourceBarrierInjection(long)}) the valves are
  *       opened again and the events are sent.
@@ -106,10 +105,13 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * <h3>Concurrency and Threading Model</h3>
  *
- * <p>This component runs mainly in a main-thread-executor, like RPC endpoints. However, some
- * actions need to be triggered synchronously by other threads. Most notably, when the checkpoint
- * future is completed by the {@code OperatorCoordinator} implementation, we need to synchronously
- * suspend event-sending.
+ * <p>This component runs strictly in the Scheduler's main-thread-executor. All calls "from the
+ * outside" are either already in the main-thread-executor (when coming from Scheduler) or put into
+ * the main-thread-executor (when coming from the CheckpointCoordinator). We rely on the executor to
+ * preserve strict order of the calls.
+ *
+ * <p>Actions from the coordinator to the "outside world" (like completing a checkpoint and sending
+ * an event) are also enqueued back into the scheduler main-thread executor, strictly in order.
  */
 public class OperatorCoordinatorHolder
         implements OperatorCoordinator, OperatorCoordinatorCheckpointContext {
@@ -146,6 +148,7 @@ public class OperatorCoordinatorHolder
             ComponentMainThreadExecutor mainThreadExecutor) {
         this.globalFailureHandler = globalFailureHandler;
         this.mainThreadExecutor = mainThreadExecutor;
+        eventValve.setMainThreadExecutorForValidation(mainThreadExecutor);
         context.lazyInitialize(globalFailureHandler, mainThreadExecutor);
     }
 
@@ -238,8 +241,11 @@ public class OperatorCoordinatorHolder
     @Override
     public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData)
             throws Exception {
-        // ideally we would like to check this here, however this method is called early during
-        // execution graph construction, before the main thread executor is set
+        // the first time this method is called is early during execution graph construction,
+        // before the main thread executor is set. hence this conditional check.
+        if (mainThreadExecutor != null) {
+            mainThreadExecutor.assertRunningInMainThread();
+        }
 
         eventValve.reset();
         if (context != null) {
@@ -252,8 +258,9 @@ public class OperatorCoordinatorHolder
             final long checkpointId, final CompletableFuture<byte[]> result) {
         mainThreadExecutor.assertRunningInMainThread();
 
-        // synchronously!!!, with the completion, we need to shut the event valve
-        result.whenComplete(
+        final CompletableFuture<byte[]> coordinatorCheckpoint = new CompletableFuture<>();
+
+        coordinatorCheckpoint.whenCompleteAsync(
                 (success, failure) -> {
                     if (failure != null) {
                         result.completeExceptionally(failure);
@@ -265,11 +272,12 @@ public class OperatorCoordinatorHolder
                             result.completeExceptionally(e);
                         }
                     }
-                });
+                },
+                mainThreadExecutor);
 
         try {
             eventValve.markForCheckpoint(checkpointId);
-            coordinator.checkpointCoordinator(checkpointId, result);
+            coordinator.checkpointCoordinator(checkpointId, coordinatorCheckpoint);
         } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
             result.completeExceptionally(t);
@@ -283,34 +291,20 @@ public class OperatorCoordinatorHolder
 
     @Override
     public void afterSourceBarrierInjection(long checkpointId) {
-        // this method is commonly called by the CheckpointCoordinator's executor thread (timer
-        // thread).
-
-        // we ideally want the scheduler main-thread to be the one that sends the blocked events
-        // however, we need to react synchronously here, to maintain consistency and not allow
-        // another checkpoint injection in-between (unlikely, but possible).
-        // fortunately, the event-sending goes pretty much directly to the RPC gateways, which are
-        // thread safe.
-
-        // this will automatically be fixed once the checkpoint coordinator runs in the
+        // unfortunately, this method does not run in the scheduler executor, but in the
+        // checkpoint coordinator time thread.
+        // we can remove the delegation once the checkpoint coordinator runs fully in the
         // scheduler's main thread executor
-        eventValve.openValveAndUnmarkCheckpoint();
+        mainThreadExecutor.execute(() -> eventValve.openValveAndUnmarkCheckpoint(checkpointId));
     }
 
     @Override
     public void abortCurrentTriggering() {
-        // this method is commonly called by the CheckpointCoordinator's executor thread (timer
-        // thread).
-
-        // we ideally want the scheduler main-thread to be the one that sends the blocked events
-        // however, we need to react synchronously here, to maintain consistency and not allow
-        // another checkpoint injection in-between (unlikely, but possible).
-        // fortunately, the event-sending goes pretty much directly to the RPC gateways, which are
-        // thread safe.
-
-        // this will automatically be fixed once the checkpoint coordinator runs in the
+        // unfortunately, this method does not run in the scheduler executor, but in the
+        // checkpoint coordinator time thread.
+        // we can remove the delegation once the checkpoint coordinator runs fully in the
         // scheduler's main thread executor
-        eventValve.openValveAndUnmarkCheckpoint();
+        mainThreadExecutor.execute(eventValve::openValveAndUnmarkCheckpoint);
     }
 
     // ------------------------------------------------------------------------
@@ -465,12 +459,10 @@ public class OperatorCoordinatorHolder
                 throw new FlinkRuntimeException("Cannot serialize operator event", e);
             }
 
-            try {
-                return eventValve.sendEvent(serializedEvent, targetSubtask);
-            } catch (Throwable t) {
-                ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-                return FutureUtils.completedExceptionally(t);
-            }
+            final CompletableFuture<Acknowledge> result = new CompletableFuture<>();
+            schedulerExecutor.execute(
+                    () -> eventValve.sendEvent(serializedEvent, targetSubtask, result));
+            return result;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -212,7 +212,7 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
         @Override
         public synchronized CompletableFuture<Acknowledge> sendEvent(
-                OperatorEvent evt, int targetSubtask) throws TaskNotRunningException {
+                OperatorEvent evt, int targetSubtask) {
             // Do not enter the sending procedure if the context has been quiesced.
             if (quiesced) {
                 return CompletableFuture.completedFuture(Acknowledge.get());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -41,6 +41,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
 
 import static org.apache.flink.util.NetUtils.isValidClientPort;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -340,6 +341,12 @@ public class AkkaRpcServiceUtils {
         }
 
         public AkkaRpcService createAndStart() throws Exception {
+            return createAndStart(AkkaRpcService::new);
+        }
+
+        public AkkaRpcService createAndStart(
+                BiFunction<ActorSystem, AkkaRpcServiceConfiguration, AkkaRpcService> constructor)
+                throws Exception {
             if (actorSystemExecutorConfiguration == null) {
                 actorSystemExecutorConfiguration =
                         BootstrapTools.ForkJoinExecutorConfiguration.fromConfiguration(
@@ -372,7 +379,7 @@ public class AkkaRpcServiceUtils {
                                 customConfig);
             }
 
-            return new AkkaRpcService(
+            return constructor.apply(
                     actorSystem, AkkaRpcServiceConfiguration.fromConfiguration(configuration));
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -182,14 +182,15 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                             .assignment()
                             .forEach(
                                     (id, splits) -> {
+                                        final AddSplitEvent<SplitT> addSplitEvent;
                                         try {
-                                            operatorCoordinatorContext.sendEvent(
-                                                    new AddSplitEvent<>(splits, splitSerializer),
-                                                    id);
+                                            addSplitEvent =
+                                                    new AddSplitEvent<>(splits, splitSerializer);
                                         } catch (IOException e) {
                                             throw new FlinkRuntimeException(
                                                     "Failed to serialize splits.", e);
                                         }
+                                        operatorCoordinatorContext.sendEvent(addSplitEvent, id);
                                     });
                     return null;
                 },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -30,7 +30,6 @@ import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
-import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
@@ -147,16 +146,8 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
         callInCoordinatorThread(
                 () -> {
-                    try {
-                        operatorCoordinatorContext.sendEvent(
-                                new SourceEventWrapper(event), subtaskId);
-                        return null;
-                    } catch (TaskNotRunningException e) {
-                        throw new FlinkRuntimeException(
-                                String.format(
-                                        "Failed to send event %s to subtask %d", event, subtaskId),
-                                e);
-                    }
+                    operatorCoordinatorContext.sendEvent(new SourceEventWrapper(event), subtaskId);
+                    return null;
                 },
                 String.format("Failed to send event %s to subtask %d", event, subtaskId));
     }
@@ -195,12 +186,6 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                                             operatorCoordinatorContext.sendEvent(
                                                     new AddSplitEvent<>(splits, splitSerializer),
                                                     id);
-                                        } catch (TaskNotRunningException e) {
-                                            throw new FlinkRuntimeException(
-                                                    String.format(
-                                                            "Failed to assign splits %s to reader %d.",
-                                                            splits, id),
-                                                    e);
                                         } catch (IOException e) {
                                             throw new FlinkRuntimeException(
                                                     "Failed to serialize splits.", e);
@@ -216,13 +201,8 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         // Ensure the split assignment is done by the the coordinator executor.
         callInCoordinatorThread(
                 () -> {
-                    try {
-                        operatorCoordinatorContext.sendEvent(new NoMoreSplitsEvent(), subtask);
-                        return null; // void return value
-                    } catch (TaskNotRunningException e) {
-                        throw new FlinkRuntimeException(
-                                "Failed to send 'NoMoreSplits' to reader " + subtask, e);
-                    }
+                    operatorCoordinatorContext.sendEvent(new NoMoreSplitsEvent(), subtask);
+                    return null; // void return value
                 },
                 "Failed to send 'NoMoreSplits' to reader " + subtask);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.PartitionInfo;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.TaskThreadInfoResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.rest.messages.LogInfo;
+import org.apache.flink.runtime.rest.messages.taskmanager.ThreadDumpInfo;
+import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
+import org.apache.flink.types.SerializableOptional;
+import org.apache.flink.util.SerializedValue;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A class that decorates/forwards calls to a {@link TaskExecutorGateway}.
+ *
+ * <p>This class is meant as a base for custom decorators, to avoid having to maintain all the
+ * method overrides in each decorator.
+ */
+public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
+
+    protected final TaskExecutorGateway originalGateway;
+
+    protected TaskExecutorGatewayDecoratorBase(TaskExecutorGateway originalGateway) {
+        this.originalGateway = originalGateway;
+    }
+
+    @Override
+    public String getAddress() {
+        return originalGateway.getAddress();
+    }
+
+    @Override
+    public String getHostname() {
+        return originalGateway.getHostname();
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> requestSlot(
+            SlotID slotId,
+            JobID jobId,
+            AllocationID allocationId,
+            ResourceProfile resourceProfile,
+            String targetAddress,
+            ResourceManagerId resourceManagerId,
+            Time timeout) {
+        return originalGateway.requestSlot(
+                slotId,
+                jobId,
+                allocationId,
+                resourceProfile,
+                targetAddress,
+                resourceManagerId,
+                timeout);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> submitTask(
+            TaskDeploymentDescriptor tdd, JobMasterId jobMasterId, Time timeout) {
+        return originalGateway.submitTask(tdd, jobMasterId, timeout);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> updatePartitions(
+            ExecutionAttemptID executionAttemptID,
+            Iterable<PartitionInfo> partitionInfos,
+            Time timeout) {
+        return originalGateway.updatePartitions(executionAttemptID, partitionInfos, timeout);
+    }
+
+    @Override
+    public void releaseOrPromotePartitions(
+            JobID jobId,
+            Set<ResultPartitionID> partitionToRelease,
+            Set<ResultPartitionID> partitionsToPromote) {
+        originalGateway.releaseOrPromotePartitions(jobId, partitionToRelease, partitionsToPromote);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> releaseClusterPartitions(
+            Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
+        return originalGateway.releaseClusterPartitions(dataSetsToRelease, timeout);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> triggerCheckpoint(
+            ExecutionAttemptID executionAttemptID,
+            long checkpointID,
+            long checkpointTimestamp,
+            CheckpointOptions checkpointOptions) {
+        return originalGateway.triggerCheckpoint(
+                executionAttemptID, checkpointID, checkpointTimestamp, checkpointOptions);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> confirmCheckpoint(
+            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+        return originalGateway.confirmCheckpoint(
+                executionAttemptID, checkpointId, checkpointTimestamp);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> abortCheckpoint(
+            ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
+        return originalGateway.abortCheckpoint(
+                executionAttemptID, checkpointId, checkpointTimestamp);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> cancelTask(
+            ExecutionAttemptID executionAttemptID, Time timeout) {
+        return originalGateway.cancelTask(executionAttemptID, timeout);
+    }
+
+    @Override
+    public void heartbeatFromJobManager(
+            ResourceID heartbeatOrigin, AllocatedSlotReport allocatedSlotReport) {
+        originalGateway.heartbeatFromJobManager(heartbeatOrigin, allocatedSlotReport);
+    }
+
+    @Override
+    public void heartbeatFromResourceManager(ResourceID heartbeatOrigin) {
+        originalGateway.heartbeatFromResourceManager(heartbeatOrigin);
+    }
+
+    @Override
+    public void disconnectJobManager(JobID jobId, Exception cause) {
+        originalGateway.disconnectJobManager(jobId, cause);
+    }
+
+    @Override
+    public void disconnectResourceManager(Exception cause) {
+        originalGateway.disconnectResourceManager(cause);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> freeSlot(
+            AllocationID allocationId, Throwable cause, Time timeout) {
+        return originalGateway.freeSlot(allocationId, cause, timeout);
+    }
+
+    @Override
+    public void freeInactiveSlots(JobID jobId, Time timeout) {
+        originalGateway.freeInactiveSlots(jobId, timeout);
+    }
+
+    @Override
+    public CompletableFuture<TransientBlobKey> requestFileUploadByType(
+            FileType fileType, Time timeout) {
+        return originalGateway.requestFileUploadByType(fileType, timeout);
+    }
+
+    @Override
+    public CompletableFuture<TransientBlobKey> requestFileUploadByName(
+            String fileName, Time timeout) {
+        return originalGateway.requestFileUploadByName(fileName, timeout);
+    }
+
+    @Override
+    public CompletableFuture<SerializableOptional<String>> requestMetricQueryServiceAddress(
+            Time timeout) {
+        return originalGateway.requestMetricQueryServiceAddress(timeout);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> canBeReleased() {
+        return originalGateway.canBeReleased();
+    }
+
+    @Override
+    public CompletableFuture<Collection<LogInfo>> requestLogList(Time timeout) {
+        return originalGateway.requestLogList(timeout);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> sendOperatorEventToTask(
+            ExecutionAttemptID task, OperatorID operator, SerializedValue<OperatorEvent> evt) {
+        return originalGateway.sendOperatorEventToTask(task, operator, evt);
+    }
+
+    @Override
+    public CompletableFuture<ThreadDumpInfo> requestThreadDump(Time timeout) {
+        return originalGateway.requestThreadDump(timeout);
+    }
+
+    @Override
+    public CompletableFuture<TaskThreadInfoResponse> requestThreadInfoSamples(
+            ExecutionAttemptID taskExecutionAttemptId,
+            ThreadInfoSamplesRequest requestParams,
+            Time timeout) {
+        return originalGateway.requestThreadInfoSamples(
+                taskExecutionAttemptId, requestParams, timeout);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -349,15 +349,13 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
             if (nextNumber > maxNumber) {
                 return;
             }
-            try {
-                if (nextNumber == maxNumber) {
-                    context.sendEvent(new EndEvent(), 0);
-                } else {
-                    context.sendEvent(new IntegerEvent(nextNumber), 0);
-                }
-                nextNumber++;
-            } catch (TaskNotRunningException ignored) {
+
+            if (nextNumber == maxNumber) {
+                context.sendEvent(new EndEvent(), 0);
+            } else {
+                context.sendEvent(new IntegerEvent(nextNumber), 0);
             }
+            nextNumber++;
         }
 
         private void checkWhetherToTriggerFailure() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -75,8 +75,7 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     }
 
     @Override
-    public CompletableFuture<Acknowledge> sendEvent(OperatorEvent evt, int targetSubtask)
-            throws TaskNotRunningException {
+    public CompletableFuture<Acknowledge> sendEvent(OperatorEvent evt, int targetSubtask) {
         eventsToOperator.computeIfAbsent(targetSubtask, subtaskId -> new ArrayList<>()).add(evt);
         if (failEventSending) {
             CompletableFuture<Acknowledge> future = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventValveTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventValveTest.java
@@ -42,8 +42,8 @@ public class OperatorEventValveTest {
         final OperatorEventValve valve = new OperatorEventValve(sender);
 
         final OperatorEvent event = new TestOperatorEvent();
-        final CompletableFuture<Acknowledge> future =
-                valve.sendEvent(new SerializedValue<>(event), 11);
+        final CompletableFuture<Acknowledge> future = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(event), 11, future);
 
         assertThat(sender.events, contains(new EventWithSubtask(event, 11)));
         assertTrue(future.isDone());
@@ -74,8 +74,8 @@ public class OperatorEventValveTest {
         valve.markForCheckpoint(1L);
         valve.shutValve(1L);
 
-        final CompletableFuture<Acknowledge> future =
-                valve.sendEvent(new SerializedValue<>(new TestOperatorEvent()), 1);
+        final CompletableFuture<Acknowledge> future = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(new TestOperatorEvent()), 1, future);
 
         assertTrue(sender.events.isEmpty());
         assertFalse(future.isDone());
@@ -91,10 +91,10 @@ public class OperatorEventValveTest {
 
         final OperatorEvent event1 = new TestOperatorEvent();
         final OperatorEvent event2 = new TestOperatorEvent();
-        final CompletableFuture<Acknowledge> future1 =
-                valve.sendEvent(new SerializedValue<>(event1), 3);
-        final CompletableFuture<Acknowledge> future2 =
-                valve.sendEvent(new SerializedValue<>(event2), 0);
+        final CompletableFuture<Acknowledge> future1 = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(event1), 3, future1);
+        final CompletableFuture<Acknowledge> future2 = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(event2), 0, future2);
 
         valve.openValveAndUnmarkCheckpoint();
 
@@ -114,8 +114,8 @@ public class OperatorEventValveTest {
         valve.markForCheckpoint(17L);
         valve.shutValve(17L);
 
-        final CompletableFuture<Acknowledge> future =
-                valve.sendEvent(new SerializedValue<>(new TestOperatorEvent()), 10);
+        final CompletableFuture<Acknowledge> future = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(new TestOperatorEvent()), 10, future);
         valve.openValveAndUnmarkCheckpoint();
 
         assertTrue(future.isCompletedExceptionally());
@@ -128,8 +128,10 @@ public class OperatorEventValveTest {
         valve.markForCheckpoint(17L);
         valve.shutValve(17L);
 
-        valve.sendEvent(new SerializedValue<>(new TestOperatorEvent()), 0);
-        valve.sendEvent(new SerializedValue<>(new TestOperatorEvent()), 1);
+        valve.sendEvent(
+                new SerializedValue<>(new TestOperatorEvent()), 0, new CompletableFuture<>());
+        valve.sendEvent(
+                new SerializedValue<>(new TestOperatorEvent()), 1, new CompletableFuture<>());
 
         valve.reset();
         valve.openValveAndUnmarkCheckpoint();
@@ -146,10 +148,10 @@ public class OperatorEventValveTest {
 
         final OperatorEvent event1 = new TestOperatorEvent();
         final OperatorEvent event2 = new TestOperatorEvent();
-        final CompletableFuture<Acknowledge> future1 =
-                valve.sendEvent(new SerializedValue<>(event1), 0);
-        final CompletableFuture<Acknowledge> future2 =
-                valve.sendEvent(new SerializedValue<>(event2), 1);
+        final CompletableFuture<Acknowledge> future1 = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(event1), 0, future1);
+        final CompletableFuture<Acknowledge> future2 = new CompletableFuture<>();
+        valve.sendEvent(new SerializedValue<>(event2), 1, future2);
 
         valve.resetForTask(1);
         valve.openValveAndUnmarkCheckpoint();

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceEnumerator;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.source.event.AddSplitEvent;
+import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGatewayDecoratorBase;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.TriFunction;
+
+import akka.actor.ActorSystem;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A test suite for source enumerator (operator coordinator) for situations where RPC calls for
+ * split assignments (operator events) fails from time to time.
+ */
+public class OperatorEventSendingCheckpointITCase extends TestLogger {
+
+    private static final int PARALLELISM = 1;
+    private static MiniCluster flinkCluster;
+
+    @BeforeClass
+    public static void setupMiniClusterAndEnv() throws Exception {
+        flinkCluster = new MiniClusterWithRpcIntercepting(PARALLELISM);
+        flinkCluster.start();
+        TestStreamEnvironment.setAsContext(flinkCluster, PARALLELISM);
+    }
+
+    @AfterClass
+    public static void clearEnvAndStopMiniCluster() throws Exception {
+        TestStreamEnvironment.unsetAsContext();
+        if (flinkCluster != null) {
+            flinkCluster.close();
+            flinkCluster = null;
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  tests
+    // ------------------------------------------------------------------------
+
+    /**
+     * Every second assign split event is lost. Eventually, the enumerator must recognize that an
+     * event was lost and trigger recovery to prevent data loss. Data loss would manifest in a
+     * stalled test, because we could wait forever to collect the required number of events back.
+     */
+    @Ignore // ignore for now, because this test fails due to FLINK-21996
+    @Test
+    public void testOperatorEventLostNoReaderFailure() throws Exception {
+        final int[] eventsToLose = new int[] {2, 4, 6};
+
+        OpEventRpcInterceptor.currentHandler =
+                new OperatorEventRpcHandler(
+                        (task, operator, event, originalRpcHandler) -> askTimeoutFuture(),
+                        eventsToLose);
+
+        runTest(false);
+    }
+
+    /**
+     * First and third assign split events are lost. In the middle of all events being processed
+     * (which is after the second successful event delivery, the fourth event), there is
+     * additionally a failure on the reader that triggers recovery.
+     */
+    @Ignore // ignore for now, because this test fails due to FLINK-21996
+    @Test
+    public void testOperatorEventLostWithReaderFailure() throws Exception {
+        final int[] eventsToLose = new int[] {1, 3};
+
+        OpEventRpcInterceptor.currentHandler =
+                new OperatorEventRpcHandler(
+                        (task, operator, event, originalRpcHandler) -> askTimeoutFuture(),
+                        eventsToLose);
+
+        runTest(true);
+    }
+
+    /**
+     * This test the case that the enumerator must handle the case of presumably lost splits that
+     * were actually delivered.
+     *
+     * <p>Some split assignment events happen normally, but for some their acknowledgement never
+     * comes back. The enumerator must assume the assignments were unsuccessful, even though the
+     * split assignment was received by the reader.
+     */
+    @Test
+    public void testOperatorEventAckLost() throws Exception {
+        final int[] eventsWithLostAck = new int[] {2, 4};
+
+        OpEventRpcInterceptor.currentHandler =
+                new OperatorEventRpcHandler(
+                        (task, operator, event, originalRpcHandler) -> {
+                            // forward call
+                            originalRpcHandler.apply(task, operator, event);
+                            // but return an ack future that times out to simulate lost response
+                            return askTimeoutFuture();
+                        },
+                        eventsWithLostAck);
+
+        runTest(false);
+    }
+
+    /**
+     * This tests the case where the status of an assignment remains unknown across checkpoints.
+     *
+     * <p>Some split assignment events happen normally, but for some their acknowledgement comes
+     * very late, so that we expect multiple checkpoints would have normally happened in the
+     * meantime. We trigger a failure (which happens after the second split)
+     */
+    @Test
+    public void testOperatorEventAckDelay() throws Exception {
+        final int[] eventsWithLateAck = new int[] {2, 4};
+
+        OpEventRpcInterceptor.currentHandler =
+                new OperatorEventRpcHandler(
+                        (task, operator, event, originalRpcHandler) -> {
+                            // forward call
+                            final CompletableFuture<Acknowledge> result =
+                                    originalRpcHandler.apply(task, operator, event);
+                            // but return an ack future that completes late, after
+                            // multiple checkpoints should have happened
+                            final CompletableFuture<Acknowledge> late = lateFuture();
+                            return result.thenCompose((v) -> late);
+                        },
+                        eventsWithLateAck);
+
+        runTest(false);
+    }
+
+    /**
+     * Runs the test program, which uses a single reader (parallelism = 1) and has three splits of
+     * data, to be assigned to the same reader.
+     *
+     * <p>If an intermittent failure should happen, it will happen after the second split was
+     * assigned.
+     */
+    private void runTest(boolean intermittentFailure) throws Exception {
+        final int numElements = 100;
+        final int failAt = intermittentFailure ? numElements / 2 : numElements * 2;
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(50);
+
+        final DataStream<Long> numbers =
+                env.fromSource(
+                                new TestingNumberSequenceSource(1L, numElements, 3),
+                                WatermarkStrategy.noWatermarks(),
+                                "numbers")
+                        .map(
+                                new MapFunction<Long, Long>() {
+                                    private int num;
+
+                                    @Override
+                                    public Long map(Long value) throws Exception {
+                                        if (++num > failAt) {
+                                            throw new Exception("Artificial intermittent failure.");
+                                        }
+                                        return value;
+                                    }
+                                });
+
+        final List<Long> sequence = numbers.executeAndCollect(numElements);
+
+        final List<Long> expectedSequence =
+                LongStream.rangeClosed(1L, numElements).boxed().collect(Collectors.toList());
+
+        assertEquals(expectedSequence, sequence);
+    }
+
+    private static CompletableFuture<Acknowledge> askTimeoutFuture() {
+        final CompletableFuture<Acknowledge> future = new CompletableFuture<>();
+        FutureUtils.orTimeout(future, 500, TimeUnit.MILLISECONDS);
+        return future;
+    }
+
+    private static CompletableFuture<Acknowledge> lateFuture() {
+        final CompletableFuture<Acknowledge> future = new CompletableFuture<>();
+        FutureUtils.completeDelayed(future, Acknowledge.get(), Duration.ofMillis(500));
+        return future;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Specialized Source
+    // ------------------------------------------------------------------------
+
+    /**
+     * This is an enumerator for the {@link NumberSequenceSource}, which only responds to the split
+     * requests after the next checkpoint is complete. That way, we naturally draw the split
+     * processing across checkpoints without artificial sleep statements.
+     */
+    private static final class AssignAfterCheckpointEnumerator<
+                    SplitT extends IteratorSourceSplit<?, ?>>
+            extends IteratorSourceEnumerator<SplitT> {
+
+        private final Queue<Integer> pendingRequests = new ArrayDeque<>();
+        private final SplitEnumeratorContext<?> context;
+
+        public AssignAfterCheckpointEnumerator(
+                SplitEnumeratorContext<SplitT> context, Collection<SplitT> splits) {
+            super(context, splits);
+            this.context = context;
+        }
+
+        @Override
+        public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+            pendingRequests.add(subtaskId);
+        }
+
+        @Override
+        public Collection<SplitT> snapshotState() throws Exception {
+            // this will be enqueued in the enumerator thread, so it will actually run after this
+            // method (the snapshot operation) is complete!
+            context.runInCoordinatorThread(this::fullFillPendingRequests);
+
+            return super.snapshotState();
+        }
+
+        private void fullFillPendingRequests() {
+            for (int subtask : pendingRequests) {
+                super.handleSplitRequest(subtask, null);
+            }
+            pendingRequests.clear();
+        }
+    }
+
+    private static class TestingNumberSequenceSource extends NumberSequenceSource {
+        private static final long serialVersionUID = 1L;
+
+        private final int numSplits;
+
+        public TestingNumberSequenceSource(long from, long to, int numSplits) {
+            super(from, to);
+            this.numSplits = numSplits;
+        }
+
+        @Override
+        public SplitEnumerator<NumberSequenceSplit, Collection<NumberSequenceSplit>>
+                createEnumerator(final SplitEnumeratorContext<NumberSequenceSplit> enumContext) {
+            final List<NumberSequenceSplit> splits =
+                    splitNumberRange(getFrom(), getTo(), numSplits);
+            return new AssignAfterCheckpointEnumerator<>(enumContext, splits);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  Source Operator Event specific intercepting
+    // ------------------------------------------------------------------------
+
+    private static class OperatorEventRpcHandler {
+
+        private final FilteredRpcAction actionForFilteredEvent;
+        private final Set<Integer> eventsToFilter;
+        private int eventNum;
+
+        OperatorEventRpcHandler(FilteredRpcAction actionForFilteredEvent, int... eventsToFilter) {
+            this(
+                    actionForFilteredEvent,
+                    IntStream.of(eventsToFilter).boxed().collect(Collectors.toSet()));
+        }
+
+        OperatorEventRpcHandler(
+                FilteredRpcAction actionForFilteredEvent, Set<Integer> eventsToFilter) {
+            this.actionForFilteredEvent = actionForFilteredEvent;
+            this.eventsToFilter = eventsToFilter;
+        }
+
+        CompletableFuture<Acknowledge> filterCall(
+                ExecutionAttemptID task,
+                OperatorID operator,
+                SerializedValue<OperatorEvent> evt,
+                TriFunction<
+                                ExecutionAttemptID,
+                                OperatorID,
+                                SerializedValue<OperatorEvent>,
+                                CompletableFuture<Acknowledge>>
+                        rpcHandler) {
+
+            final Object o;
+            try {
+                o = evt.deserializeValue(getClass().getClassLoader());
+            } catch (Exception e) {
+                throw new Error(e); // should never happen
+            }
+
+            if (o instanceof AddSplitEvent || o instanceof NoMoreSplitsEvent) {
+                // only deal with split related events here
+                if (eventsToFilter.contains(++eventNum)) {
+                    return actionForFilteredEvent.handleEvent(task, operator, evt, rpcHandler);
+                }
+            }
+
+            return rpcHandler.apply(task, operator, evt);
+        }
+
+        interface FilteredRpcAction {
+
+            CompletableFuture<Acknowledge> handleEvent(
+                    ExecutionAttemptID task,
+                    OperatorID operator,
+                    SerializedValue<OperatorEvent> evt,
+                    TriFunction<
+                                    ExecutionAttemptID,
+                                    OperatorID,
+                                    SerializedValue<OperatorEvent>,
+                                    CompletableFuture<Acknowledge>>
+                            rpcHandler);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  Utils for MiniCluster RPC intercepting
+    // ------------------------------------------------------------------------
+
+    private static final class OpEventRpcInterceptor extends TaskExecutorGatewayDecoratorBase {
+
+        // initialize with a handler that filters nothing
+        static OperatorEventRpcHandler currentHandler =
+                new OperatorEventRpcHandler((task, id, evt, rpc) -> null, Collections.emptySet());
+
+        OpEventRpcInterceptor(TaskExecutorGateway originalGateway) {
+            super(originalGateway);
+        }
+
+        @Override
+        public CompletableFuture<Acknowledge> sendOperatorEventToTask(
+                ExecutionAttemptID task, OperatorID operator, SerializedValue<OperatorEvent> evt) {
+            return currentHandler.filterCall(task, operator, evt, super::sendOperatorEventToTask);
+        }
+    }
+
+    private static class InterceptingRpcService extends AkkaRpcService {
+
+        public InterceptingRpcService(
+                ActorSystem actorSystem, AkkaRpcServiceConfiguration configuration) {
+            super(actorSystem, configuration);
+        }
+
+        @Override
+        public <C extends RpcGateway> CompletableFuture<C> connect(String address, Class<C> clazz) {
+            final CompletableFuture<C> future = super.connect(address, clazz);
+            return clazz == TaskExecutorGateway.class ? decorateTmGateway(future) : future;
+        }
+
+        @SuppressWarnings("unchecked")
+        private <C extends RpcGateway> CompletableFuture<C> decorateTmGateway(
+                CompletableFuture<C> future) {
+            final CompletableFuture<TaskExecutorGateway> wrapped =
+                    future.thenApply(
+                            (gateway) -> new OpEventRpcInterceptor((TaskExecutorGateway) gateway));
+            return (CompletableFuture<C>) wrapped;
+        }
+    }
+
+    private static class MiniClusterWithRpcIntercepting extends MiniCluster {
+
+        private boolean localRpcCreated;
+
+        public MiniClusterWithRpcIntercepting(final int numSlots) {
+            super(
+                    new MiniClusterConfiguration.Builder()
+                            .setRpcServiceSharing(RpcServiceSharing.SHARED)
+                            .setNumTaskManagers(1)
+                            .setNumSlotsPerTaskManager(numSlots)
+                            .build());
+        }
+
+        @Override
+        public void start() throws Exception {
+            super.start();
+
+            if (!localRpcCreated) {
+                throw new Exception(
+                        "MiniClusterWithRpcIntercepting is broken, the intercepting local RPC service was not created.");
+            }
+        }
+
+        @Override
+        protected RpcService createLocalRpcService(Configuration configuration) throws Exception {
+            localRpcCreated = true;
+
+            return AkkaRpcServiceUtils.localServiceBuilder(configuration)
+                    .withCustomConfig(AkkaUtils.testDispatcherConfig())
+                    .createAndStart(InterceptingRpcService::new);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose of this PR

This is the first part of the fix for [FLINK-21996](https://issues.apache.org/jira/browse/FLINK-21996).

### (1) Refactoring of Number Sequence Source

The initial commits refactor the Number Sequence Source to increase the flexibility.
The source was previously very inflexible any could only deal with one split per parallel reader.
To reduce future maintenance for the tests, I wanted to reuse this existing source and thus needed to increase the flexibility a bit (which is also good for that source in any case).

### (2) Test for RPC message loss

The big commit 6360d65 introduces an Integration Test Case that simulates lost RPC messages and lost RPC acks for the events that assign source splits. As expected, this currently violates exactly-once semantics.

The main test is in `OperatorEventSendingCheckpointITCase` and uses some tricks to inject an RPC gateway decorator to the MiniCluster, which can then be used to set various filters for the RPC calls. Some test methods are annotated with `@Ignore`, because they would detect the current shortcoming and fail. The `@Ignore` will be removed once the follow-up fix is in.

### (3) Operator Coordinator Event sending threading model

Previously, events sent from the `OperatorCoordinator` to the tasks went synchronously to the Job Vertex and the latest `Execution` and the TaskManager RPC Gateway. However, this leads to hard-to-handle situations with races between event sending and task failures and recoveries. In extreme cases, an the Coordinator's thread could trigger an event to be send, and before the event reached the `Execution` a failure and recovery happened, meaning the event went to a later `Execution` than intended.

Commit eea2bac changes the threading model so that event to be sent from an OperatorCoordinator to a task are now passed into the Scheduler Main Thread and sent from there. Because we need to preserve the order of events and checkpoints, the checkpoint completion is also passed into the main thread now.

This does not fully fix the above-mentioned possible race, but it simplifies parts to make the next fix easier.

## Verifying this change

  - This change is covered by existing tests and adds a new test.
  - To verify the `OperatorEventSendingCheckpointITCase`, remove the `@Ignore` annotation and see it fail: The program never completes because it waits for data that got lost with the lost RPC calls.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
