### PR TITLE
[FLINK-22307][network] Increase the default value of data writing cache size (not configurable) for sort-merge blocking shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -66,9 +66,9 @@ public class SortMergeResultPartition extends ResultPartition {
 
     /**
      * Number of expected buffer size to allocate for data writing. Currently, it is an empirical
-     * value (8M) which can not be configured.
+     * value (16M) which can not be configured.
      */
-    private static final int NUM_WRITE_BUFFER_BYTES = 8 * 1024 * 1024;
+    private static final int NUM_WRITE_BUFFER_BYTES = 16 * 1024 * 1024;
 
     private final Object lock = new Object();
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the data writing cache of sort-merge blocking shuffle is 8M, which can be not enough if data compression is enabled. This patch increases the cache size to 16M which can improve the performance for high compression ratio scenarios.

## Brief change log

  - Increase the data writing cache size of sort-merge blocking shuffle to 16M.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
