### PR TITLE
[FLINK-22372][table] Rename LogicalTypeCasts class variables in the castTo method.

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -358,8 +358,8 @@ public final class LogicalTypeCasts {
         return false;
     }
 
-    private static CastingRuleBuilder castTo(LogicalTypeRoot sourceType) {
-        return new CastingRuleBuilder(sourceType);
+    private static CastingRuleBuilder castTo(LogicalTypeRoot targetType) {
+        return new CastingRuleBuilder(targetType);
     }
 
     private static LogicalTypeRoot[] allTypes() {


### PR DESCRIPTION
## What is the purpose of the change

Rename LogicalTypeCasts class variables in the castTo method. 
castTo parameter has a mistake name. It should be 'targetType'.

## Brief change log

rename 'sourceType' to 'targetType'.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
