### PR TITLE
[FLINK-22233][Table SQL / API]Modified the spelling error of word "constant" in source code

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -955,7 +955,7 @@ public class SqlToOperationConverter {
         if (constraint.isEnforced()) {
             throw new ValidationException(
                     "Flink doesn't support ENFORCED mode for "
-                            + "PRIMARY KEY constaint. ENFORCED/NOT ENFORCED  controls if the constraint "
+                            + "PRIMARY KEY constraint. ENFORCED/NOT ENFORCED  controls if the constraint "
                             + "checks are performed on the incoming/outgoing data. "
                             + "Flink does not own the data therefore the only supported mode "
                             + "is the NOT ENFORCED mode");

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -473,7 +473,7 @@ public class SqlToOperationConverterTest {
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
                 "Flink doesn't support ENFORCED mode for PRIMARY KEY "
-                        + "constaint. ENFORCED/NOT ENFORCED  controls if the constraint "
+                        + "constraint. ENFORCED/NOT ENFORCED  controls if the constraint "
                         + "checks are performed on the incoming/outgoing data. "
                         + "Flink does not own the data therefore the only supported mode is the NOT ENFORCED mode");
         parse(sql, planner, parser);
@@ -1230,7 +1230,7 @@ public class SqlToOperationConverterTest {
         // Test alter table add enforced
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
-                "Flink doesn't support ENFORCED mode for PRIMARY KEY constaint. "
+                "Flink doesn't support ENFORCED mode for PRIMARY KEY constraint. "
                         + "ENFORCED/NOT ENFORCED  controls if the constraint checks are performed on the "
                         + "incoming/outgoing data. Flink does not own the data therefore the "
                         + "only supported mode is the NOT ENFORCED mode");


### PR DESCRIPTION
## What is the purpose of the change

Modified the spelling error of word "constant" in source code.   As described in FLINK-22233.


## Brief change log

  - The description about ValidationException message in method org.apache.flink.table.planner.operations.SqlToOperationConverter#validateTableConstraint, change constaint to constraint.
  - The description about ValidationException message in method org.apache.flink.table.planner.operations.SqlToOperationConverterTest#testCreateTableWithPrimaryKeyEnforced, change constaint to constraint.
  - The description about ValidationException message in method org.apache.flink.table.planner.operations.SqlToOperationConverterTest#testAlterTableAddPkConstraintEnforced, change constaint to constraint.
  


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
