### PR TITLE
[FLINK-22180][coordination] Only reclaim slots if job is removed 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1055,8 +1055,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             jmResourceIdRegistrations.remove(jobManagerResourceId);
 
             if (resourceRequirementHandling == ResourceRequirementHandling.CLEAR) {
-                slotManager.processResourceRequirements(
-                        ResourceRequirements.empty(jobId, jobMasterGateway.getAddress()));
+                slotManager.clearResourceRequirements(jobId);
             }
 
             // tell the job manager about the disconnect

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -246,6 +246,14 @@ public class DeclarativeSlotManager implements SlotManager {
     // ---------------------------------------------------------------------------------------------
 
     @Override
+    public void clearResourceRequirements(JobID jobId) {
+        checkInit();
+        maybeReclaimInactiveSlots(jobId);
+        jobMasterTargetAddresses.remove(jobId);
+        resourceTracker.notifyResourceRequirements(jobId, Collections.emptyList());
+    }
+
+    @Override
     public void processResourceRequirements(ResourceRequirements resourceRequirements) {
         checkInit();
         if (resourceRequirements.getResourceRequirements().isEmpty()) {
@@ -257,11 +265,7 @@ public class DeclarativeSlotManager implements SlotManager {
                     resourceRequirements.getResourceRequirements());
         }
 
-        if (resourceRequirements.getResourceRequirements().isEmpty()) {
-            jobMasterTargetAddresses.remove(resourceRequirements.getJobId());
-
-            maybeReclaimInactiveSlots(resourceRequirements.getJobId());
-        } else {
+        if (!resourceRequirements.getResourceRequirements().isEmpty()) {
             jobMasterTargetAddresses.put(
                     resourceRequirements.getJobId(), resourceRequirements.getTargetAddress());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -257,6 +257,12 @@ public class FineGrainedSlotManager implements SlotManager {
     // ---------------------------------------------------------------------------------------------
 
     @Override
+    public void clearResourceRequirements(JobID jobId) {
+        jobMasterTargetAddresses.remove(jobId);
+        resourceTracker.notifyResourceRequirements(jobId, Collections.emptyList());
+    }
+
+    @Override
     public void processResourceRequirements(ResourceRequirements resourceRequirements) {
         checkInit();
         LOG.debug(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
@@ -90,6 +91,14 @@ public interface SlotManager extends AutoCloseable {
 
     /** Suspends the component. This clears the internal state of the slot manager. */
     void suspend();
+
+    /**
+     * Notifies the slot manager that the resource requirements for the given job should be cleared.
+     * The slot manager may assume that no further updates to the resource requirements will occur.
+     *
+     * @param jobId job for which to clear the requirements
+     */
+    void clearResourceRequirements(JobID jobId);
 
     /**
      * Notifies the slot manager about the resource requirements of a job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -394,6 +394,9 @@ public class SlotManagerImpl implements SlotManager {
     // ---------------------------------------------------------------------------------------------
 
     @Override
+    public void clearResourceRequirements(JobID jobId) {}
+
+    @Override
     public void processResourceRequirements(ResourceRequirements resourceRequirements) {
         // no-op; don't throw an UnsupportedOperationException here because there are code paths
         // where the resource

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -1376,7 +1376,6 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
     @Test
     public void testReclaimInactiveSlotsOnEmptyRequirements() throws Exception {
-        final SlotTracker slotTracker = new DefaultSlotTracker();
 
         final CompletableFuture<JobID> freeInactiveSlotsJobIdFuture = new CompletableFuture<>();
 
@@ -1387,7 +1386,6 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
         try (final DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()
-                        .setSlotTracker(slotTracker)
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
@@ -42,12 +43,18 @@ public class TestingSlotManager implements SlotManager {
 
     private final Consumer<Boolean> setFailUnfulfillableRequestConsumer;
     private final Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier;
+    private final Consumer<ResourceRequirements> processRequirementsConsumer;
+    private final Consumer<JobID> clearRequirementsConsumer;
 
     TestingSlotManager(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer,
-            Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
+            Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier,
+            Consumer<ResourceRequirements> processRequirementsConsumer,
+            Consumer<JobID> clearRequirementsConsumer) {
         this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
         this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
+        this.processRequirementsConsumer = processRequirementsConsumer;
+        this.clearRequirementsConsumer = clearRequirementsConsumer;
     }
 
     @Override
@@ -115,7 +122,14 @@ public class TestingSlotManager implements SlotManager {
     public void suspend() {}
 
     @Override
-    public void processResourceRequirements(ResourceRequirements resourceRequirements) {}
+    public void clearResourceRequirements(JobID jobId) {
+        clearRequirementsConsumer.accept(jobId);
+    }
+
+    @Override
+    public void processResourceRequirements(ResourceRequirements resourceRequirements) {
+        processRequirementsConsumer.accept(resourceRequirements);
+    }
 
     @Override
     public boolean registerSlotRequest(SlotRequest slotRequest) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.slots.ResourceRequirements;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,6 +33,8 @@ public class TestingSlotManagerBuilder {
     private Consumer<Boolean> setFailUnfulfillableRequestConsumer = ignored -> {};
     private Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier =
             () -> Collections.emptyMap();
+    private Consumer<ResourceRequirements> processRequirementsConsumer = ignored -> {};
+    private Consumer<JobID> clearRequirementsConsumer = ignored -> {};
 
     public TestingSlotManagerBuilder setSetFailUnfulfillableRequestConsumer(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
@@ -44,8 +48,23 @@ public class TestingSlotManagerBuilder {
         return this;
     }
 
+    public TestingSlotManagerBuilder setProcessRequirementsConsumer(
+            Consumer<ResourceRequirements> processRequirementsConsumer) {
+        this.processRequirementsConsumer = processRequirementsConsumer;
+        return this;
+    }
+
+    public TestingSlotManagerBuilder setClearRequirementsConsumer(
+            Consumer<JobID> clearRequirementsConsumer) {
+        this.clearRequirementsConsumer = clearRequirementsConsumer;
+        return this;
+    }
+
     public TestingSlotManager createSlotManager() {
         return new TestingSlotManager(
-                setFailUnfulfillableRequestConsumer, getRequiredResourcesSupplier);
+                setFailUnfulfillableRequestConsumer,
+                getRequiredResourcesSupplier,
+                processRequirementsConsumer,
+                clearRequirementsConsumer);
     }
 }


### PR DESCRIPTION
Fixes an issue where the RM was reclaiming slots during the execution of a batch job when the job was switching to the next stage and temporarily reduced the requirements to 0.
Slots are now only reclaimed if the job is removed from the RM.