### PR TITLE
[FLINK-22124][python] Fix the bug that errors are not thrown in custom python function

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -1145,6 +1145,21 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         expected.sort()
         self.assertEqual(expected, results)
 
+    def test_function_with_error(self):
+        ds = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1), ('e', 1)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        keyed_stream = ds.key_by(MyKeySelector(), key_type=Types.INT())
+
+        def flat_map_func(x):
+            raise ValueError('flat_map_func error')
+            yield x
+
+        from py4j.protocol import Py4JJavaError
+        import pytest
+        with pytest.raises(Py4JJavaError, match="flat_map_func error"):
+            keyed_stream.flat_map(flat_map_func).print()
+            self.env.execute("test_process_function_with_error")
+
 
 class BatchModeDataStreamTests(DataStreamTests, PyFlinkBatchTestCase):
 

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -34,7 +34,7 @@ cdef class InternalRow:
     cdef bint is_accumulate_msg(self)
 
 cdef class BaseCoderImpl:
-    cpdef void encode_to_stream(self, value, LengthPrefixOutputStream output_stream)
+    cpdef encode_to_stream(self, value, LengthPrefixOutputStream output_stream)
     cpdef decode_from_stream(self, LengthPrefixInputStream input_stream)
 
 cdef unsigned char ROW_KIND_BIT_SIZE

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -60,7 +60,7 @@ cdef class InternalRow:
         return "InternalRow(%s, %s)" % (self.row_kind, self.values)
 
 cdef class BaseCoderImpl:
-    cpdef void encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
+    cpdef encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
         pass
 
     cpdef decode_from_stream(self, LengthPrefixInputStream input_stream):
@@ -72,7 +72,7 @@ cdef class TableFunctionRowCoderImpl(FlattenRowCoderImpl):
         self._end_message = <char*> malloc(1)
         self._end_message[0] = 0x00
 
-    cpdef void encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
+    cpdef encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
         cdef is_row_or_tuple = False
         if iter_value:
             if isinstance(iter_value, (tuple, Row)):
@@ -97,7 +97,7 @@ cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
         self._is_row_data = True
         self._is_first_row = True
 
-    cpdef void encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
+    cpdef encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
         self._encode_list_value(iter_value, output_stream)
 
     cpdef decode_from_stream(self, LengthPrefixInputStream input_stream):
@@ -161,7 +161,7 @@ cdef class DataStreamFlatMapCoderImpl(BaseCoderImpl):
         self._end_message = <char*> malloc(1)
         self._end_message[0] = 0x00
 
-    cpdef void encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
+    cpdef encode_to_stream(self, iter_value, LengthPrefixOutputStream output_stream):
         if iter_value:
             for value in iter_value:
                 self._single_field_coder.encode_to_stream(value, output_stream)
@@ -181,7 +181,7 @@ cdef class DataStreamMapCoderImpl(FlattenRowCoderImpl):
         super(DataStreamMapCoderImpl, self).__init__([field_coder])
         self._single_field_coder = self._field_coders[0]
 
-    cpdef void encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
+    cpdef encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
         coder_type = self._single_field_coder.coder_type()
         type_name = self._single_field_coder.type_name()
         self._encode_field(coder_type, type_name, self._single_field_coder, value)
@@ -221,7 +221,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
         else:
             self._single_output = True
 
-    cpdef void encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
+    cpdef encode_to_stream(self, value, LengthPrefixOutputStream output_stream):
         if self._single_output:
             self._encode_one_row(value, output_stream)
         else:


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug that errors are not thrown in custom python function*


## Brief change log

  - *Change the signature of  `encode_to_stream` in `BaseCoderImpl`*

## Verifying this change

This change added tests and can be verified as follows:

- *`test_function_with_error` in `test_data_stream.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
