### PR TITLE
[FLINK-22352][mesos] Deprecates Mesos support

### DIFF
--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -218,6 +218,11 @@ The options in this section are necessary for setups where Flink itself actively
 
 ### Mesos
 
+{{< hint warning >}}
+Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the future (see 
+[FLINK-22352](https://issues.apache.org/jira/browse/FLINK-22352) for further details).
+{{< /hint >}}
+
 {{< generated/mesos_configuration >}}
 
 **Mesos TaskManager**

--- a/docs/content.zh/docs/deployment/resource-providers/mesos.md
+++ b/docs/content.zh/docs/deployment/resource-providers/mesos.md
@@ -27,6 +27,11 @@ under the License.
 
 # Flink on Mesos
 
+{{< hint warning >}}
+Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the future (see 
+[FLINK-22352](https://issues.apache.org/jira/browse/FLINK-22352) for further details).
+{{< /hint >}}
+
 ## Getting Started
 
 This *Getting Started* section guides you through setting up a fully functional Flink Cluster on Mesos.

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -219,6 +219,11 @@ The options in this section are necessary for setups where Flink itself actively
 
 ### Mesos
 
+{{< hint warning >}}
+Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the future (see 
+[FLINK-22352](https://issues.apache.org/jira/browse/FLINK-22352) for further details).
+{{< /hint >}}
+
 {{< generated/mesos_configuration >}}
 
 **Mesos TaskManager**

--- a/docs/content/docs/deployment/resource-providers/mesos.md
+++ b/docs/content/docs/deployment/resource-providers/mesos.md
@@ -27,6 +27,11 @@ under the License.
 
 # Flink on Mesos
 
+{{< hint warning >}}
+Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the future (see 
+[FLINK-22352](https://issues.apache.org/jira/browse/FLINK-22352) for further details).
+{{< /hint >}}
+
 ## Getting Started
 
 This *Getting Started* section guides you through setting up a fully functional Flink Cluster on Mesos.

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
@@ -24,7 +24,13 @@ import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
-/** The set of configuration options relating to mesos settings. */
+/**
+ * The set of configuration options relating to mesos settings.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosOptions {
 
     /**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -40,7 +40,13 @@ import org.apache.flink.runtime.util.SignalHandler;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-/** Entry point for Mesos per-job clusters. */
+/**
+ * Entry point for Mesos per-job clusters.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 
     private MesosConfiguration schedulerConfiguration;
@@ -96,6 +102,9 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
                 LOG, MesosJobClusterEntrypoint.class.getSimpleName(), args);
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
+
+        LOG.warn(
+                "Mesos support was deprecated in Flink 1.13 and is subject to removal in the future (see FLINK-22352 for further details).");
 
         // load configuration incl. dynamic properties
         Configuration dynamicProperties =

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -38,7 +38,13 @@ import org.apache.flink.runtime.util.SignalHandler;
 
 import java.util.concurrent.CompletableFuture;
 
-/** Entry point for Mesos session clusters. */
+/**
+ * Entry point for Mesos session clusters.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
     private MesosConfiguration mesosConfig;
@@ -90,6 +96,9 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
                 LOG, MesosSessionClusterEntrypoint.class.getSimpleName(), args);
         SignalHandler.register(LOG);
         JvmShutdownSafeguard.installAsShutdownHook(LOG);
+
+        LOG.warn(
+                "Mesos support was deprecated in Flink 1.13 and is subject to removal in the future (see FLINK-22352 for further details).");
 
         // load configuration incl. dynamic properties
         Configuration dynamicProperties =

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -33,7 +33,13 @@ import org.apache.commons.cli.PosixParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** The entry point for running a TaskManager in a Mesos container. */
+/**
+ * The entry point for running a TaskManager in a Mesos container.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosTaskExecutorRunner {
 
     private static final Logger LOG = LoggerFactory.getLogger(MesosTaskExecutorRunner.class);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -63,7 +63,11 @@ import static org.apache.flink.mesos.configuration.MesosOptions.PORT_ASSIGNMENTS
  *
  * <p>Translates the abstract {@link ContainerSpecification} into a concrete Mesos-specific {@link
  * Protos.TaskInfo}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public class LaunchableMesosWorker implements LaunchableTask {
 
     protected static final Logger LOG = LoggerFactory.getLogger(LaunchableMesosWorker.class);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosConfigKeys.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosConfigKeys.java
@@ -18,7 +18,13 @@
 
 package org.apache.flink.mesos.runtime.clusterframework;
 
-/** The Mesos environment variables used for settings of the containers. */
+/**
+ * The Mesos environment variables used for settings of the containers.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosConfigKeys {
     // ------------------------------------------------------------------------
     //  Environment variable names

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActions.java
@@ -28,7 +28,11 @@ import org.apache.flink.mesos.scheduler.messages.AcceptOffers;
  *
  * <p>These are called by the MesosResourceManager components such as {@link LaunchCoordinator}, and
  * {@link TaskMonitor}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public interface MesosResourceManagerActions {
 
     /**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactory.java
@@ -30,7 +30,13 @@ import java.util.concurrent.CompletableFuture;
 
 import scala.concurrent.duration.FiniteDuration;
 
-/** Factory class for actors used in mesos deployment. */
+/**
+ * Factory class for actors used in mesos deployment.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public interface MesosResourceManagerActorFactory {
 
     /** Create self actor for mesos resource manager. */

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactoryImpl.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactoryImpl.java
@@ -42,7 +42,13 @@ import java.util.concurrent.CompletableFuture;
 
 import scala.concurrent.duration.FiniteDuration;
 
-/** Implementation of {@link MesosResourceManagerActorFactory}. */
+/**
+ * Implementation of {@link MesosResourceManagerActorFactory}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosResourceManagerActorFactoryImpl implements MesosResourceManagerActorFactory {
 
     private static final Logger LOG =

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerDriver.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerDriver.java
@@ -76,7 +76,13 @@ import java.util.stream.Collectors;
 import scala.Option;
 import scala.concurrent.duration.FiniteDuration;
 
-/** Implementation of {@link ResourceManagerDriver} for Mesos deployment. */
+/**
+ * Implementation of {@link ResourceManagerDriver} for Mesos deployment.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosResourceManagerDriver
         extends AbstractResourceManagerDriver<RegisteredMesosWorkerNode> {
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
@@ -38,7 +38,11 @@ import javax.annotation.Nullable;
 /**
  * {@link ActiveResourceManagerFactory} implementation which creates {@link ActiveResourceManager}
  * with {@link MesosResourceManagerDriver}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public class MesosResourceManagerFactory
         extends ActiveResourceManagerFactory<RegisteredMesosWorkerNode> {
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -47,7 +47,11 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  *
  * <p>These parameters are in addition to the common parameters provided by {@link
  * ContaineredTaskManagerParameters}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public class MesosTaskManagerParameters {
 
     /**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosWorkerResourceSpecFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosWorkerResourceSpecFactory.java
@@ -24,7 +24,13 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpecFactory;
 
-/** Implementation of {@link WorkerResourceSpecFactory} for Mesos deployments. */
+/**
+ * Implementation of {@link WorkerResourceSpecFactory} for Mesos deployments.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
 
     public static final MesosWorkerResourceSpecFactory INSTANCE =

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/RegisteredMesosWorkerNode.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/RegisteredMesosWorkerNode.java
@@ -27,7 +27,11 @@ import java.io.Serializable;
 
 /**
  * A representation of a registered Mesos task managed by the {@link MesosResourceManagerDriver}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public class RegisteredMesosWorkerNode implements Serializable, ResourceIDRetrievable {
 
     private static final long serialVersionUID = 2;

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/AbstractMesosServices.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/AbstractMesosServices.java
@@ -32,7 +32,13 @@ import org.apache.mesos.SchedulerDriver;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** An abstract implementation of {@link MesosServices}. */
+/**
+ * An abstract implementation of {@link MesosServices}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public abstract class AbstractMesosServices implements MesosServices {
 
     private final ActorSystem actorSystem;

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/MesosServices.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/MesosServices.java
@@ -28,7 +28,13 @@ import akka.actor.ActorSystem;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 
-/** Service factory interface for Mesos. */
+/**
+ * Service factory interface for Mesos.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public interface MesosServices {
 
     /**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/MesosServicesUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/MesosServicesUtils.java
@@ -31,7 +31,13 @@ import akka.actor.ActorSystem;
 
 import java.util.UUID;
 
-/** Utilities for the {@link MesosServices}. */
+/**
+ * Utilities for the {@link MesosServices}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosServicesUtils {
 
     /**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/StandaloneMesosServices.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/StandaloneMesosServices.java
@@ -25,7 +25,13 @@ import org.apache.flink.mesos.util.MesosArtifactServer;
 
 import akka.actor.ActorSystem;
 
-/** {@link MesosServices} implementation for the standalone mode. */
+/**
+ * {@link MesosServices} implementation for the standalone mode.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class StandaloneMesosServices extends AbstractMesosServices {
 
     protected StandaloneMesosServices(ActorSystem actorSystem, MesosArtifactServer artifactServer) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/ZooKeeperMesosServices.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/ZooKeeperMesosServices.java
@@ -34,7 +34,13 @@ import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorSystem;
 
-/** {@link MesosServices} implementation for the ZooKeeper high availability based mode. */
+/**
+ * {@link MesosServices} implementation for the ZooKeeper high availability based mode.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class ZooKeeperMesosServices extends AbstractMesosServices {
 
     // Factory to create ZooKeeper utility classes

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/MesosWorkerStore.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/MesosWorkerStore.java
@@ -29,7 +29,13 @@ import scala.Option;
 
 import static java.util.Objects.requireNonNull;
 
-/** A store of Mesos workers and associated framework information. */
+/**
+ * A store of Mesos workers and associated framework information.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public interface MesosWorkerStore {
 
     /** The template for naming the worker. */

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/StandaloneMesosWorkerStore.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/StandaloneMesosWorkerStore.java
@@ -27,7 +27,13 @@ import java.util.Map;
 
 import scala.Option;
 
-/** A standalone Mesos worker store. */
+/**
+ * A standalone Mesos worker store.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class StandaloneMesosWorkerStore implements MesosWorkerStore {
 
     private Option<Protos.FrameworkID> frameworkID = Option.empty();

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/ZooKeeperMesosWorkerStore.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/ZooKeeperMesosWorkerStore.java
@@ -42,7 +42,13 @@ import scala.Option;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
-/** A ZooKeeper-backed Mesos worker store. */
+/**
+ * A ZooKeeper-backed Mesos worker store.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class ZooKeeperMesosWorkerStore implements MesosWorkerStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperMesosWorkerStore.class);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactResolver.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactResolver.java
@@ -24,7 +24,13 @@ import java.net.URL;
 
 import scala.Option;
 
-/** An interface for resolving artifact URIs. */
+/**
+ * An interface for resolving artifact URIs.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public interface MesosArtifactResolver {
     Option<URL> resolve(Path remoteFile);
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServer.java
@@ -29,7 +29,11 @@ import java.net.URL;
  *
  * <p>More information: http://mesos.apache.org/documentation/latest/fetcher/
  * http://mesos.apache.org/documentation/latest/fetcher-cache-internals/
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public interface MesosArtifactServer extends MesosArtifactResolver {
 
     /**

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServerImpl.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServerImpl.java
@@ -78,7 +78,13 @@ import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRes
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
-/** Implemenation of {@link MesosArtifactServer}. */
+/**
+ * Implemenation of {@link MesosArtifactServer}.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosArtifactServerImpl implements MesosArtifactServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(MesosArtifactServerImpl.class);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosConfiguration.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosConfiguration.java
@@ -29,7 +29,13 @@ import scala.Option;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** The typed configuration settings associated with a Mesos scheduler. */
+/**
+ * The typed configuration settings associated with a Mesos scheduler.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosConfiguration {
 
     private final String masterUrl;

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosResourceAllocation.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosResourceAllocation.java
@@ -52,7 +52,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * protocol definition.
  *
  * <p>This class is not thread-safe.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
  */
+@Deprecated
 public class MesosResourceAllocation {
 
     protected static final Logger LOG = LoggerFactory.getLogger(MesosResourceAllocation.class);

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -48,7 +48,13 @@ import java.util.concurrent.TimeUnit;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
-/** Utils for Mesos. */
+/**
+ * Utils for Mesos.
+ *
+ * @deprecated Apache Mesos support was deprecated in Flink 1.13 and is subject to removal in the
+ *     future (see FLINK-22352 for further details).
+ */
+@Deprecated
 public class MesosUtils {
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

According to the discussion on the dev mailing list ([[SURVEY] Remove Mesos support](http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/SURVEY-Remove-Mesos-support-td45974.html) and [[VOTE] Deprecating Mesos support](http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/VOTE-Deprecating-Mesos-support-td50142.html)), the community decided to deprecate Mesos support in Apache Flink (see [[RESULT][VOTE]Deprecating Mesos support](http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/RESULT-VOTE-Deprecating-Mesos-support-td50260.html)).


## Brief change log

* Adds `@Deprecated` note to Mesos-related implementations and extended the corresponding JavaDoc
* Adds a warning to the intro of the Flink on Mesos documentation and Flink's Mesos-specific configuration subsection in the docs
* Adds log statement to `MesosJobClusterEntrypoint` and `MesosSessionClusterEntrypoint`

## Verifying this change

Build docs locally and verified that the warning is shown.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs & JavaDocs
