### PR TITLE
[FLINK-22125][python] Returns None when a key doesn't exist when calling MapState.get()

### DIFF
--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -203,9 +203,6 @@ class MapState(State, Generic[K, V]):
     def get(self, key: K) -> V:
         """
         Returns the current value associated with the given key.
-
-        Raises:
-            KeyError if the key doesn't exist.
         """
         pass
 

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -706,21 +706,21 @@ class InternalSynchronousMapRuntimeState(object):
 
     def get(self, map_key):
         if self._is_empty:
-            raise KeyError("Map key %s not found!" % str(map_key))
+            return None
         if map_key in self._write_cache:
             exists, value = self._write_cache[map_key]
             if exists:
                 return value
             else:
-                raise KeyError("Map key %s not found!" % str(map_key))
+                return None
         if self._cleared:
-            raise KeyError("Map key %s not found!" % str(map_key))
+            return None
         exists, value = self._map_state_handler.blocking_get(
             self._state_key, map_key, self._map_key_coder_impl, self._map_value_coder_impl)
         if exists:
             return value
         else:
-            raise KeyError("Map key %s not found!" % str(map_key))
+            return None
 
     def put(self, map_key, map_value):
         self._write_cache[map_key] = (True, map_value)

--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -754,11 +754,10 @@ class InternalSynchronousMapRuntimeState(object):
     def contains(self, map_key):
         if self._is_empty:
             return False
-        try:
-            self.get(map_key)
-            return True
-        except KeyError:
+        if self.get(map_key) is None:
             return False
+        else:
+            return True
 
     def is_empty(self):
         if self._is_empty is None:


### PR DESCRIPTION

## What is the purpose of the change

*Currently it will throw KeyError when a key doesn't exist when calling MapState.get. This pull request change the behavior of MapState.get to None when a key doesn't exist.*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
