### PR TITLE
[FLINK-21174][coordination] Optimize the performance of DefaultResourceAllocationStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategy.java
@@ -19,16 +19,15 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.slots.ResourceRequirement;
-import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerUtils.getEffectiveResourceProfile;
@@ -48,8 +47,9 @@ import static org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerUt
  * exist.
  *
  * <p>Note: The current implementation of this strategy is non-optimal, in terms of computation
- * efficiency. In the worst case, for each requirement it checks all registered and pending
- * resources. TODO: This will be optimized in FLINK-21174.
+ * efficiency. In the worst case, for each distinctly profiled requirement it checks all registered
+ * and pending resources. Further optimization requires complex data structures for ordering
+ * multi-dimensional resource profiles. The complexity is not necessary.
  */
 public class DefaultResourceAllocationStrategy implements ResourceAllocationStrategy {
     private final ResourceProfile defaultSlotResourceProfile;
@@ -71,24 +71,18 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
             TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
         final ResourceAllocationResult.Builder resultBuilder = ResourceAllocationResult.builder();
 
-        // Tuples of available and default slot resource for registered task managers, indexed by
-        // instanceId
-        final Map<InstanceID, Tuple2<ResourceProfile, ResourceProfile>> registeredResources =
-                getRegisteredResources(taskManagerResourceInfoProvider);
-        // Available resources of pending task managers, indexed by the pendingTaskManagerId
-        final Map<PendingTaskManagerId, ResourceProfile> pendingResources =
-                getPendingResources(taskManagerResourceInfoProvider);
+        final List<InternalResourceInfo> registeredResources =
+                getRegisteredResources(taskManagerResourceInfoProvider, resultBuilder);
+        final List<InternalResourceInfo> pendingResources =
+                getPendingResources(taskManagerResourceInfoProvider, resultBuilder);
 
         for (Map.Entry<JobID, Collection<ResourceRequirement>> resourceRequirements :
                 missingResources.entrySet()) {
             final JobID jobId = resourceRequirements.getKey();
 
-            final ResourceCounter unfulfilledJobRequirements =
-                    tryFulfillRequirementsForJobWithRegisteredResources(
-                            jobId,
-                            resourceRequirements.getValue(),
-                            registeredResources,
-                            resultBuilder);
+            final Collection<ResourceRequirement> unfulfilledJobRequirements =
+                    tryFulfillRequirementsForJobWithResources(
+                            jobId, resourceRequirements.getValue(), registeredResources);
 
             if (!unfulfilledJobRequirements.isEmpty()) {
                 tryFulfillRequirementsForJobWithPendingResources(
@@ -98,88 +92,80 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
         return resultBuilder.build();
     }
 
-    private static Map<InstanceID, Tuple2<ResourceProfile, ResourceProfile>> getRegisteredResources(
-            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
+    private static List<InternalResourceInfo> getRegisteredResources(
+            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider,
+            ResourceAllocationResult.Builder resultBuilder) {
         return taskManagerResourceInfoProvider.getRegisteredTaskManagers().stream()
-                .collect(
-                        Collectors.toMap(
-                                TaskManagerInfo::getInstanceId,
-                                taskManager ->
-                                        Tuple2.of(
-                                                taskManager.getAvailableResource(),
-                                                taskManager.getDefaultSlotResourceProfile())));
+                .map(
+                        taskManager ->
+                                new InternalResourceInfo(
+                                        taskManager.getDefaultSlotResourceProfile(),
+                                        taskManager.getAvailableResource(),
+                                        (jobId, slotProfile) ->
+                                                resultBuilder.addAllocationOnRegisteredResource(
+                                                        jobId,
+                                                        taskManager.getInstanceId(),
+                                                        slotProfile)))
+                .collect(Collectors.toList());
     }
 
-    private static Map<PendingTaskManagerId, ResourceProfile> getPendingResources(
-            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
+    private static List<InternalResourceInfo> getPendingResources(
+            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider,
+            ResourceAllocationResult.Builder resultBuilder) {
         return taskManagerResourceInfoProvider.getPendingTaskManagers().stream()
-                .collect(
-                        Collectors.toMap(
-                                PendingTaskManager::getPendingTaskManagerId,
-                                PendingTaskManager::getTotalResourceProfile));
+                .map(
+                        pendingTaskManager ->
+                                new InternalResourceInfo(
+                                        pendingTaskManager.getDefaultSlotResourceProfile(),
+                                        pendingTaskManager.getTotalResourceProfile(),
+                                        (jobId, slotProfile) ->
+                                                resultBuilder.addAllocationOnPendingResource(
+                                                        jobId,
+                                                        pendingTaskManager
+                                                                .getPendingTaskManagerId(),
+                                                        slotProfile)))
+                .collect(Collectors.toList());
     }
 
-    private static ResourceCounter tryFulfillRequirementsForJobWithRegisteredResources(
-            JobID jobId,
-            Collection<ResourceRequirement> missingResources,
-            Map<InstanceID, Tuple2<ResourceProfile, ResourceProfile>> registeredResources,
-            ResourceAllocationResult.Builder resultBuilder) {
-        ResourceCounter outstandingRequirements = ResourceCounter.empty();
-
-        for (ResourceRequirement resourceRequirement : missingResources) {
-            int numMissingRequirements =
-                    tryFindSlotsForRequirement(
-                            jobId, resourceRequirement, registeredResources, resultBuilder);
-            if (numMissingRequirements > 0) {
-                outstandingRequirements =
-                        outstandingRequirements.add(
-                                resourceRequirement.getResourceProfile(), numMissingRequirements);
+    private static int tryFulfilledRequirementWithResource(
+            List<InternalResourceInfo> internalResource,
+            int numUnfulfilled,
+            ResourceProfile requiredResource,
+            JobID jobId) {
+        final Iterator<InternalResourceInfo> internalResourceInfoItr = internalResource.iterator();
+        while (numUnfulfilled > 0 && internalResourceInfoItr.hasNext()) {
+            final InternalResourceInfo currentTaskManager = internalResourceInfoItr.next();
+            while (numUnfulfilled > 0
+                    && currentTaskManager.tryAllocateSlotForJob(jobId, requiredResource)) {
+                numUnfulfilled--;
             }
-        }
-        return outstandingRequirements;
-    }
-
-    private static int tryFindSlotsForRequirement(
-            JobID jobId,
-            ResourceRequirement resourceRequirement,
-            Map<InstanceID, Tuple2<ResourceProfile, ResourceProfile>> registeredResources,
-            ResourceAllocationResult.Builder resultBuilder) {
-        final ResourceProfile requiredResource = resourceRequirement.getResourceProfile();
-
-        int numUnfulfilled = resourceRequirement.getNumberOfRequiredSlots();
-        while (numUnfulfilled > 0) {
-            final Optional<InstanceID> matchedTaskManager =
-                    findMatchingTaskManager(requiredResource, registeredResources);
-
-            if (!matchedTaskManager.isPresent()) {
-                // exit loop early; we won't find a matching slot for this requirement
-                break;
+            if (currentTaskManager.availableProfile.equals(ResourceProfile.ZERO)) {
+                internalResourceInfoItr.remove();
             }
-
-            final ResourceProfile effectiveProfile =
-                    getEffectiveResourceProfile(
-                            requiredResource, registeredResources.get(matchedTaskManager.get()).f1);
-            resultBuilder.addAllocationOnRegisteredResource(
-                    jobId, matchedTaskManager.get(), effectiveProfile);
-            deductionRegisteredResource(
-                    registeredResources, matchedTaskManager.get(), effectiveProfile);
-            numUnfulfilled--;
         }
         return numUnfulfilled;
     }
 
-    private static Optional<InstanceID> findMatchingTaskManager(
-            ResourceProfile requirement,
-            Map<InstanceID, Tuple2<ResourceProfile, ResourceProfile>> registeredResources) {
-        return registeredResources.entrySet().stream()
-                .filter(
-                        taskManager ->
-                                canFulfillRequirement(
-                                        getEffectiveResourceProfile(
-                                                requirement, taskManager.getValue().f1),
-                                        taskManager.getValue().f0))
-                .findAny()
-                .map(Map.Entry::getKey);
+    private static Collection<ResourceRequirement> tryFulfillRequirementsForJobWithResources(
+            JobID jobId,
+            Collection<ResourceRequirement> missingResources,
+            List<InternalResourceInfo> registeredResources) {
+        Collection<ResourceRequirement> outstandingRequirements = new ArrayList<>();
+
+        for (ResourceRequirement resourceRequirement : missingResources) {
+            int numMissingRequirements =
+                    tryFulfilledRequirementWithResource(
+                            registeredResources,
+                            resourceRequirement.getNumberOfRequiredSlots(),
+                            resourceRequirement.getResourceProfile(),
+                            jobId);
+            if (numMissingRequirements > 0) {
+                outstandingRequirements.add(
+                        ResourceRequirement.create(
+                                resourceRequirement.getResourceProfile(), numMissingRequirements));
+            }
+        }
+        return outstandingRequirements;
     }
 
     private static boolean canFulfillRequirement(
@@ -187,71 +173,80 @@ public class DefaultResourceAllocationStrategy implements ResourceAllocationStra
         return resourceProfile.allFieldsNoLessThan(requirement);
     }
 
-    private static void deductionRegisteredResource(
-            Map<InstanceID, Tuple2<ResourceProfile, ResourceProfile>> registeredResources,
-            InstanceID instanceId,
-            ResourceProfile resourceProfile) {
-        registeredResources.compute(
-                instanceId,
-                (id, tuple2) -> {
-                    Preconditions.checkNotNull(tuple2);
-                    if (tuple2.f0.subtract(resourceProfile).equals(ResourceProfile.ZERO)) {
-                        return null;
-                    } else {
-                        return Tuple2.of(tuple2.f0.subtract(resourceProfile), tuple2.f1);
-                    }
-                });
-    }
-
-    private static Optional<PendingTaskManagerId> findPendingManagerToFulfill(
-            ResourceProfile resourceProfile,
-            Map<PendingTaskManagerId, ResourceProfile> availableResources) {
-        return availableResources.entrySet().stream()
-                .filter(entry -> entry.getValue().allFieldsNoLessThan(resourceProfile))
-                .findAny()
-                .map(Map.Entry::getKey);
-    }
-
     private void tryFulfillRequirementsForJobWithPendingResources(
             JobID jobId,
-            ResourceCounter unfulfilledRequirements,
-            Map<PendingTaskManagerId, ResourceProfile> availableResources,
+            Collection<ResourceRequirement> unfulfilledRequirements,
+            List<InternalResourceInfo> availableResources,
             ResourceAllocationResult.Builder resultBuilder) {
-        for (Map.Entry<ResourceProfile, Integer> missingResource :
-                unfulfilledRequirements.getResourcesWithCount()) {
+        final Collection<ResourceRequirement> missingResources =
+                tryFulfillRequirementsForJobWithResources(
+                        jobId, unfulfilledRequirements, availableResources);
+        for (ResourceRequirement missingResource : missingResources) {
             // for this strategy, all pending resources should have the same default slot resource
             final ResourceProfile effectiveProfile =
                     getEffectiveResourceProfile(
-                            missingResource.getKey(), defaultSlotResourceProfile);
-            for (int i = 0; i < missingResource.getValue(); i++) {
-                Optional<PendingTaskManagerId> matchedPendingTaskManager =
-                        findPendingManagerToFulfill(effectiveProfile, availableResources);
-                if (matchedPendingTaskManager.isPresent()) {
-                    availableResources.compute(
-                            matchedPendingTaskManager.get(),
-                            ((pendingTaskManagerId, resourceProfile) ->
-                                    Preconditions.checkNotNull(resourceProfile)
-                                            .subtract(effectiveProfile)));
+                            missingResource.getResourceProfile(), defaultSlotResourceProfile);
+            int numUnfulfilled = missingResource.getNumberOfRequiredSlots();
+
+            if (!totalResourceProfile.allFieldsNoLessThan(effectiveProfile)) {
+                // Can not fulfill this resource type will the default worker.
+                resultBuilder.addUnfulfillableJob(jobId);
+                continue;
+            }
+
+            while (numUnfulfilled > 0) {
+                // Circularly add new pending task manager
+                final PendingTaskManager newPendingTaskManager =
+                        new PendingTaskManager(totalResourceProfile, numSlotsPerWorker);
+                resultBuilder.addPendingTaskManagerAllocate(newPendingTaskManager);
+                ResourceProfile remainResource = totalResourceProfile;
+                while (numUnfulfilled > 0
+                        && canFulfillRequirement(effectiveProfile, remainResource)) {
+                    numUnfulfilled--;
                     resultBuilder.addAllocationOnPendingResource(
-                            jobId, matchedPendingTaskManager.get(), effectiveProfile);
-                } else {
-                    if (totalResourceProfile.allFieldsNoLessThan(effectiveProfile)) {
-                        // Add new pending task manager
-                        final PendingTaskManager pendingTaskManager =
-                                new PendingTaskManager(totalResourceProfile, numSlotsPerWorker);
-                        resultBuilder.addPendingTaskManagerAllocate(pendingTaskManager);
-                        resultBuilder.addAllocationOnPendingResource(
-                                jobId,
-                                pendingTaskManager.getPendingTaskManagerId(),
-                                effectiveProfile);
-                        availableResources.put(
-                                pendingTaskManager.getPendingTaskManagerId(),
-                                totalResourceProfile.subtract(effectiveProfile));
-                    } else {
-                        resultBuilder.addUnfulfillableJob(jobId);
-                        break;
-                    }
+                            jobId,
+                            newPendingTaskManager.getPendingTaskManagerId(),
+                            effectiveProfile);
+                    remainResource = remainResource.subtract(effectiveProfile);
                 }
+                if (!remainResource.equals(ResourceProfile.ZERO)) {
+                    availableResources.add(
+                            new InternalResourceInfo(
+                                    defaultSlotResourceProfile,
+                                    remainResource,
+                                    (jobID, slotProfile) ->
+                                            resultBuilder.addAllocationOnPendingResource(
+                                                    jobID,
+                                                    newPendingTaskManager.getPendingTaskManagerId(),
+                                                    slotProfile)));
+                }
+            }
+        }
+    }
+
+    private static class InternalResourceInfo {
+        private final ResourceProfile defaultSlotProfile;
+        private final BiConsumer<JobID, ResourceProfile> allocationConsumer;
+        private ResourceProfile availableProfile;
+
+        InternalResourceInfo(
+                ResourceProfile defaultSlotProfile,
+                ResourceProfile availableProfile,
+                BiConsumer<JobID, ResourceProfile> allocationConsumer) {
+            this.defaultSlotProfile = defaultSlotProfile;
+            this.availableProfile = availableProfile;
+            this.allocationConsumer = allocationConsumer;
+        }
+
+        boolean tryAllocateSlotForJob(JobID jobId, ResourceProfile requirement) {
+            final ResourceProfile effectiveProfile =
+                    getEffectiveResourceProfile(requirement, defaultSlotProfile);
+            if (availableProfile.allFieldsNoLessThan(effectiveProfile)) {
+                availableProfile = availableProfile.subtract(effectiveProfile);
+                allocationConsumer.accept(jobId, effectiveProfile);
+                return true;
+            } else {
+                return false;
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerResourceInfoProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingTaskManagerResourceInfoProvider.java
@@ -158,7 +158,7 @@ public class TestingTaskManagerResourceInfoProvider implements TaskManagerResour
             return this;
         }
 
-        public Builder setgetPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction(
+        public Builder setGetPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction(
                 BiFunction<ResourceProfile, ResourceProfile, Collection<PendingTaskManager>>
                         getPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction) {
             this.getPendingTaskManagersByTotalAndDefaultSlotResourceProfileFunction =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
