### PR TITLE
[FLINK-22239][jdbc] Support exactly-once (sink) for PgSql and MySql 

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -165,6 +165,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>1.15.1</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcExactlyOnceOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcExactlyOnceOptions.java
@@ -50,7 +50,7 @@ import java.util.Optional;
 @PublicEvolving
 public class JdbcExactlyOnceOptions implements Serializable {
 
-    private static final boolean DEFAULT_RECOVERED_AND_ROLLBACK = false;
+    private static final boolean DEFAULT_RECOVERED_AND_ROLLBACK = true;
     private static final int DEFAULT_MAX_COMMIT_ATTEMPTS = 3;
     private static final boolean DEFAULT_ALLOW_OUT_OF_ORDER_COMMITS = false;
 
@@ -102,7 +102,11 @@ public class JdbcExactlyOnceOptions implements Serializable {
         private boolean allowOutOfOrderCommits = DEFAULT_ALLOW_OUT_OF_ORDER_COMMITS;
         private Optional<Integer> timeoutSec = Optional.empty();
 
-        /** Toggle discovery and rollback of transactions upon recovery. */
+        /**
+         * Toggle discovery and rollback of prepared transactions upon recovery to prevent new
+         * transactions from being blocked by the older ones. Each subtask rollbacks its own
+         * transaction. This flag must be disabled when rescaling to prevent data loss.
+         */
         public JDBCExactlyOnceOptionsBuilder withRecoveredAndRollback(
                 boolean recoveredAndRollback) {
             this.recoveredAndRollback = recoveredAndRollback;

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/JdbcSink.java
@@ -30,7 +30,6 @@ import org.apache.flink.util.function.SerializableSupplier;
 
 import javax.sql.XADataSource;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 /** Facade to create JDBC {@link SinkFunction sinks}. */
@@ -109,8 +108,7 @@ public class JdbcSink {
                 sql,
                 statementBuilder,
                 XaFacade.fromXaDataSourceSupplier(
-                        dataSourceSupplier,
-                        Optional.ofNullable(exactlyOnceOptions.getTimeoutSec())),
+                        dataSourceSupplier, exactlyOnceOptions.getTimeoutSec()),
                 executionOptions,
                 exactlyOnceOptions);
     }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaFacade.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaFacade.java
@@ -27,7 +27,6 @@ import javax.transaction.xa.Xid;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -40,7 +39,7 @@ import java.util.function.Supplier;
  *   <li>{@link #open}
  *   <li>{@link #start} transaction
  *   <li>{@link #getConnection}, write some data
- *   <li>{@link #endAndPrepare} (or {@link #failOrRollback})
+ *   <li>{@link #endAndPrepare} (or {@link #failAndRollback})
  *   <li>{@link #commit} / {@link #rollback}
  *   <li>{@link #close}
  * </ol>
@@ -52,8 +51,8 @@ public interface XaFacade extends JdbcConnectionProvider, Serializable, AutoClos
 
     /** @return a non-serializable instance. */
     static XaFacade fromXaDataSourceSupplier(
-            Supplier<XADataSource> dataSourceSupplier, Optional<Integer> timeoutSec) {
-        return new XaFacadeImpl(dataSourceSupplier, timeoutSec);
+            Supplier<XADataSource> dataSourceSupplier, Integer timeoutSec) {
+        return new XaFacadePoolingImpl(() -> new XaFacadeImpl(dataSourceSupplier, timeoutSec));
     }
 
     void open() throws Exception;
@@ -61,10 +60,10 @@ public interface XaFacade extends JdbcConnectionProvider, Serializable, AutoClos
     boolean isOpen();
 
     /** Start a new transaction. */
-    void start(Xid xid) throws TransientXaException;
+    void start(Xid xid) throws Exception;
 
     /** End and then prepare the transaction. Transaction can't be resumed afterwards. */
-    void endAndPrepare(Xid xid) throws TransientXaException, EmptyXaTransactionException;
+    void endAndPrepare(Xid xid) throws Exception;
 
     /**
      * Commit previously prepared transaction.
@@ -81,7 +80,7 @@ public interface XaFacade extends JdbcConnectionProvider, Serializable, AutoClos
      * End transaction as {@link javax.transaction.xa.XAResource#TMFAIL failed}; in case of error,
      * try to roll it back.
      */
-    void failOrRollback(Xid xid) throws TransientXaException;
+    void failAndRollback(Xid xid) throws TransientXaException;
 
     /**
      * Note: this can block on some non-MVCC databases if there are ended not prepared transactions.

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaFacadePoolingImpl.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaFacadePoolingImpl.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.xa;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.transaction.xa.Xid;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.ExceptionUtils.rethrow;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A "pooling" implementation of {@link XaFacade}. Some database implement XA such that one
+ * connection is limited to a single transaction. As a workaround, this implementation creates a new
+ * XA resource after each xa_start call is made (and associates it with the xid to commit later).
+ */
+@Internal
+class XaFacadePoolingImpl implements XaFacade {
+    private static final long serialVersionUID = 1L;
+
+    public interface FacadeSupplier extends Serializable, Supplier<XaFacade> {}
+
+    private static final transient Logger LOG = LoggerFactory.getLogger(XaFacadePoolingImpl.class);
+    private final FacadeSupplier facadeSupplier;
+    private transient XaFacade active;
+    private transient Map<Xid, XaFacade> mappedToXids;
+    private transient Deque<XaFacade> pooled;
+
+    XaFacadePoolingImpl(FacadeSupplier facadeSupplier) {
+        this.facadeSupplier = facadeSupplier;
+    }
+
+    @Override
+    public void open() throws Exception {
+        checkState(active == null);
+        pooled = new LinkedList<>();
+        mappedToXids = new HashMap<>();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return active != null && active.isOpen();
+    }
+
+    @Override
+    public void start(Xid xid) throws Exception {
+        checkState(active == null);
+        if (pooled.isEmpty()) {
+            active = facadeSupplier.get();
+            active.open();
+        } else {
+            active = pooled.poll();
+        }
+        active.start(xid);
+        mappedToXids.put(xid, active);
+    }
+
+    /**
+     * Must be called after {@link #start(Xid)} with the same {@link Xid}.
+     *
+     * @see XaFacade#endAndPrepare(Xid)
+     */
+    @Override
+    public void endAndPrepare(Xid xid) throws Exception {
+        checkState(active == mappedToXids.get(xid));
+        try {
+            active.endAndPrepare(xid);
+        } finally {
+            active = null;
+        }
+    }
+
+    @Override
+    public void commit(Xid xid, boolean ignoreUnknown) throws TransientXaException {
+        runForXid(xid, facade -> facade.commit(xid, ignoreUnknown));
+    }
+
+    @Override
+    public void rollback(Xid xid) throws TransientXaException {
+        runForXid(xid, facade -> facade.rollback(xid));
+    }
+
+    @Override
+    public void failAndRollback(Xid xid) throws TransientXaException {
+        runForXid(xid, facade -> facade.failAndRollback(xid));
+    }
+
+    @Override
+    public Collection<Xid> recover() throws TransientXaException {
+        return peekPooled().recover();
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (XaFacade facade : mappedToXids.values()) {
+            facade.close();
+        }
+        for (XaFacade facade : pooled) {
+            facade.close();
+        }
+        if (active != null && active.isOpen()) {
+            active.close();
+        }
+    }
+
+    @Nullable
+    @Override
+    public Connection getConnection() {
+        return active.getConnection();
+    }
+
+    @Override
+    public boolean isConnectionValid() throws SQLException {
+        return active.isConnectionValid();
+    }
+
+    @Override
+    public Connection getOrEstablishConnection() throws SQLException, ClassNotFoundException {
+        return active.getOrEstablishConnection();
+    }
+
+    @Override
+    public void closeConnection() {
+        active.closeConnection();
+    }
+
+    @Override
+    public Connection reestablishConnection() throws SQLException, ClassNotFoundException {
+        return active.reestablishConnection();
+    }
+
+    // WARN: action MUST leave the facade in IDLE state (i.e. not start/end/prepare any tx)
+    private void runForXid(Xid xid, ThrowingConsumer<XaFacade, TransientXaException> action) {
+        XaFacade mapped = mappedToXids.remove(xid);
+        if (mapped == null) {
+            // a transaction can be not known during recovery
+            LOG.debug("No XA resource found associated with XID: {}", xid);
+            action.accept(peekPooled());
+        } else {
+            LOG.debug("Found mapped XA resource for XID: {} {}", xid, mapped);
+            try {
+                action.accept(mapped);
+            } finally {
+                pooled.offer(mapped);
+            }
+        }
+    }
+
+    // WARN: the returned facade MUST be left in IDLE state (i.e. not start/end/prepare any tx)
+    private XaFacade peekPooled() {
+        XaFacade xaFacade = pooled.peek();
+        if (xaFacade == null) {
+            xaFacade = facadeSupplier.get();
+            try {
+                xaFacade.open();
+            } catch (Exception e) {
+                rethrow(e);
+            }
+            pooled.offer(xaFacade);
+        }
+        return xaFacade;
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaGroupOps.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaGroupOps.java
@@ -18,6 +18,7 @@
 package org.apache.flink.connector.jdbc.xa;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.transaction.xa.Xid;
@@ -36,7 +37,7 @@ interface XaGroupOps extends Serializable {
 
     GroupXaOperationResult<Xid> failOrRollback(Collection<Xid> xids);
 
-    void recoverAndRollback();
+    void recoverAndRollback(RuntimeContext runtimeContext, XidGenerator xidGenerator);
 
     class GroupXaOperationResult<T> {
         private final List<T> succeeded = new ArrayList<>();

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaGroupOpsImpl.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaGroupOpsImpl.java
@@ -18,6 +18,7 @@
 package org.apache.flink.connector.jdbc.xa;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.connector.jdbc.xa.XaFacade.TransientXaException;
 
 import org.slf4j.Logger;
@@ -104,17 +105,19 @@ class XaGroupOpsImpl implements XaGroupOps {
     }
 
     @Override
-    public void recoverAndRollback() {
+    public void recoverAndRollback(RuntimeContext runtimeContext, XidGenerator xidGenerator) {
         Collection<Xid> recovered = xaFacade.recover();
         if (recovered.isEmpty()) {
             return;
         }
         LOG.warn("rollback {} recovered transactions", recovered.size());
         for (Xid xid : recovered) {
-            try {
-                xaFacade.rollback(xid);
-            } catch (Exception e) {
-                LOG.info("unable to rollback recovered transaction, xid={}", xid, e);
+            if (xidGenerator.belongsToSubtask(xid, runtimeContext)) {
+                try {
+                    xaFacade.rollback(xid);
+                } catch (Exception e) {
+                    LOG.info("unable to rollback recovered transaction, xid={}", xid, e);
+                }
             }
         }
     }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaGroupOpsImpl.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XaGroupOpsImpl.java
@@ -87,7 +87,7 @@ class XaGroupOpsImpl implements XaGroupOps {
         }
         for (Xid x : xids) {
             try {
-                xaFacade.failOrRollback(x);
+                xaFacade.failAndRollback(x);
                 result.succeeded(x);
             } catch (TransientXaException e) {
                 LOG.info("unable to fail/rollback transaction, xid={}: {}", x, e.getMessage());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XidGenerator.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/xa/XidGenerator.java
@@ -46,6 +46,9 @@ public interface XidGenerator extends Serializable, AutoCloseable {
 
     default void open() {}
 
+    /** @return true if the provided transaction belongs to this subtask */
+    boolean belongsToSubtask(Xid xid, RuntimeContext ctx);
+
     @Override
     default void close() {}
 

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/DbMetadata.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/DbMetadata.java
@@ -28,6 +28,14 @@ public interface DbMetadata extends Serializable {
 
     String getUrl();
 
+    default String getUser() {
+        return "";
+    }
+
+    default String getPassword() {
+        return "";
+    }
+
     XADataSource buildXaDataSource();
 
     String getDriverClass();

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestBase.java
@@ -27,12 +27,12 @@ import org.junit.Before;
 public abstract class JdbcTestBase {
 
     @Before
-    public final void before() throws Exception {
+    public void before() throws Exception {
         JdbcTestFixture.initSchema(getDbMetadata());
     }
 
     @After
-    public final void after() throws Exception {
+    public void after() throws Exception {
         JdbcTestFixture.cleanupData(getDbMetadata().getUrl());
         JdbcTestFixture.cleanUpDatabasesStatic(getDbMetadata());
     }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestFixture.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcTestFixture.java
@@ -188,7 +188,9 @@ public class JdbcTestFixture {
         System.setProperty(
                 "derby.stream.error.field", JdbcTestFixture.class.getCanonicalName() + ".DEV_NULL");
         Class.forName(dbMetadata.getDriverClass());
-        try (Connection conn = DriverManager.getConnection(dbMetadata.getInitUrl())) {
+        try (Connection conn =
+                DriverManager.getConnection(
+                        dbMetadata.getInitUrl(), dbMetadata.getUser(), dbMetadata.getPassword())) {
             createTable(conn, JdbcTestFixture.INPUT_TABLE);
             createTable(conn, OUTPUT_TABLE);
             createTable(conn, OUTPUT_TABLE_2);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -17,12 +17,18 @@
 
 package org.apache.flink.connector.jdbc.xa;
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies.NoRestartStrategyConfiguration;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.jdbc.DbMetadata;
 import org.apache.flink.connector.jdbc.JdbcExactlyOnceOptions;
 import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
 import org.apache.flink.connector.jdbc.JdbcITCase;
 import org.apache.flink.connector.jdbc.JdbcSink;
+import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.connector.jdbc.JdbcTestFixture.TestEntry;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -31,68 +37,172 @@ import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.util.ExceptionUtils;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.postgresql.xa.PGXADataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
 
-import java.io.Serializable;
+import javax.sql.XADataSource;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.connector.jdbc.JdbcTestFixture.DERBY_EBOOKSHOP_DB;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.configuration.JobManagerOptions.EXECUTION_FAILOVER_STRATEGY;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.INPUT_TABLE;
 import static org.apache.flink.connector.jdbc.JdbcTestFixture.INSERT_TEMPLATE;
-import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
+import static org.apache.flink.connector.jdbc.xa.JdbcXaFacadeTestHelper.getInsertedIds;
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertTrue;
 
 /** A simple end-to-end test for {@link JdbcXaSinkFunction}. */
-public class JdbcExactlyOnceSinkE2eTest extends JdbcXaSinkTestBase {
+public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
+
+    private static final class PgXaDb extends PostgreSQLContainer<PgXaDb> {
+        public PgXaDb(String dockerImageName) {
+            super(dockerImageName);
+            // set max_prepared_transactions to non-zero
+            this.setCommand("postgres", "-c", "max_prepared_transactions=50", "-c", "fsync=off");
+        }
+    }
+
+    @Rule public PgXaDb db = new PgXaDb("postgres:9.6.12");
+
+    @Override
+    public void after() throws Exception {
+        // no need for cleanup - done by test container tear down
+    }
 
     @Test
     public void testInsert() throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
-        env.setRestartStrategy(new NoRestartStrategyConfiguration());
+        int parallelism = 4;
+        int elementsPerSource = 500;
+        int numElementsPerCheckpoint = 7;
+        int minElementsPerFailure = numElementsPerCheckpoint / 3;
+        int maxElementsPerFailure = numElementsPerCheckpoint * 3;
+
+        Configuration configuration = new Configuration();
+        configuration.set(
+                EXECUTION_FAILOVER_STRATEGY,
+                "full" /* allow checkpointing even after some sources have finished */);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1000, Time.milliseconds(100)));
         env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
         env.enableCheckpointing(50, CheckpointingMode.EXACTLY_ONCE);
-        env.addSource(new CheckpointAwaitingSource<>(TEST_DATA))
-                .returns(TestEntry.class)
+        env.setParallelism(parallelism);
+        env.disableOperatorChaining();
+        String password = db.getPassword();
+        String username = db.getUsername();
+        String jdbcUrl = db.getJdbcUrl();
+
+        env.addSource(new TestEntrySource(elementsPerSource, numElementsPerCheckpoint))
+                .setParallelism(parallelism)
+                .map(new FailingMapper(minElementsPerFailure, maxElementsPerFailure))
                 .addSink(
                         JdbcSink.exactlyOnceSink(
                                 String.format(INSERT_TEMPLATE, INPUT_TABLE),
                                 JdbcITCase.TEST_ENTRY_JDBC_STATEMENT_BUILDER,
                                 JdbcExecutionOptions.builder().build(),
                                 JdbcExactlyOnceOptions.defaults(),
-                                DERBY_EBOOKSHOP_DB::buildXaDataSource));
+                                () -> getXaDataSource(jdbcUrl, username, password)));
         env.execute();
-        xaHelper.assertDbContentsEquals(IntStream.range(0, TEST_DATA.length));
+
+        List<Integer> insertedIds = getInsertedIds(jdbcUrl, username, password, INPUT_TABLE);
+        List<Integer> expectedIds =
+                IntStream.range(0, elementsPerSource * parallelism)
+                        .boxed()
+                        .collect(Collectors.toList());
+        assertTrue(
+                insertedIds.toString(),
+                insertedIds.size() == expectedIds.size() && expectedIds.containsAll(insertedIds));
     }
 
     @Override
     protected DbMetadata getDbMetadata() {
-        return DERBY_EBOOKSHOP_DB;
+        return new DbMetadata() {
+            @Override
+            public String getInitUrl() {
+                return db.getJdbcUrl();
+            }
+
+            @Override
+            public String getUrl() {
+                return db.getJdbcUrl();
+            }
+
+            @Override
+            public XADataSource buildXaDataSource() {
+                return getXaDataSource(db.getJdbcUrl(), db.getUsername(), db.getPassword());
+            }
+
+            @Override
+            public String getDriverClass() {
+                return db.getDriverClassName();
+            }
+
+            @Override
+            public String getUser() {
+                return db.getUsername();
+            }
+
+            @Override
+            public String getPassword() {
+                return db.getPassword();
+            }
+        };
     }
 
-    /** {@link SourceFunction} emits all the data and waits for the checkpoint. */
-    private static class CheckpointAwaitingSource<T extends Serializable>
-            implements SourceFunction<T>, CheckpointListener, CheckpointedFunction {
-        private volatile boolean allDataEmitted = false;
-        private volatile boolean dataCheckpointed = false;
-        private volatile boolean running = true;
-        private volatile long checkpointAfterData = -1L;
-        private final T[] data;
+    /** {@link SourceFunction} emits {@link TestEntry test entries} and waits for the checkpoint. */
+    private static class TestEntrySource extends RichParallelSourceFunction<TestEntry>
+            implements CheckpointListener, CheckpointedFunction {
+        private final int numElements;
+        private final int numElementsPerCheckpoint;
 
-        private CheckpointAwaitingSource(T... data) {
-            this.data = data;
+        private transient ListState<SourceRange> ranges;
+
+        private volatile boolean allDataEmitted = false;
+        private volatile boolean snapshotTaken = false;
+        private volatile long lastCheckpointId = -1L;
+        private volatile boolean lastSnapshotConfirmed = false;
+        private volatile boolean running = true;
+        private static volatile CountDownLatch runningSources;
+
+        private TestEntrySource(int numElements, int numElementsPerCheckpoint) {
+            this.numElements = numElements;
+            this.numElementsPerCheckpoint = numElementsPerCheckpoint;
         }
 
         @Override
-        public void run(SourceContext<T> ctx) {
-            for (T datum : data) {
-                ctx.collect(datum);
+        public void run(SourceContext<TestEntry> ctx) throws Exception {
+            for (SourceRange range : ranges.get()) {
+                for (int i = range.from; i < range.to; ) {
+                    synchronized (ctx.getCheckpointLock()) {
+                        snapshotTaken = false;
+                        for (int j = 0; j < numElementsPerCheckpoint && i < range.to; j++, i++) {
+                            emit(ctx, i);
+                            range.advance();
+                        }
+                    }
+                    sleep(() -> !snapshotTaken);
+                }
             }
             allDataEmitted = true;
-            while (!dataCheckpointed && running) {
-                Thread.yield();
-            }
+            sleep(() -> !lastSnapshotConfirmed);
+            runningSources.countDown();
+            runningSources.await(); // participate in checkpointing
+        }
+
+        private void emit(SourceContext<TestEntry> ctx, int i) {
+            ctx.collect(new TestEntry(i, Integer.toString(i), Integer.toString(i), (double) i, i));
         }
 
         @Override
@@ -102,19 +212,108 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcXaSinkTestBase {
 
         @Override
         public void notifyCheckpointComplete(long checkpointId) {
-            if (checkpointId == this.checkpointAfterData) {
-                dataCheckpointed = true;
+            if (lastCheckpointId > -1L && checkpointId >= this.lastCheckpointId) {
+                lastSnapshotConfirmed = true;
+            }
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+                runningSources =
+                        new CountDownLatch(getRuntimeContext().getNumberOfParallelSubtasks());
+            }
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            ranges =
+                    context.getOperatorStateStore()
+                            .getListState(
+                                    new ListStateDescriptor<>("SourceState", SourceRange.class));
+            if (!context.isRestored()) {
+                ranges.update(
+                        singletonList(
+                                SourceRange.forSubtask(
+                                        getRuntimeContext().getIndexOfThisSubtask(), numElements)));
             }
         }
 
         @Override
         public void snapshotState(FunctionSnapshotContext context) {
+            snapshotTaken = true;
             if (allDataEmitted) {
-                checkpointAfterData = context.getCheckpointId();
+                lastCheckpointId = context.getCheckpointId();
             }
         }
 
+        private void sleep(Supplier<Boolean> condition) {
+            while (condition.get() && running && !Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    ExceptionUtils.rethrow(e);
+                }
+            }
+        }
+
+        private static final class SourceRange {
+            private int from;
+            private final int to;
+
+            private SourceRange(int from, int to) {
+                this.from = from;
+                this.to = to;
+            }
+
+            public static SourceRange forSubtask(int subtaskIndex, int elementCount) {
+                return new SourceRange(
+                        subtaskIndex * elementCount, (subtaskIndex + 1) * elementCount);
+            }
+
+            public void advance() {
+                checkState(from < to);
+                from++;
+            }
+        }
+    }
+
+    private static XADataSource getXaDataSource(String jdbcUrl, String username, String password) {
+        PGXADataSource xaDataSource = new PGXADataSource();
+        xaDataSource.setUrl(jdbcUrl);
+        xaDataSource.setUser(username);
+        xaDataSource.setPassword(password);
+        return xaDataSource;
+    }
+
+    private static class FailingMapper extends RichMapFunction<TestEntry, TestEntry> {
+        private final int minElementsPerFailure;
+        private final int maxElementsPerFailure;
+        private transient int remaining;
+
+        public FailingMapper(int minElementsPerFailure, int maxElementsPerFailure) {
+            this.minElementsPerFailure = minElementsPerFailure;
+            this.maxElementsPerFailure = maxElementsPerFailure;
+        }
+
         @Override
-        public void initializeState(FunctionInitializationContext context) {}
+        public void open(Configuration parameters) throws Exception {
+            remaining = minElementsPerFailure + new Random().nextInt(maxElementsPerFailure);
+        }
+
+        @Override
+        public TestEntry map(TestEntry value) throws Exception {
+            if (--remaining <= 0) {
+                throw new TestException();
+            }
+            return value;
+        }
+    }
+
+    private static final class TestException extends Exception {
+        public TestException() {
+            super("expected", null, true, false);
+        }
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaFacadeTestHelper.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaFacadeTestHelper.java
@@ -39,14 +39,24 @@ class JdbcXaFacadeTestHelper implements AutoCloseable {
     private final XADataSource xaDataSource;
     private final String table;
     private final String dbUrl;
+    private final String user;
+    private final String pass;
     private final XaFacade xaFacade;
 
     JdbcXaFacadeTestHelper(XADataSource xaDataSource, String dbUrl, String table) throws Exception {
+        this(xaDataSource, dbUrl, table, "", "");
+    }
+
+    JdbcXaFacadeTestHelper(
+            XADataSource xaDataSource, String dbUrl, String table, String user, String pass)
+            throws Exception {
         this.xaDataSource = xaDataSource;
         this.dbUrl = dbUrl;
         this.table = table;
         this.xaFacade = XaFacadeImpl.fromXaDataSource(this.xaDataSource);
         this.xaFacade.open();
+        this.user = user;
+        this.pass = pass;
     }
 
     void assertPreparedTxCountEquals(int expected) {
@@ -77,7 +87,7 @@ class JdbcXaFacadeTestHelper implements AutoCloseable {
 
     private List<Integer> getInsertedIds() throws SQLException {
         List<Integer> dbContents = new ArrayList<>();
-        try (Connection connection = DriverManager.getConnection(dbUrl)) {
+        try (Connection connection = DriverManager.getConnection(dbUrl, user, pass)) {
             connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
             connection.setReadOnly(true);
             try (Statement st = connection.createStatement()) {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaFacadeTestHelper.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaFacadeTestHelper.java
@@ -36,24 +36,18 @@ import static org.apache.flink.connector.jdbc.JdbcTestFixture.TEST_DATA;
 import static org.junit.Assert.assertEquals;
 
 class JdbcXaFacadeTestHelper implements AutoCloseable {
-    private final XADataSource xaDataSource;
     private final String table;
     private final String dbUrl;
     private final String user;
     private final String pass;
     private final XaFacade xaFacade;
 
-    JdbcXaFacadeTestHelper(XADataSource xaDataSource, String dbUrl, String table) throws Exception {
-        this(xaDataSource, dbUrl, table, "", "");
-    }
-
     JdbcXaFacadeTestHelper(
             XADataSource xaDataSource, String dbUrl, String table, String user, String pass)
             throws Exception {
-        this.xaDataSource = xaDataSource;
         this.dbUrl = dbUrl;
         this.table = table;
-        this.xaFacade = XaFacadeImpl.fromXaDataSource(this.xaDataSource);
+        this.xaFacade = XaFacadeImpl.fromXaDataSource(xaDataSource);
         this.xaFacade.open();
         this.user = user;
         this.pass = pass;
@@ -61,14 +55,6 @@ class JdbcXaFacadeTestHelper implements AutoCloseable {
 
     void assertPreparedTxCountEquals(int expected) {
         assertEquals(expected, xaFacade.recover().size());
-    }
-
-    void assertDbContentsEquals(int[]... dataIdx) throws SQLException {
-        assertDbContentsEquals(Arrays.stream(dataIdx).flatMapToInt(Arrays::stream));
-    }
-
-    void assertDbContentsEquals(int... dataIdx) throws SQLException {
-        assertDbContentsEquals(Arrays.stream(dataIdx));
     }
 
     void assertDbContentsEquals(JdbcTestCheckpoint... checkpoints) throws SQLException {
@@ -86,6 +72,11 @@ class JdbcXaFacadeTestHelper implements AutoCloseable {
     }
 
     private List<Integer> getInsertedIds() throws SQLException {
+        return getInsertedIds(dbUrl, user, pass, table);
+    }
+
+    static List<Integer> getInsertedIds(String dbUrl, String user, String pass, String table)
+            throws SQLException {
         List<Integer> dbContents = new ArrayList<>();
         try (Connection connection = DriverManager.getConnection(dbUrl, user, pass)) {
             connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
@@ -112,14 +103,6 @@ class JdbcXaFacadeTestHelper implements AutoCloseable {
                 }
             }
         }
-    }
-
-    public XADataSource getXaDataSource() {
-        return xaDataSource;
-    }
-
-    XaFacade getXaFacade() {
-        return xaFacade;
     }
 
     @Override

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkMigrationTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkMigrationTest.java
@@ -90,7 +90,9 @@ public class JdbcXaSinkMigrationTest extends JdbcTestBase {
                 new JdbcXaFacadeTestHelper(
                         JdbcXaSinkDerbyTest.derbyXaDs(),
                         getDbMetadata().getUrl(),
-                        JdbcTestFixture.INPUT_TABLE)) {
+                        JdbcTestFixture.INPUT_TABLE,
+                        getDbMetadata().getUser(),
+                        getDbMetadata().getPassword())) {
             h.assertDbContentsEquals(CP0);
         }
     }
@@ -178,7 +180,9 @@ public class JdbcXaSinkMigrationTest extends JdbcTestBase {
                 new JdbcXaFacadeTestHelper(
                         derbyXaDs(),
                         JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl(),
-                        JdbcTestFixture.INPUT_TABLE)) {
+                        JdbcTestFixture.INPUT_TABLE,
+                        JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUser(),
+                        JdbcTestFixture.DERBY_EBOOKSHOP_DB.getPassword())) {
             xa.cancelAllTx();
         }
     }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
@@ -164,147 +164,151 @@ public abstract class JdbcXaSinkTestBase extends JdbcTestBase {
         return sink;
     }
 
-    static final RuntimeContext TEST_RUNTIME_CONTEXT =
-            new RuntimeContext() {
-                @Override
-                public JobID getJobId() {
-                    return new JobID();
-                }
+    static final RuntimeContext TEST_RUNTIME_CONTEXT = getRuntimeContext(new JobID());
 
-                @Override
-                public String getTaskName() {
-                    return "test";
-                }
+    static RuntimeContext getRuntimeContext(final JobID jobID) {
+        return new RuntimeContext() {
 
-                @Override
-                public MetricGroup getMetricGroup() {
-                    return null;
-                }
+            @Override
+            public JobID getJobId() {
+                return jobID;
+            }
 
-                @Override
-                public int getNumberOfParallelSubtasks() {
-                    return 1;
-                }
+            @Override
+            public String getTaskName() {
+                return "test";
+            }
 
-                @Override
-                public int getMaxNumberOfParallelSubtasks() {
-                    return 1;
-                }
+            @Override
+            public MetricGroup getMetricGroup() {
+                return null;
+            }
 
-                @Override
-                public int getIndexOfThisSubtask() {
-                    return 0;
-                }
+            @Override
+            public int getNumberOfParallelSubtasks() {
+                return 1;
+            }
 
-                @Override
-                public int getAttemptNumber() {
-                    return 0;
-                }
+            @Override
+            public int getMaxNumberOfParallelSubtasks() {
+                return 1;
+            }
 
-                @Override
-                public String getTaskNameWithSubtasks() {
-                    return "test";
-                }
+            @Override
+            public int getIndexOfThisSubtask() {
+                return 0;
+            }
 
-                @Override
-                public ExecutionConfig getExecutionConfig() {
-                    return null;
-                }
+            @Override
+            public int getAttemptNumber() {
+                return 0;
+            }
 
-                @Override
-                public ClassLoader getUserCodeClassLoader() {
-                    return null;
-                }
+            @Override
+            public String getTaskNameWithSubtasks() {
+                return "test";
+            }
 
-                @Override
-                public <V, A extends Serializable> void addAccumulator(
-                        String name, Accumulator<V, A> accumulator) {}
+            @Override
+            public ExecutionConfig getExecutionConfig() {
+                return null;
+            }
 
-                @Override
-                public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
-                    return null;
-                }
+            @Override
+            public ClassLoader getUserCodeClassLoader() {
+                return null;
+            }
 
-                @Override
-                public void registerUserCodeClassLoaderReleaseHookIfAbsent(
-                        String releaseHookName, Runnable releaseHook) {
-                    throw new UnsupportedOperationException();
-                }
+            @Override
+            public <V, A extends Serializable> void addAccumulator(
+                    String name, Accumulator<V, A> accumulator) {}
 
-                @Override
-                public IntCounter getIntCounter(String name) {
-                    return null;
-                }
+            @Override
+            public <V, A extends Serializable> Accumulator<V, A> getAccumulator(String name) {
+                return null;
+            }
 
-                @Override
-                public LongCounter getLongCounter(String name) {
-                    return null;
-                }
+            @Override
+            public void registerUserCodeClassLoaderReleaseHookIfAbsent(
+                    String releaseHookName, Runnable releaseHook) {
+                throw new UnsupportedOperationException();
+            }
 
-                @Override
-                public DoubleCounter getDoubleCounter(String name) {
-                    return null;
-                }
+            @Override
+            public IntCounter getIntCounter(String name) {
+                return null;
+            }
 
-                @Override
-                public Histogram getHistogram(String name) {
-                    return null;
-                }
+            @Override
+            public LongCounter getLongCounter(String name) {
+                return null;
+            }
 
-                @Override
-                public boolean hasBroadcastVariable(String name) {
-                    return false;
-                }
+            @Override
+            public DoubleCounter getDoubleCounter(String name) {
+                return null;
+            }
 
-                @Override
-                public <RT> List<RT> getBroadcastVariable(String name) {
-                    return null;
-                }
+            @Override
+            public Histogram getHistogram(String name) {
+                return null;
+            }
 
-                @Override
-                public <T, C> C getBroadcastVariableWithInitializer(
-                        String name, BroadcastVariableInitializer<T, C> initializer) {
-                    return null;
-                }
+            @Override
+            public boolean hasBroadcastVariable(String name) {
+                return false;
+            }
 
-                @Override
-                public DistributedCache getDistributedCache() {
-                    return null;
-                }
+            @Override
+            public <RT> List<RT> getBroadcastVariable(String name) {
+                return null;
+            }
 
-                @Override
-                public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
-                    return null;
-                }
+            @Override
+            public <T, C> C getBroadcastVariableWithInitializer(
+                    String name, BroadcastVariableInitializer<T, C> initializer) {
+                return null;
+            }
 
-                @Override
-                public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
-                    return null;
-                }
+            @Override
+            public DistributedCache getDistributedCache() {
+                return null;
+            }
 
-                @Override
-                public <T> ReducingState<T> getReducingState(
-                        ReducingStateDescriptor<T> stateProperties) {
-                    return null;
-                }
+            @Override
+            public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
+                return null;
+            }
 
-                @Override
-                public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(
-                        AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
-                    return null;
-                }
+            @Override
+            public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
+                return null;
+            }
 
-                @Override
-                public Set<ExternalResourceInfo> getExternalResourceInfos(String resourceName) {
-                    throw new UnsupportedOperationException();
-                }
+            @Override
+            public <T> ReducingState<T> getReducingState(
+                    ReducingStateDescriptor<T> stateProperties) {
+                return null;
+            }
 
-                @Override
-                public <UK, UV> MapState<UK, UV> getMapState(
-                        MapStateDescriptor<UK, UV> stateProperties) {
-                    return null;
-                }
-            };
+            @Override
+            public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(
+                    AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
+                return null;
+            }
+
+            @Override
+            public Set<ExternalResourceInfo> getExternalResourceInfos(String resourceName) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <UK, UV> MapState<UK, UV> getMapState(
+                    MapStateDescriptor<UK, UV> stateProperties) {
+                return null;
+            }
+        };
+    }
 
     static final SinkFunction.Context TEST_SINK_CONTEXT =
             new SinkFunction.Context() {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcXaSinkTestBase.java
@@ -86,7 +86,11 @@ public abstract class JdbcXaSinkTestBase extends JdbcTestBase {
         xaDataSource = getDbMetadata().buildXaDataSource();
         xaHelper =
                 new JdbcXaFacadeTestHelper(
-                        getDbMetadata().buildXaDataSource(), getDbMetadata().getUrl(), INPUT_TABLE);
+                        getDbMetadata().buildXaDataSource(),
+                        getDbMetadata().getUrl(),
+                        INPUT_TABLE,
+                        getDbMetadata().getUser(),
+                        getDbMetadata().getPassword());
         sinkHelper = buildSinkHelper(createStateHandler());
     }
 
@@ -103,7 +107,12 @@ public abstract class JdbcXaSinkTestBase extends JdbcTestBase {
             xaHelper.close();
         }
         try (JdbcXaFacadeTestHelper xa =
-                new JdbcXaFacadeTestHelper(xaDataSource, getDbMetadata().getUrl(), INPUT_TABLE)) {
+                new JdbcXaFacadeTestHelper(
+                        xaDataSource,
+                        getDbMetadata().getUrl(),
+                        INPUT_TABLE,
+                        getDbMetadata().getUser(),
+                        getDbMetadata().getPassword())) {
             xa.cancelAllTx();
         }
     }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/SemanticXidGeneratorTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/SemanticXidGeneratorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.connector.jdbc.xa;
 
+import org.apache.flink.api.common.JobID;
+
 import org.junit.Test;
 
 import javax.transaction.xa.Xid;
@@ -46,7 +48,8 @@ public class SemanticXidGeneratorTest {
         checkUniqueness(
                 unused -> {
                     generator.open();
-                    return generator.generateXid(TEST_RUNTIME_CONTEXT, checkpointId);
+                    return generator.generateXid(
+                            JdbcXaSinkTestBase.getRuntimeContext(new JobID()), checkpointId);
                 });
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Implement workaround for limitation of some XA-compliant databases
of a single XA-transaction per connection by pooling connections.

Docs need to be updated but can be done separately in FLINK-22289.

## Verifying this change

Update existing `JdbcExactlyOnceSinkE2eTest` to work against (containerized) postgresql.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
