### PR TITLE
[FLINK-22260][table-planner-blink] Use unresolvedSchema during operation convertions

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -89,7 +89,10 @@ class SqlCreateTableConverter {
         if (sqlCreateTable.getTableLike().isPresent()) {
             SqlTableLike sqlTableLike = sqlCreateTable.getTableLike().get();
             CatalogTable table = lookupLikeSourceTable(sqlTableLike);
-            sourceTableSchema = table.getSchema();
+            sourceTableSchema =
+                    TableSchema.fromResolvedSchema(
+                            table.getUnresolvedSchema()
+                                    .resolve(catalogManager.getSchemaResolver()));
             sourcePartitionKeys = table.getPartitionKeys();
             likeOptions = sqlTableLike.getOptions();
             sourceProperties = table.getOptions();

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -381,7 +381,11 @@ public class SqlToOperationConverter {
             SqlTableConstraint constraint =
                     ((SqlAlterTableAddConstraint) sqlAlterTable).getConstraint();
             validateTableConstraint(constraint);
-            TableSchema oriSchema = baseTable.getSchema();
+            TableSchema oriSchema =
+                    TableSchema.fromResolvedSchema(
+                            baseTable
+                                    .getUnresolvedSchema()
+                                    .resolve(catalogManager.getSchemaResolver()));
             // Sanity check for constraint.
             TableSchema.Builder builder = TableSchemaUtils.builderWithGivenSchema(oriSchema);
             if (constraint.getConstraintName().isPresent()) {
@@ -399,7 +403,11 @@ public class SqlToOperationConverter {
             SqlAlterTableDropConstraint dropConstraint =
                     ((SqlAlterTableDropConstraint) sqlAlterTable);
             String constraintName = dropConstraint.getConstraintName().getSimple();
-            TableSchema oriSchema = baseTable.getSchema();
+            TableSchema oriSchema =
+                    TableSchema.fromResolvedSchema(
+                            baseTable
+                                    .getUnresolvedSchema()
+                                    .resolve(catalogManager.getSchemaResolver()));
             if (!oriSchema
                     .getPrimaryKey()
                     .filter(pk -> pk.getName().equals(constraintName))

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.utils;
 
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
@@ -115,18 +116,17 @@ public class OperationMatchers {
     }
 
     /**
-     * Checks that the schema of {@link CreateTableOperation} is equal to the given {@link
-     * TableSchema}.
+     * Checks that the schema of {@link CreateTableOperation} is equal to the given {@link Schema}.
      *
      * @param schema TableSchema that the {@link CreateTableOperation} should have
      * @see #isCreateTableOperation(Matcher[])
      */
-    public static Matcher<CreateTableOperation> withSchema(TableSchema schema) {
-        return new FeatureMatcher<CreateTableOperation, TableSchema>(
-                equalTo(schema), "table schema of the derived table", "table schema") {
+    public static Matcher<CreateTableOperation> withSchema(Schema schema) {
+        return new FeatureMatcher<CreateTableOperation, Schema>(
+                equalTo(schema), "schema of the derived table", "schema") {
             @Override
-            protected TableSchema featureValueOf(CreateTableOperation actual) {
-                return actual.getCatalogTable().getSchema();
+            protected Schema featureValueOf(CreateTableOperation actual) {
+                return actual.getCatalogTable().getUnresolvedSchema();
             }
         };
     }


### PR DESCRIPTION
## What is the purpose of the change

The #getSchema implementation has been deprecated and returns null by
default, so we need to instead use the unresolved schema and derive the
TableSchema from that to prevent exceptions.

*NOTE:* Some tests in this PR now fail due to the issue fixed in https://github.com/apache/flink/pull/15539. I will rebase once that one is merged.

## Brief change log

- *SqlToOperationsConverter* makes multiple calls to `CatalogTable#getSchema` that are replaced with `#getUnresolvedSchema`.

## Verifying this change

This change is already covered by existing tests, such as `SqlToOperationsConverter`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
