### PR TITLE
[FLINK-22197][tests] Shutdown cluster before collecting checkpoints

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -105,7 +105,6 @@ import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStor
 import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterables.getOnlyElement;
 import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_TIMEOUT;
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.junit.Assert.fail;
 
 /** Base class for tests related to unaligned checkpoints. */
 @Category(FailsWithAdaptiveScheduler.class) // FLINK-21689
@@ -170,19 +169,14 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             if (!ExceptionUtils.findThrowable(e, TestException.class).isPresent()) {
                 throw e;
             }
-            if (settings.generateCheckpoint) {
-                return Files.find(checkpointDir.toPath(), 2, this::isCompletedCheckpoint)
-                        .max(Comparator.comparing(Path::toString))
-                        .map(Path::toFile)
-                        .orElseThrow(
-                                () -> new IllegalStateException("Cannot generate checkpoint", e));
-            }
-            throw e;
         } finally {
             miniCluster.after();
         }
         if (settings.generateCheckpoint) {
-            fail("Could not generate checkpoint");
+            return Files.find(checkpointDir.toPath(), 2, this::isCompletedCheckpoint)
+                    .max(Comparator.comparing(Path::toString))
+                    .map(Path::toFile)
+                    .orElseThrow(() -> new IllegalStateException("Cannot generate checkpoint"));
         }
         return null;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -172,7 +172,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             }
             if (settings.generateCheckpoint) {
                 return Files.find(checkpointDir.toPath(), 2, this::isCompletedCheckpoint)
-                        .min(Comparator.comparing(Path::toString))
+                        .max(Comparator.comparing(Path::toString))
                         .map(Path::toFile)
                         .orElseThrow(
                                 () -> new IllegalStateException("Cannot generate checkpoint", e));


### PR DESCRIPTION
## What is the purpose of the change

`UnalignedCheckpointRescaleITCase` iterates over the checkpoints to return a completed one.
Currently, during the iteration the cluster isn't shut down so it can concurrently remove any files read.

With this change, cluster is shut down first and then checkpoint is collected.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
