### PR TITLE
[FLINK-22359][python] Set the version to 1.13.dev0 for PyFlink

### DIFF
--- a/flink-python/pyflink/version.py
+++ b/flink-python/pyflink/version.py
@@ -20,4 +20,4 @@
 The pyflink version will be consistent with the flink version and follow the PEP440.
 .. seealso:: https://www.python.org/dev/peps/pep-0440
 """
-__version__ = "1.13.0"
+__version__ = "1.13.dev0"

--- a/tools/releasing/create_snapshot_branch.sh
+++ b/tools/releasing/create_snapshot_branch.sh
@@ -63,8 +63,6 @@ perl -pi -e "s#^  PreviousDocs = \[#  PreviousDocs = \[\n    \[\"${SHORT_RELEASE
 
 perl -pi -e "s#^  IsStable = .*#  IsStable = true#" ${config_file}
 
-perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${RELEASE_VERSION}\"#" ../flink-python/pyflink/version.py
-
 perl -pi -e "s#dev-master#dev-${SHORT_RELEASE_VERSION}#" ../flink-end-to-end-tests/test-scripts/common_docker.sh
 
 git commit -am "Update for ${RELEASE_VERSION}"


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will reset version to 1.13-SNAPSHOT in `version.py`*


## Brief change log

  - *Remove the logic of updating `version.py` in `create_snapshot_branch.sh`*
  - *Reset the version of `version.py` to `1.13-SNAPSHOT`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
