### PR TITLE
[FLINK-22329][hive] Inject current ugi credentials into jobconf when getting file split in hive connector

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -71,9 +72,10 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
             Integer configuredParallelism =
                     Configuration.fromMap(context.getCatalogTable().getOptions())
                             .get(FileSystemOptions.SINK_PARALLELISM);
+            JobConf jobConf = JobConfUtils.createJobConfWithCredentials(hiveConf);
             return new HiveTableSink(
                     context.getConfiguration(),
-                    new JobConf(hiveConf),
+                    jobConf,
                     context.getObjectIdentifier(),
                     context.getCatalogTable(),
                     configuredParallelism);
@@ -114,17 +116,18 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                                                     STREAMING_SOURCE_PARTITION_INCLUDE.key(),
                                                     STREAMING_SOURCE_PARTITION_INCLUDE
                                                             .defaultValue()));
+            JobConf jobConf = JobConfUtils.createJobConfWithCredentials(hiveConf);
             // hive table source that has not lookup ability
             if (isStreamingSource && includeAllPartition) {
                 return new HiveTableSource(
-                        new JobConf(hiveConf),
+                        jobConf,
                         context.getConfiguration(),
                         context.getObjectIdentifier().toObjectPath(),
                         catalogTable);
             } else {
                 // hive table source that has scan and lookup ability
                 return new HiveLookupTableSource(
-                        new JobConf(hiveConf),
+                        jobConf,
                         context.getConfiguration(),
                         context.getObjectIdentifier().toObjectPath(),
                         catalogTable);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.configuration.ReadableConfig;
@@ -506,5 +507,10 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 throw new UncheckedIOException(e);
             }
         }
+    }
+
+    @VisibleForTesting
+    public JobConf getJobConf() {
+        return jobConf;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -439,4 +439,9 @@ public class HiveTableSource
             }
         }
     }
+
+    @VisibleForTesting
+    public JobConf getJobConf() {
+        return jobConf;
+    }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
@@ -27,11 +27,16 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.filesystem.FileSystemLookupFunction;
 import org.apache.flink.util.ExceptionUtils;
 
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -47,6 +52,7 @@ import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOUR
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_PARTITION_ORDER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /** Unit tests for {@link HiveDynamicTableFactory}. */
@@ -230,6 +236,43 @@ public class HiveDynamicTableFactoryTest {
         }
     }
 
+    @Test
+    public void testJobConfWithCredentials() throws Exception {
+        final Text hdfsDelegationTokenKind = new Text("HDFS_DELEGATION_TOKEN");
+        final Text hdfsDelegationTokenService = new Text("ha-hdfs:hadoop-namespace");
+        Credentials credentials = new Credentials();
+        credentials.addToken(
+                hdfsDelegationTokenService,
+                new Token<>(
+                        new byte[4],
+                        new byte[4],
+                        hdfsDelegationTokenKind,
+                        hdfsDelegationTokenService));
+        UserGroupInformation.getCurrentUser().addCredentials(credentials);
+
+        // test table source's jobConf with credentials
+        tableEnv.executeSql(
+                String.format(
+                        "create table table10 (x int, y string, z int) partitioned by ("
+                                + " pt_year int, pt_mon string, pt_day string)"));
+        DynamicTableSource tableSource1 = getTableSource("table10");
+
+        HiveTableSource tableSource = (HiveTableSource) tableSource1;
+        Token token =
+                tableSource.getJobConf().getCredentials().getToken(hdfsDelegationTokenService);
+        assertNotNull(token);
+        assertEquals(hdfsDelegationTokenKind, token.getKind());
+        assertEquals(hdfsDelegationTokenService, token.getService());
+
+        // test table sink's jobConf with credentials
+        DynamicTableSink tableSink1 = getTableSink("table10");
+        HiveTableSink tableSink = (HiveTableSink) tableSink1;
+        token = tableSink.getJobConf().getCredentials().getToken(hdfsDelegationTokenService);
+        assertNotNull(token);
+        assertEquals(hdfsDelegationTokenKind, token.getKind());
+        assertEquals(hdfsDelegationTokenService, token.getService());
+    }
+
     private DynamicTableSource getTableSource(String tableName) throws Exception {
         TableEnvironmentInternal tableEnvInternal = (TableEnvironmentInternal) tableEnv;
         ObjectIdentifier tableIdentifier =
@@ -237,6 +280,21 @@ public class HiveDynamicTableFactoryTest {
         CatalogTable catalogTable =
                 (CatalogTable) hiveCatalog.getTable(tableIdentifier.toObjectPath());
         return FactoryUtil.createTableSource(
+                hiveCatalog,
+                tableIdentifier,
+                tableEnvInternal.getCatalogManager().resolveCatalogTable(catalogTable),
+                tableEnv.getConfig().getConfiguration(),
+                Thread.currentThread().getContextClassLoader(),
+                false);
+    }
+
+    private DynamicTableSink getTableSink(String tableName) throws Exception {
+        TableEnvironmentInternal tableEnvInternal = (TableEnvironmentInternal) tableEnv;
+        ObjectIdentifier tableIdentifier =
+                ObjectIdentifier.of(hiveCatalog.getName(), "default", tableName);
+        CatalogTable catalogTable =
+                (CatalogTable) hiveCatalog.getTable(tableIdentifier.toObjectPath());
+        return FactoryUtil.createTableSink(
                 hiveCatalog,
                 tableIdentifier,
                 tableEnvInternal.getCatalogManager().resolveCatalogTable(catalogTable),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
