### PR TITLE
[FLINK-22016][table-planner-blink] RexNodeExtractor#visitLiteral now deal with NULL literals correctly

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -466,7 +466,12 @@ class RexNodeToExpressionConverter(
         literal.getValue
     }
 
-    Some(valueLiteral(literalValue, fromLogicalTypeToDataType(literalType).notNull()))
+    val dataType = fromLogicalTypeToDataType(literalType)
+    if (literalValue == null) {
+      Some(valueLiteral(null, dataType.nullable()))
+    } else {
+      Some(valueLiteral(literalValue, dataType.notNull()))
+    }
   }
 
   override def visitCall(oriRexCall: RexCall): Option[ResolvedExpression] = {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
@@ -129,11 +129,11 @@ public abstract class PushFilterIntoTableSourceScanRuleTestBase extends TableTes
     @Test
     public void testWithNullLiteral() {
         util.verifyRelPlan(
-                "WITH MyView AS (SELECT CASE\n" +
-                        "  WHEN amount > 0 THEN name\n" +
-                        "  ELSE CAST(NULL AS STRING)\n" +
-                        "  END AS a\n" +
-                        "  FROM MyTable)\n" +
-                        "SELECT a FROM MyView WHERE a IS NOT NULL\n");
+                "WITH MyView AS (SELECT CASE\n"
+                        + "  WHEN amount > 0 THEN name\n"
+                        + "  ELSE CAST(NULL AS STRING)\n"
+                        + "  END AS a\n"
+                        + "  FROM MyTable)\n"
+                        + "SELECT a FROM MyView WHERE a IS NOT NULL\n");
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTestBase.java
@@ -125,4 +125,15 @@ public abstract class PushFilterIntoTableSourceScanRuleTestBase extends TableTes
         // requires its condition to be "flat"
         util.verifyRelPlan("SELECT * FROM MyTable WHERE name IN ('Alice', 'Bob', 'Dave')");
     }
+
+    @Test
+    public void testWithNullLiteral() {
+        util.verifyRelPlan(
+                "WITH MyView AS (SELECT CASE\n" +
+                        "  WHEN amount > 0 THEN name\n" +
+                        "  ELSE CAST(NULL AS STRING)\n" +
+                        "  END AS a\n" +
+                        "  FROM MyTable)\n" +
+                        "SELECT a FROM MyView WHERE a IS NOT NULL\n");
+    }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -349,4 +349,29 @@ FlinkLogicalCalc(select=[name, id, amount, price], where=[<(Func1$(amount), 32)]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWithNullLiteral">
+    <Resource name="sql">
+      <![CDATA[WITH MyView AS (SELECT CASE
+  WHEN amount > 0 THEN name
+  ELSE CAST(NULL AS STRING)
+  END AS a
+  FROM MyTable)
+SELECT a FROM MyView WHERE a IS NOT NULL
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalFilter(condition=[IS NOT NULL($0)])
+   +- LogicalProject(a=[CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[CASE(>(amount, 0), name, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS a], where=[IS NOT NULL(CASE(>(amount, 0), name, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[name, id, amount, price])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -350,4 +350,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWithNullLiteral">
+    <Resource name="sql">
+      <![CDATA[WITH MyView AS (SELECT CASE
+  WHEN amount > 0 THEN name
+  ELSE CAST(NULL AS STRING)
+  END AS a
+  FROM MyTable)
+SELECT a FROM MyView WHERE a IS NOT NULL
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalFilter(condition=[IS NOT NULL($0)])
+   +- LogicalProject(a=[CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalProject(a=[CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+   +- LogicalFilter(condition=[IS NOT NULL(CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -350,4 +350,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWithNullLiteral">
+    <Resource name="sql">
+      <![CDATA[WITH MyView AS (SELECT CASE
+  WHEN amount > 0 THEN name
+  ELSE CAST(NULL AS STRING)
+  END AS a
+  FROM MyTable)
+SELECT a FROM MyView WHERE a IS NOT NULL
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalFilter(condition=[IS NOT NULL($0)])
+   +- LogicalProject(a=[CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0])
++- LogicalProject(a=[CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
+   +- LogicalFilter(condition=[IS NOT NULL(CASE(>($2, 0), $0, null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+  </TestCase>
 </Root>


### PR DESCRIPTION
## What is the purpose of the change

`RexLiteral` could not contain null values in the past according to @dawidwys , however this is currently not true and will cause filter push down rules to throw exceptions when faced with NULL literals.

This PR fixes this issue.

## Brief change log

 - RexNodeExtractor#visitLiteral now deal with NULL literals correctly.

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable