### PR TITLE
[FLINK-22325][runtime] Synchronize access to iterator when writing channel state

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/CloseableIterator.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CloseableIterator.java
@@ -77,6 +77,7 @@ public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
                         exception = ExceptionUtils.firstOrSuppressed(e, exception);
                     }
                 }
+                stack.clear();
                 if (exception != null) {
                     throw exception;
                 }

--- a/flink-core/src/test/java/org/apache/flink/util/CloseableIteratorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CloseableIteratorTest.java
@@ -25,12 +25,22 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /** {@link CloseableIterator} test. */
 @SuppressWarnings("unchecked")
 public class CloseableIteratorTest {
 
     private static final String[] ELEMENTS = new String[] {"flink", "blink"};
+
+    @Test
+    public void testClearOnClose() throws Exception {
+        List<Integer> list = asList(1, 2, 3, 4, 5, 6);
+        CloseableIterator<Integer> iterator = CloseableIterator.fromList(list, unused -> {});
+        assertTrue(iterator.hasNext());
+        iterator.close();
+        assertFalse(iterator.hasNext());
+    }
 
     @Test
     public void testFlattenEmpty() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/CheckpointInProgressRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/CheckpointInProgressRequestTest.java
@@ -60,15 +60,16 @@ public class CheckpointInProgressRequestTest {
 
     private CheckpointInProgressRequest cancelCountingRequest(
             AtomicInteger cancelCounter, CyclicBarrier cb) {
-        return new CheckpointInProgressRequest(
-                "test",
-                1L,
-                unused -> {},
-                unused -> {
-                    cancelCounter.incrementAndGet();
-                    await(cb);
-                },
-                false);
+        return new CheckpointInProgressRequest("test", 1L, false) {
+            @Override
+            protected void executeInternal(ChannelStateCheckpointWriter writer) {}
+
+            @Override
+            protected void discard(Throwable cause) {
+                cancelCounter.incrementAndGet();
+                await(cb);
+            }
+        };
     }
 
     private void await(CyclicBarrier cb) {


### PR DESCRIPTION
## What is the purpose of the change

From FLINK-22325:
> ChannelStateWriter adds input/output data that is written by a dedicated thread.
> The data is passed as CloseableIterator.
> In some cases, iterator.close can be called from the task thread which can lead to double release of buffers.

Another issue is that after closing an iterator created with `CloseableIterator.fromList` it can still produce elements.

To simplify synchronization and improve readability, composition in `ChannelStateWriteRequest` changed to inheritance.

## Verifying this change

Added `CloseableIteratorTest.testClearOnClose`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
