### PR TITLE
[Flink-22248][Flink-22249] Harden JobMasterStopWithSavepointITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -99,13 +99,13 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
 
     private JobGraph jobGraph;
 
-    @Test(timeout = 5000)
+    @Test
     public void suspendWithSavepointWithoutComplicationsShouldSucceedAndLeadJobToFinished()
             throws Exception {
         stopWithSavepointNormalExecutionHelper(false);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void terminateWithSavepointWithoutComplicationsShouldSucceedAndLeadJobToFinished()
             throws Exception {
         stopWithSavepointNormalExecutionHelper(true);
@@ -130,12 +130,12 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
         assertThat(savepoints, hasItem(Paths.get(savepointLocation).getFileName()));
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void throwingExceptionOnCallbackWithNoRestartsShouldFailTheSuspend() throws Exception {
         throwingExceptionOnCallbackWithoutRestartsHelper(false);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void throwingExceptionOnCallbackWithNoRestartsShouldFailTheTerminate() throws Exception {
         throwingExceptionOnCallbackWithoutRestartsHelper(true);
     }
@@ -158,13 +158,13 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
                 getJobStatus(), either(equalTo(JobStatus.FAILED)).or(equalTo(JobStatus.FAILING)));
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void throwingExceptionOnCallbackWithRestartsShouldSimplyRestartInSuspend()
             throws Exception {
         throwingExceptionOnCallbackWithRestartsHelper(false);
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void throwingExceptionOnCallbackWithRestartsShouldSimplyRestartInTerminate()
             throws Exception {
         throwingExceptionOnCallbackWithRestartsHelper(true);
@@ -210,7 +210,7 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
                 either(equalTo(JobStatus.CANCELLING)).or(equalTo(JobStatus.CANCELED)));
     }
 
-    @Test(timeout = 5000)
+    @Test
     public void testRestartCheckpointCoordinatorIfStopWithSavepointFails() throws Exception {
         setUpJobGraph(CheckpointCountingTask.class, RestartStrategies.noRestart());
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -47,7 +47,6 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -80,7 +79,6 @@ import static org.junit.Assert.fail;
  * ITCases testing the stop with savepoint functionality. This includes checking both SUSPEND and
  * TERMINATE.
  */
-@Ignore("FLINK-22249, FLINK-22248")
 public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
 
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointITCase.java
@@ -154,7 +154,8 @@ public class JobMasterStopWithSavepointITCase extends AbstractTestBase {
 
         // verifying that we actually received a synchronous checkpoint
         assertTrue(syncSavepointId.get() > 0);
-        assertThat(getJobStatus(), equalTo(JobStatus.FAILED));
+        assertThat(
+                getJobStatus(), either(equalTo(JobStatus.FAILED)).or(equalTo(JobStatus.FAILING)));
     }
 
     @Test(timeout = 5000)


### PR DESCRIPTION
## What is the purpose of the change

Harden the JobMasterStopWithSavepointITCase

## Brief change log

  - Increased timeouts (I run tests 10k times locally and they always pass)
  - Added "Failling" state to an assertion, as we might not reach the "FAILED" state before that assertion


## Verifying this change

Tests pass


