### PR TITLE
[FLINK-22305][network] Improve log messages of sort-merge blocking shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPool.java
@@ -135,11 +135,6 @@ public class BatchShuffleReadBufferPool {
 
     /** Initializes this buffer pool which allocates all the buffers. */
     public void initialize() {
-        LOG.info(
-                "Initializing batch shuffle IO buffer pool: numBuffers={}, bufferSize={}.",
-                numTotalBuffers,
-                bufferSize);
-
         synchronized (buffers) {
             checkState(!destroyed, "Buffer pool is already destroyed.");
 
@@ -175,6 +170,11 @@ public class BatchShuffleReadBufferPool {
                                 TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key()));
             }
         }
+
+        LOG.info(
+                "Batch shuffle IO buffer pool initialized: numBuffers={}, bufferSize={}.",
+                numTotalBuffers,
+                bufferSize);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFile.java
@@ -63,6 +63,15 @@ public class PartitionedFile {
     /** Path of the index file which stores all index entries in this {@link PartitionedFile}. */
     private final Path indexFilePath;
 
+    /** Size of the data file. */
+    private final long dataFileSize;
+
+    /** Size of the index file. */
+    private final long indexFileSize;
+
+    /** Total number of buffers in the data file. */
+    private final long numBuffers;
+
     /** Used to accelerate index data access. */
     @Nullable private final ByteBuffer indexEntryCache;
 
@@ -71,6 +80,9 @@ public class PartitionedFile {
             int numSubpartitions,
             Path dataFilePath,
             Path indexFilePath,
+            long dataFileSize,
+            long indexFileSize,
+            long numBuffers,
             @Nullable ByteBuffer indexEntryCache) {
         checkArgument(numRegions >= 0, "Illegal number of data regions.");
         checkArgument(numSubpartitions > 0, "Illegal number of subpartitions.");
@@ -79,6 +91,9 @@ public class PartitionedFile {
         this.numSubpartitions = numSubpartitions;
         this.dataFilePath = checkNotNull(dataFilePath);
         this.indexFilePath = checkNotNull(indexFilePath);
+        this.dataFileSize = dataFileSize;
+        this.indexFileSize = indexFileSize;
+        this.numBuffers = numBuffers;
         this.indexEntryCache = indexEntryCache;
     }
 
@@ -144,8 +159,14 @@ public class PartitionedFile {
                 + dataFilePath
                 + ", indexFilePath="
                 + indexFilePath
-                + ", indexDataCache="
-                + indexEntryCache
+                + ", dataFileSize="
+                + dataFileSize
+                + ", indexFileSize="
+                + indexFileSize
+                + ", numBuffers="
+                + numBuffers
+                + ", indexDataCached="
+                + (indexEntryCache != null)
                 + '}';
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -160,18 +160,12 @@ public class SortMergeResultPartition extends ResultPartition {
         }
 
         int numRequiredBuffer = bufferPool.getNumberOfRequiredMemorySegments();
-        String errorMessage =
-                String.format(
-                        "Too few sort buffers, please increase %s to a larger value (more than %d).",
-                        NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS,
-                        2 * expectedWriteBuffers);
-        if (numRequiredBuffer < 2 * expectedWriteBuffers) {
-            LOG.warn(errorMessage);
-        }
-
         int numWriteBuffers = Math.min(numRequiredBuffer / 2, expectedWriteBuffers);
         if (numWriteBuffers < 1) {
-            throw new IOException(errorMessage);
+            throw new IOException(
+                    String.format(
+                            "Too few sort buffers, please increase %s.",
+                            NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS));
         }
         numBuffersForSort = numRequiredBuffer - numWriteBuffers;
 
@@ -187,6 +181,12 @@ public class SortMergeResultPartition extends ResultPartition {
                 throw new IOException(exception);
             }
         }
+
+        LOG.info(
+                "Sort-merge partition {} initialized, num sort buffers: {}, num write buffers: {}.",
+                getPartitionId(),
+                numBuffersForSort,
+                numWriteBuffers);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Improve log messages of sort-merge blocking shuffle.


## Brief change log

  - Improve log messages of sort-merge blocking shuffle.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
