### PR TITLE
[FLINK-22021][table-planner-blink] Fix exception when PushFilterIntoLegacyTableSourceScanRule is faced with INTERVAL types  

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractor.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.utils
 import org.apache.flink.annotation.VisibleForTesting
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, FunctionLookup, UnresolvedIdentifier}
+import org.apache.flink.table.data.conversion.{DayTimeIntervalDurationConverter, YearMonthIntervalPeriodConverter}
 import org.apache.flink.table.data.util.DataFormatConverters.{LocalDateConverter, LocalTimeConverter}
 import org.apache.flink.table.expressions._
 import ApiExpressionUtils._
@@ -30,6 +31,7 @@ import org.apache.flink.table.planner.utils.Logging
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.YearMonthIntervalType
 import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
 import org.apache.flink.util.Preconditions
 
@@ -388,6 +390,16 @@ class RexNodeToExpressionConverter(
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val v = literal.getValueAs(classOf[TimestampString])
         toLocalDateTime(v).atZone(timeZone.toZoneId).toInstant
+
+      case INTERVAL_DAY_TIME =>
+        val v = literal.getValueAs(classOf[java.lang.Long])
+        DayTimeIntervalDurationConverter.INSTANCE.toExternal(v)
+
+      case INTERVAL_YEAR_MONTH =>
+        val v = literal.getValueAs(classOf[java.lang.Integer])
+        YearMonthIntervalPeriodConverter
+          .create(literalType.asInstanceOf[YearMonthIntervalType])
+          .toExternal(v)
 
       case TINYINT =>
         // convert from BigDecimal to Byte

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -209,6 +209,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWithInterval">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MTable
+WHERE
+  TIMESTAMPADD(HOUR, 5, a) >= b
+  OR
+  TIMESTAMPADD(YEAR, 2, b) >= a
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL DAY TO SECOND, 5)), $1), >=(+($1, *(12:INTERVAL YEAR TO MONTH, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[true], filter=[]]]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPartialPushDown2">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR price > 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -209,6 +209,31 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
 ]]>
 		</Resource>
 	</TestCase>
+	<TestCase name="testWithInterval">
+		<Resource name="sql">
+			<![CDATA[
+SELECT * FROM MTable
+WHERE
+  TIMESTAMPADD(HOUR, 5, a) >= b
+  OR
+  TIMESTAMPADD(YEAR, 2, b) >= a
+]]>
+		</Resource>
+		<Resource name="planBefore">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+		</Resource>
+		<Resource name="planAfter">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[OR(>=(+($0, *(3600000:INTERVAL HOUR, 5)), $1), >=(+($1, *(12:INTERVAL YEAR, 2)), $0))])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MTable, source: [filterPushedDown=[false], filter=[]]]])
+]]>
+		</Resource>
+	</TestCase>
 	<TestCase name="testPartialPushDown2">
 		<Resource name="sql">
 			<![CDATA[SELECT * FROM MyTable WHERE amount > 2 OR price > 10]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.rules.logical
 import org.apache.flink.table.api.{DataTypes, TableSchema}
 import org.apache.flink.table.planner.expressions.utils.Func1
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkBatchProgram, FlinkHepRuleSetProgramBuilder, HEP_RULES_EXECUTION_TYPE}
+import org.apache.flink.table.planner.utils.DateTimeTestUtil.localDateTime
 import org.apache.flink.table.planner.utils.{TableConfigUtils, TableTestBase, TestLegacyFilterableTableSource}
 import org.apache.flink.types.Row
 
@@ -166,5 +167,33 @@ class PushFilterIntoLegacyTableSourceScanRuleTest extends TableTestBase {
       List("a", "b"))
 
     util.verifyPlan("SELECT * FROM MTable WHERE LOWER(a) = 'foo' AND UPPER(b) = 'bar'")
+  }
+
+  @Test
+  def testWithInterval(): Unit = {
+    val schema = TableSchema
+      .builder()
+      .field("a", DataTypes.TIMESTAMP)
+      .field("b", DataTypes.TIMESTAMP)
+      .build()
+
+    val data = List(Row.of(
+      localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 15:00:00")))
+    TestLegacyFilterableTableSource.createTemporaryTable(
+      util.tableEnv,
+      schema,
+      "MTable",
+      isBounded = true,
+      data,
+      List("a", "b"))
+
+    util.verifyPlan(
+      """
+        |SELECT * FROM MTable
+        |WHERE
+        |  TIMESTAMPADD(HOUR, 5, a) >= b
+        |  OR
+        |  TIMESTAMPADD(YEAR, 2, b) >= a
+        |""".stripMargin)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.common.typeinfo.Types.INSTANT
 import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.{DataTypes, ValidationException}
+import org.apache.flink.table.api.{DataTypes, TableSchema, ValidationException}
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.data.{DecimalDataUtils, TimestampData}
 import org.apache.flink.table.data.util.DataFormatConverters.LocalDateConverter
@@ -38,11 +38,10 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils._
 import org.apache.flink.table.planner.runtime.utils.{BatchTableEnvUtil, BatchTestBase, TestData, UserDefinedFunctionTestUtils}
-import org.apache.flink.table.planner.utils.DateTimeTestUtil
+import org.apache.flink.table.planner.utils.{DateTimeTestUtil, TestLegacyFilterableTableSource}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils.unixTimestampToLocalDateTime
 import org.apache.flink.types.Row
-import org.apache.flink.util.CollectionUtil
 
 import org.junit.Assert.assertEquals
 import org.junit._
@@ -1341,4 +1340,43 @@ class CalcITCase extends BatchTestBase {
     )
   }
 
+  @Test
+  def testFilterPushDownWithInterval(): Unit = {
+    val schema = TableSchema
+      .builder()
+      .field("a", DataTypes.TIMESTAMP)
+      .field("b", DataTypes.TIMESTAMP)
+      .build()
+
+    val data = List(
+      row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 14:59:59")),
+      row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 15:00:00")),
+      row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 15:00:01")),
+      row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 09:59:59")),
+      row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 10:00:00")),
+      row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 10:00:01")))
+
+    TestLegacyFilterableTableSource.createTemporaryTable(
+      tEnv,
+      schema,
+      "myTable",
+      isBounded = true,
+      data,
+      List("a", "b"))
+
+    checkResult(
+      "SELECT * FROM myTable WHERE TIMESTAMPADD(HOUR, 5, a) >= b",
+      Seq(
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 14:59:59")),
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 15:00:00"))))
+
+    checkResult(
+      "SELECT * FROM myTable WHERE TIMESTAMPADD(YEAR, 2, a) >= b",
+      Seq(
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 14:59:59")),
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 15:00:00")),
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2021-03-30 15:00:01")),
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 09:59:59")),
+        row(localDateTime("2021-03-30 10:00:00"), localDateTime("2023-03-30 10:00:00"))))
+  }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/DayTimeIntervalDurationConverter.java
@@ -28,6 +28,9 @@ import java.time.Duration;
 public class DayTimeIntervalDurationConverter
         implements DataStructureConverter<Long, java.time.Duration> {
 
+    public static final DayTimeIntervalDurationConverter INSTANCE =
+            new DayTimeIntervalDurationConverter();
+
     private static final long serialVersionUID = 1L;
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/YearMonthIntervalPeriodConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/conversion/YearMonthIntervalPeriodConverter.java
@@ -58,8 +58,10 @@ public class YearMonthIntervalPeriodConverter
     // --------------------------------------------------------------------------------------------
 
     public static YearMonthIntervalPeriodConverter create(DataType dataType) {
-        final YearMonthIntervalType intervalType =
-                (YearMonthIntervalType) dataType.getLogicalType();
+        return create((YearMonthIntervalType) dataType.getLogicalType());
+    }
+
+    public static YearMonthIntervalPeriodConverter create(YearMonthIntervalType intervalType) {
         return new YearMonthIntervalPeriodConverter(
                 createPeriodConstructor(intervalType.getResolution()));
     }


### PR DESCRIPTION
## What is the purpose of the change

merge  [FLINK-22021](https://github.com/apache/flink/pull/15424) to  Flink 1.12

PushFilterIntoLegacyTableSourceScanRule will throw exception when faced with INTERVAL types, no matter it can be pushed down or not.

This PR fixes this issue.

## Brief change log

Fix exception when PushFilterIntoLegacyTableSourceScanRule is faced with INTERVAL types

## Verifying this change
This change can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
The S3 file system connector: no

## Documentation

Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable