### PR TITLE
[FLINK-21106][docs] Updates Flink docs to refer to the plugin's page

### DIFF
--- a/docs/content.zh/docs/flinkDev/ide_setup.md
+++ b/docs/content.zh/docs/flinkDev/ide_setup.md
@@ -99,13 +99,12 @@ to enable support for Scala projects and files:
 We use the [Spotless
 plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together
 with [google-java-format](https://github.com/google/google-java-format) to
-format our Java code. Due to [FLINK-21106](https://issues.apache.org/jira/browse/FLINK-21106) a
-specific, patched version of the plugin is needed to work correctly with IntelliJ.
+format our Java code.
 
 You can configure your IDE to automatically apply formatting on saving with these steps:
 
 1. Download the [google-java-format
-   plugin v1.7.0.5](https://issues.apache.org/jira/secure/attachment/13019264/google-java-format-1.7-patched.zip).
+   plugin v1.7.0.6](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/115957).
 2. Open Settings → Plugins, click on the gear icon and select "Install Plugin from Disk". Navigate to the downloaded zip file and select it.
 3. In the plugin settings, enable the plugin and change the code style to "AOSP" (4-space indents).
 4. Remember to never update this plugin to a later version!

--- a/docs/content/docs/flinkDev/ide_setup.md
+++ b/docs/content/docs/flinkDev/ide_setup.md
@@ -99,13 +99,12 @@ to enable support for Scala projects and files:
 We use the [Spotless
 plugin](https://github.com/diffplug/spotless/tree/main/plugin-maven) together
 with [google-java-format](https://github.com/google/google-java-format) to
-format our Java code. Due to [FLINK-21106](https://issues.apache.org/jira/browse/FLINK-21106) a
-specific, patched version of the plugin is needed to work correctly with IntelliJ.
+format our Java code.
 
 You can configure your IDE to automatically apply formatting on saving with these steps:
 
 1. Download the [google-java-format
-   plugin v1.7.0.5](https://issues.apache.org/jira/secure/attachment/13019264/google-java-format-1.7-patched.zip).
+   plugin v1.7.0.6](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/115957).
 2. Open Settings → Plugins, click on the gear icon and select "Install Plugin from Disk". Navigate to the downloaded zip file and select it.
 3. In the plugin settings, enable the plugin and change the code style to "AOSP" (4-space indents).
 4. Remember to never update this plugin to a later version!


### PR DESCRIPTION
google-java-format plugin 1.7.0.6 was released
(see issue [#560](https://github.com/google/google-java-format/issues/560)). Hence, we do not
have to rely on the patched version of [FLINK-21106](https://issues.apache.org/jira/browse/FLINK-21106) anymore.

## What is the purpose of the change

We needed the workaround due to a failure described in `FLINK-21106`.

## Brief change log

Updated the logs accordingly.

## Verifying this change

* I tested the new plugin version on 
```
IntelliJ IDEA 2020.2.4 (Community Edition)
Build #IC-202.8194.7, built on November 24, 2020
Runtime version: 11.0.9+11-b944.49 x86_64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
macOS 10.15.7
GC: ParNew, ConcurrentMarkSweep
Memory: 8108M
Cores: 12
Non-Bundled Plugins: IdeaVIM, CheckStyle-IDEA, Lombook Plugin, com.dubreuia, google-java-format, org.intellij.scala
```
* I rebuild the logs verifying that the link refers to the right page on the English and Chinese docs version

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
