### PR TITLE
[FLINK-21431][upsert-kafka] Use testcontainers for KafkaTable ITCase

### DIFF
--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -122,6 +122,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<version>1.15.1</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-tests</artifactId>
 			<version>${project.version}</version>

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
@@ -18,20 +18,14 @@
 
 package org.apache.flink.streaming.connectors.kafka.table;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducerBase;
-import org.apache.flink.streaming.connectors.kafka.KafkaTestBaseWithFlink;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -42,28 +36,16 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer.DEFAULT_KAFKA_PRODUCERS_POOL_SIZE;
+import static org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer.Semantic.EXACTLY_ONCE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUtils.readLines;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUtils.waitingExpectedResults;
 
 /** IT cases for Kafka with changelog format for Table API & SQL. */
-public class KafkaChangelogTableITCase extends KafkaTestBaseWithFlink {
-
-    protected StreamExecutionEnvironment env;
-    protected StreamTableEnvironment tEnv;
+public class KafkaChangelogTableITCase extends KafkaTableITCaseBase {
 
     @Before
-    public void setup() {
-        TestValuesTableFactory.clearAllData();
-        env = StreamExecutionEnvironment.getExecutionEnvironment();
-        tEnv =
-                StreamTableEnvironment.create(
-                        env,
-                        EnvironmentSettings.newInstance()
-                                // Watermark is only supported in blink planner
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
-        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+    public void before() {
         // we have to use single parallelism,
         // because we will count the messages in sink to terminate the job
         env.setParallelism(1);
@@ -88,19 +70,24 @@ public class KafkaChangelogTableITCase extends KafkaTestBaseWithFlink {
         FlinkKafkaPartitioner<String> partitioner = new FlinkFixedPartitioner<>();
 
         // the producer must not produce duplicates
-        Properties producerProperties =
-                FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings);
+        Properties producerProperties = getStandardProps();
         producerProperties.setProperty("retries", "0");
-        producerProperties.putAll(secureProps);
-        kafkaServer.produceIntoKafka(stream, topic, serSchema, producerProperties, partitioner);
         try {
+            stream.addSink(
+                    new FlinkKafkaProducer<>(
+                            topic,
+                            serSchema,
+                            producerProperties,
+                            partitioner,
+                            EXACTLY_ONCE,
+                            DEFAULT_KAFKA_PRODUCERS_POOL_SIZE));
             env.execute("Write sequence");
         } catch (Exception e) {
             throw new Exception("Failed to write debezium data to Kafka.", e);
         }
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String bootstraps = getBootstrapServers();
         String sourceDDL =
                 String.format(
                         "CREATE TABLE debezium_source ("
@@ -226,19 +213,24 @@ public class KafkaChangelogTableITCase extends KafkaTestBaseWithFlink {
         FlinkKafkaPartitioner<String> partitioner = new FlinkFixedPartitioner<>();
 
         // the producer must not produce duplicates
-        Properties producerProperties =
-                FlinkKafkaProducerBase.getPropertiesFromBrokerList(brokerConnectionStrings);
+        Properties producerProperties = getStandardProps();
         producerProperties.setProperty("retries", "0");
-        producerProperties.putAll(secureProps);
-        kafkaServer.produceIntoKafka(stream, topic, serSchema, producerProperties, partitioner);
         try {
+            stream.addSink(
+                    new FlinkKafkaProducer<>(
+                            topic,
+                            serSchema,
+                            producerProperties,
+                            partitioner,
+                            EXACTLY_ONCE,
+                            DEFAULT_KAFKA_PRODUCERS_POOL_SIZE));
             env.execute("Write sequence");
         } catch (Exception e) {
             throw new Exception("Failed to write canal data to Kafka.", e);
         }
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String bootstraps = getBootstrapServers();
         String sourceDDL =
                 String.format(
                         "CREATE TABLE canal_source ("

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
@@ -42,7 +42,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUt
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUtils.waitingExpectedResults;
 
 /** IT cases for Kafka with changelog format for Table API & SQL. */
-public class KafkaChangelogTableITCase extends KafkaTableITCaseBase {
+public class KafkaChangelogTableITCase extends KafkaTableTestBase {
 
     @Before
     public void before() {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -18,17 +18,11 @@
 
 package org.apache.flink.streaming.connectors.kafka.table;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.apache.flink.streaming.connectors.kafka.KafkaTestBase;
-import org.apache.flink.streaming.connectors.kafka.KafkaTestBaseWithFlink;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.descriptors.KafkaValidator;
 import org.apache.flink.test.util.SuccessException;
@@ -61,7 +55,7 @@ import static org.junit.Assert.fail;
 
 /** Basic IT cases for the Kafka table source and sink. */
 @RunWith(Parameterized.class)
-public class KafkaTableITCase extends KafkaTestBaseWithFlink {
+public class KafkaTableITCase extends KafkaTableITCaseBase {
 
     private static final String JSON_FORMAT = "json";
     private static final String AVRO_FORMAT = "avro";
@@ -85,21 +79,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         };
     }
 
-    protected StreamExecutionEnvironment env;
-    protected StreamTableEnvironment tEnv;
-
     @Before
-    public void setup() {
-        env = StreamExecutionEnvironment.getExecutionEnvironment();
-        tEnv =
-                StreamTableEnvironment.create(
-                        env,
-                        EnvironmentSettings.newInstance()
-                                // Watermark is only supported in blink planner
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
-        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+    public void before() {
         // we have to use single parallelism,
         // because we will count the messages in sink to terminate the job
         env.setParallelism(1);
@@ -113,8 +94,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
 
         final String createTable;
         if (!isLegacyConnector) {
@@ -243,8 +224,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
                         + "  'scan.startup.mode' = 'earliest-offset',\n"
                         + "  %s\n"
                         + ")";
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
         List<String> currencies = Arrays.asList("Euro", "Dollar", "Yen", "Dummy");
         List<String> topics =
                 currencies.stream()
@@ -316,7 +297,7 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         assertEquals(expected, TestingSinkFunction.rows);
 
         // ------------- cleanup -------------------
-        topics.forEach(KafkaTestBase::deleteTestTopic);
+        topics.forEach(super::deleteTestTopic);
     }
 
     @Test
@@ -330,8 +311,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
 
         final String createTable =
                 String.format(
@@ -430,8 +411,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
 
         // k_user_id and user_id have different data types to verify the correct mapping,
         // fields are reordered on purpose
@@ -514,8 +495,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
 
         // compared to the partial value test we cannot support both k_user_id and user_id in a full
         // value due to duplicate names after key prefix stripping,
@@ -605,8 +586,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(productTopic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
 
         // create order table and set initial values
         final String orderTableDDL =
@@ -741,8 +722,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(topic, 4, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
 
         final String createTable =
                 String.format(
@@ -834,8 +815,8 @@ public class KafkaTableITCase extends KafkaTestBaseWithFlink {
         createTestTopic(topic, 4, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
-        String groupId = standardProps.getProperty("group.id");
-        String bootstraps = standardProps.getProperty("bootstrap.servers");
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
         tEnv.getConfig()
                 .getConfiguration()
                 .set(TABLE_EXEC_SOURCE_IDLE_TIMEOUT, Duration.ofMillis(100));

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.fail;
 
 /** Basic IT cases for the Kafka table source and sink. */
 @RunWith(Parameterized.class)
-public class KafkaTableITCase extends KafkaTableITCaseBase {
+public class KafkaTableITCase extends KafkaTableTestBase {
 
     private static final String JSON_FORMAT = "json";
     private static final String AVRO_FORMAT = "avro";

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCaseBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCaseBase.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.Timeout;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+/** Base class for Kafka Table IT Cases. */
+public class KafkaTableITCaseBase extends AbstractTestBase {
+
+    private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
+    private static final Network NETWORK = Network.newNetwork();
+
+    @ClassRule
+    public static final KafkaContainer KAFKA_CONTAINER =
+            new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.5.2"))
+                    .withEmbeddedZookeeper()
+                    .withNetwork(NETWORK)
+                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+
+    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
+
+    private final int zkTimeoutMills = 30000;
+    protected StreamExecutionEnvironment env;
+    protected StreamTableEnvironment tEnv;
+
+    @Before
+    public void setUp() {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv =
+                StreamTableEnvironment.create(
+                        env,
+                        EnvironmentSettings.newInstance()
+                                // Watermark is only supported in blink planner
+                                .useBlinkPlanner()
+                                .inStreamingMode()
+                                .build());
+        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    public Properties getStandardProps() {
+        Properties standardProps = new Properties();
+        standardProps.put("bootstrap.servers", KAFKA_CONTAINER.getBootstrapServers());
+        standardProps.put("group.id", "flink-tests");
+        standardProps.put("enable.auto.commit", false);
+        standardProps.put("auto.offset.reset", "earliest");
+        standardProps.put("max.partition.fetch.bytes", 256);
+        standardProps.put("zookeeper.session.timeout.ms", zkTimeoutMills);
+        standardProps.put("zookeeper.connection.timeout.ms", zkTimeoutMills);
+        return standardProps;
+    }
+
+    public String getBootstrapServers() {
+        return KAFKA_CONTAINER.getBootstrapServers();
+    }
+
+    public void createTestTopic(String topic, int numPartitions, int replicationFactor) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
+        try (AdminClient admin = AdminClient.create(properties)) {
+            admin.createTopics(
+                    Collections.singletonList(
+                            new NewTopic(topic, numPartitions, (short) replicationFactor)));
+        }
+    }
+
+    public void deleteTestTopic(String topic) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
+        try (AdminClient admin = AdminClient.create(properties)) {
+            admin.deleteTopics(Collections.singletonList(topic));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -54,7 +54,7 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
 
-    @Rule public final Timeout TIMEOUT = Timeout.seconds(30);
+    @Rule public final Timeout timeoutPerTest = Timeout.seconds(30);
 
     protected StreamExecutionEnvironment env;
     protected StreamTableEnvironment tEnv;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.rules.Timeout;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
@@ -38,13 +39,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 /** Base class for Kafka Table IT Cases. */
-public class KafkaTableITCaseBase extends AbstractTestBase {
+public abstract class KafkaTableTestBase extends AbstractTestBase {
 
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     private static final Network NETWORK = Network.newNetwork();
+    private static final int zkTimeoutMills = 30000;
 
     @ClassRule
     public static final KafkaContainer KAFKA_CONTAINER =
@@ -53,14 +54,13 @@ public class KafkaTableITCaseBase extends AbstractTestBase {
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
 
-    @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);
+    @Rule public final Timeout TIMEOUT = Timeout.seconds(30);
 
-    private final int zkTimeoutMills = 30000;
     protected StreamExecutionEnvironment env;
     protected StreamTableEnvironment tEnv;
 
     @Before
-    public void setUp() {
+    public void setup() {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
         tEnv =
                 StreamTableEnvironment.create(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertThat;
 
 /** Upsert-kafka IT cases. */
 @RunWith(Parameterized.class)
-public class UpsertKafkaTableITCase extends KafkaTableITCaseBase {
+public class UpsertKafkaTableITCase extends KafkaTableTestBase {
 
     private static final String JSON_FORMAT = "json";
     private static final String CSV_FORMAT = "csv";


### PR DESCRIPTION
## What is the purpose of the change

* This pull request use testcontainers for UpsertKafkaTableITCase to fix the hang tests in UpsertKafkaTableITCase reported in FLINK-21516 and FLINK-21431

* The reason of the hang cases is the test clients returned latest offset rather then earliest offset for test topic  after retry about 30 times(about 20 seconds),
we can reproduce this one by debugging or running N times in  IDE. The error line is 
```
     if (newPartitionState.getOffset()
                        == KafkaTopicPartitionStateSentinel.EARLIEST_OFFSET) {
                    consumerTmp.seekToBeginning(
                            Collections.singletonList(newPartitionState.getKafkaPartitionHandle()));
newPartitionState.setOffset(
                            consumerTmp.position(newPartitionState.getKafkaPartitionHandle()) - 1);
// the expected offset is -1, but the returned offset is 10 which is wrong
```
Due to the root cause comes from the Kafka test suite(maybe `kafka.server.KafkaServer` or `org.apache.curator.test.TestingServer`), thus I test in local env using standalone Kafka cluster, the hang case disappeared ! 
This PR use test container to replace Kafka test suite to fix the unstable case.

## Brief change log
  -  Use testcontainers for all tests in UpsertKafkaTableITCase

## Verifying this change
- Run N times(N>=40) for `testTemporalJoin` in local env.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
