### PR TITLE
[FLINK-22166][table] Empty values with sort willl fail

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkLogicalRelFactories.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkLogicalRelFactories.scala
@@ -201,7 +201,7 @@ object FlinkLogicalRelFactories {
         rowType: RelDataType,
         tuples: util.List[ImmutableList[RexLiteral]]): RelNode = {
       FlinkLogicalValues.create(
-        cluster, rowType, ImmutableList.copyOf[ImmutableList[RexLiteral]](tuples))
+        cluster, null, rowType, ImmutableList.copyOf[ImmutableList[RexLiteral]](tuples))
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/ValuesTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/ValuesTest.xml
@@ -40,6 +40,24 @@ Union(all=[true], union=[EXPR$0, EXPR$1]), rowType=[RecordType(INTEGER EXPR$0, D
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEmptyValuesWithSort">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (VALUES 1, 2, 3) AS T (a) WHERE a = 1 and a = 2 ORDER BY a]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
++- LogicalProject(a=[$0])
+   +- LogicalFilter(condition=[AND(=($0, 1), =($0, 2))])
+      +- LogicalValues(tuples=[[{ 1 }, { 2 }, { 3 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Values(tuples=[[]], values=[a])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSingleRow">
     <Resource name="sql">
       <![CDATA[SELECT * FROM (VALUES (1, 2, 3)) AS T(a, b, c)]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/ValuesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/ValuesTest.scala
@@ -46,4 +46,9 @@ class ValuesTest extends TableTestBase {
     util.verifyRelPlanWithType("SELECT * FROM (VALUES (1, 2.0), (3, CAST(4 AS BIGINT))) AS T(a, b)")
   }
 
+  @Test
+  def testEmptyValuesWithSort(): Unit = {
+    util.verifyExecPlan("SELECT * FROM (VALUES 1, 2, 3) AS T (a) WHERE a = 1 and a = 2 ORDER BY a")
+  }
+
 }


### PR DESCRIPTION


## What is the purpose of the change

`SELECT * FROM (VALUES 1, 2, 3) AS T (a) WHERE a = 1 and a = 2 ORDER BY a` will fail.

## Brief change log

`FlinkLogicalValues` should deal with trait of empty values.

## Verifying this change

`ValuesTest.testEmptyValuesWithSort`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no