### PR TITLE
[FLINK-22152][python] Fix the bug of same timers are registered multiple times

### DIFF
--- a/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pyx
@@ -464,8 +464,9 @@ cdef class GroupWindowAggFunctionBase:
         cdef list timers
         cdef object timer
         timers = []
-        for timer in self._internal_timer_service.timers:
+        for timer in self._internal_timer_service.timers.keys():
             timers.append(timer)
+        self._internal_timer_service.timers.clear()
         return timers
 
     cpdef void close(self):

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
@@ -410,10 +410,8 @@ class GroupWindowAggFunctionBase(Generic[K, W]):
         return result
 
     def get_timers(self):
-        timers = []
-        for timer in self._internal_timer_service.timers:
-            timers.append(timer)
-        return timers
+        yield from self._internal_timer_service.timers.keys()
+        self._internal_timer_service.timers.clear()
 
     def to_utc_timestamp_mills(self, epoch_mills):
         if self._shift_timezone == "UTC":

--- a/flink-python/pyflink/fn_execution/utils/input_handler.py
+++ b/flink-python/pyflink/fn_execution/utils/input_handler.py
@@ -132,7 +132,7 @@ class OneInputRowWithTimerHandler(RowWithTimerInputHandler):
         if output_result:
             yield from self._output_factory.from_normal_data(output_result)
 
-        yield from self._output_factory.from_timers(self._internal_timer_service.timers)
+        yield from self._output_factory.from_timers(self._internal_timer_service.timers.keys())
 
         self._internal_timer_service.timers.clear()
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of same timers are registered multiple times*

## Brief change log

- *deduplicate same timers in Python Operation*

## Verifying this change

- *Original Tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
