### PR TITLE
[FLINK-22310][table-planner-blink] Fix the incorrect deserialization result of LogicalWindowJsonDeserializer

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerWindowReference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerWindowReference.java
@@ -26,6 +26,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import javax.annotation.Nullable;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /** Indicate timeField type. */
@@ -55,6 +56,18 @@ public class PlannerWindowReference {
     @JsonIgnore
     public Optional<LogicalType> getType() {
         return Optional.ofNullable(type);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PlannerWindowReference that = (PlannerWindowReference) o;
+        return Objects.equals(name, that.name) && Objects.equals(type, that.type);
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowJsonDeserializer.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowJsonDeserializer.java
@@ -134,6 +134,6 @@ public class LogicalWindowJsonDeserializer extends StdDeserializer<LogicalWindow
         int inputIndex = input.get(FIELD_NAME_INPUT_INDEX).asInt();
         LogicalType type =
                 mapper.readValue(input.get(FIELD_NAME_FIELD_TYPE).toString(), LogicalType.class);
-        return new FieldReferenceExpression(name, new AtomicDataType(type), fieldIndex, inputIndex);
+        return new FieldReferenceExpression(name, new AtomicDataType(type), inputIndex, fieldIndex);
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/logical/groupWindows.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/logical/groupWindows.scala
@@ -20,7 +20,9 @@ package org.apache.flink.table.planner.plan.logical
 
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.planner.expressions.PlannerWindowReference
+import org.apache.flink.table.planner.plan.utils.AggregateUtil.{hasTimeIntervalType, toLong}
 
+import java.time.Duration
 import java.util.Objects
 
 /**
@@ -49,9 +51,19 @@ abstract class LogicalWindow(
     } else if (l1 == null || l2 == null) {
       false
     } else {
-      val value1 = l1.getValueAs(classOf[java.lang.Long])
-      val value2 = l2.getValueAs(classOf[java.lang.Long])
-      value1 == value2 && l1.getOutputDataType.equals(l2.getOutputDataType)
+      if (hasTimeIntervalType(l1)) {
+        if (hasTimeIntervalType(l2)) {
+          val v1 = l1.getValueAs(classOf[Duration])
+          val v2 = l2.getValueAs(classOf[Duration])
+          v1.equals(v2) && l1.getOutputDataType.equals(l2.getOutputDataType)
+        } else {
+          false
+        }
+      } else {
+        val v1 = toLong(l1)
+        val v2 = toLong(l2)
+        v1 == v2 && l1.getOutputDataType.equals(l2.getOutputDataType)
+      }
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
@@ -58,62 +58,57 @@ public class LogicalWindowSerdeTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static List<LogicalWindow> testData() {
-        List<LogicalWindow> types =
-                Arrays.asList(
-                        new TumblingGroupWindow(
-                                new PlannerWindowReference(
-                                        "timeWindow",
+        return Arrays.asList(
+                new TumblingGroupWindow(
+                        new PlannerWindowReference(
+                                "timeWindow", new TimestampType(false, TimestampKind.ROWTIME, 3)),
+                        new FieldReferenceExpression(
+                                "rowTime",
+                                new AtomicDataType(
                                         new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                new FieldReferenceExpression(
-                                        "rowTime",
-                                        new AtomicDataType(
-                                                new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                        1,
-                                        2),
-                                new ValueLiteralExpression(Duration.ofSeconds(10))),
-                        new TumblingGroupWindow(
-                                new PlannerWindowReference("countWindow", new BigIntType()),
-                                new FieldReferenceExpression(
-                                        "rowTime",
-                                        new AtomicDataType(
-                                                new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                        1,
-                                        2),
-                                new ValueLiteralExpression(10L)),
-                        new SlidingGroupWindow(
-                                new PlannerWindowReference(
-                                        "timeWindow",
+                                1,
+                                2),
+                        new ValueLiteralExpression(Duration.ofMinutes(10))),
+                new TumblingGroupWindow(
+                        new PlannerWindowReference("countWindow", new BigIntType()),
+                        new FieldReferenceExpression(
+                                "rowTime",
+                                new AtomicDataType(
                                         new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                new FieldReferenceExpression(
-                                        "rowTime",
-                                        new AtomicDataType(
-                                                new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                        1,
-                                        2),
-                                new ValueLiteralExpression(Duration.ofSeconds(10)),
-                                new ValueLiteralExpression(Duration.ofSeconds(5))),
-                        new SlidingGroupWindow(
-                                new PlannerWindowReference("countWindow", new BigIntType()),
-                                new FieldReferenceExpression(
-                                        "rowTime",
-                                        new AtomicDataType(
-                                                new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                        1,
-                                        2),
-                                new ValueLiteralExpression(10L),
-                                new ValueLiteralExpression(5L)),
-                        new SessionGroupWindow(
-                                new PlannerWindowReference(
-                                        "timeWindow",
+                                1,
+                                2),
+                        new ValueLiteralExpression(10L)),
+                new SlidingGroupWindow(
+                        new PlannerWindowReference(
+                                "timeWindow", new TimestampType(false, TimestampKind.ROWTIME, 3)),
+                        new FieldReferenceExpression(
+                                "rowTime",
+                                new AtomicDataType(
                                         new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                new FieldReferenceExpression(
-                                        "rowTime",
-                                        new AtomicDataType(
-                                                new TimestampType(false, TimestampKind.ROWTIME, 3)),
-                                        1,
-                                        2),
-                                new ValueLiteralExpression(Duration.ofSeconds(10))));
-        return types;
+                                1,
+                                2),
+                        new ValueLiteralExpression(Duration.ofSeconds(10)),
+                        new ValueLiteralExpression(Duration.ofSeconds(5))),
+                new SlidingGroupWindow(
+                        new PlannerWindowReference("countWindow", new BigIntType()),
+                        new FieldReferenceExpression(
+                                "rowTime",
+                                new AtomicDataType(
+                                        new TimestampType(false, TimestampKind.ROWTIME, 3)),
+                                1,
+                                2),
+                        new ValueLiteralExpression(10L),
+                        new ValueLiteralExpression(5L)),
+                new SessionGroupWindow(
+                        new PlannerWindowReference(
+                                "timeWindow", new TimestampType(false, TimestampKind.ROWTIME, 3)),
+                        new FieldReferenceExpression(
+                                "rowTime",
+                                new AtomicDataType(
+                                        new TimestampType(false, TimestampKind.ROWTIME, 3)),
+                                1,
+                                2),
+                        new ValueLiteralExpression(Duration.ofDays(10))));
     }
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/LogicalWindowSerdeTest.java
@@ -138,7 +138,6 @@ public class LogicalWindowSerdeTest {
         mapper.registerModule(module);
 
         assertEquals(
-                mapper.readValue(mapper.writeValueAsString(window), LogicalWindow.class).toString(),
-                window.toString());
+                mapper.readValue(mapper.writeValueAsString(window), LogicalWindow.class), window);
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

*Fix the incorrect deserialization result of LogicalWindowJsonDeserializer*


## Brief change log

  - *Fix the incorrect deserialization result of LogicalWindowJsonDeserializer*


## Verifying this change

This change is already covered by existing tests, such as *LogicalWindowSerdeTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
