### PR TITLE
[FLINK-22303][table-planner-blink] FlinkRelMdFilteredColumnInterval should remapping the columnIndex of the inputRel otherwise may cause IllegalArgumentException or get incorrectly metadata

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnInterval.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnInterval.scala
@@ -24,6 +24,7 @@ import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysical
 import org.apache.flink.table.planner.plan.stats.ValueInterval
 import org.apache.flink.table.planner.plan.utils.{ColumnIntervalUtil, FlinkRelOptUtil}
 import org.apache.flink.util.Preconditions.checkArgument
+
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core._
@@ -40,6 +41,9 @@ import scala.collection.JavaConversions._
   *
   * The [[FlinkRelMdFilteredColumnInterval]] is almost depend on the implementation of
   * [[FlinkRelMdColumnInterval]], except to handle filter argument in Calc RelNode.
+  *
+  * Refactor this meta data to a utility class later because it only serves for calculating the
+  * monotonicity of some specific aggregate functions.
   */
 class FlinkRelMdFilteredColumnInterval private extends MetadataHandler[FilteredColumnInterval] {
 
@@ -79,9 +83,7 @@ class FlinkRelMdFilteredColumnInterval private extends MetadataHandler[FilteredC
    * Calculate the value interval of the given column (which may carry derived column interval) and
    * additional predicate expression, if the given column is a RexInputRef then the final interval
    * is intersect with the predicate, if the given column is a RexLiteral then the final interval
-   * is the literal itself, otherwise return null.
-   * This can be improved (e.g., for RexCall) later and refactor this meta data to a utility class
-   * because it only serves for calculating the monotonicity of some specific aggregate functions.
+   * is the literal itself, otherwise return null. This can be improved (e.g., for RexCall) later.
    *
    * @param column original column
    * @param origColumnInterval original column interval

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/ColumnIntervalUtil.scala
@@ -183,7 +183,7 @@ object ColumnIntervalUtil {
     * the interval of $1 is originInterval intersect with [-1, 2]
     *
     * for condition: $1 <= 2 and not ($1 < -1 or $2 is true),
-    * the interval of $1 is originInterval intersect with (-Inf, -1]
+    * the interval of $1 is originInterval intersect with [-1, 2]
     *
     * for condition $1 <= 2 or $1 > -1
     * the interval of $1 is (originInterval intersect with (-Inf, 2]) union

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -236,6 +236,40 @@ GroupAggregate(groupBy=[b], select=[b, SUM(a) AS EXPR$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFilteredColumnIntervalValidation">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+  SUM(uv) FILTER (WHERE c = 'all') AS all_uv
+FROM (
+  SELECT
+    c, COUNT(1) AS uv
+  FROM T
+  GROUP BY c
+) t
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], all_uv=[SUM($0) FILTER $1])
++- LogicalProject(uv=[$1], $f1=[IS TRUE(=($0, _UTF-16LE'all'))])
+   +- LogicalAggregate(group=[{0}], uv=[COUNT()])
+      +- LogicalProject(c=[$2])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(select=[SUM_RETRACT(uv) FILTER $f1 AS all_uv])
++- Exchange(distribution=[single])
+   +- Calc(select=[uv, (c = _UTF-16LE'all':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") IS TRUE AS $f1])
+      +- GroupAggregate(groupBy=[c], select=[c, COUNT(*) AS uv])
+         +- Exchange(distribution=[hash[c]])
+            +- Calc(select=[c])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupByWithConstantKey">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnOriginNullCountTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnOriginNullCountTest.scala
@@ -115,7 +115,8 @@ class FlinkRelMdColumnOriginNullCountTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testGetColumnOriginNullCountOnJoin(): Unit = {
-    val innerJoin1 = relBuilder.scan("MyTable3").scan("MyTable4")
+    val innerJoin1 = relBuilder.scan("MyTable3").project(relBuilder.fields().subList(0, 2))
+      .scan("MyTable4")
       .join(JoinRelType.INNER,
         relBuilder.call(EQUALS, relBuilder.field(2, 0, 1), relBuilder.field(2, 1, 1)))
       .build
@@ -124,7 +125,8 @@ class FlinkRelMdColumnOriginNullCountTest extends FlinkRelMdHandlerTestBase {
     assertEquals(0.0, mq.getColumnOriginNullCount(innerJoin1, 2))
     assertEquals(0.0, mq.getColumnOriginNullCount(innerJoin1, 3))
 
-    val innerJoin2 = relBuilder.scan("MyTable3").scan("MyTable4")
+    val innerJoin2 = relBuilder.scan("MyTable3").project(relBuilder.fields().subList(0, 2))
+      .scan("MyTable4")
       .join(JoinRelType.INNER,
         relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0)))
       .build

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
@@ -19,10 +19,9 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.planner.plan.stats.{RightSemiInfiniteValueInterval, ValueInterval}
 import org.apache.flink.table.types.logical._
-
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.RexNode
-import org.apache.calcite.sql.fun.SqlStdOperatorTable.{DIVIDE, EQUALS, GREATER_THAN, IS_FALSE, IS_TRUE, LESS_THAN, LESS_THAN_OR_EQUAL}
+import org.apache.calcite.sql.fun.SqlStdOperatorTable.{DIVIDE, EQUALS, GREATER_THAN, IS_FALSE, IS_NOT_NULL, IS_TRUE, LESS_THAN, LESS_THAN_OR_EQUAL, NOT_EQUALS}
 import org.junit.Assert.{assertEquals, assertNull}
 import org.junit.{Before, Test}
 
@@ -30,7 +29,8 @@ import scala.collection.JavaConversions._
 
 class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
   private var ts: RelNode = _
-  private var expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8, expr9: RexNode = _
+  private var expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8, expr9, expr10,
+  expr11, expr12, expr13: RexNode = _
   private var projects: List[RexNode] = _
 
   @Before
@@ -57,6 +57,14 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
     expr8 = relBuilder.call(IS_TRUE, expr4)
     // (b < 1.1) is false
     expr9 = relBuilder.call(IS_FALSE, expr4)
+    // c is not null
+    expr10 = relBuilder.call(IS_NOT_NULL, relBuilder.field(2))
+    // c in ('all', 'none')
+    expr11 = relBuilder.in(relBuilder.field(2), relBuilder.literal("all"), relBuilder.literal("none"))
+    // c = 'all'
+    expr12 = relBuilder.call(EQUALS, relBuilder.field(2), relBuilder.literal("all"))
+    // c != 'all'
+    expr13 = relBuilder.call(NOT_EQUALS, relBuilder.field(2), relBuilder.literal("all"))
 
     // a, b, true, a = 1, a <= 2, a > -1, (a /2 ) > 3, b < 1.1, a > 90, a <= -1, b > 1.9,
     // (b < 1.1) is true, (b < 1.1) is false
@@ -65,7 +73,20 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
       relBuilder.field(1),
       relBuilder.literal(true),
       relBuilder.call(EQUALS, relBuilder.field(0), relBuilder.literal(1)),
-      expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8, expr9)
+      expr1,
+      expr2,
+      expr3,
+      expr4,
+      expr5,
+      expr6,
+      expr7,
+      expr8,
+      expr9,
+      relBuilder.field(2),
+      expr10,
+      expr11,
+      expr12,
+      expr13)
   }
 
   @Test
@@ -88,6 +109,14 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
     assertEquals(
       ValueInterval(bd(0D), bd(1.1D), includeUpper = false), mq.getFilteredColumnInterval(p, 1, 11))
     assertEquals(ValueInterval(bd(1.1D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 12))
+    assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 14))
+    assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 15))
+    assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 16))
+    assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 17))
+    assertEquals(ValueInterval(String.valueOf(""), String.valueOf("zzzzz")), mq.getFilteredColumnInterval(p, 13, 14))
+    assertEquals(ValueInterval(String.valueOf("all"), String.valueOf("none")), mq.getFilteredColumnInterval(p, 13, 15))
+    assertEquals(ValueInterval(String.valueOf("all"), String.valueOf("all")), mq.getFilteredColumnInterval(p, 13, 16))
+    assertEquals(ValueInterval(String.valueOf(""), String.valueOf("zzzzz")), mq.getFilteredColumnInterval(p, 13, 17))
   }
 
   @Test
@@ -118,11 +147,13 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
   @Test
   def testGetColumnIntervalOnCalc(): Unit = {
     val outputRowType = typeFactory.buildRelNodeRowType(
-      Array("f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12"),
+      Array("f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "f10", "f11", "f12", "f13",
+        "f14", "f15", "f16", "f17"),
       Array(new IntType(), new DoubleType(), new BooleanType(), new BooleanType(),
         new BooleanType(), new BooleanType(), new BooleanType(), new BooleanType(),
         new BooleanType(), new BooleanType(), new BooleanType(), new BooleanType(),
-        new BooleanType()))
+        new BooleanType(), new VarCharType(), new BooleanType(), new BooleanType(),
+        new BooleanType(), new BooleanType()))
     val calc = createLogicalCalc(ts, outputRowType, projects, List(expr1))
     assertEquals(ValueInterval(bd(-5), bd(2)), mq.getFilteredColumnInterval(calc, 0, -1))
     assertEquals(ValueInterval(bd(0D), bd(6.1D)), mq.getFilteredColumnInterval(calc, 1, -1))
@@ -166,6 +197,48 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
       assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
       assertEquals(ValueInterval(bd(161.0), bd(172.1)), mq.getFilteredColumnInterval(agg, 2, -1))
       assertNull(mq.getFilteredColumnInterval(agg, 3, -1))
+    }
+  }
+
+  @Test
+  def testGetColumnIntervalOnAggregateWithFilter(): Unit = {
+    // FilteredColumnInterval only used for calculating MonotonicityOnAggCall, and always via its input
+    Array(logicalAggWithFilter, flinkLogicalAggWithFilter, batchGlobalAggWithoutLocalWithFilter,
+      streamGlobalAggWithoutLocalWithFilter).foreach { agg =>
+      assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg, 0, -1))
+      assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
+      assertEquals(ValueInterval(bd(2.7), null), mq.getFilteredColumnInterval(agg, 4, -1))
+      // column interval of max is null
+      assertNull(mq.getFilteredColumnInterval(agg, 7, -1))
+      assertEquals(ValueInterval(bd(0), null), mq.getFilteredColumnInterval(agg, 13, -1))
+
+      // test aggregate's input column interval with filter `sex = 'M'` and `class > 3`
+      assertEquals(ValueInterval(bd(0), null), mq.getFilteredColumnInterval(agg.getInput, 0, 7))
+      assertEquals(ValueInterval(bd(2.7), bd(4.8)), mq.getFilteredColumnInterval(agg.getInput, 2, 7))
+      assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg.getInput, 3, 8))
+      assertEquals(ValueInterval("M", "M"), mq.getFilteredColumnInterval(agg.getInput, 5, 7))
+      assertEquals(ValueInterval(bd(3), null, false), mq.getFilteredColumnInterval(agg.getInput, 6, 8))
+    }
+
+    Array(batchGlobalAggWithLocalWithFilter, streamGlobalAggWithLocalWithFilter).foreach { agg =>
+      assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg, 0, -1))
+      assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
+      assertNull(mq.getFilteredColumnInterval(agg.getInput, 2, 7))
+      assertNull(mq.getFilteredColumnInterval(agg.getInput, 3, 8))
+      assertNull(mq.getFilteredColumnInterval(agg, 4, -1))
+      assertNull(mq.getFilteredColumnInterval(agg.getInput, 5, 7))
+      assertNull(mq.getFilteredColumnInterval(agg.getInput, 6, 8))
+    }
+
+    Array(streamLocalAggWithFilter).foreach { agg =>
+      assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg, 0, -1))
+      assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
+      assertEquals(ValueInterval(bd(2.7), bd(4.8)), mq.getFilteredColumnInterval(agg.getInput, 2, 7))
+      assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg.getInput, 3, 8))
+      // local aggregate's output is not equal to logical or global agg
+      assertNull(mq.getFilteredColumnInterval(agg, 4, -1))
+      assertEquals(ValueInterval("M", "M"), mq.getFilteredColumnInterval(agg.getInput, 5, 7))
+      assertEquals(ValueInterval(bd(3), null, false), mq.getFilteredColumnInterval(agg.getInput, 6, 8))
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.planner.plan.stats.{RightSemiInfiniteValueInterval, ValueInterval}
 import org.apache.flink.table.types.logical._
+
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.sql.fun.SqlStdOperatorTable.{DIVIDE, EQUALS, GREATER_THAN, IS_FALSE, IS_NOT_NULL, IS_TRUE, LESS_THAN, LESS_THAN_OR_EQUAL, NOT_EQUALS}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdFilteredColumnIntervalTest.scala
@@ -60,7 +60,8 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
     // c is not null
     expr10 = relBuilder.call(IS_NOT_NULL, relBuilder.field(2))
     // c in ('all', 'none')
-    expr11 = relBuilder.in(relBuilder.field(2), relBuilder.literal("all"), relBuilder.literal("none"))
+    expr11 = relBuilder
+      .in(relBuilder.field(2), relBuilder.literal("all"), relBuilder.literal("none"))
     // c = 'all'
     expr12 = relBuilder.call(EQUALS, relBuilder.field(2), relBuilder.literal("all"))
     // c != 'all'
@@ -113,10 +114,18 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
     assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 15))
     assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 16))
     assertEquals(ValueInterval(bd(0.0D), bd(6.1D)), mq.getFilteredColumnInterval(p, 1, 17))
-    assertEquals(ValueInterval(String.valueOf(""), String.valueOf("zzzzz")), mq.getFilteredColumnInterval(p, 13, 14))
-    assertEquals(ValueInterval(String.valueOf("all"), String.valueOf("none")), mq.getFilteredColumnInterval(p, 13, 15))
-    assertEquals(ValueInterval(String.valueOf("all"), String.valueOf("all")), mq.getFilteredColumnInterval(p, 13, 16))
-    assertEquals(ValueInterval(String.valueOf(""), String.valueOf("zzzzz")), mq.getFilteredColumnInterval(p, 13, 17))
+    assertEquals(
+      ValueInterval(String.valueOf(""), String.valueOf("zzzzz")),
+      mq.getFilteredColumnInterval(p, 13, 14))
+    assertEquals(
+      ValueInterval(String.valueOf("all"), String.valueOf("none")),
+      mq.getFilteredColumnInterval(p, 13, 15))
+    assertEquals(
+      ValueInterval(String.valueOf("all"), String.valueOf("all")),
+      mq.getFilteredColumnInterval(p, 13, 16))
+    assertEquals(
+      ValueInterval(String.valueOf(""), String.valueOf("zzzzz")),
+      mq.getFilteredColumnInterval(p, 13, 17))
   }
 
   @Test
@@ -202,8 +211,10 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testGetColumnIntervalOnAggregateWithFilter(): Unit = {
-    // FilteredColumnInterval only used for calculating MonotonicityOnAggCall, and always via its input
-    Array(logicalAggWithFilter, flinkLogicalAggWithFilter, batchGlobalAggWithoutLocalWithFilter,
+    // FilteredColumnInterval only used for calculating MonotonicityOnAggCall, and always via its
+    // input
+    Array(
+      logicalAggWithFilter, flinkLogicalAggWithFilter, batchGlobalAggWithoutLocalWithFilter,
       streamGlobalAggWithoutLocalWithFilter).foreach { agg =>
       assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg, 0, -1))
       assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
@@ -214,10 +225,14 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
 
       // test aggregate's input column interval with filter `sex = 'M'` and `class > 3`
       assertEquals(ValueInterval(bd(0), null), mq.getFilteredColumnInterval(agg.getInput, 0, 7))
-      assertEquals(ValueInterval(bd(2.7), bd(4.8)), mq.getFilteredColumnInterval(agg.getInput, 2, 7))
+      assertEquals(
+        ValueInterval(bd(2.7), bd(4.8)),
+        mq.getFilteredColumnInterval(agg.getInput, 2, 7))
       assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg.getInput, 3, 8))
       assertEquals(ValueInterval("M", "M"), mq.getFilteredColumnInterval(agg.getInput, 5, 7))
-      assertEquals(ValueInterval(bd(3), null, false), mq.getFilteredColumnInterval(agg.getInput, 6, 8))
+      assertEquals(
+        ValueInterval(bd(3), null, false),
+        mq.getFilteredColumnInterval(agg.getInput, 6, 8))
     }
 
     Array(batchGlobalAggWithLocalWithFilter, streamGlobalAggWithLocalWithFilter).foreach { agg =>
@@ -233,12 +248,16 @@ class FlinkRelMdFilteredColumnIntervalTest extends FlinkRelMdHandlerTestBase {
     Array(streamLocalAggWithFilter).foreach { agg =>
       assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg, 0, -1))
       assertNull(mq.getFilteredColumnInterval(agg, 1, -1))
-      assertEquals(ValueInterval(bd(2.7), bd(4.8)), mq.getFilteredColumnInterval(agg.getInput, 2, 7))
+      assertEquals(
+        ValueInterval(bd(2.7), bd(4.8)),
+        mq.getFilteredColumnInterval(agg.getInput, 2, 7))
       assertEquals(ValueInterval(bd(12), bd(18)), mq.getFilteredColumnInterval(agg.getInput, 3, 8))
       // local aggregate's output is not equal to logical or global agg
       assertNull(mq.getFilteredColumnInterval(agg, 4, -1))
       assertEquals(ValueInterval("M", "M"), mq.getFilteredColumnInterval(agg.getInput, 5, 7))
-      assertEquals(ValueInterval(bd(3), null, false), mq.getFilteredColumnInterval(agg.getInput, 6, 8))
+      assertEquals(
+        ValueInterval(bd(3), null, false),
+        mq.getFilteredColumnInterval(agg.getInput, 6, 8))
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -48,6 +48,7 @@ import org.apache.flink.table.types.AtomicDataType
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.utils.CatalogManagerMocks
+
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.plan._
@@ -67,6 +68,7 @@ import org.apache.calcite.sql.fun.{SqlCountAggFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.util._
 import org.junit.{Before, BeforeClass}
+
 import java.math.BigDecimal
 import java.util
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
@@ -150,7 +150,7 @@ class FlinkRelMdSelectivityTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testGetSelectivityOnExpand(): Unit = {
-    val ts = relBuilder.scan("MyTable3").build()
+    val ts = relBuilder.scan("MyTable3").project(relBuilder.fields().subList(0, 2)).build()
     val expandProjects = ExpandUtil.createExpandProjects(
       ts.getCluster.getRexBuilder,
       ts.getRowType,
@@ -464,7 +464,7 @@ class FlinkRelMdSelectivityTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testGetSelectivityOnJoin(): Unit = {
-    val ts = relBuilder.scan("MyTable3").build()
+    val ts = relBuilder.scan("MyTable3").project(relBuilder.fields().subList(0, 2)).build()
     // right is $0 <= 2 and $1 < 1.1
     val right = relBuilder.push(ts).filter(
       relBuilder.call(LESS_THAN_OR_EQUAL, relBuilder.field(0), relBuilder.literal(2)),
@@ -507,7 +507,7 @@ class FlinkRelMdSelectivityTest extends FlinkRelMdHandlerTestBase {
   def testGetSelectivityOnUnion(): Unit = {
     val union = relBuilder
       .scan("MyTable4").project(relBuilder.fields().subList(0, 2))
-      .scan("MyTable3")
+      .scan("MyTable3").project(relBuilder.fields().subList(0, 2))
       .union(true).build()
     // a <= 2
     val pred = relBuilder.push(union).call(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -29,6 +29,7 @@ import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, Tabl
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
 import org.apache.flink.table.types.logical.{BigIntType, DoubleType, IntType, LocalZonedTimestampType, LogicalType, TimestampKind, TimestampType, VarCharType}
+
 import org.apache.calcite.config.CalciteConnectionConfig
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
@@ -36,7 +37,6 @@ import org.apache.calcite.schema.Schema.TableType
 import org.apache.calcite.schema.{Schema, SchemaPlus, Table}
 import org.apache.calcite.sql.{SqlCall, SqlNode}
 
-import java.lang.{String => JString}
 import java.util
 import java.util.Collections
 
@@ -157,13 +157,12 @@ object MetadataTestUtil {
         BasicTypeInfo.DOUBLE_TYPE_INFO,
         BasicTypeInfo.STRING_TYPE_INFO))
 
-
     val colStatsMap = Map[String, ColumnStats](
       "a" -> new ColumnStats(10L, 1L, 4D, 4, 5, -5),
       "b" -> new ColumnStats(5L, 0L, 8D, 8, 6.1D, 0D),
       "c" ->
         ColumnStats.Builder.builder().setNdv(100L).setNullCount(1L).setAvgLen(16D).setMaxLen(128)
-          .setMax(JString.valueOf("zzzzz")).setMin(JString.valueOf("")).build()
+          .setMax("zzzzz").setMin("").build()
     )
 
     val tableStats = new TableStats(100L, colStatsMap)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo}
 import org.apache.flink.table.api.{DataTypes, TableException, TableSchema}
-import org.apache.flink.table.catalog.{CatalogTable, CatalogTableImpl, Column, ObjectIdentifier, ResolvedCatalogTable, ResolvedSchema, UniqueConstraint}
+import org.apache.flink.table.catalog.{CatalogTable, Column, ObjectIdentifier, ResolvedCatalogTable, ResolvedSchema, UniqueConstraint}
 import org.apache.flink.table.connector.ChangelogMode
 import org.apache.flink.table.connector.source.{DynamicTableSource, ScanTableSource}
 import org.apache.flink.table.plan.stats.{ColumnStats, TableStats}
@@ -36,6 +36,7 @@ import org.apache.calcite.schema.Schema.TableType
 import org.apache.calcite.schema.{Schema, SchemaPlus, Table}
 import org.apache.calcite.sql.{SqlCall, SqlNode}
 
+import java.lang.{String => JString}
 import java.util
 import java.util.Collections
 
@@ -150,12 +151,19 @@ object MetadataTestUtil {
 
   private def createMyTable3(): Table = {
     val schema = new TableSchema(
-      Array("a", "b"),
-      Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.DOUBLE_TYPE_INFO))
+      Array("a", "b", "c"),
+      Array(
+        BasicTypeInfo.INT_TYPE_INFO,
+        BasicTypeInfo.DOUBLE_TYPE_INFO,
+        BasicTypeInfo.STRING_TYPE_INFO))
+
 
     val colStatsMap = Map[String, ColumnStats](
       "a" -> new ColumnStats(10L, 1L, 4D, 4, 5, -5),
-      "b" -> new ColumnStats(5L, 0L, 8D, 8, 6.1D, 0D)
+      "b" -> new ColumnStats(5L, 0L, 8D, 8, 6.1D, 0D),
+      "c" ->
+        ColumnStats.Builder.builder().setNdv(100L).setNullCount(1L).setAvgLen(16D).setMaxLen(128)
+          .setMax(JString.valueOf("zzzzz")).setMin(JString.valueOf("")).build()
     )
 
     val tableStats = new TableStats(100L, colStatsMap)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
@@ -24,9 +24,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.utils.{StreamTableTestUtil, TableTestBase}
 import org.apache.flink.table.runtime.typeutils.DecimalDataTypeInfo
-
 import java.time.Duration
-
 import org.junit.Test
 
 class AggregateTest extends TableTestBase {
@@ -279,5 +277,21 @@ class AggregateTest extends TableTestBase {
   def testColumnIntervalValidation(): Unit = {
     // test for FLINK-16577
     util.verifyExecPlan("SELECT b, SUM(a) FROM MyTable WHERE a > 0.1 and a < 10 GROUP BY b")
+  }
+
+  @Test
+  def testFilteredColumnIntervalValidation(): Unit = {
+    // test for FLINK-22303
+    util.verifyExecPlan(
+      s"""
+         |SELECT
+         |  SUM(uv) FILTER (WHERE c = 'all') AS all_uv
+         |FROM (
+         |  SELECT
+         |    c, COUNT(1) AS uv
+         |  FROM T
+         |  GROUP BY c
+         |) t
+         |""".stripMargin)
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

fix FlinkRelMdFilteredColumnInterval:  remapping the columnIndex of the inputRel avoid IllegalArgumentException or 
 incorrect metadata

## Brief change log
- fix FlinkRelMdFilteredColumnInterval#getFilteredColumnInterval logic and add related tests

## Verifying this change

Added ut

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): ( no )
- The public API, i.e., is any changed class annotated with @public(Evolving): ( no )
- The serializers: ( no )
- The runtime per-record code paths (performance sensitive): ( no )
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, -ZooKeeper: ( no )
-The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
