### PR TITLE
[FLINK-22191][python] Fix the thread safe problem in PythonSharedResources

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/PythonSharedResources.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/PythonSharedResources.java
@@ -58,7 +58,7 @@ public final class PythonSharedResources implements AutoCloseable {
         return environment;
     }
 
-    void addPythonEnvironmentManager(PythonEnvironmentManager environmentManager) {
+    synchronized void addPythonEnvironmentManager(PythonEnvironmentManager environmentManager) {
         environmentManagers.add(environmentManager);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the thread safe problem in `PythonSharedResources`*


## Brief change log

  - *Set the method `addPythonEnvironmentManager` as `synchronized`*

## Verifying this change

This change added tests and can be verified as follows:
 
 - *Original Tests and test the method 1000 times manually*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
