### PR TITLE
[FLINK-21859][coordination] Ignore outdated slot offer responses

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1498,7 +1498,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             UUID offerId) {
         return (Iterable<SlotOffer> acceptedSlots, Throwable throwable) -> {
             // check if this is the latest offer
-            if (offerId != currentSlotOfferPerJob.get(jobId)) {
+            if (!offerId.equals(currentSlotOfferPerJob.get(jobId))) {
                 // If this offer is outdated then it can be safely ignored.
                 // If the response for a given slot is identical in both offers (accepted/rejected),
                 // then this is naturally the case since the end-result is the same.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1516,7 +1516,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 //   execution.
 
                 log.debug(
-                        "Discard offer slot response since there is a newer offer for the job {}.",
+                        "Discard slot offer response since there is a newer offer for the job {}.",
                         jobId);
                 return;
             }
@@ -1571,7 +1571,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 } else {
                     // discard the response since there is a new leader for the job
                     log.debug(
-                            "Discard offer slot response since there is a new leader "
+                            "Discard slot offer response since there is a new leader "
                                     + "for the job {}.",
                             jobId);
                 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1215,13 +1215,13 @@ public class TaskExecutorTest extends TestLogger {
             offerSlotsLatch.await();
 
             firstOfferResponseFuture.complete(Collections.singletonList(slotOffer1));
-            firstOfferResponseFuture.complete(Collections.singletonList(slotOffer2));
+            secondOfferResponseFuture.complete(Collections.singletonList(slotOffer2));
 
             assertThat(
-                    threadSafeTaskSlotTable.getAllocationIdsPerJob(jobId),
+                    threadSafeTaskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId),
                     contains(slotOffer1.getAllocationId()));
             assertThat(
-                    threadSafeTaskSlotTable.getAllocationIdsPerJob(jobId2),
+                    threadSafeTaskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId2),
                     contains(slotOffer2.getAllocationId()));
         } finally {
             RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -1096,16 +1096,14 @@ public class TaskExecutorTest extends TestLogger {
                     assertThat(
                             threadSafeTaskSlotTable.getActiveTaskSlotAllocationIdsPerJob(jobId),
                             empty());
-                    secondOfferResponseFuture.completeExceptionally(
-                            new RuntimeException("Test exception"));
+                    secondOfferResponseFuture.complete(Collections.emptyList());
                     assertThat(threadSafeTaskSlotTable.getAllocationIdsPerJob(jobId), empty());
                     return;
                 case REJECT_THEN_ACCEPT:
                     // fail the first offer, but accept both slots for the second offer
                     // in the past the rejection of the first offer freed the slot; when the slot is
                     // accepted from the second offer the activation of said slot then failed
-                    firstOfferResponseFuture.completeExceptionally(
-                            new RuntimeException("Test exception"));
+                    firstOfferResponseFuture.complete(Collections.emptyList());
                     secondOfferResponseFuture.complete(Arrays.asList(slotOffer1, slotOffer2));
                     assertThat(
                             threadSafeTaskSlotTable.getAllocationIdsPerJob(jobId),


### PR DESCRIPTION
Fixes an issue where outdated slot offer responses could result in slots being freed while they are still being offered to the JM in a new offer.
Each slot offer is now internally identified with an ID, and the response is only processed if this is matches the current slot offer counter.