### PR TITLE
[FLINK-22272][table/catalog]Some scenes can't drop table by hive catalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -781,11 +781,9 @@ public class HiveCatalog extends AbstractCatalog {
                                     () ->
                                             tableSchemaProps
                                                     .getOptionalTableSchema("generic.table.schema")
-                                                    .orElseThrow(
+                                                    .orElseGet(
                                                             () ->
-                                                                    new CatalogException(
-                                                                            "Failed to get table schema from properties for generic table "
-                                                                                    + tablePath)));
+                                                                    TableSchema.builder().build()));
             partitionKeys = tableSchemaProps.getPartitionKeys();
             // remove the schema from properties
             properties = CatalogTableImpl.removeRedundant(properties, tableSchema, partitionKeys);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -782,8 +782,7 @@ public class HiveCatalog extends AbstractCatalog {
                                             tableSchemaProps
                                                     .getOptionalTableSchema("generic.table.schema")
                                                     .orElseGet(
-                                                            () ->
-                                                                    TableSchema.builder().build()));
+                                                            () -> TableSchema.builder().build()));
             partitionKeys = tableSchemaProps.getPartitionKeys();
             // remove the schema from properties
             properties = CatalogTableImpl.removeRedundant(properties, tableSchema, partitionKeys);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -137,4 +137,22 @@ public class HiveCatalogTest {
         hiveConf = HiveCatalog.createHiveConf(hiveConfDir, null);
         assertNull(hiveConf.get("common-key", null));
     }
+
+    @Test
+    public void testGetNoSchemaGenericTable() throws Exception {
+        ObjectPath hiveObjectPath =
+                new ObjectPath(HiveCatalog.DEFAULT_DB, "testGetNoSchemaGenericTable");
+
+        Map<String, String> properties = new HashMap<>();
+
+        properties.put(CONNECTOR.key(), "jdbc");
+
+        hiveCatalog.createTable(
+                hiveObjectPath,
+                new CatalogTableImpl(TableSchema.builder().build(), properties, null),
+                false);
+
+        CatalogBaseTable catalogTable = hiveCatalog.getTable(hiveObjectPath);
+        assertEquals(TableSchema.builder().build(), catalogTable.getSchema());
+    }
 }


### PR DESCRIPTION
### What is the purpose of the change
When user create generic tables with empty schema, it should also allow retrieving such table.

### Brief change log
When user create generic tables with empty schema, it should also allow retrieving such table.
### Verifying this change
Manually verified.
### Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (yes / **no**)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes / **no**)
The serializers: (yes / **no** / don't know)
The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
The S3 file system connector: (yes / **no** / don't know)
### Documentation
Does this pull request introduce a new feature? (yes / **no**)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)