### PR TITLE
[FLINK-22327][python] Set bundleStarted to false even if it throws exception in finishBundle

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -313,8 +313,11 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
     @Override
     public void flush() throws Exception {
         if (bundleStarted) {
-            finishBundle();
-            bundleStarted = false;
+            try {
+                finishBundle();
+            } finally {
+                bundleStarted = false;
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request sets bundleStarted to false even if it throws exception in finishBundle. Otherwise, if it throws exceptions in finishBundle during job shutdown, NPE exception may happen if time-based finish bundle is scheduled. It caused the actual exception is not propagated.*


## Verifying this change

Test manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
