### PR TITLE
[FLINK-22064][sql-client] Support ADD JAR command in sql client

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseOperation;
+import org.apache.flink.table.operations.command.AddJarOperation;
 import org.apache.flink.table.operations.command.ClearOperation;
 import org.apache.flink.table.operations.command.HelpOperation;
 import org.apache.flink.table.operations.command.QuitOperation;
@@ -46,6 +47,8 @@ import org.apache.flink.table.operations.ddl.AlterOperation;
 import org.apache.flink.table.operations.ddl.CreateOperation;
 import org.apache.flink.table.operations.ddl.DropOperation;
 import org.apache.flink.table.utils.PrintUtils;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
@@ -63,9 +66,12 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -336,7 +342,8 @@ public class CliClient implements AutoCloseable {
                     && !(operation instanceof UseOperation)
                     && !(operation instanceof AlterOperation)
                     && !(operation instanceof LoadModuleOperation)
-                    && !(operation instanceof UnloadModuleOperation)) {
+                    && !(operation instanceof UnloadModuleOperation)
+                    && !(operation instanceof AddJarOperation)) {
                 throw new SqlExecutionException(
                         "Unsupported operation in sql init file: " + operation.asSummaryString());
             }
@@ -414,10 +421,31 @@ public class CliClient implements AutoCloseable {
         } else if (operation instanceof EndStatementSetOperation) {
             // END
             callEndStatementSet();
+        } else if (operation instanceof AddJarOperation) {
+            // END
+            callAddJar((AddJarOperation) operation);
         } else {
             // fallback to default implementation
             executeOperation(operation);
         }
+    }
+
+    private void callAddJar(AddJarOperation operation) {
+        Optional<String> jarPath = operation.getValue();
+        if (!jarPath.isPresent()) {
+            printWarning("ADD JAR path is empty");
+            return;
+        }
+        URL url = null;
+        try {
+            url = urlFromPathString(jarPath.get());
+        } catch (MalformedURLException e) {
+            printWarning(
+                    String.format(CliStrings.MESSAGE_ADD_JAR_BAD_PATH, jarPath.get() + ", " + e));
+            return;
+        }
+        executor.addJars(sessionId, Lists.newArrayList(url));
+        printInfo(CliStrings.MESSAGE_EXECUTE_STATEMENT);
     }
 
     private void callQuit() {
@@ -657,6 +685,15 @@ public class CliClient implements AutoCloseable {
             LOG.warn(msg);
         }
         return lineReader;
+    }
+
+    /** Create a URL from a string representing a path to a local file. */
+    private URL urlFromPathString(String path) throws MalformedURLException {
+        URL url =
+                org.apache.flink.core.fs.Path.fromLocalFile(new File(path).getAbsoluteFile())
+                        .toUri()
+                        .toURL();
+        return url;
     }
 
     /**

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -225,6 +225,8 @@ public final class CliStrings {
 
     public static final String MESSAGE_EXECUTE_STATEMENT = "Execute statement succeed.";
 
+    public static final String MESSAGE_ADD_JAR_BAD_PATH = "Bad PATH %s";
+
     // --------------------------------------------------------------------------------------------
 
     public static final String RESULT_TITLE = "SQL Query Result";

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ClassLoaderUtilities.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ClassLoaderUtilities.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+import java.util.Set;
+
+/** Utilities for dynamic load jar. */
+public class ClassLoaderUtilities {
+
+    public static ClassLoader addToClassPath(URLClassLoader loader, List<URL> urls) {
+        if (useExistingClassLoader(loader)) {
+            final JarResourceClassLoader udfClassLoader = (JarResourceClassLoader) loader;
+            for (URL url : urls) {
+                udfClassLoader.addURL(url);
+            }
+            return udfClassLoader;
+        } else {
+            return createJARClassLoader(loader, urls);
+        }
+    }
+
+    public static ClassLoader createJARClassLoader(URLClassLoader loader, List<URL> urls) {
+        final Set<URL> curPathsSet = Sets.newHashSet(loader.getURLs());
+        final List<URL> curPaths = Lists.newArrayList(curPathsSet);
+        for (URL oneurl : urls) {
+            if (oneurl != null && !curPathsSet.contains(oneurl)) {
+                curPaths.add(oneurl);
+            }
+        }
+        return new JarResourceClassLoader(curPaths.toArray(new URL[0]), loader);
+    }
+
+    private static boolean useExistingClassLoader(ClassLoader cl) {
+        if (!(cl instanceof JarResourceClassLoader)) {
+            // Cannot use the same classloader if it is not an instance of {@code
+            // JarResourceClassLoader}
+            return false;
+        }
+        final JarResourceClassLoader udfClassLoader = (JarResourceClassLoader) cl;
+        if (udfClassLoader.isClosed()) {
+            // The classloader may have been closed, Cannot add to the same instance
+            return false;
+        }
+        return true;
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -27,6 +27,7 @@ import org.apache.flink.types.Row;
 
 import javax.annotation.Nullable;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -139,4 +140,12 @@ public interface Executor {
      * has been sent to cluster.
      */
     void cancelQuery(String sessionId, String resultId) throws SqlExecutionException;
+
+    /**
+     * Add JAR resource to classloader path of current SessionContext.
+     *
+     * @param sessionId
+     * @param jarUrls
+     */
+    void addJars(String sessionId, List<URL> jarUrls);
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/JarResourceClassLoader.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/JarResourceClassLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkState;
+
+/**
+ * {@link JarResourceClassLoader} is used to dynamically register jars each session will have its
+ * own instance of {@link JarResourceClassLoader}.
+ */
+public class JarResourceClassLoader extends URLClassLoader {
+    private boolean isClosed;
+
+    public JarResourceClassLoader(URL[] urls) {
+        super(urls);
+        isClosed = false;
+    }
+
+    public JarResourceClassLoader(URL[] urls, ClassLoader parent) {
+        super(urls, parent);
+        isClosed = false;
+    }
+
+    @Override
+    public void addURL(URL url) {
+        checkState(!isClosed, getClass().getSimpleName() + " is already closed");
+        super.addURL(url);
+    }
+
+    /** See {@link URLClassLoader#close}. */
+    public boolean isClosed() {
+        return isClosed;
+    }
+
+    @Override
+    public void close() throws IOException {
+        isClosed = true;
+        super.close();
+    }
+}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -223,6 +224,7 @@ public class LocalExecutor implements Executor {
         final TableEnvironmentInternal tEnv =
                 (TableEnvironmentInternal) context.getTableEnvironment();
         try {
+
             return context.wrapClassLoader(() -> tEnv.executeInternal(operations));
         } catch (Exception e) {
             throw new SqlExecutionException(MESSAGE_SQL_EXECUTION_ERROR, e);
@@ -306,5 +308,11 @@ public class LocalExecutor implements Executor {
             throw new SqlExecutionException("Could not cancel the query execution", e);
         }
         resultStore.removeResult(resultId);
+    }
+
+    @Override
+    public void addJars(String sessionId, List<URL> urls) {
+        final SessionContext context = getSessionContext(sessionId);
+        context.addJars(urls);
     }
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -62,6 +62,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -520,6 +521,11 @@ public class CliClientTest extends TestLogger {
 
         @Override
         public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
+            // nothing to do
+        }
+
+        @Override
+        public void addJars(String sessionId, List<URL> jarUrls) {
             // nothing to do
         }
     }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.io.File;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -218,6 +219,11 @@ public class CliResultViewTest {
         @Override
         public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
             cancellationCounter.countDown();
+        }
+
+        @Override
+        public void addJars(String sessionId, List<URL> jarUrls) {
+            // nothing to do
         }
     }
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.Nullable;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
@@ -62,6 +63,11 @@ class TestingExecutor implements Executor {
     @Override
     public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
         numCancelCalls++;
+    }
+
+    @Override
+    public void addJars(String sessionId, List<URL> jarUrls) {
+        // nothing to do
     }
 
     @Override

--- a/flink-table/flink-sql-client/src/test/resources/sql/add.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/add.q
@@ -1,0 +1,25 @@
+# add.q - ADD JAR
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test add jar statement
+ADD JAR foo.jar;
+[INFO] Execute statement succeed.
+!info
+
+ADD JAR /path/jar/foo.jar;
+[INFO] Execute statement succeed.
+!info

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/command/AddJarOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/command/AddJarOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.command;
+
+import org.apache.flink.table.operations.Operation;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Operation to represent ADD JAR command. If {@link #getValue()} and {@link #getValue()} are empty,
+ * it means show all the configurations. Otherwise, set value to the configuration key.
+ */
+public class AddJarOperation implements Operation {
+
+    @Nullable private final String value;
+
+    public AddJarOperation(String value) {
+        this.value = checkNotNull(value);
+    }
+
+    public Optional<String> getValue() {
+        return Optional.ofNullable(value);
+    }
+
+    @Override
+    public String asSummaryString() {
+        if (value == null) {
+            return "ADD JAR";
+        } else {
+            return String.format("ADD JAR %s", value);
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/AddJarOperationParseStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/AddJarOperationParseStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.parse;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.command.AddJarOperation;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Strategy to parse statement to {@link AddJarOperationParseStrategy}. */
+public class AddJarOperationParseStrategy extends AbstractRegexParseStrategy {
+
+    static final AddJarOperationParseStrategy INSTANCE = new AddJarOperationParseStrategy();
+
+    protected AddJarOperationParseStrategy() {
+        super(Pattern.compile("ADD JAR\\s+(?<val>\\S+)", DEFAULT_PATTERN_FLAGS));
+    }
+
+    @Override
+    public Operation convert(String statement) {
+        Matcher matcher = pattern.matcher(statement.trim());
+        String val;
+
+        if (matcher.find()) {
+            val = matcher.group("val");
+        } else {
+            throw new TableException(
+                    String.format(
+                            "Failed to convert the statement to ADD JAR operation: %s.",
+                            statement));
+        }
+        return new AddJarOperation(val);
+    }
+
+    @Override
+    public String[] getHints() {
+        return new String[] {"ADD JAR"};
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/ExtendedParser.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/ExtendedParser.java
@@ -40,7 +40,8 @@ public class ExtendedParser {
                     HelpOperationParseStrategy.INSTANCE,
                     QuitOperationParseStrategy.INSTANCE,
                     ResetOperationParseStrategy.INSTANCE,
-                    SetOperationParseStrategy.INSTANCE);
+                    SetOperationParseStrategy.INSTANCE,
+                    AddJarOperationParseStrategy.INSTANCE);
 
     /**
      * Parse the input statement to the {@link Operation}.

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -57,6 +57,7 @@ import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.UseModulesOperation;
+import org.apache.flink.table.operations.command.AddJarOperation;
 import org.apache.flink.table.operations.ddl.AlterDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterTableAddConstraintOperation;
 import org.apache.flink.table.operations.ddl.AlterTableDropConstraintOperation;
@@ -74,6 +75,7 @@ import org.apache.flink.table.planner.expressions.utils.Func0$;
 import org.apache.flink.table.planner.expressions.utils.Func1$;
 import org.apache.flink.table.planner.expressions.utils.Func8$;
 import org.apache.flink.table.planner.parse.CalciteParser;
+import org.apache.flink.table.planner.parse.ExtendedParser;
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.CatalogManagerMocks;
@@ -94,6 +96,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1405,6 +1408,17 @@ public class SqlToOperationConverterTest {
                 (EndStatementSetOperation) operation;
 
         assertEquals("END", endStatementSetOperation.asSummaryString());
+    }
+
+    @Test
+    public void testAddJarOperation() {
+        final String sql = "ADD JAR   a/b/foo.jar   ";
+        Optional<Operation> optionalOpe = ExtendedParser.INSTANCE.parse(sql);
+        assertEquals(true, optionalOpe.isPresent());
+        Operation operation = optionalOpe.get();
+        assert operation instanceof AddJarOperation;
+        final AddJarOperation addJarOperation = (AddJarOperation) operation;
+        assertEquals("ADD JAR a/b/foo.jar", addJarOperation.asSummaryString());
     }
 
     // ~ Tool Methods ----------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*this change is to support "ADD JAR" statement in the SQL Client*


## Brief change log

  - *Add a method addJars in Executor*
  - *Add a method addJars in SessionContext*
  - *Add a class AddJarOperationParseStrategy for `ADD JAR` statement*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added grammar test in `SqlToOperationConverterTest`*
  - *Add single statement test in SessionContextTest*
  - *Added integration tests for `add jar` statement in resources/sql/add.q*
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
