### PR TITLE
[FLINK-21329][tests] Increase timeout and delay in local test_local_recovery_and_scheduling.sh

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -244,12 +244,12 @@ fi
 ################################################################################
 
 if [[ ${PROFILE} != *"enable-adaptive-scheduler"* ]]; then #FLINK-21450
-	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 hashmap false false" "skip_check_exceptions"
-	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 hashmap false true" "skip_check_exceptions"
-	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false false" "skip_check_exceptions"
-	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false" "skip_check_exceptions"
-	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true" "skip_check_exceptions"
-	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true" "skip_check_exceptions"
+	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 hashmap false false 100" "skip_check_exceptions"
+	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 hashmap false true 100" "skip_check_exceptions"
+	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false false 100" "skip_check_exceptions"
+	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false 100" "skip_check_exceptions"
+	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true 100" "skip_check_exceptions"
+	run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true 100" "skip_check_exceptions"
 fi
 
 printf "\n[PASS] All bash e2e-tests passed\n"

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -60,13 +60,15 @@ function run_local_recovery_test {
     local backend=$3
     local incremental=$4
     local kill_jvm=$5
+    local delay=$6
 
     echo "Running local recovery test with configuration:
         parallelism: ${parallelism}
         max attempts: ${max_attempts}
         backend: ${backend}
         incremental checkpoints: ${incremental}
-        kill JVM: ${kill_jvm}"
+        kill JVM: ${kill_jvm}
+        delay: ${delay}ms"
 
     TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
     # configure for HA
@@ -97,11 +99,11 @@ function run_local_recovery_test {
     --checkpointDir file://$TEST_DATA_DIR/local_recovery_test/checkpoints \
     --output $TEST_DATA_DIR/out/local_recovery_test/out --killJvmOnFail ${kill_jvm} --checkpointInterval 1000 \
     --maxAttempts ${max_attempts} --parallelism ${parallelism} --stateBackend ${backend} \
-    --incrementalCheckpoints ${incremental}
+    --incrementalCheckpoints ${incremental} --delay ${delay}
 
     check_logs ${parallelism} ${max_attempts}
     cleanup_after_test
 }
 
 ## MAIN
-run_test_with_timeout 600 run_local_recovery_test "$@"
+run_test_with_timeout 900 run_local_recovery_test "$@"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetaData.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetaData.java
@@ -28,12 +28,20 @@ public class CheckpointMetaData implements Serializable {
     /** The ID of the checkpoint. */
     private final long checkpointId;
 
-    /** The timestamp of the checkpoint. */
+    /** The timestamp of the checkpoint triggering. */
     private final long timestamp;
 
+    /** The timestamp of the checkpoint receiving by this subtask. */
+    private final long receiveTimestamp;
+
     public CheckpointMetaData(long checkpointId, long timestamp) {
+        this(checkpointId, timestamp, System.currentTimeMillis());
+    }
+
+    public CheckpointMetaData(long checkpointId, long timestamp, long receiveTimestamp) {
         this.checkpointId = checkpointId;
         this.timestamp = timestamp;
+        this.receiveTimestamp = receiveTimestamp;
     }
 
     public long getCheckpointId() {
@@ -42,6 +50,10 @@ public class CheckpointMetaData implements Serializable {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public long getReceiveTimestamp() {
+        return receiveTimestamp;
     }
 
     @Override
@@ -55,13 +67,16 @@ public class CheckpointMetaData implements Serializable {
 
         CheckpointMetaData that = (CheckpointMetaData) o;
 
-        return (checkpointId == that.checkpointId) && (timestamp == that.timestamp);
+        return (checkpointId == that.checkpointId)
+                && (timestamp == that.timestamp)
+                && (receiveTimestamp == that.receiveTimestamp);
     }
 
     @Override
     public int hashCode() {
         int result = (int) (checkpointId ^ (checkpointId >>> 32));
         result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        result = 31 * result + (int) (receiveTimestamp ^ (receiveTimestamp >>> 32));
         return result;
     }
 
@@ -70,6 +85,8 @@ public class CheckpointMetaData implements Serializable {
         return "CheckpointMetaData{"
                 + "checkpointId="
                 + checkpointId
+                + ", receiveTimestamp="
+                + receiveTimestamp
                 + ", timestamp="
                 + timestamp
                 + '}';

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1285,7 +1285,8 @@ public class Task
 
         final AbstractInvokable invokable = this.invokable;
         final CheckpointMetaData checkpointMetaData =
-                new CheckpointMetaData(checkpointID, checkpointTimestamp);
+                new CheckpointMetaData(
+                        checkpointID, checkpointTimestamp, System.currentTimeMillis());
 
         if (executionState == ExecutionState.RUNNING && invokable != null) {
             try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
@@ -108,7 +108,10 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
     protected void notifyCheckpoint(CheckpointBarrier checkpointBarrier) throws IOException {
         CheckpointMetaData checkpointMetaData =
-                new CheckpointMetaData(checkpointBarrier.getId(), checkpointBarrier.getTimestamp());
+                new CheckpointMetaData(
+                        checkpointBarrier.getId(),
+                        checkpointBarrier.getTimestamp(),
+                        System.currentTimeMillis());
 
         CheckpointMetricsBuilder checkpointMetrics =
                 new CheckpointMetricsBuilder()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -148,7 +148,7 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         final long timestamp = System.currentTimeMillis();
 
         final CheckpointMetaData checkpointMetaData =
-                new CheckpointMetaData(checkpointId, timestamp);
+                new CheckpointMetaData(checkpointId, timestamp, timestamp);
 
         super.triggerCheckpointAsync(checkpointMetaData, checkpointOptions);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -113,7 +113,7 @@ public class SourceStreamTask<
                             final long timestamp = System.currentTimeMillis();
 
                             final CheckpointMetaData checkpointMetaData =
-                                    new CheckpointMetaData(checkpointId, timestamp);
+                                    new CheckpointMetaData(checkpointId, timestamp, timestamp);
 
                             try {
                                 SourceStreamTask.super


### PR DESCRIPTION
## What is the purpose of the change

1. Fix `test_local_recovery_and_scheduling.sh` by increasing test timeout and add emit interval at sources
1. Ease further debug by logging the time checkpoint mail spent in the mailbox

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
