### PR TITLE
[FLINK-20816][tests] Fix race condition in NotifyCheckpointAbortedITCase. [1.12]

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -59,7 +59,6 @@ import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackend;
-import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -129,6 +128,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
                                 .build());
         cluster.before();
 
+        NormalSource.reset();
         NormalMap.reset();
         DeclineSink.reset();
         TestingCompletedCheckpointStore.reset();
@@ -185,7 +185,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         resetAllOperatorsNotifyAbortedLatches();
         verifyAllOperatorsNotifyAbortedTimes(1);
 
-        DeclineSink.waitLatch.trigger();
+        NormalSource.waitLatch.trigger();
         log.info("Verifying whether all operators have been notified of checkpoint-2 aborted.");
         verifyAllOperatorsNotifyAborted();
         log.info("Verified that all operators have been notified of checkpoint-2 aborted.");
@@ -211,9 +211,11 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
     }
 
     /** Normal source function. */
-    private static class NormalSource implements SourceFunction<Tuple2<Integer, Integer>> {
+    private static class NormalSource
+            implements SourceFunction<Tuple2<Integer, Integer>>, CheckpointedFunction {
         private static final long serialVersionUID = 1L;
         protected volatile boolean running;
+        private static final OneShotLatch waitLatch = new OneShotLatch();
 
         NormalSource() {
             this.running = true;
@@ -235,6 +237,20 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         @Override
         public void cancel() {
             this.running = false;
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            if (context.getCheckpointId() == DECLINE_CHECKPOINT_ID) {
+                waitLatch.await();
+            }
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {}
+
+        static void reset() {
+            waitLatch.reset();
         }
     }
 
@@ -286,7 +302,6 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
     private static class DeclineSink extends StreamSink<Integer> {
         private static final long serialVersionUID = 1L;
         private static final OneShotLatch notifiedAbortedLatch = new OneShotLatch();
-        private static final OneShotLatch waitLatch = new OneShotLatch();
         private static final AtomicInteger notifiedAbortedTimes = new AtomicInteger(0);
 
         public DeclineSink() {
@@ -297,14 +312,6 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
         }
 
         @Override
-        public void snapshotState(StateSnapshotContext context) throws Exception {
-            if (context.getCheckpointId() == DECLINE_CHECKPOINT_ID) {
-                DeclineSink.waitLatch.await();
-            }
-            super.snapshotState(context);
-        }
-
-        @Override
         public void notifyCheckpointAborted(long checkpointId) {
             notifiedAbortedTimes.incrementAndGet();
             notifiedAbortedLatch.trigger();
@@ -312,7 +319,6 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
 
         static void reset() {
             notifiedAbortedLatch.reset();
-            waitLatch.reset();
             notifiedAbortedTimes.set(0);
         }
     }


### PR DESCRIPTION
Unchanged backport of #15554.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`NotifyCheckpointAbortedITCase` implicitly assumes that abortion of chk-1 happens before sync phase of chk-2. If abortion is late, the mail that handles the abortion is never executed since the waitLatch blocks the mailbox thread. The latch in turn is never triggered as chk-1 is not aborted.

## Brief change log

The fix is to move the wait latch on chk-2 into the source - the only operator that isn't checked for abortion. Thus, the deadlock cannot happen.

## Verifying this change

Test fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no /** don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
