### PR TITLE
[FLINK-22292][python][docs] Add documentation for state acess in Python DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -36,9 +36,9 @@ to learn about the concepts behind stateful stream processing.
 
 If you want to use keyed state, you first need to specify a key on a
 `DataStream` that should be used to partition the state (and also the records
-in the stream themselves). You can specify a key using `keyBy(KeySelector)` on
-a `DataStream`. This will yield a `KeyedDataStream`, which then allows
-operations that use keyed state.
+in the stream themselves). You can specify a key using `keyBy(KeySelector)`
+in Java/Scala API or `key_by(KeySelector)` in Python API on a `DataStream`.
+This will yield a `KeyedStream`, which then allows operations that use keyed state.
 
 A key selector function takes a single record as input and returns the key for
 that record. The key can be of any type and **must** be derived from
@@ -76,12 +76,20 @@ val words: DataStream[WC] = // [...]
 val keyed = words.keyBy( _.word )
 ```
 {{< /tab >}}
+
+{{< tab "Python" >}}
+```python
+words = # type: DataStream[Row]
+keyed = words.key_by(lambda row: row[0])
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 #### Tuple Keys and Expression Keys
 
 Flink also has two alternative ways of defining keys: tuple keys and expression
-keys. With this you can specify keys using tuple field indices or expressions
+keys in the Java API(still not supported in the Python API). With this you can
+specify keys using tuple field indices or expressions
 for selecting fields of objects. We don't recommend using these today but you
 can refer to the Javadoc of DataStream to learn about them. Using a KeySelector
 function is strictly superior: with Java lambdas they are easy to use and they
@@ -92,7 +100,7 @@ have potentially less overhead at runtime.
 ## 使用 Keyed State
 
 keyed state 接口提供不同类型状态的访问接口，这些状态都作用于当前输入数据的 key 下。换句话说，这些状态仅可在 `KeyedStream`
-上使用，可以通过 `stream.keyBy(...)` 得到 `KeyedStream`.
+上使用，在Java API上可以通过 `stream.keyBy(...)` 得到 `KeyedStream`，在Python API上可以通过 `stream.key_by(...)` 得到 `KeyedStream`。
 
 接下来，我们会介绍不同类型的状态，然后介绍如何使用他们。所有支持的状态类型如下所示：
 
@@ -240,6 +248,54 @@ object ExampleCountWindowAverage extends App {
 }
 ```
 {{< /tab >}}
+
+{{< tab "Python" >}}
+```python
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import StreamExecutionEnvironment, FlatMapFunction, RuntimeContext
+from pyflink.datastream.state import ValueStateDescriptor
+
+class CountWindowAverage(FlatMapFunction):
+
+    def __init__(self):
+        self.sum = None
+
+    def open(self, runtime_context: RuntimeContext):
+        descriptor = ValueStateDescriptor(
+            "average",  # the state name
+            Types.TUPLE([Types.LONG(), Types.LONG()])  # type information
+        )
+        self.sum = runtime_context.get_state(descriptor)
+
+    def flat_map(self, value):
+        # access the state value
+        current_sum = self.sum.value()
+        if current_sum is None:
+            current_sum = (0, 0)
+
+        # update the count
+        current_sum = (current_sum[0] + 1, current_sum[1] + value[1])
+
+        # update the state
+        self.sum.update(current_sum)
+
+        # if the count reaches 2, emit the average and clear the state
+        if current_sum[0] >= 2:
+            self.sum.clear()
+            yield value[0], current_sum[1] / current_sum[0]
+
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.from_collection([(1, 3), (1, 5), (1, 7), (1, 4), (1, 2)]) \
+    .key_by(lambda row: row[0]) \
+    .flat_map(CountWindowAverage()) \
+    .print()
+
+env.execute()
+
+# the printed output will be (1,4) and (1,5)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 这个例子实现了一个简单的计数窗口。 我们把元组的第一个元素当作 key（在示例中都 key 都是 "1"）。 该函数将出现的次数以及总和存储在 "ValueState" 中。 
@@ -318,6 +374,8 @@ Heap state backend 会额外存储一个包括用户状态以及时间戳的 Jav
 - 当前开启 TTL 的 map state 仅在用户值序列化器支持 null 的情况下，才支持用户值为 null。如果用户值序列化器不支持 null，
 可以用 `NullableSerializer` 包装一层。
 
+- State TTL 当前在 PyFlink DataStream API 中还不支持。
+
 #### 过期数据的清理
 
 默认情况下，过期数据会在读取的时候被删除，例如 `ValueState#value`，同时会有后台线程定期清理（如果 StateBackend 支持的话）。可以通过 `StateTtlConfig` 配置关闭后台清理：
@@ -342,6 +400,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .disableCleanupInBackground
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL 当前在 PyFlink DataStream API 中还不支持。
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -376,6 +439,11 @@ val ttlConfig = StateTtlConfig
     .build
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL 当前在 PyFlink DataStream API 中还不支持。
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 这种策略在 `RocksDBStateBackend` 的增量 checkpoint 模式下无效。
@@ -407,6 +475,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupIncrementally(10, true)
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL 当前在 PyFlink DataStream API 中还不支持。
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -447,6 +520,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupInRocksdbCompactFilter(1000)
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL 当前在 PyFlink DataStream API 中还不支持。
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -498,6 +576,8 @@ In a typical stateful Flink Application you don't need operators state. It is
 mostly a special type of state that is used in source/sink implementations and
 scenarios where you don't have a key by which state can be partitioned.
 
+**Notes:** Operator state is still not supported in Python DataStream API.
+
 ## Broadcast State
 
 *Broadcast State* is a special type of *Operator State*.  It was introduced to
@@ -514,6 +594,8 @@ in that:
  2. it is only available to specific operators that have as inputs a
     *broadcasted* stream and a *non-broadcasted* one, and
  3. such an operator can have *multiple broadcast states* with different names.
+
+**Notes:** Broadcast state is still not supported in Python DataStream API.
 
 {{< top >}}
 

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -88,7 +88,7 @@ keyed = words.key_by(lambda row: row[0])
 #### Tuple Keys and Expression Keys
 
 Flink also has two alternative ways of defining keys: tuple keys and expression
-keys in the Java API(still not supported in the Python API). With this you can
+keys in the Java/Scala API(still not supported in the Python API). With this you can
 specify keys using tuple field indices or expressions
 for selecting fields of objects. We don't recommend using these today but you
 can refer to the Javadoc of DataStream to learn about them. Using a KeySelector
@@ -100,7 +100,7 @@ have potentially less overhead at runtime.
 ## 使用 Keyed State
 
 keyed state 接口提供不同类型状态的访问接口，这些状态都作用于当前输入数据的 key 下。换句话说，这些状态仅可在 `KeyedStream`
-上使用，在Java API上可以通过 `stream.keyBy(...)` 得到 `KeyedStream`，在Python API上可以通过 `stream.key_by(...)` 得到 `KeyedStream`。
+上使用，在Java/Scala API上可以通过 `stream.keyBy(...)` 得到 `KeyedStream`，在Python API上可以通过 `stream.key_by(...)` 得到 `KeyedStream`。
 
 接下来，我们会介绍不同类型的状态，然后介绍如何使用他们。所有支持的状态类型如下所示：
 
@@ -282,7 +282,7 @@ class CountWindowAverage(FlatMapFunction):
         # if the count reaches 2, emit the average and clear the state
         if current_sum[0] >= 2:
             self.sum.clear()
-            yield value[0], current_sum[1] / current_sum[0]
+            yield value[0], int(current_sum[1] / current_sum[0])
 
 
 env = StreamExecutionEnvironment.get_execution_environment()

--- a/docs/content.zh/docs/dev/python/datastream/state.md
+++ b/docs/content.zh/docs/dev/python/datastream/state.md
@@ -1,0 +1,27 @@
+---
+title: "State"
+weight: 31
+type: docs
+aliases:
+- /zh/docs/dev/python/datastream/state.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<meta http-equiv="refresh" content="0; url=/zh/docs/dev/datastream/fault-tolerance/state/" />

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -88,7 +88,7 @@ keyed = words.key_by(lambda row: row[0])
 #### Tuple Keys and Expression Keys
 
 Flink also has two alternative ways of defining keys: tuple keys and expression
-keys in the Java API(still not supported in the Python API). With this you can
+keys in the Java/Scala API(still not supported in the Python API). With this you can
 specify keys using tuple field indices or expressions
 for selecting fields of objects. We don't recommend using these today but you
 can refer to the Javadoc of DataStream to learn about them. Using a KeySelector
@@ -101,7 +101,7 @@ have potentially less overhead at runtime.
 
 The keyed state interfaces provides access to different types of state that are all scoped to
 the key of the current input element. This means that this type of state can only be used
-on a `KeyedStream`, which can be created via `stream.keyBy(…)` in Java API or `stream.key_by(…)` in Python API.
+on a `KeyedStream`, which can be created via `stream.keyBy(…)` in Java/Scala API or `stream.key_by(…)` in Python API.
 
 Now, we will first look at the different types of state available and then we will see
 how they can be used in a program. The available state primitives are:
@@ -302,7 +302,7 @@ class CountWindowAverage(FlatMapFunction):
         # if the count reaches 2, emit the average and clear the state
         if current_sum[0] >= 2:
             self.sum.clear()
-            yield value[0], current_sum[1] / current_sum[0]
+            yield value[0], int(current_sum[1] / current_sum[0])
 
 
 env = StreamExecutionEnvironment.get_execution_environment()

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -36,9 +36,9 @@ to learn about the concepts behind stateful stream processing.
 
 If you want to use keyed state, you first need to specify a key on a
 `DataStream` that should be used to partition the state (and also the records
-in the stream themselves). You can specify a key using `keyBy(KeySelector)` on
-a `DataStream`. This will yield a `KeyedDataStream`, which then allows
-operations that use keyed state.
+in the stream themselves). You can specify a key using `keyBy(KeySelector)`
+in Java/Scala API or `key_by(KeySelector)` in Python API on a `DataStream`.
+This will yield a `KeyedStream`, which then allows operations that use keyed state.
 
 A key selector function takes a single record as input and returns the key for
 that record. The key can be of any type and **must** be derived from
@@ -76,12 +76,20 @@ val words: DataStream[WC] = // [...]
 val keyed = words.keyBy( _.word )
 ```
 {{< /tab >}}
+
+{{< tab "Python" >}}
+```python
+words = # type: DataStream[Row]
+keyed = words.key_by(lambda row: row[0])
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 #### Tuple Keys and Expression Keys
 
 Flink also has two alternative ways of defining keys: tuple keys and expression
-keys. With this you can specify keys using tuple field indices or expressions
+keys in the Java API(still not supported in the Python API). With this you can
+specify keys using tuple field indices or expressions
 for selecting fields of objects. We don't recommend using these today but you
 can refer to the Javadoc of DataStream to learn about them. Using a KeySelector
 function is strictly superior: with Java lambdas they are easy to use and they
@@ -93,7 +101,7 @@ have potentially less overhead at runtime.
 
 The keyed state interfaces provides access to different types of state that are all scoped to
 the key of the current input element. This means that this type of state can only be used
-on a `KeyedStream`, which can be created via `stream.keyBy(…)`.
+on a `KeyedStream`, which can be created via `stream.keyBy(…)` in Java API or `stream.key_by(…)` in Python API.
 
 Now, we will first look at the different types of state available and then we will see
 how they can be used in a program. The available state primitives are:
@@ -260,6 +268,54 @@ object ExampleCountWindowAverage extends App {
 }
 ```
 {{< /tab >}}
+
+{{< tab "Python" >}}
+```python
+from pyflink.common.typeinfo import Types
+from pyflink.datastream import StreamExecutionEnvironment, FlatMapFunction, RuntimeContext
+from pyflink.datastream.state import ValueStateDescriptor
+
+class CountWindowAverage(FlatMapFunction):
+
+    def __init__(self):
+        self.sum = None
+
+    def open(self, runtime_context: RuntimeContext):
+        descriptor = ValueStateDescriptor(
+            "average",  # the state name
+            Types.TUPLE([Types.LONG(), Types.LONG()])  # type information
+        )
+        self.sum = runtime_context.get_state(descriptor)
+
+    def flat_map(self, value):
+        # access the state value
+        current_sum = self.sum.value()
+        if current_sum is None:
+            current_sum = (0, 0)
+
+        # update the count
+        current_sum = (current_sum[0] + 1, current_sum[1] + value[1])
+
+        # update the state
+        self.sum.update(current_sum)
+
+        # if the count reaches 2, emit the average and clear the state
+        if current_sum[0] >= 2:
+            self.sum.clear()
+            yield value[0], current_sum[1] / current_sum[0]
+
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.from_collection([(1, 3), (1, 5), (1, 7), (1, 4), (1, 2)]) \
+    .key_by(lambda row: row[0]) \
+    .flat_map(CountWindowAverage()) \
+    .print()
+
+env.execute()
+
+# the printed output will be (1,4) and (1,5)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 This example implements a poor man's counting window. We key the tuples by the first field
@@ -354,6 +410,8 @@ will lead to compatibility failure and `StateMigrationException`.
 - The map state with TTL currently supports null user values only if the user value serializer can handle null values. 
 If the serializer does not support null values, it can be wrapped with `NullableSerializer` at the cost of an extra byte in the serialized form.
 
+- State TTL is still not supported in PyFlink DataStream API.
+
 #### Cleanup of Expired State
 
 By default, expired values are explicitly removed on read, such as `ValueState#value`, and periodically garbage collected
@@ -376,6 +434,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .disableCleanupInBackground
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL is still not supported in PyFlink DataStream API.
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -411,6 +474,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupFullSnapshot
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL is still not supported in PyFlink DataStream API.
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -450,6 +518,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupIncrementally(10, true)
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL is still not supported in PyFlink DataStream API.
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -497,6 +570,11 @@ val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
     .cleanupInRocksdbCompactFilter(1000)
     .build
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+State TTL is still not supported in PyFlink DataStream API.
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -559,6 +637,8 @@ In a typical stateful Flink Application you don't need operators state. It is
 mostly a special type of state that is used in source/sink implementations and
 scenarios where you don't have a key by which state can be partitioned.
 
+**Notes:** Operator state is still not supported in Python DataStream API.
+
 ## Broadcast State
 
 *Broadcast State* is a special type of *Operator State*.  It was introduced to
@@ -575,6 +655,8 @@ in that:
  2. it is only available to specific operators that have as inputs a
     *broadcasted* stream and a *non-broadcasted* one, and
  3. such an operator can have *multiple broadcast states* with different names.
+
+**Notes:** Broadcast state is still not supported in Python DataStream API.
 
 {{< top >}}
 

--- a/docs/content/docs/dev/python/datastream/state.md
+++ b/docs/content/docs/dev/python/datastream/state.md
@@ -1,0 +1,27 @@
+---
+title: "State"
+weight: 31
+type: docs
+aliases:
+- /docs/dev/python/datastream/state.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<meta http-equiv="refresh" content="0; url=/docs/dev/datastream/fault-tolerance/state/" />


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds documentation for state acess in Python DataStream API.*


## Verifying this change

This change is a documentation work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
