### PR TITLE
[FLINK-22358][connector base] Add stability annotations to connector base and iterator sources.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEmitter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEmitter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 
@@ -28,6 +29,7 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
  * @param <T> the type of records that are eventually emitted to the {@link SourceOutput}.
  * @param <SplitStateT> the mutable type of split state.
  */
+@PublicEvolving
 public interface RecordEmitter<E, T, SplitStateT> {
 
     /**

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsBySplits.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsBySplits.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceSplit;
 
 import javax.annotation.Nullable;
@@ -34,6 +35,7 @@ import java.util.Set;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** An implementation of RecordsWithSplitIds to host all the records by splits. */
+@PublicEvolving
 public class RecordsBySplits<E> implements RecordsWithSplitIds<E> {
 
     private final Set<String> finishedSplits;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsWithSplitIds.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsWithSplitIds.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import javax.annotation.Nullable;
 
 import java.util.Set;
 
 /** An interface for the elements passed from the fetchers to the source reader. */
+@PublicEvolving
 public interface RecordsWithSplitIds<E> {
 
     /**

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -26,7 +26,7 @@ import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcher
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
-import java.util.Collection;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
  *   <li>The class must override the methods to convert back and forth between the immutable splits
  *       ({@code SplitT}) and the mutable split state representation ({@code SplitStateT}).
  *   <li>Finally, the reader must decide what to do when it starts ({@link #start()}) or when a
- *       split is finished ({@link #onSplitFinished(Collection)}).
+ *       split is finished ({@link #onSplitFinished(Map)}).
  * </ul>
  *
  * @param <E> The type of the records (the raw type that typically contains checkpointing

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -56,6 +57,7 @@ import java.util.function.Supplier;
  * @param <SplitT> The type of the splits processed by the source.
  * @param <SplitStateT> The type of the mutable state per split.
  */
+@PublicEvolving
 public abstract class SingleThreadMultiplexSourceReaderBase<
                 E, T, SplitT extends SourceSplit, SplitStateT>
         extends SourceReaderBase<E, T, SplitT, SplitStateT> {

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceOutput;
@@ -55,6 +56,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * @param <SplitT> the immutable split type.
  * @param <SplitStateT> the mutable type of split state.
  */
+@PublicEvolving
 public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitStateT>
         implements SourceReader<T, SplitT> {
     private static final Logger LOG = LoggerFactory.getLogger(SourceReaderBase.class);

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderOptions.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderOptions.java
@@ -18,11 +18,13 @@
 
 package org.apache.flink.connector.base.source.reader;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 
 /** The options tht can be set for the {@link SourceReaderBase}. */
+@PublicEvolving
 public class SourceReaderOptions {
 
     public static final ConfigOption<Long> SOURCE_READER_CLOSE_TIMEOUT =

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/AddSplitsTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/AddSplitsTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 /** The task to add splits. */
+@Internal
 class AddSplitsTask<SplitT extends SourceSplit> implements SplitFetcherTask {
 
     private final SplitReader<?, SplitT> splitReader;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -28,6 +29,7 @@ import java.util.Collection;
 import java.util.function.Consumer;
 
 /** The default fetch task that fetches the records into the element queue. */
+@Internal
 class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
     private final SplitReader<E, SplitT> splitReader;
     private final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
@@ -36,6 +37,7 @@ import java.util.function.Supplier;
  * via the same client. In the example of the file source, there is a single thread that reads the
  * files after another.
  */
+@Internal
 public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
         extends SplitFetcherManager<E, SplitT> {
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /** The internal fetcher runnable responsible for polling message from the external system. */
+@Internal
 public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(SplitFetcher.class);
     private static final SplitFetcherTask WAKEUP_TASK = new DummySplitFetcherTask("WAKEUP_TASK");

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
@@ -49,6 +50,7 @@ import java.util.function.Supplier;
  * manager would only start a single fetcher and assign all the splits to it. A one-thread-per-split
  * fetcher may spawn a new thread every time a new split is assigned.
  */
+@Internal
 public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
     private static final Logger LOG = LoggerFactory.getLogger(SplitFetcherManager.class);
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTask.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.annotation.Internal;
+
 import java.io.IOException;
 
 /** An interface similar to {@link Runnable} but allows throwing exceptions and wakeup. */
+@Internal
 public interface SplitFetcherTask {
 
     /**

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.splitreader;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 
@@ -30,6 +31,7 @@ import java.io.IOException;
  * @param <E> the element type.
  * @param <SplitT> the split type.
  */
+@PublicEvolving
 public interface SplitReader<E, SplitT extends SourceSplit> {
 
     /**

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitsAddition.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitsAddition.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connector.base.source.reader.splitreader;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import java.util.List;
 
 /**
@@ -25,6 +27,7 @@ import java.util.List;
  *
  * @param <SplitT> the split type.
  */
+@PublicEvolving
 public class SplitsAddition<SplitT> extends SplitsChange<SplitT> {
 
     public SplitsAddition(List<SplitT> splits) {

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitsChange.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitsChange.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.connector.base.source.reader.splitreader;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import java.util.Collections;
 import java.util.List;
 
 /** An abstract class to host splits change. */
+@PublicEvolving
 public abstract class SplitsChange<SplitT> {
     private final List<SplitT> splits;
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueue.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.synchronization;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -69,6 +70,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  *
  * @param <T> the type of the elements in the queue.
  */
+@PublicEvolving
 public class FutureCompletingBlockingQueue<T> {
 
     /**

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/utils/SerdeUtils.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/utils/SerdeUtils.java
@@ -18,6 +18,7 @@ limitations under the License.
 
 package org.apache.flink.connector.base.source.utils;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /** A util class with some helper method for serde in the sources. */
+@Internal
 public class SerdeUtils {
 
     /** Private constructor for util class. */

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/NumberSequenceSource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/NumberSequenceSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.source.lib;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.connector.source.Boundedness;
@@ -57,6 +58,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * long integer values), user may want to consider executing the application in a streaming manner,
  * because, despite the fact that the produced stream is bounded, the end bound is pretty far away.
  */
+@PublicEvolving
 public class NumberSequenceSource
         implements Source<
                         Long,

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.source.lib.util;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 
@@ -36,6 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * @param <SplitT> The type of the splits used by the source.
  */
+@PublicEvolving
 public class IteratorSourceEnumerator<SplitT extends IteratorSourceSplit<?, ?>>
         implements SplitEnumerator<SplitT, Collection<SplitT>> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.source.lib.util;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
@@ -48,6 +49,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <SplitT> The concrete type of the {@code IteratorSourceSplit} that creates and converts
  *     the iterator that produces this reader's elements.
  */
+@PublicEvolving
 public class IteratorSourceReader<
                 E, IterT extends Iterator<E>, SplitT extends IteratorSourceSplit<E, IterT>>
         implements SourceReader<E, SplitT> {

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceSplit.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceSplit.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.connector.source.lib.util;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceSplit;
 
 import java.util.Iterator;
@@ -28,6 +29,7 @@ import java.util.Iterator;
  *
  * @param <E> The type of the elements returned by the iterator.
  */
+@PublicEvolving
 public interface IteratorSourceSplit<E, IterT extends Iterator<E>> extends SourceSplit {
 
     /** Gets the iterator over the elements of this split. */


### PR DESCRIPTION
## What is the purpose of the change

Adds missing stability annotations to the Iterator Sources and Split Reader API:

  - The *iterator sources* classes are all `@PublicEvolving`: They are simple and stable across the 1.13 release.
  - The top-level Split Reader API classes are `@PublicEvolving`: `SourceReaderBase`, `SplitReader`, `RecordEmitter`, ...
  - The remaining classes used by the `SourceReaderBase` are `@Internal`: `FutureCompletingBlockingQueue`, `SplitFetcher`, `SplitFetcherManager`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
