### PR TITLE
[FLINK-22264][docs] Fix misleading statement about Flink Job Cluster Kubernetes Support in Flink Architecture page

### DIFF
--- a/docs/content.zh/docs/concepts/flink-architecture.md
+++ b/docs/content.zh/docs/concepts/flink-architecture.md
@@ -113,7 +113,7 @@ Flink 应用程序的作业可以被提交到长期运行的 [Flink Session 集�
 
 ### Flink Job 集群
 
-* **集群生命周期**：在 Flink Job 集群中，可用的集群管理器（例如 YARN 或 Kubernetes）用于为每个提交的作业启动一个集群，并且该集群仅可用于该作业。在这里，客户端首先从集群管理器请求资源启动 JobManager，然后将作业提交给在这个进程中运行的 Dispatcher。然后根据作业的资源请求惰性的分配 TaskManager。一旦作业完成，Flink Job 集群将被拆除。
+* **集群生命周期**：在 Flink Job 集群中，可用的集群管理器（例如 YARN）用于为每个提交的作业启动一个集群，并且该集群仅可用于该作业。在这里，客户端首先从集群管理器请求资源启动 JobManager，然后将作业提交给在这个进程中运行的 Dispatcher。然后根据作业的资源请求惰性的分配 TaskManager。一旦作业完成，Flink Job 集群将被拆除。
 
 * **资源隔离**：JobManager 中的致命错误仅影响在 Flink Job 集群中运行的一个作业。
 
@@ -121,6 +121,9 @@ Flink 应用程序的作业可以被提交到长期运行的 [Flink Session 集�
 
 {{< hint info >}}
 以前，Flink Job 集群也被称为<i> job (or per-job) 模式</i>下的 Flink 集群。
+{{< /hint >}}
+{{< hint info >}}
+Kubernetes 不支持 Flink Job 集群。 请参考 [Standalone Kubernetes]({{< ref "docs/deployment/resource-providers/standalone/kubernetes" >}}#per-job-cluster-mode) 和 [Native Kubernetes]({{< ref "docs/deployment/resource-providers/native_kubernetes" >}}#per-job-cluster-mode)。
 {{< /hint >}}
 
 ### Flink Application 集群

--- a/docs/content/docs/concepts/flink-architecture.md
+++ b/docs/content/docs/concepts/flink-architecture.md
@@ -204,7 +204,7 @@ Formerly, a Flink Session Cluster was also known as a Flink Cluster in `session 
 ### Flink Job Cluster
 
 * **Cluster Lifecycle**: in a Flink Job Cluster, the available cluster manager
-  (like YARN or Kubernetes) is used to spin up a cluster for each submitted job
+  (like YARN) is used to spin up a cluster for each submitted job
   and this cluster is available to that job only. Here, the client first
   requests resources from the cluster manager to start the JobManager and
   submits the job to the Dispatcher running inside this process. TaskManagers
@@ -221,6 +221,9 @@ Formerly, a Flink Session Cluster was also known as a Flink Cluster in `session 
 
 {{< hint info >}}
 Formerly, a Flink Job Cluster was also known as a Flink Cluster in `job (or per-job) mode`.
+{{< /hint >}}
+{{< hint info >}}
+Kubernetes doesn't support Flink Job Cluster. See details in [Standalone Kubernetes]({{< ref "docs/deployment/resource-providers/standalone/kubernetes" >}}#per-job-cluster-mode) and [Native Kubernetes]({{< ref "docs/deployment/resource-providers/native_kubernetes" >}}#per-job-cluster-mode).
 {{< /hint >}}
 
 ### Flink Application Cluster


### PR DESCRIPTION
## What is the purpose of the change
I noticed a conflict in the document statement for per-job mode support for Kubernetes.

In the doc here [1], it mentions

in a Flink Job Cluster, the available cluster manager (like YARN or Kubernetes) is used to spin up a cluster for each submitted job and this cluster is available to that job only.

It implies per job mode is supported in Kubernetes.

 

However, in the docs [2] and [3], it clearly points out per-job mode is not supported in Kubernetes.

To avoid the misunderstanding, I think we should fix the statement in the Flink Architecture page and add an extra hint note here. I had a discussion with @wangyang0918  in flink user mailing list earlier on this issue and he agrees to patch such a change.

 
[1] https://ci.apache.org/projects/flink/flink-docs-master/docs/concepts/flink-architecture/#flink-job-cluster

[2] https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#per-job-cluster-mode

[3] https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/resource-providers/standalone/kubernetes/


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)