### PR TITLE
[FLINK-22286][python] Fix picklebytescoder doesn't support custom python class

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -1160,6 +1160,26 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
             keyed_stream.flat_map(flat_map_func).print()
             self.env.execute("test_process_function_with_error")
 
+    def test_data_with_custom_class(self):
+
+        class Data(object):
+            def __init__(self, name, num):
+                self.name = name
+                self.num = num
+
+        ds = self.env.from_collection([('a', 0), ('b', 1), ('c', 2)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+
+        ds.map(lambda a: Data(a[0], a[1])) \
+            .flat_map(lambda data: [data.name for _ in range(data.num)]) \
+            .add_sink(self.test_sink)
+        self.env.execute("test_data_with_custom_class")
+        results = self.test_sink.get_results(True)
+        expected = ['c', 'c', 'b']
+        results.sort()
+        expected.sort()
+        self.assertEqual(expected, results)
+
 
 class BatchModeDataStreamTests(DataStreamTests, PyFlinkBatchTestCase):
 

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -18,7 +18,7 @@
 
 import datetime
 import decimal
-import pickle
+import cloudpickle
 import struct
 from typing import Any, Tuple
 from typing import List
@@ -310,7 +310,7 @@ class PickledBytesCoderImpl(StreamCoderImpl):
         self.field_coder = BinaryCoderImpl()
 
     def encode_to_stream(self, value, out_stream, nested):
-        coded_data = pickle.dumps(value)
+        coded_data = cloudpickle.dumps(value)
         self.field_coder.encode_to_stream(coded_data, out_stream, nested)
 
     def decode_from_stream(self, in_stream, nested):
@@ -318,7 +318,7 @@ class PickledBytesCoderImpl(StreamCoderImpl):
 
     def _decode_one_value_from_stream(self, in_stream: create_InputStream, nested):
         real_data = self.field_coder.decode_from_stream(in_stream, nested)
-        value = pickle.loads(real_data)
+        value = cloudpickle.loads(real_data)
         return value
 
     def __repr__(self) -> str:

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -25,7 +25,7 @@ from libc.string cimport memcpy
 
 import datetime
 import decimal
-import pickle
+import cloudpickle
 
 from pyflink.fn_execution.flink_fn_execution_pb2 import CoderParam
 from pyflink.datastream.window import TimeWindow, CountWindow
@@ -372,7 +372,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
             return datetime.time(hours, minutes, seconds, milliseconds * 1000)
         elif field_type == PICKLED_BYTES:
             decoded_bytes = self._decode_bytes()
-            return pickle.loads(decoded_bytes)
+            return cloudpickle.loads(decoded_bytes)
         elif field_type == BIG_DEC:
             return decimal.Decimal(self._decode_bytes().decode("utf-8"))
 
@@ -584,7 +584,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
             self._encode_int(milliseconds)
         elif field_type == PICKLED_BYTES:
             # pickled object
-            pickled_bytes = pickle.dumps(item)
+            pickled_bytes = cloudpickle.dumps(item)
             self._encode_bytes(pickled_bytes, len(pickled_bytes))
         elif field_type == BIG_DEC:
             item_bytes = str(item).encode('utf-8')


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix picklebytescoder doesn't support custom python class*

## Brief change log

  - *replace `pickle` with `cloudpickle` in `PickledBytesCoderImpl`*

## Verifying this change

This change added tests and can be verified as follows:

- *`test_data_with_custom_class` in `test_data_stream.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
