### PR TITLE
[hotfix][tests] test logger level to INFO for the flink-connector-kafka module

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-kafka/src/test/resources/log4j2-test.properties
@@ -18,7 +18,8 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+# TODO: set log level to OFF after FLINK-22085 is fixed.
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger


### PR DESCRIPTION
## Contribution Checklist

This PR updated test logger level to INFO for the flink-connector-kafka module. This is needed to debug FLINK-22085.

## Brief change log

This PR updated test logger level to INFO for the flink-connector-kafka module

## Verifying this change

Verified that INFO level log would be printed by running `mvn test -Dtest=KafkaSourceLegacyITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
