### PR TITLE
[FLINK-21743] Document limitation of JdbcXaSinkFunction for MySQL support

### DIFF
--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -142,7 +142,12 @@ public class JdbcSinkExample {
 
 ## `JdbcSink.exactlyOnceSink`
 
-Since 1.13, Flink JDBC sink supports exactly-once mode. The implementation relies on the JDBC driver support of XA [standard](https://pubs.opengroup.org/onlinepubs/009680699/toc.pdf).
+Since 1.13, Flink JDBC sink supports exactly-once mode. 
+The implementation relies on the JDBC driver support of XA 
+[standard](https://pubs.opengroup.org/onlinepubs/009680699/toc.pdf).
+
+Attention: In 1.13, Flink JDBC sink does not support exactly-once mode with MySQL or other databases
+that do not support multiple XA transaction per connection. We will improve the support in FLINK-22239.
 
 To use it, create a sink using `exactlyOnceSink()` method as above and additionally provide:
 - {{< javadoc name="exactly-once options" file="org/apache/flink/connector/jdbc/JdbcExactlyOnceOptions.html" >}}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkFunction.java
@@ -120,6 +120,10 @@ import static org.apache.flink.connector.jdbc.xa.JdbcXaSinkFunctionState.of;
  * </tbody>
  * </table>
  *
+ * <p>Attention: JdbcXaSinkFunction does not support exactly-once mode with MySQL or other databases
+ * that do not support multiple XA transaction per connection. We will improve the support in
+ * FLINK-22239.
+ *
  * @since 1.13
  */
 @Internal


### PR DESCRIPTION
MySQL supports XA transaction as global trans, and allows one xa trans open per connection. For JDBC exactly once sink, it needs at least two xa trans per connection (snapshot -> prepare trans; and then begin transaction)

Document the limitation for MySQL support.

For future improve, please refer to FLINK-22239