### PR TITLE
[FLINK-21986][State Backends] fix native memory used by RocksDB not be released timely after job restart

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
@@ -250,7 +250,8 @@ public class RocksDBOperationUtils {
         try {
             // IMPORTANT NOTE: Do not call ColumnFamilyHandle#getDescriptor() just to judge if it
             // return null and then call it again when it return is not null. That will cause
-            // task manager native memory used by RocksDB can't be released timely after job restart.
+            // task manager native memory used by RocksDB can't be released timely after job
+            // restart.
             // The problem can find in : https://issues.apache.org/jira/browse/FLINK-21986
             if (columnFamilyHandle != null) {
                 ColumnFamilyDescriptor columnFamilyDescriptor = columnFamilyHandle.getDescriptor();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
@@ -248,8 +248,15 @@ public class RocksDBOperationUtils {
     public static void addColumnFamilyOptionsToCloseLater(
             List<ColumnFamilyOptions> columnFamilyOptions, ColumnFamilyHandle columnFamilyHandle) {
         try {
-            if (columnFamilyHandle != null && columnFamilyHandle.getDescriptor() != null) {
-                columnFamilyOptions.add(columnFamilyHandle.getDescriptor().getOptions());
+            // IMPORTANT NOTE: Do not call ColumnFamilyHandle#getDescriptor() just to judge if it
+            // return null and then call it again when it return is not null. That will cause
+            // task manager native memory used by RocksDB can't be released timely after job restart.
+            // The problem can find in : https://issues.apache.org/jira/browse/FLINK-21986
+            if (columnFamilyHandle != null) {
+                ColumnFamilyDescriptor columnFamilyDescriptor = columnFamilyHandle.getDescriptor();
+                if (columnFamilyDescriptor != null) {
+                    columnFamilyOptions.add(columnFamilyDescriptor.getOptions());
+                }
             }
         } catch (RocksDBException e) {
             // ignore


### PR DESCRIPTION
fix native memory used by RocksDB not be released timely after job restart

## What is the purpose of the change

This pull request fix the problem described in [FLINK-21986](https://issues.apache.org/jira/browse/FLINK-21986). 

Concisely, *RocksDBOperationUtils#addColumnFamilyOptionsToCloseLater()* invoke *ColumnFamilyHandle#getDescriptor()* twice just for get ColumnFamilyOptions used by ColumnFamilyHandle. Every invocation create a new ColumnFamilyOptions instance, but only one added to "to close later list". 
That resulted in some ColumnFamilyOptions was not closed and task manager native memory used by RocksDB can't be released timely. This situation often leads to task manager OOM killed by container manager such as Yarn and Kubernetes.

## Brief change log

  - *RocksDBOperationUtils#addColumnFamilyOptionsToCloseLater()* only invoke *ColumnFamilyHandle#getDescriptor()* once to get ColumnFamilyOptions instance.


## Verifying this change

This change can be verified as follows:

  - Run a test job use RocksDBStateBackend and store a mass of state data (such as regular join job [flink-21986-regular-join-test-case](https://github.com/zoltar9264/flink-21986-regular-join-test-case/blob/master/src/main/java/top/zoltar/flink/issue/StreamingJob.java) )
  - Manually trigger restart (such as kill a task manager manually) and verifying that other task manager process RSS memory decrease after restart. As shown in the picture below :

![image](https://user-images.githubusercontent.com/16664055/114829393-99598680-9dfd-11eb-8926-b11d44ca3d3d.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
