### PR TITLE
[FLINK-22113][table-planner-blink] Implement the column uniqueness checking for TableSourceTable

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -18,15 +18,14 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank}
-import org.apache.flink.table.planner.plan.utils.ExpandUtil
-import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
-
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.rel.`type`.RelDataTypeFieldImpl
 import org.apache.calcite.rel.{RelCollations, RelNode}
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, VARCHAR}
 import org.apache.calcite.util.ImmutableBitSet
+import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank}
+import org.apache.flink.table.planner.plan.utils.ExpandUtil
+import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 import org.junit.Assert._
 import org.junit.Test
 
@@ -620,6 +619,17 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
     (0 until testRel.getRowType.getFieldCount).foreach { idx =>
       assertNull(mq.areColumnsUnique(testRel, ImmutableBitSet.of(idx)))
     }
+  }
+
+  @Test
+  def testAreColumnsUniqueOnTableSourceTable(): Unit = {
+    Array(tableSourceTableLogicalScan, tableSourceTableFlinkLogicalScan, tableSourceTableBatchScan, tableSourceTableStreamScan)
+      .foreach { scan =>
+        assertTrue(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1, 2, 3)))
+        assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(1, 2)))
+        assertTrue(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1)))
+        assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(0)))
+      }
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -632,4 +632,12 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
       }
   }
 
+  @Test
+  def testAreColumnsUniqueOntableSourceTableNonKeyNonKey(): Unit = {
+    Array(tableSourceTableNonKeyLogicalScan, tableSourceTableNonKeyFlinkLogicalScan, tableSourceTableNonKeyBatchScan, tableSourceTableNonKeyStreamScan)
+      .foreach { scan =>
+        assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1, 2, 3)))
+      }
+  }
+
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -18,14 +18,14 @@
 
 package org.apache.flink.table.planner.plan.metadata
 
+import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank}
+import org.apache.flink.table.planner.plan.utils.ExpandUtil
+import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.rel.`type`.RelDataTypeFieldImpl
 import org.apache.calcite.rel.{RelCollations, RelNode}
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, VARCHAR}
 import org.apache.calcite.util.ImmutableBitSet
-import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank}
-import org.apache.flink.table.planner.plan.utils.ExpandUtil
-import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 import org.junit.Assert._
 import org.junit.Test
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -173,6 +173,15 @@ class FlinkRelMdHandlerTestBase {
     createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), batchPhysicalTraits)
   protected lazy val tableSourceTableStreamScan: StreamPhysicalDataStreamScan =
     createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), streamPhysicalTraits)
+  
+  protected lazy val tableSourceTableNonKeyLogicalScan: LogicalTableScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), logicalTraits)
+  protected lazy val tableSourceTableNonKeyFlinkLogicalScan: FlinkLogicalDataStreamTableScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), flinkLogicalTraits)
+  protected lazy val tableSourceTableNonKeyBatchScan: BatchPhysicalBoundedStreamScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), batchPhysicalTraits)
+  protected lazy val tableSourceTableNonKeyStreamScan: StreamPhysicalDataStreamScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), streamPhysicalTraits)
 
   private lazy val valuesType = relBuilder.getTypeFactory
     .builder()
@@ -2590,7 +2599,7 @@ class FlinkRelMdHandlerTestBase {
     .scan("MyTable2")
     .minus(false).build()
 
-  // select * from TableSourceTable1 left join TableSourceTable1 on TableSourceTable1.b = TableSourceTable2.b
+  // select * from TableSourceTable1 left join TableSourceTable2 on TableSourceTable1.b = TableSourceTable2.b
   protected lazy val logicalLeftJoinOnContainedUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable2")
@@ -2598,10 +2607,18 @@ class FlinkRelMdHandlerTestBase {
       relBuilder.call(EQUALS, relBuilder.field(2, 0, 1), relBuilder.field(2, 1, 1)))
     .build
 
-  // select * from TableSourceTable1 left join TableSourceTable1 on TableSourceTable1.a = TableSourceTable2.a
+  // select * from TableSourceTable1 left join TableSourceTable2 on TableSourceTable1.a = TableSourceTable2.a
   protected lazy val logicalLeftJoinOnDisjointUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable2")
+    .join(JoinRelType.LEFT,
+      relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0)))
+    .build
+
+  // select * from TableSourceTable1 left join TableSourceTable3 on TableSourceTable1.a = TableSourceTable3.a
+  protected lazy val logicalLeftJoinWithNoneKeyTableUniqueKeys: RelNode = relBuilder
+    .scan("TableSourceTable1")
+    .scan("TableSourceTable3")
     .join(JoinRelType.LEFT,
       relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0)))
     .build

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -2616,7 +2616,7 @@ class FlinkRelMdHandlerTestBase {
     .build
 
   // select * from TableSourceTable1 left join TableSourceTable3 on TableSourceTable1.a = TableSourceTable3.a
-  protected lazy val logicalLeftJoinWithNoneKeyTableUniqueKeys: RelNode = relBuilder
+  protected lazy val logicalLeftJoinWithNonKeyTableUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable3")
     .join(JoinRelType.LEFT,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -39,7 +39,7 @@ import org.apache.flink.table.planner.plan.nodes.calcite._
 import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
-import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase
+import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, TableSourceTable}
 import org.apache.flink.table.planner.plan.stream.sql.join.TestTemporalTable
 import org.apache.flink.table.planner.plan.utils._
 import org.apache.flink.table.planner.utils.Top3
@@ -48,7 +48,6 @@ import org.apache.flink.table.types.AtomicDataType
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.utils.CatalogManagerMocks
-
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.plan._
@@ -69,7 +68,6 @@ import org.apache.calcite.sql.fun.{SqlCountAggFunction, SqlStdOperatorTable}
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.util._
 import org.junit.{Before, BeforeClass}
-
 import java.math.BigDecimal
 import java.util
 import java.util.Collections
@@ -166,6 +164,15 @@ class FlinkRelMdHandlerTestBase {
     createDataStreamScan(ImmutableList.of("emp"), batchPhysicalTraits)
   protected lazy val empStreamScan: StreamPhysicalDataStreamScan =
     createDataStreamScan(ImmutableList.of("emp"), streamPhysicalTraits)
+
+  protected lazy val tableSourceTableLogicalScan: LogicalTableScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), logicalTraits)
+  protected lazy val tableSourceTableFlinkLogicalScan: FlinkLogicalDataStreamTableScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), flinkLogicalTraits)
+  protected lazy val tableSourceTableBatchScan: BatchPhysicalBoundedStreamScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), batchPhysicalTraits)
+  protected lazy val tableSourceTableStreamScan: StreamPhysicalDataStreamScan =
+    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), streamPhysicalTraits)
 
   private lazy val valuesType = relBuilder.getTypeFactory
     .builder()
@@ -2583,6 +2590,22 @@ class FlinkRelMdHandlerTestBase {
     .scan("MyTable2")
     .minus(false).build()
 
+  // select * from TableSourceTable1 left join TableSourceTable1 on TableSourceTable1.b = TableSourceTable2.b
+  protected lazy val logicalLeftJoinOnContainedUniqueKeys: RelNode = relBuilder
+    .scan("TableSourceTable1")
+    .scan("TableSourceTable2")
+    .join(JoinRelType.LEFT,
+      relBuilder.call(EQUALS, relBuilder.field(2, 0, 1), relBuilder.field(2, 1, 1)))
+    .build
+
+  // select * from TableSourceTable1 left join TableSourceTable1 on TableSourceTable1.a = TableSourceTable2.a
+  protected lazy val logicalLeftJoinOnDisjointUniqueKeys: RelNode = relBuilder
+    .scan("TableSourceTable1")
+    .scan("TableSourceTable2")
+    .join(JoinRelType.LEFT,
+      relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0)))
+    .build
+
   protected def createDataStreamScan[T](
       tableNames: util.List[String], traitSet: RelTraitSet): T = {
     val table = relBuilder
@@ -2590,6 +2613,33 @@ class FlinkRelMdHandlerTestBase {
       .asInstanceOf[CalciteCatalogReader]
       .getTable(tableNames)
       .asInstanceOf[FlinkPreparingTableBase]
+    val conventionTrait = traitSet.getTrait(ConventionTraitDef.INSTANCE)
+    val scan = conventionTrait match {
+      case Convention.NONE =>
+        relBuilder.clear()
+        val scan = relBuilder.scan(tableNames).build()
+        scan.copy(traitSet, scan.getInputs)
+      case FlinkConventions.LOGICAL =>
+        new FlinkLogicalDataStreamTableScan(
+          cluster, traitSet, Collections.emptyList[RelHint](), table)
+      case FlinkConventions.BATCH_PHYSICAL =>
+        new BatchPhysicalBoundedStreamScan(
+          cluster, traitSet, Collections.emptyList[RelHint](), table, table.getRowType)
+      case FlinkConventions.STREAM_PHYSICAL =>
+        new StreamPhysicalDataStreamScan(
+          cluster, traitSet, Collections.emptyList[RelHint](), table, table.getRowType)
+      case _ => throw new TableException(s"Unsupported convention trait: $conventionTrait")
+    }
+    scan.asInstanceOf[T]
+  }
+
+  protected def createDataStreamScanForTableSourceTable[T](
+                                         tableNames: util.List[String], traitSet: RelTraitSet): T = {
+    val table = relBuilder
+      .getRelOptSchema
+      .asInstanceOf[CalciteCatalogReader]
+      .getTable(tableNames)
+      .asInstanceOf[TableSourceTable]
     val conventionTrait = traitSet.getTrait(ConventionTraitDef.INSTANCE)
     val scan = conventionTrait match {
       case Convention.NONE =>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -314,6 +314,12 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
     assertNull(mq.getUniqueKeys(testRel))
   }
 
+  @Test
+  def testGetUniqueKeysOnTableScanTable(): Unit = {
+    assertEquals(uniqueKeys(Array(0, 1), Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnContainedUniqueKeys).toSet)
+    assertEquals(uniqueKeys(Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnDisjointUniqueKeys).toSet)
+  }
+
   private def uniqueKeys(keys: Array[Int]*): Set[ImmutableBitSet] = {
     keys.map(k => ImmutableBitSet.of(k: _*)).toSet
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -318,6 +318,7 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   def testGetUniqueKeysOnTableScanTable(): Unit = {
     assertEquals(uniqueKeys(Array(0, 1), Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnContainedUniqueKeys).toSet)
     assertEquals(uniqueKeys(Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnDisjointUniqueKeys).toSet)
+    assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalLeftJoinWithNoneKeyTableUniqueKeys).toSet)
   }
 
   private def uniqueKeys(keys: Array[Int]*): Set[ImmutableBitSet] = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -318,7 +318,7 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   def testGetUniqueKeysOnTableScanTable(): Unit = {
     assertEquals(uniqueKeys(Array(0, 1), Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnContainedUniqueKeys).toSet)
     assertEquals(uniqueKeys(Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnDisjointUniqueKeys).toSet)
-    assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalLeftJoinWithNoneKeyTableUniqueKeys).toSet)
+    assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalLeftJoinWithNonKeyTableUniqueKeys).toSet)
   }
 
   private def uniqueKeys(keys: Array[Int]*): Set[ImmutableBitSet] = {


### PR DESCRIPTION
## What is the purpose of the change
Implement the column uniqueness checking to avoid losing uniqueness information during join operations.

More specifically,
```
CREATE TEMPORARY TABLE passengers (
  passenger_key STRING,
  PRIMARY KEY (passenger_key) NOT ENFORCED
) WITH (
  'connector' = 'values'
)

CREATE TEMPORARY TABLE booking_channels (
  booking_channel_key STRING,
  PRIMARY KEY (booking_channel_key) NOT ENFORCED
) WITH (
  'connector' = 'values'
)

CREATE TEMPORARY TABLE train_activities (
  passenger_key STRING,
  booking_channel_key STRING,
  PRIMARY KEY (booking_channel_key) NOT ENFORCED
) WITH (
  'connector' = 'values'
)

SELECT t.booking_channel_key as booking_channel_key, t.passenger_key as passenger_key, b.booking_channel_key as booking_channel_key_0
FROM train_activities t
LEFT JOIN booking_channels b
ON t.booking_channel_key = b.booking_channel_key
LEFT JOIN passengers p
on t.passenger_key = p.passenger_key

== Optimized Physical Plan ==
Calc(select=[booking_channel_key, passenger_key, booking_channel_key0 AS booking_channel_key_0])
+- Join(joinType=[LeftOuterJoin], where=[=(passenger_key, passenger_key0)], select=[passenger_key, booking_channel_key, booking_channel_key0, passenger_key0], leftInputSpec=[HasUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :- Exchange(distribution=[hash[passenger_key]])
   :  +- Join(joinType=[LeftOuterJoin], where=[=(booking_channel_key, booking_channel_key0)], select=[passenger_key, booking_channel_key, booking_channel_key0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :     :- Exchange(distribution=[hash[booking_channel_key]])
   :     :  +- TableSourceScan(table=[[default_catalog, default_database, train_activities]], fields=[passenger_key, booking_channel_key])
   :     +- Exchange(distribution=[hash[booking_channel_key]])
   :        +- TableSourceScan(table=[[default_catalog, default_database, booking_channels]], fields=[booking_channel_key])
   +- Exchange(distribution=[hash[passenger_key]])
      +- TableSourceScan(table=[[default_catalog, default_database, passengers]], fields=[passenger_key])
```
VS
```
SELECT t.booking_channel_key as booking_channel_key, t.passenger_key as passenger_key
FROM train_activities t
LEFT JOIN booking_channels b
ON t.booking_channel_key = b.booking_channel_key
LEFT JOIN passengers p
on t.passenger_key = p.passenger_key


== Optimized Physical Plan ==
Calc(select=[booking_channel_key, passenger_key])
+- Join(joinType=[LeftOuterJoin], where=[=(passenger_key, passenger_key0)], select=[passenger_key, booking_channel_key, passenger_key0], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :- Exchange(distribution=[hash[passenger_key]])
   :  +- Calc(select=[passenger_key, booking_channel_key])
   :     +- Join(joinType=[LeftOuterJoin], where=[=(booking_channel_key, booking_channel_key0)], select=[passenger_key, booking_channel_key, booking_channel_key0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :        :- Exchange(distribution=[hash[booking_channel_key]])
   :        :  +- TableSourceScan(table=[[default_catalog, default_database, train_activities]], fields=[passenger_key, booking_channel_key])
   :        +- Exchange(distribution=[hash[booking_channel_key]])
   :           +- TableSourceScan(table=[[default_catalog, default_database, booking_channels]], fields=[booking_channel_key])
   +- Exchange(distribution=[hash[passenger_key]])
      +- TableSourceScan(table=[[default_catalog, default_database, passengers]], fields=[passenger_key])

```
 

**_The only difference is that we select booking_channel_key from both left and right table in the first case and only booking_channel_key from left table in the second case. The result is one has uniqueKey and the other doesn't._**

 
`t.booking_channel_key, t.passenger_key` can be the unique key of the first join output, but it seems we lost this unique information. 

## Brief change log
- *Implement the column uniqueness checking for TableSourceTable*
- *Add some test cases of uniqueness checking and getUniqueKey for TableSourceTable*


## Verifying this change

Existing and added test cases, manually rerun the example above and the uniqueness information was remained successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
