### PR TITLE
[FLINK-22276][runtime] Adds workaround for FLINK-22276

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/TestFailoverStrategyFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/TestFailoverStrategyFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph.utils;
+
+import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
+import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
+
+import java.util.Set;
+
+/**
+ * A {@code FailoverStrategyFactory} provides a {@link FailoverStrategy} implementation that can be
+ * used in tests to specify the vertices that need to be restarted.
+ */
+public class TestFailoverStrategyFactory implements FailoverStrategy.Factory {
+
+    private Set<ExecutionVertexID> tasksToRestart;
+
+    public TestFailoverStrategyFactory() {}
+
+    public void setTasksToRestart(ExecutionVertexID... tasksToRestart) {
+        this.tasksToRestart = Sets.newHashSet(tasksToRestart);
+    }
+
+    @Override
+    public FailoverStrategy create(
+            SchedulingTopology topology,
+            ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
+        return new TestFailoverStrategy();
+    }
+
+    private class TestFailoverStrategy implements FailoverStrategy {
+
+        @Override
+        public Set<ExecutionVertexID> getTasksNeedingRestart(
+                ExecutionVertexID executionVertexId, Throwable cause) {
+            return TestFailoverStrategyFactory.this.tasksToRestart;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -22,11 +22,13 @@ package org.apache.flink.runtime.scheduler;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.core.testutils.ScheduledTask;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.hooks.TestMasterHook;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ArchivedExecution;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -39,6 +41,7 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.RestartAllFailover
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.TestRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.executiongraph.utils.TestFailoverStrategyFactory;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -79,14 +82,17 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -1127,6 +1133,94 @@ public class DefaultSchedulerTest extends TestLogger {
     }
 
     @Test
+    public void testExceptionHistoryConcurrentRestart() throws Exception {
+        final JobGraph jobGraph = singleJobVertexJobGraph(2);
+
+        final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+        final TestingLogicalSlotBuilder logicalSlotBuilder = new TestingLogicalSlotBuilder();
+        logicalSlotBuilder.setTaskManagerLocation(taskManagerLocation);
+
+        executionSlotAllocatorFactory = new TestExecutionSlotAllocatorFactory(logicalSlotBuilder);
+
+        final ReorganizableManuallyTriggeredScheduledExecutor delayExecutor =
+                new ReorganizableManuallyTriggeredScheduledExecutor();
+        final TestFailoverStrategyFactory failoverStrategyFactory =
+                new TestFailoverStrategyFactory();
+        final DefaultScheduler scheduler =
+                createScheduler(
+                        jobGraph,
+                        ComponentMainThreadExecutorServiceAdapter.forMainThread(),
+                        new PipelinedRegionSchedulingStrategy.Factory(),
+                        failoverStrategyFactory,
+                        delayExecutor);
+        scheduler.startScheduling();
+
+        final ExecutionVertex executionVertex0 =
+                Iterables.get(scheduler.getExecutionGraph().getAllExecutionVertices(), 0);
+        final ExecutionVertex executionVertex1 =
+                Iterables.get(scheduler.getExecutionGraph().getAllExecutionVertices(), 1);
+
+        // single-ExecutionVertex failure
+        final RuntimeException exception0 = new RuntimeException("failure #0");
+        failoverStrategyFactory.setTasksToRestart(executionVertex0.getID());
+        final long updateStateTriggeringRestartTimestamp0 =
+                initiateFailure(
+                        scheduler,
+                        executionVertex0.getCurrentExecutionAttempt().getAttemptId(),
+                        exception0);
+
+        // multi-ExecutionVertex failure
+        final RuntimeException exception1 = new RuntimeException("failure #1");
+        failoverStrategyFactory.setTasksToRestart(
+                executionVertex1.getID(), executionVertex0.getID());
+        final long updateStateTriggeringRestartTimestamp1 =
+                initiateFailure(
+                        scheduler,
+                        executionVertex1.getCurrentExecutionAttempt().getAttemptId(),
+                        exception1);
+
+        // there might be a race condition with the delayExecutor if the tasks are scheduled quite
+        // close to each other which we want to simulate here
+        Collections.reverse(delayExecutor.getCollectedScheduledTasks());
+
+        delayExecutor.triggerNonPeriodicScheduledTasks();
+
+        assertThat(scheduler.getExceptionHistory(), IsIterableWithSize.iterableWithSize(2));
+        final Iterator<RootExceptionHistoryEntry> actualExceptionHistory =
+                scheduler.getExceptionHistory().iterator();
+
+        final RootExceptionHistoryEntry entry0 = actualExceptionHistory.next();
+        assertThat(
+                entry0,
+                is(
+                        ExceptionHistoryEntryMatcher.matchesFailure(
+                                exception0,
+                                updateStateTriggeringRestartTimestamp0,
+                                executionVertex0.getTaskNameWithSubtaskIndex(),
+                                executionVertex0.getCurrentAssignedResourceLocation())));
+        assertThat(
+                entry0.getConcurrentExceptions(),
+                IsIterableContainingInOrder.contains(
+                        ExceptionHistoryEntryMatcher.matchesFailure(
+                                exception1,
+                                updateStateTriggeringRestartTimestamp1,
+                                executionVertex1.getTaskNameWithSubtaskIndex(),
+                                executionVertex1.getCurrentAssignedResourceLocation())));
+
+        final RootExceptionHistoryEntry entry1 = actualExceptionHistory.next();
+        assertThat(entry1.getConcurrentExceptions(), IsEmptyIterable.emptyIterable());
+        FlinkException expectedFailure =
+                new FlinkException(
+                        "This is a workaround for FLINK-22276: The actual failure was cleaned up already.");
+        assertThat(
+                entry1.getException()
+                        .deserializeError(ClassLoader.getSystemClassLoader())
+                        .getMessage(),
+                is(expectedFailure.getMessage()));
+        assertThat(entry1.getConcurrentExceptions(), IsEmptyIterable.emptyIterable());
+    }
+
+    @Test
     public void testExceptionHistoryTruncation() {
         final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
 
@@ -1289,12 +1383,27 @@ public class DefaultSchedulerTest extends TestLogger {
             final SchedulingStrategyFactory schedulingStrategyFactory,
             final FailoverStrategy.Factory failoverStrategyFactory)
             throws Exception {
+        return createScheduler(
+                jobGraph,
+                mainThreadExecutor,
+                schedulingStrategyFactory,
+                failoverStrategyFactory,
+                taskRestartExecutor);
+    }
+
+    private DefaultScheduler createScheduler(
+            final JobGraph jobGraph,
+            final ComponentMainThreadExecutor mainThreadExecutor,
+            final SchedulingStrategyFactory schedulingStrategyFactory,
+            final FailoverStrategy.Factory failoverStrategyFactory,
+            final ScheduledExecutor delayExecutor)
+            throws Exception {
         return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
                 .setLogger(log)
                 .setIoExecutor(executor)
                 .setJobMasterConfiguration(configuration)
                 .setFutureExecutor(scheduledExecutorService)
-                .setDelayExecutor(taskRestartExecutor)
+                .setDelayExecutor(delayExecutor)
                 .setSchedulingStrategyFactory(schedulingStrategyFactory)
                 .setFailoverStrategyFactory(failoverStrategyFactory)
                 .setRestartBackoffTimeStrategy(testRestartBackoffTimeStrategy)
@@ -1302,6 +1411,77 @@ public class DefaultSchedulerTest extends TestLogger {
                 .setExecutionVertexVersioner(executionVertexVersioner)
                 .setExecutionSlotAllocatorFactory(executionSlotAllocatorFactory)
                 .build();
+    }
+
+    /**
+     * {@code ReorganizableManuallyTriggeredScheduledExecutor} can be used to re-organize scheduled
+     * tasks before actually triggering them. This can be used to test cases with race conditions in
+     * the delayed scheduler.
+     */
+    private static class ReorganizableManuallyTriggeredScheduledExecutor
+            extends ManuallyTriggeredScheduledExecutor {
+
+        private final List<ScheduledTask<?>> scheduledTasks = new ArrayList<>();
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            return schedule(
+                    () -> {
+                        command.run();
+                        return null;
+                    },
+                    delay,
+                    unit);
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            final ScheduledTask<V> scheduledTask =
+                    new ScheduledTask<>(callable, unit.convert(delay, TimeUnit.MILLISECONDS));
+            scheduledTasks.add(scheduledTask);
+            return scheduledTask;
+        }
+
+        /**
+         * Returns the collected {@link ScheduledTask ScheduledTasks}. This collection can be
+         * re-organized in-place.
+         *
+         * @return The list of scheduled tasks.
+         */
+        public List<ScheduledTask<?>> getCollectedScheduledTasks() {
+            return scheduledTasks;
+        }
+
+        /** Actually schedules the collected {@link ScheduledTask ScheduledTasks}. */
+        public void scheduleCollectedScheduledTasks() {
+            for (ScheduledTask<?> scheduledTask : scheduledTasks) {
+                super.schedule(
+                        scheduledTask.getCallable(),
+                        scheduledTask.getDelay(TimeUnit.MILLISECONDS),
+                        TimeUnit.MILLISECONDS);
+            }
+            scheduledTasks.clear();
+        }
+
+        /**
+         * Schedules all already collected tasks before actually triggering the actual scheduling of
+         * the next task in the queue.
+         */
+        @Override
+        public void triggerNonPeriodicScheduledTask() {
+            scheduleCollectedScheduledTasks();
+            super.triggerNonPeriodicScheduledTask();
+        }
+
+        /**
+         * Schedules all already collected tasks before actually triggering the actual scheduling of
+         * all tasks in the queue.
+         */
+        @Override
+        public void triggerNonPeriodicScheduledTasks() {
+            scheduleCollectedScheduledTasks();
+            super.triggerNonPeriodicScheduledTasks();
+        }
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntryExtractorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntryExtractorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -82,6 +83,7 @@ public class ExceptionHistoryEntryExtractorTest extends TestLogger {
                 Collections.emptyList());
     }
 
+    @Ignore // disabled due to FLINK-22276 workaround in ExceptionHistoryEntryExtractor
     @Test(expected = IllegalArgumentException.class)
     public void testRootExecutionVertexIdNotFailed() {
         final ExecutionVertex rootExecutionVertex = extractExecutionVertex(0);

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ScheduledTask.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ScheduledTask.java
@@ -112,4 +112,8 @@ public final class ScheduledTask<T> implements ScheduledFuture<T> {
             throws InterruptedException, ExecutionException, TimeoutException {
         return result.get(timeout, unit);
     }
+
+    public Callable<T> getCallable() {
+        return this.callable;
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This is just a temporary workaround to support the RC testing. The actual fix should be provided by [FLINK-22276](https://issues.apache.org/jira/browse/FLINK-22276) before releasing 1.13. See PR #15640 .


## Brief change log

It provides a fallback `RooExceptionHistoryEntry` if the failureInfo is not set anymore for the given `ExecutionVertex`.

## Verifying this change

* I added the slightly adapted `DefaultSchedulerTest.testExceptionHistoryConcurrentRestart` from PR #15640 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
