### PR TITLE
 Reduce the delete file api when the checkpoint is completed. [FLINK-…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -147,6 +147,13 @@ public class CheckpointingOptions {
 			.withDescription("The minimum size of state data files. All state chunks smaller than that are stored" +
 				" inline in the root checkpoint metadata file. The max memory threshold for this configuration is 1MB.");
 
+	/** Flag Whether to enable recursively deletion. If true, can reduce delete api call in the full checkpoint scenario */
+	public static final ConfigOption<Boolean> ENABLE_DELETE_RECURSIVELY = ConfigOptions
+		.key("completed.checkpoint.delete.recursive")
+		.defaultValue(true)
+		.withDescription("Flag Whether to enable recursive deletes. If true, can reduce delete api call when cleaning up the last completed checkpoint."
+			+ "If file system does not support recursive delete API, can turn off this feature, like s3 etc.");
+
 	/**
 	 * The default size of the write buffer for the checkpoint streams that write to file systems.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -197,6 +197,18 @@ public class CheckpointCoordinator {
 	/** Registry that tracks state which is shared across (incremental) checkpoints. */
 	private SharedStateRegistry sharedStateRegistry;
 
+	/** Flag Whether to enable recursively deletion. If true, can reduce delete api call in CompletedCheckpoint.doDiscard */
+	private boolean enableDeleteRecursive;
+
+	// Getter and Setter
+	public boolean getEnableDeleteRecursive() {
+		return enableDeleteRecursive;
+	}
+
+	public void setEnableDeleteRecursive(boolean enableDeleteRecursive) {
+		this.enableDeleteRecursive = enableDeleteRecursive;
+	}
+
 	private boolean isPreferCheckpointForRecovery;
 
 	private final CheckpointFailureManager failureManager;
@@ -1077,6 +1089,7 @@ public class CheckpointCoordinator {
 		try {
 			try {
 				completedCheckpoint = pendingCheckpoint.finalizeCheckpoint(checkpointsCleaner, this::scheduleTriggerRequest, executor);
+				completedCheckpoint.setEnableDeleteRecursive(enableDeleteRecursive);
 				failureManager.handleCheckpointSuccess(pendingCheckpoint.getCheckpointId());
 			}
 			catch (Exception e1) {
@@ -1475,6 +1488,7 @@ public class CheckpointCoordinator {
 		// Load the savepoint as a checkpoint into the system
 		CompletedCheckpoint savepoint = Checkpoints.loadAndValidateCheckpoint(
 				job, tasks, checkpointLocation, userClassLoader, allowNonRestored);
+		savepoint.setEnableDeleteRecursive(enableDeleteRecursive);
 
 		completedCheckpointStore.addCheckpoint(savepoint, checkpointsCleaner, this::scheduleTriggerRequest);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -38,8 +40,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -107,6 +111,17 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
 	/** Optional stats tracker callback for discard. */
 	@Nullable
 	private transient volatile CompletedCheckpointStats.DiscardCallback discardCallback;
+
+	private boolean enableDeleteRecursive;
+
+	//Getter and Setter
+	public boolean getEnableDeleteRecursive() {
+		return enableDeleteRecursive;
+	}
+
+	public void setEnableDeleteRecursive(boolean enableDeleteRecursive) {
+		this.enableDeleteRecursive = enableDeleteRecursive;
+	}
 
 	// ------------------------------------------------------------------------
 
@@ -253,14 +268,14 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
 
 			// discard private state objects
 			try {
-				StateUtil.bestEffortDiscardAllStateObjects(operatorStates.values());
+				StateUtil.bestEffortDiscardAllStateObjects(enableDeleteRecursive ? getIncrementKeyedStates() : operatorStates.values());
 			} catch (Exception e) {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
 			}
 
 			// discard location as a whole
 			try {
-				storageLocation.disposeStorageLocation();
+				storageLocation.disposeStorageLocation(enableDeleteRecursive);
 			}
 			catch (Exception e) {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
@@ -289,6 +304,33 @@ public class CompletedCheckpoint implements Serializable, Checkpoint {
 			jobStatus == JobStatus.CANCELED && props.discardOnJobCancelled() ||
 			jobStatus == JobStatus.FAILED && props.discardOnJobFailed() ||
 			jobStatus == JobStatus.SUSPENDED && props.discardOnJobSuspended();
+	}
+
+	private Set<KeyedStateHandle> getIncrementKeyedStates() {
+		Set<KeyedStateHandle> incrementKeyedState = new HashSet<>(16);
+
+		//reference SavepointV2Serializer.serializeKeyedStateHandle
+		operatorStates.values().forEach(operatorState -> {
+			operatorState.getStates().forEach(operatorSubtaskState -> {
+				if (operatorSubtaskState != null) {
+					for (KeyedStateHandle managedKeyedState : operatorSubtaskState.getManagedKeyedState()) {
+						if (managedKeyedState instanceof IncrementalRemoteKeyedStateHandle) {
+							incrementKeyedState.add(managedKeyedState);
+						}
+					}
+				}
+
+				if (operatorSubtaskState != null) {
+					for (KeyedStateHandle rawKeyedState : operatorSubtaskState.getRawKeyedState()) {
+						if (rawKeyedState instanceof IncrementalRemoteKeyedStateHandle) {
+							incrementKeyedState.add(rawKeyedState);
+						}
+					}
+				}
+			});
+		});
+
+		return incrementKeyedState;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -353,7 +353,8 @@ public class ExecutionGraphBuilder {
 				checkpointIdCounter,
 				completedCheckpoints,
 				rootBackend,
-				checkpointStatsTracker);
+				checkpointStatsTracker,
+				jobManagerConfig.getBoolean(CheckpointingOptions.ENABLE_DELETE_RECURSIVELY));
 		}
 
 		// create all the metrics for the Execution Graph

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompletedCheckpointStorageLocation.java
@@ -45,4 +45,14 @@ public interface CompletedCheckpointStorageLocation extends java.io.Serializable
 	 * like the checkpoint directory.
 	 */
 	void disposeStorageLocation() throws IOException;
+
+	/**
+	 * Disposes the storage location. This method should be called after all state objects have
+	 * been released. It typically disposes the base structure of the checkpoint storage,
+	 * like the checkpoint directory.
+	 *
+	 * @param recursive Flag Whether to enable recursively deletion. According to the value of 'apus.checkpoint.delete.recursive'
+	 * @throws IOException
+	 */
+	void disposeStorageLocation(boolean recursive) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCompletedCheckpointStorageLocation.java
@@ -68,9 +68,14 @@ public class FsCompletedCheckpointStorageLocation implements CompletedCheckpoint
 
 	@Override
 	public void disposeStorageLocation() throws IOException {
+		disposeStorageLocation(false);
+	}
+
+	@Override
+	public void disposeStorageLocation(boolean recursive) throws IOException {
 		if (fs == null) {
 			fs = exclusiveCheckpointDir.getFileSystem();
 		}
-		fs.delete(exclusiveCheckpointDir, false);
+		fs.delete(exclusiveCheckpointDir, recursive);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/NonPersistentMetadataCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/NonPersistentMetadataCheckpointStorageLocation.java
@@ -86,6 +86,11 @@ public class NonPersistentMetadataCheckpointStorageLocation
 
 		@Override
 		public void disposeStorageLocation() {}
+
+		@Override
+		public void disposeStorageLocation(boolean recursive) throws IOException {
+			
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -2190,5 +2190,10 @@ public class JobMasterTest extends TestLogger {
 		public void disposeStorageLocation() throws IOException {
 
 		}
+
+		@Override
+		public void disposeStorageLocation(boolean recursive) throws IOException {
+			
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/TestCompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/testutils/TestCompletedCheckpointStorageLocation.java
@@ -63,4 +63,9 @@ public class TestCompletedCheckpointStorageLocation implements CompletedCheckpoi
 	public void disposeStorageLocation() throws IOException {
 		disposed = true;
 	}
+
+	@Override
+	public void disposeStorageLocation(boolean recursive) throws IOException {
+		disposed = true;
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Reduce the delete file api when the checkpoint is completed*


## Brief change log

  - *In full checkpoint, to delete the snapshot(chk-) folder directly*
  - *In incremental checkpoint, unregister the shared state first, and then dropping the exclusive location as a whole.*

## Verifying this change

This change added tests and can be verified as follows:

  - *refator CompletedCheckpoint.doDiscard, add private method  getIncrementKeyedStates to get increment key*
  - *add method void disposeStorageLocation(boolean recursive) throws IOException  in  CompletedCheckpointStorageLocation*
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

