### PR TITLE
[FLINK-22288][connectors / jdbc] Remove unnecessary argument in JdbcSink

### DIFF
--- a/docs/content/docs/connectors/datastream/jdbc.md
+++ b/docs/content/docs/connectors/datastream/jdbc.md
@@ -168,10 +168,6 @@ env
                     ps.setInt(5, t.qty);
                 },
                 JdbcExecutionOptions.builder().build(),
-                new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
-                        .withUrl(getDbMetadata().getUrl())
-                        .withDriverName(getDbMetadata().getDriverClass())
-                        .build()),
                 JdbcExactlyOnceOptions.defaults(),
                 () -> {
                     // create a driver-specific XA DataSource

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
@@ -96,7 +96,6 @@ public class JdbcSink {
      * @param <T> type of data in {@link
      *     org.apache.flink.streaming.runtime.streamrecord.StreamRecord StreamRecord}.
      * @param executionOptions parameters of execution, such as batch size and maximum retries
-     * @param connectionOptions parameters of connection, such as JDBC URL
      * @param exactlyOnceOptions exactly-once options
      * @param dataSourceSupplier supplies the {@link XADataSource}
      */
@@ -104,7 +103,6 @@ public class JdbcSink {
             String sql,
             JdbcStatementBuilder<T> statementBuilder,
             JdbcExecutionOptions executionOptions,
-            JdbcConnectionOptions connectionOptions,
             JdbcExactlyOnceOptions exactlyOnceOptions,
             SerializableSupplier<XADataSource> dataSourceSupplier) {
         return new JdbcXaSinkFunction<>(

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -60,7 +60,6 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcXaSinkTestBase {
                                 String.format(INSERT_TEMPLATE, INPUT_TABLE),
                                 JdbcITCase.TEST_ENTRY_JDBC_STATEMENT_BUILDER,
                                 JdbcExecutionOptions.builder().build(),
-                                DERBY_EBOOKSHOP_DB.toConnectionOptions(),
                                 JdbcExactlyOnceOptions.defaults(),
                                 DERBY_EBOOKSHOP_DB::buildXaDataSource));
         env.execute();


### PR DESCRIPTION
## What is the purpose of the change

A trivial change to remove unnecessary argument in `JdbcSink`.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
