### PR TITLE
[FLINK-22384][docs]Chinese typos in "fault-tolerance/state/"  page

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -733,7 +733,7 @@ class BufferingSink(threshold: Int = 0)
 `initializeState` 方法接收一个 `FunctionInitializationContext` 参数，会用来初始化 non-keyed state 的 "容器"。这些容器是一个 `ListState`
 用于在 checkpoint 时保存 non-keyed state 对象。
 
-注意这些状态是如何初始化的，和 keyed state 类系，`StateDescriptor` 会包括状态名字、以及状态类型相关信息。
+注意这些状态是如何初始化的，和 keyed state 类似，`StateDescriptor` 会包括状态名字、以及状态类型相关信息。
 
 
 {{< tabs "9f372f5f-ad80-4b2c-a318-fcbdb19c7d2a" >}}


### PR DESCRIPTION
## What is the purpose of the change

i found Chinese typos in  https://ci.apache.org/projects/flink/flink-docs-master/zh/docs/dev/datastream/fault-tolerance/state/  text content  "和 keyed state 类系"  Should be replaced with  "和 keyed state 类似"

## Brief change log

change "和 keyed state 类系"  to "和 keyed state 类似"

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
