### PR TITLE
[FLINK-22369][rocksdb] RocksDB state backend might occur ClassNotFoundException when deserializing on TM side

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -216,7 +216,6 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend
         }
         this.checkpointStreamBackend = checkNotNull(checkpointStreamBackend);
         this.rocksDBStateBackend = new EmbeddedRocksDBStateBackend(enableIncrementalCheckpointing);
-        this.rocksDBStateBackend.setLogger(LOG);
     }
 
     /** @deprecated Use {@link #RocksDBStateBackend(StateBackend)} instead. */
@@ -588,7 +587,7 @@ public class RocksDBStateBackend extends AbstractManagedMemoryStateBackend
 
     @VisibleForTesting
     static void ensureRocksDBIsLoaded(String tempDirectory) throws IOException {
-        EmbeddedRocksDBStateBackend.ensureRocksDBIsLoaded(tempDirectory, LOG);
+        EmbeddedRocksDBStateBackend.ensureRocksDBIsLoaded(tempDirectory);
     }
 
     @VisibleForTesting

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBInitTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBInitTest.java
@@ -62,7 +62,7 @@ public class RocksDBInitTest {
 
         File tempFolder = temporaryFolder.newFolder();
         try {
-            EmbeddedRocksDBStateBackend.ensureRocksDBIsLoaded(tempFolder.getAbsolutePath(), LOG);
+            EmbeddedRocksDBStateBackend.ensureRocksDBIsLoaded(tempFolder.getAbsolutePath());
             fail("Not throwing expected exception.");
         } catch (IOException ignored) {
             // ignored


### PR DESCRIPTION
## What is the purpose of the change

Removes a new logging configuration from the `EmbeddedRocksDBStateBackend` that can cause a ClassNotFoundException if the TM uses a different logging configuration from the client. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
