### PR TITLE
[FLINK-22291][hive] Fix split switching in HiveInputFormatPartitionReader

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReader.java
@@ -97,11 +97,13 @@ public class HiveInputFormatPartitionReader
 
     private boolean hasNext() throws IOException {
         if (inputSplits.length > 0) {
-            if (hiveTableInputFormat.reachedEnd() && readingSplitId == inputSplits.length - 1) {
-                return false;
-            } else if (hiveTableInputFormat.reachedEnd()) {
-                readingSplitId++;
-                hiveTableInputFormat.open(inputSplits[readingSplitId]);
+            while (hiveTableInputFormat.reachedEnd()) {
+                if (readingSplitId == inputSplits.length - 1) {
+                    return false;
+                } else {
+                    readingSplitId++;
+                    hiveTableInputFormat.open(inputSplits[readingSplitId]);
+                }
             }
             return true;
         }


### PR DESCRIPTION
## What is the purpose of the change

Due to a bug if HiveInputFormatPartitionReader has read all data from an input split, and switches to a next one in hasNext(), no data will be read from that new one, thus it will return an empty row. The problem is that the reachedEnd() function call "loads" the next row, which is not invoked in case of split switching, thus the row will be empty.

## Brief change log

Fix the split change logic to make sure that reachedEnd() is invoked for the new split.

## Verifying this change

No test has covered this part so far, but there should be one. I've tested it, works fine.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
