### PR TITLE
[FLINK-22202][parquet] Thread safety in ParquetColumnarRowInputFormat

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormat.java
@@ -95,6 +95,15 @@ public class ParquetColumnarRowInputFormat<SplitT extends FileSourceSplit>
     }
 
     @Override
+    protected int numBatchesToCirculate(org.apache.flink.configuration.Configuration config) {
+        // In a VectorizedColumnBatch, the dictionary will be lazied deserialized.
+        // If there are multiple batches at the same time, there may be thread safety problems,
+        // because the deserialization of the dictionary depends on some internal structures.
+        // We need set numBatchesToCirculate to 1.
+        return 1;
+    }
+
+    @Override
     protected ParquetReaderBatch<RowData> createReaderBatch(
             WritableColumnVector[] writableVectors,
             VectorizedColumnBatch columnarBatch,

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -133,12 +133,14 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
 
         checkSchema(fileSchema, requestedSchema);
 
-        final int numBatchesToCirculate =
-                config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
         final Pool<ParquetReaderBatch<T>> poolOfBatches =
-                createPoolOfBatches(split, requestedSchema, numBatchesToCirculate);
+                createPoolOfBatches(split, requestedSchema, numBatchesToCirculate(config));
 
         return new ParquetReader(reader, requestedSchema, totalRowCount, poolOfBatches);
+    }
+
+    protected int numBatchesToCirculate(Configuration config) {
+        return config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
     }
 
     @Override


### PR DESCRIPTION

## What is the purpose of the change

In a VectorizedColumnBatch, the dictionary will be lazied deserialized. 

If there are multiple batches at the same time, there may be thread safety problems, because the deserialization of the dictionary depends on some internal structures.

We need set numBatchesToCirculate to 1 for ParquetColumnarRowInputFormat.

## Brief change log

Set numBatchesToCirculate to 1 in `ParquetColumnarRowInputFormat`.

## Verifying this change

`ParquetColumnarRowInputFormatTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no