### PR TITLE
[FLINK-22339][python] Fix some encoding exceptions were not thrown in cython coders

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -74,14 +74,14 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
 
     cpdef bytes encode_nested(self, value)
     # encode data to output_stream
-    cdef void _encode_one_row_to_buffer(self, value, unsigned char row_kind_value)
-    cdef void _encode_one_row(self, value, LengthPrefixOutputStream output_stream)
-    cdef void _encode_one_row_with_row_kind(self, value, LengthPrefixOutputStream output_stream,
+    cdef _encode_one_row_to_buffer(self, value, unsigned char row_kind_value)
+    cdef _encode_one_row(self, value, LengthPrefixOutputStream output_stream)
+    cdef _encode_one_row_with_row_kind(self, value, LengthPrefixOutputStream output_stream,
                                             unsigned char row_kind_value)
-    cdef void _encode_field(self, CoderType coder_type, TypeName field_type, FieldCoder field_coder,
+    cdef _encode_field(self, CoderType coder_type, TypeName field_type, FieldCoder field_coder,
                             item)
-    cdef void _encode_field_simple(self, TypeName field_type, item)
-    cdef void _encode_field_complex(self, TypeName field_type, FieldCoder field_coder, item)
+    cdef _encode_field_simple(self, TypeName field_type, item)
+    cdef _encode_field_complex(self, TypeName field_type, FieldCoder field_coder, item)
     cdef void _extend(self, size_t missing)
     cdef void _encode_byte(self, unsigned char val)
     cdef void _encode_smallint(self, libc.stdint.int16_t v)
@@ -109,8 +109,8 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
 cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
     cdef bint _is_row_data
     cdef bint _is_first_row
-    cdef void _encode_list_value(self, list list_value, LengthPrefixOutputStream output_stream)
-    cdef void _encode_internal_row(self, InternalRow row, LengthPrefixOutputStream output_stream)
+    cdef _encode_list_value(self, list list_value, LengthPrefixOutputStream output_stream)
+    cdef _encode_internal_row(self, InternalRow row, LengthPrefixOutputStream output_stream)
 
 cdef class TableFunctionRowCoderImpl(FlattenRowCoderImpl):
     cdef char* _end_message

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -108,7 +108,7 @@ cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
             result.append(self.row[:])
         return result
 
-    cdef void _encode_list_value(self, list results, LengthPrefixOutputStream output_stream):
+    cdef _encode_list_value(self, list results, LengthPrefixOutputStream output_stream):
         cdef list result
         cdef InternalRow value
         if self._is_first_row and results:
@@ -122,7 +122,7 @@ cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
                 for value in result:
                     self._encode_internal_row(value, output_stream)
 
-    cdef void _encode_internal_row(self, InternalRow row, LengthPrefixOutputStream output_stream):
+    cdef _encode_internal_row(self, InternalRow row, LengthPrefixOutputStream output_stream):
         self._encode_one_row_to_buffer(row.values, row.row_kind)
         output_stream.write(self._tmp_output_data, self._tmp_output_pos)
         self._tmp_output_pos = 0
@@ -249,7 +249,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
             self._field_type[i] = self._field_coders[i].type_name()
             self._field_coder_type[i] = self._field_coders[i].coder_type()
 
-    cdef void _encode_one_row_to_buffer(self, value, unsigned char row_kind_value):
+    cdef _encode_one_row_to_buffer(self, value, unsigned char row_kind_value):
         cdef size_t i
         self._write_mask(
             value,
@@ -272,10 +272,10 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
         self._tmp_output_pos = 0
         return self._tmp_output_data[:pos]
 
-    cdef void _encode_one_row(self, value, LengthPrefixOutputStream output_stream):
+    cdef _encode_one_row(self, value, LengthPrefixOutputStream output_stream):
         self._encode_one_row_with_row_kind(value, output_stream, 0)
 
-    cdef void _encode_one_row_with_row_kind(
+    cdef _encode_one_row_with_row_kind(
             self, value, LengthPrefixOutputStream output_stream, unsigned char row_kind_value):
         self._encode_one_row_to_buffer(value, row_kind_value)
         output_stream.write(self._tmp_output_data, self._tmp_output_pos)
@@ -531,14 +531,14 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
         self._input_pos += size
         return self._input_data[self._input_pos - size: self._input_pos]
 
-    cdef void _encode_field(self, CoderType coder_type, TypeName field_type, FieldCoder field_coder,
+    cdef _encode_field(self, CoderType coder_type, TypeName field_type, FieldCoder field_coder,
                             item):
         if coder_type == SIMPLE:
             self._encode_field_simple(field_type, item)
         else:
             self._encode_field_complex(field_type, field_coder, item)
 
-    cdef void _encode_field_simple(self, TypeName field_type, item):
+    cdef _encode_field_simple(self, TypeName field_type, item):
         cdef libc.stdint.int32_t hour, minute, seconds, microsecond, milliseconds
         cdef bytes item_bytes
         if field_type == TINYINT:
@@ -590,7 +590,7 @@ cdef class FlattenRowCoderImpl(BaseCoderImpl):
             item_bytes = str(item).encode('utf-8')
             self._encode_bytes(item_bytes, len(item_bytes))
 
-    cdef void _encode_field_complex(self, TypeName field_type, FieldCoder field_coder, item):
+    cdef _encode_field_complex(self, TypeName field_type, FieldCoder field_coder, item):
         cdef libc.stdint.int32_t nanoseconds, microseconds_of_second, length, row_field_count
         cdef libc.stdint.int32_t leading_complete_bytes_num, remaining_bits_num
         cdef libc.stdint.int64_t timestamp_milliseconds, timestamp_seconds

--- a/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_fast_coders.py
@@ -243,6 +243,18 @@ class CodersTest(PyFlinkTestCase):
         window = CountWindow(100)
         self.assertEqual(fast_coder.encode_nested(window), slow_coder.encode_nested(window))
 
+    def test_cython_coder_with_wrong_result_type(self):
+        from apache_beam.coders.coder_impl import create_OutputStream
+        from pyflink.fn_execution.beam.beam_stream import BeamOutputStream
+        data = ['1']
+        cython_field_coders = [coder_impl_fast.BigIntCoderImpl() for _ in range(len(data))]
+        cy_flatten_row_coder = coder_impl_fast.FlattenRowCoderImpl(cython_field_coders)
+        beam_output_stream = create_OutputStream()
+        output_stream = BeamOutputStream(beam_output_stream)
+        with self.assertRaises(TypeError) as context:
+            cy_flatten_row_coder.encode_to_stream(data, output_stream)
+        self.assertIn('an integer is required', str(context.exception))
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix some encoding exceptions were not thrown in cython coders*


## Brief change log

  - *remove the return type `void` of some encode_\* methods  so that Python Exceptions will be thrown*


## Verifying this change

This change added tests and can be verified as follows:

  - *UT `test_cython_coder_with_wrong_result_type` in `test_fast_coders.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
