### PR TITLE
[FLINK-21941] Make sure jobs do not finish before taking savepoint in RescalingITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -293,6 +293,8 @@ public class RescalingITCase extends TestLogger {
             JobGraph jobGraph =
                     createJobGraphWithOperatorState(
                             parallelism, maxParallelism, OperatorCheckpointMethod.NON_PARTITIONED);
+            // make sure the job does not finish before we take the savepoint
+            StateSourceBase.canFinishLatch = new CountDownLatch(1);
 
             final JobID jobID = jobGraph.getJobID();
 
@@ -306,8 +308,9 @@ public class RescalingITCase extends TestLogger {
             final String savepointPath =
                     savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
+            // we took a savepoint, the job can finish now
+            StateSourceBase.canFinishLatch.countDown();
             client.cancel(jobID).get();
-
             while (!getRunningJobs(client).isEmpty()) {
                 Thread.sleep(50);
             }
@@ -366,6 +369,8 @@ public class RescalingITCase extends TestLogger {
 
             final JobID jobID = jobGraph.getJobID();
 
+            // make sure the job does not finish before we take the savepoint
+            StateSourceBase.canFinishLatch = new CountDownLatch(1);
             client.submitJob(jobGraph).get();
 
             // wait til the sources have emitted numberElements for each key and completed a
@@ -400,6 +405,8 @@ public class RescalingITCase extends TestLogger {
             final String savepointPath =
                     savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
+            // we took a savepoint, the job can finish now
+            StateSourceBase.canFinishLatch.countDown();
             client.cancel(jobID).get();
 
             while (!getRunningJobs(client).isEmpty()) {
@@ -508,6 +515,8 @@ public class RescalingITCase extends TestLogger {
         try {
             JobGraph jobGraph =
                     createJobGraphWithOperatorState(parallelism, maxParallelism, checkpointMethod);
+            // make sure the job does not finish before we take the savepoint
+            StateSourceBase.canFinishLatch = new CountDownLatch(1);
 
             final JobID jobID = jobGraph.getJobID();
 
@@ -527,8 +536,9 @@ public class RescalingITCase extends TestLogger {
             final String savepointPath =
                     savepointPathFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
+            // we took a savepoint, the job can finish now
+            StateSourceBase.canFinishLatch.countDown();
             client.cancel(jobID).get();
-
             while (!getRunningJobs(client).isEmpty()) {
                 Thread.sleep(50);
             }
@@ -852,6 +862,7 @@ public class RescalingITCase extends TestLogger {
 
         private static final long serialVersionUID = 7512206069681177940L;
         private static CountDownLatch workStartedLatch = new CountDownLatch(1);
+        private static CountDownLatch canFinishLatch = new CountDownLatch(0);
 
         protected volatile int counter = 0;
         protected volatile boolean running = true;
@@ -876,6 +887,8 @@ public class RescalingITCase extends TestLogger {
                     break;
                 }
             }
+
+            canFinishLatch.await();
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -784,7 +784,7 @@ public class RescalingITCase extends TestLogger {
 
         private static final long serialVersionUID = 5273172591283191348L;
 
-        private static volatile CountDownLatch workCompletedLatch = new CountDownLatch(1);
+        private static CountDownLatch workCompletedLatch = new CountDownLatch(1);
 
         private transient ValueState<Integer> counter;
         private transient ValueState<Integer> sum;
@@ -851,7 +851,7 @@ public class RescalingITCase extends TestLogger {
     private static class StateSourceBase extends RichParallelSourceFunction<Integer> {
 
         private static final long serialVersionUID = 7512206069681177940L;
-        private static volatile CountDownLatch workStartedLatch = new CountDownLatch(1);
+        private static CountDownLatch workStartedLatch = new CountDownLatch(1);
 
         protected volatile int counter = 0;
         protected volatile boolean running = true;


### PR DESCRIPTION
## What is the purpose of the change

Tests occasionally fail on Azure, because it might happen that the job finishes before we take a savepoint. I added a latch that lets us wait until we are sure we took a savepoint correctly.

## Verifying this change

Tests pass on Azure

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
