### PR TITLE
[FLINK-22207][connectors/hive]Hive Catalog retrieve Flink Properties …

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -785,7 +785,7 @@ public class HiveCatalog extends AbstractCatalog {
                                         || e.getKey().equals(CatalogPropertiesUtil.IS_GENERIC))
                 .collect(
                         Collectors.toMap(
-                                e -> e.getKey().replace(FLINK_PROPERTY_PREFIX, ""),
+                                e -> e.getKey().replaceFirst(FLINK_PROPERTY_PREFIX, ""),
                                 e -> e.getValue()));
     }
 


### PR DESCRIPTION
### What is the purpose of the change
Fix hive catalog handle propertie error "java.lang.IllegalStateException: Duplicate key". As said in FLINK-22207 like below.

If we use hive catalog and set flink propertie eg."url",and then when we add the other propertie like start with string "flink." like "flink.url" will show we the error "java.lang.IllegalStateException: Duplicate key" , and what's worse is because of this error we can`t drop or alter this tabel more.

I found in this method , "org.apache.flink.table.catalog.hive.HiveCatalog.retrieveFlinkProperties", replace all "flink." of propertie. So , the  propertie of HiveCatalog "flink.url" and "flink.flink.url" both result to "url". 

### Brief change log
Hive Catalog retrieve Flink Properties error
### Verifying this change
Manually verified.
### Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (yes / **no**)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes / **no**)
The serializers: (yes / **no** / don't know)
The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
The S3 file system connector: (yes / **no** / don't know)
### Documentation
Does this pull request introduce a new feature? (yes / **no**)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)