### PR TITLE
[FLINK-19980][table] Support fromChangelogStream/toChangelogStream

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/StreamTableEnvironment.java
@@ -34,6 +34,9 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.internal.StreamTableEnvironmentImpl;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
 import org.apache.flink.table.descriptors.StreamTableDescriptor;
 import org.apache.flink.table.expressions.Expression;
@@ -228,6 +231,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * @param dataStream The {@link DataStream} to be converted.
      * @param <T> The external type of the {@link DataStream}.
      * @return The converted {@link Table}.
+     * @see #fromChangelogStream(DataStream)
      */
     <T> Table fromDataStream(DataStream<T> dataStream);
 
@@ -300,7 +304,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *     // physical columns will be derived automatically
      *
      *     Schema.newBuilder()
-     *         .columnByMetadata("rowtime", "TIMESTAMP(3)") // extract timestamp into a table column
+     *         .columnByMetadata("rowtime", "TIMESTAMP_LTZ(3)") // extract timestamp into a column
      *         .watermark("rowtime", "SOURCE_WATERMARK()")  // declare watermarks propagation
      *         .build()
      *
@@ -314,11 +318,124 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * </pre>
      *
      * @param dataStream The {@link DataStream} to be converted.
-     * @param schema customized schema for the final table.
+     * @param schema The customized schema for the final table.
      * @param <T> The external type of the {@link DataStream}.
      * @return The converted {@link Table}.
+     * @see #fromChangelogStream(DataStream, Schema)
      */
     <T> Table fromDataStream(DataStream<T> dataStream, Schema schema);
+
+    /**
+     * Converts the given {@link DataStream} of changelog entries into a {@link Table}.
+     *
+     * <p>Compared to {@link #fromDataStream(DataStream)}, this method consumes instances of {@link
+     * Row} and evaluates the {@link RowKind} flag that is contained in every record during runtime.
+     * The runtime behavior is similar to that of a {@link DynamicTableSource}.
+     *
+     * <p>This method expects a changelog containing all kinds of changes (enumerated in {@link
+     * RowKind}) as the default {@link ChangelogMode}. Use {@link #fromChangelogStream(DataStream,
+     * Schema, ChangelogMode)} to limit the kinds of changes (e.g. for upsert mode).
+     *
+     * <p>Column names and types of the {@link Table} are automatically derived from the {@link
+     * TypeInformation} of the {@link DataStream}. If the outermost record's {@link TypeInformation}
+     * is a {@link CompositeType}, it will be flattened in the first level. {@link TypeInformation}
+     * that cannot be represented as one of the listed {@link DataTypes} will be treated as a
+     * black-box {@link DataTypes#RAW(Class, TypeSerializer)} type. Thus, composite nested fields
+     * will not be accessible.
+     *
+     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
+     * explicitly declared via {@link #fromChangelogStream(DataStream, Schema)}.
+     *
+     * @param dataStream The changelog stream of {@link Row}.
+     * @return The converted {@link Table}.
+     */
+    Table fromChangelogStream(DataStream<Row> dataStream);
+
+    /**
+     * Converts the given {@link DataStream} of changelog entries into a {@link Table}.
+     *
+     * <p>Compared to {@link #fromDataStream(DataStream)}, this method consumes instances of {@link
+     * Row} and evaluates the {@link RowKind} flag that is contained in every record during runtime.
+     * The runtime behavior is similar to that of a {@link DynamicTableSource}.
+     *
+     * <p>This method expects a changelog containing all kinds of changes (enumerated in {@link
+     * RowKind}) as the default {@link ChangelogMode}. Use {@link #fromChangelogStream(DataStream,
+     * Schema, ChangelogMode)} to limit the kinds of changes (e.g. for upsert mode).
+     *
+     * <p>Column names and types of the {@link Table} are automatically derived from the {@link
+     * TypeInformation} of the {@link DataStream}. If the outermost record's {@link TypeInformation}
+     * is a {@link CompositeType}, it will be flattened in the first level. {@link TypeInformation}
+     * that cannot be represented as one of the listed {@link DataTypes} will be treated as a
+     * black-box {@link DataTypes#RAW(Class, TypeSerializer)} type. Thus, composite nested fields
+     * will not be accessible.
+     *
+     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
+     * explicitly declared.
+     *
+     * <p>This method allows to declare a {@link Schema} for the resulting table. The declaration is
+     * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
+     *
+     * <ul>
+     *   <li>enrich or overwrite automatically derived columns with a custom {@link DataType}
+     *   <li>reorder columns
+     *   <li>add computed or metadata columns next to the physical columns
+     *   <li>access a stream record's timestamp
+     *   <li>declare a watermark strategy or propagate the {@link DataStream} watermarks
+     *   <li>declare a primary key
+     * </ul>
+     *
+     * <p>See {@link #fromDataStream(DataStream, Schema)} for more information and examples on how
+     * to declare a {@link Schema}.
+     *
+     * @param dataStream The changelog stream of {@link Row}.
+     * @param schema The customized schema for the final table.
+     * @return The converted {@link Table}.
+     */
+    Table fromChangelogStream(DataStream<Row> dataStream, Schema schema);
+
+    /**
+     * Converts the given {@link DataStream} of changelog entries into a {@link Table}.
+     *
+     * <p>Compared to {@link #fromDataStream(DataStream)}, this method consumes instances of {@link
+     * Row} and evaluates the {@link RowKind} flag that is contained in every record during runtime.
+     * The runtime behavior is similar to that of a {@link DynamicTableSource}.
+     *
+     * <p>This method requires an explicitly declared {@link ChangelogMode}. For example, use {@link
+     * ChangelogMode#upsert()} if the stream will not contain {@link RowKind#UPDATE_BEFORE}, or
+     * {@link ChangelogMode#insertOnly()} for non-updating streams.
+     *
+     * <p>Column names and types of the {@link Table} are automatically derived from the {@link
+     * TypeInformation} of the {@link DataStream}. If the outermost record's {@link TypeInformation}
+     * is a {@link CompositeType}, it will be flattened in the first level. {@link TypeInformation}
+     * that cannot be represented as one of the listed {@link DataTypes} will be treated as a
+     * black-box {@link DataTypes#RAW(Class, TypeSerializer)} type. Thus, composite nested fields
+     * will not be accessible.
+     *
+     * <p>By default, the stream record's timestamp and watermarks are not propagated unless
+     * explicitly declared.
+     *
+     * <p>This method allows to declare a {@link Schema} for the resulting table. The declaration is
+     * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
+     *
+     * <ul>
+     *   <li>enrich or overwrite automatically derived columns with a custom {@link DataType}
+     *   <li>reorder columns
+     *   <li>add computed or metadata columns next to the physical columns
+     *   <li>access a stream record's timestamp
+     *   <li>declare a watermark strategy or propagate the {@link DataStream} watermarks
+     *   <li>declare a primary key
+     * </ul>
+     *
+     * <p>See {@link #fromDataStream(DataStream, Schema)} for more information and examples of how
+     * to declare a {@link Schema}.
+     *
+     * @param dataStream The changelog stream of {@link Row}.
+     * @param schema The customized schema for the final table.
+     * @param changelogMode The expected kinds of changes in the incoming changelog.
+     * @return The converted {@link Table}.
+     */
+    Table fromChangelogStream(
+            DataStream<Row> dataStream, Schema schema, ChangelogMode changelogMode);
 
     /**
      * Creates a view from the given {@link DataStream} in a given path. Registered views can be
@@ -351,7 +468,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
      *
      * @param path The path under which the {@link DataStream} is created. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @param schema customized schema for the final table.
+     * @param schema The customized schema for the final table.
      * @param dataStream The {@link DataStream} out of which to create the view.
      * @param <T> The type of the {@link DataStream}.
      */
@@ -376,9 +493,10 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * <p>If the input table contains a single rowtime column, it will be propagated into a stream
      * record's timestamp. Watermarks will be propagated as well.
      *
-     * @param table The {@link Table} to convert.
+     * @param table The {@link Table} to convert. It must be insert-only.
      * @return The converted {@link DataStream}.
      * @see #toDataStream(Table, AbstractDataType)
+     * @see #toChangelogStream(Table)
      */
     DataStream<Row> toDataStream(Table table);
 
@@ -391,17 +509,18 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * <p>This method is a shortcut for:
      *
      * <pre>
-     *     tableEnv.toDataStream(table, DataTypes.of(class))
+     *     tableEnv.toDataStream(table, DataTypes.of(targetClass))
      * </pre>
      *
      * <p>Calling this method with a class of {@link Row} will redirect to {@link
      * #toDataStream(Table)}.
      *
-     * @param table The {@link Table} to convert.
+     * @param table The {@link Table} to convert. It must be insert-only.
      * @param targetClass The {@link Class} that decides about the final external representation in
      *     {@link DataStream} records.
      * @param <T> External record.
      * @return The converted {@link DataStream}.
+     * @see #toChangelogStream(Table, Schema)
      */
     <T> DataStream<T> toDataStream(Table table, Class<T> targetClass);
 
@@ -444,14 +563,163 @@ public interface StreamTableEnvironment extends TableEnvironment {
      * <p>If the input table contains a single rowtime column, it will be propagated into a stream
      * record's timestamp. Watermarks will be propagated as well.
      *
-     * @param table The {@link Table} to convert.
+     * @param table The {@link Table} to convert. It must be insert-only.
      * @param targetDataType The {@link DataType} that decides about the final external
      *     representation in {@link DataStream} records.
      * @param <T> External record.
      * @return The converted {@link DataStream}.
      * @see #toDataStream(Table)
+     * @see #toChangelogStream(Table, Schema)
      */
     <T> DataStream<T> toDataStream(Table table, AbstractDataType<?> targetDataType);
+
+    /**
+     * Converts the given {@link Table} into a {@link DataStream} of changelog entries.
+     *
+     * <p>Compared to {@link #toDataStream(Table)}, this method produces instances of {@link Row}
+     * and sets the {@link RowKind} flag that is contained in every record during runtime. The
+     * runtime behavior is similar to that of a {@link DynamicTableSink}.
+     *
+     * <p>This method can emit a changelog containing all kinds of changes (enumerated in {@link
+     * RowKind}) that the given updating table requires as the default {@link ChangelogMode}. Use
+     * {@link #toChangelogStream(Table, Schema, ChangelogMode)} to limit the kinds of changes (e.g.
+     * for upsert mode).
+     *
+     * <p>Note that the type system of the table ecosystem is richer than the one of the DataStream
+     * API. The table runtime will make sure to properly serialize the output records to the first
+     * operator of the DataStream API. Afterwards, the {@link Types} semantics of the DataStream API
+     * need to be considered.
+     *
+     * <p>If the input table contains a single rowtime column, it will be propagated into a stream
+     * record's timestamp. Watermarks will be propagated as well.
+     *
+     * @param table The {@link Table} to convert. It can be updating or insert-only.
+     * @return The converted changelog stream of {@link Row}.
+     */
+    DataStream<Row> toChangelogStream(Table table);
+
+    /**
+     * Converts the given {@link Table} into a {@link DataStream} of changelog entries.
+     *
+     * <p>Compared to {@link #toDataStream(Table)}, this method produces instances of {@link Row}
+     * and sets the {@link RowKind} flag that is contained in every record during runtime. The
+     * runtime behavior is similar to that of a {@link DynamicTableSink}.
+     *
+     * <p>This method can emit a changelog containing all kinds of changes (enumerated in {@link
+     * RowKind}) that the given updating table requires as the default {@link ChangelogMode}. Use
+     * {@link #toChangelogStream(Table, Schema, ChangelogMode)} to limit the kinds of changes (e.g.
+     * for upsert mode).
+     *
+     * <p>The given {@link Schema} is used to configure the table runtime to convert columns and
+     * internal data structures to the desired representation. The following example shows how to
+     * convert a table column into a POJO type.
+     *
+     * <pre>
+     *     // given a Table of (id BIGINT, payload ROW < name STRING , age INT >)
+     *
+     *     public static class MyPojo {
+     *         public String name;
+     *         public Integer age;
+     *
+     *         // default constructor for DataStream API
+     *         public MyPojo() {}
+     *
+     *         // fully assigning constructor for field order in Table API
+     *         public MyPojo(String name, Integer age) {
+     *             this.name = name;
+     *             this.age = age;
+     *         }
+     *     }
+     *
+     *     tableEnv.toChangelogStream(
+     *         table,
+     *         Schema.newBuilder()
+     *             .column("id", DataTypes.BIGINT())
+     *             .column("payload", DataTypes.of(MyPojo.class)) // force an implicit conversion
+     *             .build());
+     * </pre>
+     *
+     * <p>Note that the type system of the table ecosystem is richer than the one of the DataStream
+     * API. The table runtime will make sure to properly serialize the output records to the first
+     * operator of the DataStream API. Afterwards, the {@link Types} semantics of the DataStream API
+     * need to be considered.
+     *
+     * <p>If the input table contains a single rowtime column, it will be propagated into a stream
+     * record's timestamp. Watermarks will be propagated as well.
+     *
+     * <p>If the rowtime should not be a concrete field in the final {@link Row} anymore, or the
+     * schema should be symmetrical for both {@link #fromChangelogStream} and {@link
+     * #toChangelogStream}, the rowtime can also be declared as a metadata column that will be
+     * propagated into a stream record's timestamp. It is possible to declare a schema without
+     * physical/regular columns. In this case, those columns will be automatically derived and
+     * implicitly put at the beginning of the schema declaration.
+     *
+     * <p>The following examples illustrate common schema declarations and their semantics:
+     *
+     * <pre>
+     *     // given a Table of (id INT, name STRING, my_rowtime TIMESTAMP_LTZ(3))
+     *
+     *     // === EXAMPLE 1 ===
+     *
+     *     // no physical columns defined, they will be derived automatically,
+     *     // the last derived physical column will be skipped in favor of the metadata column
+     *
+     *     Schema.newBuilder()
+     *         .columnByMetadata("rowtime", "TIMESTAMP_LTZ(3)")
+     *         .build()
+     *
+     *     // equal to: CREATE TABLE (id INT, name STRING, rowtime TIMESTAMP_LTZ(3) METADATA)
+     *
+     *     // === EXAMPLE 2 ===
+     *
+     *     // physical columns defined, all columns must be defined
+     *
+     *     Schema.newBuilder()
+     *         .column("id", "INT")
+     *         .column("name", "STRING")
+     *         .columnByMetadata("rowtime", "TIMESTAMP_LTZ(3)")
+     *         .build()
+     *
+     *     // equal to: CREATE TABLE (id INT, name STRING, rowtime TIMESTAMP_LTZ(3) METADATA)
+     * </pre>
+     *
+     * @param table The {@link Table} to convert. It can be updating or insert-only.
+     * @param targetSchema The {@link Schema} that decides about the final external representation
+     *     in {@link DataStream} records.
+     * @return The converted changelog stream of {@link Row}.
+     */
+    DataStream<Row> toChangelogStream(Table table, Schema targetSchema);
+
+    /**
+     * Converts the given {@link Table} into a {@link DataStream} of changelog entries.
+     *
+     * <p>Compared to {@link #toDataStream(Table)}, this method produces instances of {@link Row}
+     * and sets the {@link RowKind} flag that is contained in every record during runtime. The
+     * runtime behavior is similar to that of a {@link DynamicTableSink}.
+     *
+     * <p>This method requires an explicitly declared {@link ChangelogMode}. For example, use {@link
+     * ChangelogMode#upsert()} if the stream will not contain {@link RowKind#UPDATE_BEFORE}, or
+     * {@link ChangelogMode#insertOnly()} for non-updating streams.
+     *
+     * <p>Note that the type system of the table ecosystem is richer than the one of the DataStream
+     * API. The table runtime will make sure to properly serialize the output records to the first
+     * operator of the DataStream API. Afterwards, the {@link Types} semantics of the DataStream API
+     * need to be considered.
+     *
+     * <p>If the input table contains a single rowtime column, it will be propagated into a stream
+     * record's timestamp. Watermarks will be propagated as well. However, it is also possible to
+     * write out the rowtime as a metadata column. See {@link #toChangelogStream(Table, Schema)} for
+     * more information and examples on how to declare a {@link Schema}.
+     *
+     * @param table The {@link Table} to convert. It can be updating or insert-only.
+     * @param targetSchema The {@link Schema} that decides about the final external representation
+     *     in {@link DataStream} records.
+     * @param changelogMode The required kinds of changes in the result changelog. An exception will
+     *     be thrown if the given updating table cannot be represented in this changelog mode.
+     * @return The converted changelog stream of {@link Row}.
+     */
+    DataStream<Row> toChangelogStream(
+            Table table, Schema targetSchema, ChangelogMode changelogMode);
 
     /**
      * Converts the given {@link DataStream} into a {@link Table} with specified field names.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExternalModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExternalModifyOperation.java
@@ -25,9 +25,12 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.types.DataType;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /** Internal operation used to convert a {@link Table} into a DataStream. */
@@ -42,7 +45,8 @@ public final class ExternalModifyOperation implements ModifyOperation {
 
     private final ResolvedSchema resolvedSchema;
 
-    private final ChangelogMode changelogMode;
+    /** Null if changelog mode is derived from input. */
+    private final @Nullable ChangelogMode changelogMode;
 
     private final DataType physicalDataType;
 
@@ -76,8 +80,8 @@ public final class ExternalModifyOperation implements ModifyOperation {
         return physicalDataType;
     }
 
-    public ChangelogMode getChangelogMode() {
-        return changelogMode;
+    public Optional<ChangelogMode> getChangelogMode() {
+        return Optional.ofNullable(changelogMode);
     }
 
     public ResolvedSchema getResolvedSchema() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
@@ -38,6 +38,13 @@ public final class ChangelogMode {
     private static final ChangelogMode INSERT_ONLY =
             ChangelogMode.newBuilder().addContainedKind(RowKind.INSERT).build();
 
+    private static final ChangelogMode UPSERT =
+            ChangelogMode.newBuilder()
+                    .addContainedKind(RowKind.INSERT)
+                    .addContainedKind(RowKind.UPDATE_AFTER)
+                    .addContainedKind(RowKind.DELETE)
+                    .build();
+
     private final Set<RowKind> kinds;
 
     private ChangelogMode(Set<RowKind> kinds) {
@@ -49,6 +56,14 @@ public final class ChangelogMode {
     /** Shortcut for a simple {@link RowKind#INSERT}-only changelog. */
     public static ChangelogMode insertOnly() {
         return INSERT_ONLY;
+    }
+
+    /**
+     * Shortcut for an upsert changelog that describes idempotent updates on a key and thus does not
+     * contain {@link RowKind#UPDATE_BEFORE} rows.
+     */
+    public static ChangelogMode upsert() {
+        return UPSERT;
     }
 
     /** Builder for configuring and creating instances of {@link ChangelogMode}. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
@@ -45,6 +45,14 @@ public final class ChangelogMode {
                     .addContainedKind(RowKind.DELETE)
                     .build();
 
+    private static final ChangelogMode ALL =
+            ChangelogMode.newBuilder()
+                    .addContainedKind(RowKind.INSERT)
+                    .addContainedKind(RowKind.UPDATE_BEFORE)
+                    .addContainedKind(RowKind.UPDATE_AFTER)
+                    .addContainedKind(RowKind.DELETE)
+                    .build();
+
     private final Set<RowKind> kinds;
 
     private ChangelogMode(Set<RowKind> kinds) {
@@ -64,6 +72,11 @@ public final class ChangelogMode {
      */
     public static ChangelogMode upsert() {
         return UPSERT;
+    }
+
+    /** Shortcut for a changelog that can contain all {@link RowKind}s. */
+    public static ChangelogMode all() {
+        return ALL;
     }
 
     /** Builder for configuring and creating instances of {@link ChangelogMode}. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/connectors/DynamicSinkUtils.java
@@ -138,7 +138,7 @@ public final class DynamicSinkUtils {
         final ResolvedCatalogTable catalogTable = new ResolvedCatalogTable(unresolvedTable, schema);
         final DynamicTableSink tableSink =
                 new ExternalDynamicSink(
-                        externalModifyOperation.getChangelogMode(),
+                        externalModifyOperation.getChangelogMode().orElse(null),
                         externalModifyOperation.getPhysicalDataType());
         return convertSinkToRel(
                 relBuilder,

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSource.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSource.java
@@ -59,7 +59,7 @@ final class ExternalDynamicSource<E>
 
     // mutable attributes
 
-    private boolean attachRowtime;
+    private boolean produceRowtimeMetadata;
 
     private boolean propagateWatermark;
 
@@ -81,7 +81,7 @@ final class ExternalDynamicSource<E>
         final ExternalDynamicSource<E> copy =
                 new ExternalDynamicSource<>(
                         identifier, dataStream, physicalDataType, isTopLevelRecord, changelogMode);
-        copy.attachRowtime = attachRowtime;
+        copy.produceRowtimeMetadata = produceRowtimeMetadata;
         copy.propagateWatermark = propagateWatermark;
         return copy;
     }
@@ -110,7 +110,7 @@ final class ExternalDynamicSource<E>
                         new InputConversionOperator<>(
                                 physicalConverter,
                                 !isTopLevelRecord,
-                                attachRowtime,
+                                produceRowtimeMetadata,
                                 propagateWatermark,
                                 changelogMode.containsOnly(RowKind.INSERT)),
                         null, // will be filled by the framework
@@ -124,7 +124,7 @@ final class ExternalDynamicSource<E>
                 "DataSteamToTable(stream=%s, type=%s, rowtime=%s, watermark=%s)",
                 identifier.asSummaryString(),
                 physicalDataType.toString(),
-                attachRowtime,
+                produceRowtimeMetadata,
                 propagateWatermark);
     }
 
@@ -135,7 +135,7 @@ final class ExternalDynamicSource<E>
 
     @Override
     public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-        attachRowtime = metadataKeys.contains(ROWTIME_METADATA_KEY);
+        produceRowtimeMetadata = metadataKeys.contains(ROWTIME_METADATA_KEY);
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -38,11 +38,14 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.WatermarkSpec;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Either;
 import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
 
@@ -288,6 +291,150 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                 Row.of("c", 1000));
     }
 
+    @Test
+    public void testFromAndToChangelogStreamEventTime() throws Exception {
+        final DataStream<Tuple3<Long, Integer, String>> dataStream = getWatermarkedDataStream();
+
+        final DataStream<Row> changelogStream =
+                dataStream
+                        .map(t -> Row.ofKind(RowKind.INSERT, t.f1, t.f2))
+                        .returns(Types.ROW(Types.INT, Types.STRING));
+
+        // derive physical columns and add a rowtime
+        final Table table =
+                tableEnv.fromChangelogStream(
+                        changelogStream,
+                        Schema.newBuilder()
+                                .columnByMetadata("rowtime", DataTypes.TIMESTAMP(3))
+                                .watermark("rowtime", "SOURCE_WATERMARK()")
+                                .build());
+        tableEnv.createTemporaryView("t", table);
+
+        // access and reorder columns
+        final Table reordered = tableEnv.sqlQuery("SELECT f1, rowtime, f0 FROM t");
+
+        // write out the rowtime column with fully declared schema
+        final DataStream<Row> result =
+                tableEnv.toChangelogStream(
+                        reordered,
+                        Schema.newBuilder()
+                                .column("f1", DataTypes.STRING())
+                                .columnByMetadata("rowtime", DataTypes.TIMESTAMP_LTZ(3))
+                                .column("f0", DataTypes.INT())
+                                .build());
+
+        // test event time window and field access
+        testResult(
+                result.keyBy(k -> k.getField("f1"))
+                        .window(TumblingEventTimeWindows.of(Time.milliseconds(5)))
+                        .<Row>apply(
+                                (key, window, input, out) -> {
+                                    int sum = 0;
+                                    for (Row row : input) {
+                                        sum += row.<Integer>getFieldAs("f0");
+                                    }
+                                    out.collect(Row.of(key, sum));
+                                })
+                        .returns(Types.ROW(Types.STRING, Types.INT)),
+                Row.of("a", 47),
+                Row.of("c", 1000),
+                Row.of("c", 1000));
+    }
+
+    @Test
+    public void testFromAndToChangelogStreamRetract() throws Exception {
+        final List<Either<Row, Row>> inputOrOutput =
+                Arrays.asList(
+                        input(RowKind.INSERT, "bob", 0),
+                        output(RowKind.INSERT, "bob", 0),
+                        // --
+                        input(RowKind.UPDATE_BEFORE, "bob", 0),
+                        output(RowKind.DELETE, "bob", 0),
+                        // --
+                        input(RowKind.UPDATE_AFTER, "bob", 1),
+                        output(RowKind.INSERT, "bob", 1),
+                        // --
+                        input(RowKind.INSERT, "alice", 1),
+                        output(RowKind.INSERT, "alice", 1),
+                        // --
+                        input(RowKind.INSERT, "alice", 1),
+                        output(RowKind.UPDATE_BEFORE, "alice", 1),
+                        output(RowKind.UPDATE_AFTER, "alice", 2),
+                        // --
+                        input(RowKind.UPDATE_BEFORE, "alice", 1),
+                        output(RowKind.UPDATE_BEFORE, "alice", 2),
+                        output(RowKind.UPDATE_AFTER, "alice", 1),
+                        // --
+                        input(RowKind.UPDATE_AFTER, "alice", 2),
+                        output(RowKind.UPDATE_BEFORE, "alice", 1),
+                        output(RowKind.UPDATE_AFTER, "alice", 3),
+                        // --
+                        input(RowKind.UPDATE_BEFORE, "alice", 2),
+                        output(RowKind.UPDATE_BEFORE, "alice", 3),
+                        output(RowKind.UPDATE_AFTER, "alice", 1),
+                        // --
+                        input(RowKind.UPDATE_AFTER, "alice", 100),
+                        output(RowKind.UPDATE_BEFORE, "alice", 1),
+                        output(RowKind.UPDATE_AFTER, "alice", 101));
+
+        final DataStream<Row> changelogStream = env.fromElements(getInput(inputOrOutput));
+        tableEnv.createTemporaryView("t", tableEnv.fromChangelogStream(changelogStream));
+
+        final Table result = tableEnv.sqlQuery("SELECT f0, SUM(f1) FROM t GROUP BY f0");
+
+        testResult(result.execute(), getOutput(inputOrOutput));
+
+        testResult(tableEnv.toChangelogStream(result), getOutput(inputOrOutput));
+    }
+
+    @Test
+    public void testFromAndToChangelogStreamUpsert() throws Exception {
+        final List<Either<Row, Row>> inputOrOutput =
+                Arrays.asList(
+                        input(RowKind.INSERT, "bob", 0),
+                        output(RowKind.INSERT, "bob", 0),
+                        // --
+                        input(RowKind.UPDATE_AFTER, "bob", 1),
+                        output(RowKind.DELETE, "bob", 0),
+                        output(RowKind.INSERT, "bob", 1),
+                        // --
+                        input(RowKind.INSERT, "alice", 1),
+                        output(RowKind.INSERT, "alice", 1),
+                        // --
+                        input(RowKind.INSERT, "alice", 1), // no impact
+                        // --
+                        input(RowKind.UPDATE_AFTER, "alice", 2),
+                        output(RowKind.DELETE, "alice", 1),
+                        output(RowKind.INSERT, "alice", 2),
+                        // --
+                        input(RowKind.UPDATE_AFTER, "alice", 100),
+                        output(RowKind.DELETE, "alice", 2),
+                        output(RowKind.INSERT, "alice", 100));
+
+        final DataStream<Row> changelogStream = env.fromElements(getInput(inputOrOutput));
+        tableEnv.createTemporaryView(
+                "t",
+                tableEnv.fromChangelogStream(
+                        changelogStream,
+                        Schema.newBuilder().primaryKey("f0").build(),
+                        ChangelogMode.upsert()));
+
+        final Table result = tableEnv.sqlQuery("SELECT f0, SUM(f1) FROM t GROUP BY f0");
+
+        testResult(result.execute(), getOutput(inputOrOutput));
+
+        testResult(
+                tableEnv.toChangelogStream(
+                        result,
+                        Schema.newBuilder().primaryKey("f0").build(),
+                        ChangelogMode.upsert()),
+                getOutput(inputOrOutput));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper methods
+    // --------------------------------------------------------------------------------------------
+
     private DataStream<Tuple3<Long, Integer, String>> getWatermarkedDataStream() {
         final DataStream<Tuple3<Long, Integer, String>> dataStream =
                 env.fromCollection(
@@ -301,6 +448,25 @@ public class DataStreamJavaITCase extends AbstractTestBase {
         return dataStream.assignTimestampsAndWatermarks(
                 WatermarkStrategy.<Tuple3<Long, Integer, String>>forMonotonousTimestamps()
                         .withTimestampAssigner((ctx) -> (element, recordTimestamp) -> element.f0));
+    }
+
+    private static Either<Row, Row> input(RowKind kind, Object... fields) {
+        return Either.Left(Row.ofKind(kind, fields));
+    }
+
+    private static Row[] getInput(List<Either<Row, Row>> inputOrOutput) {
+        return inputOrOutput.stream().filter(Either::isLeft).map(Either::left).toArray(Row[]::new);
+    }
+
+    private static Either<Row, Row> output(RowKind kind, Object... fields) {
+        return Either.Right(Row.ofKind(kind, fields));
+    }
+
+    private static Row[] getOutput(List<Either<Row, Row>> inputOrOutput) {
+        return inputOrOutput.stream()
+                .filter(Either::isRight)
+                .map(Either::right)
+                .toArray(Row[]::new);
     }
 
     private static void testSchema(Table table, Column... expectedColumns) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperator.java
@@ -40,15 +40,19 @@ public class OutputConversionOperator extends TableStreamOperator<Object>
 
     private final int rowtimeIndex;
 
+    private final boolean consumeRowtimeMetadata;
+
     private transient StreamRecord<Object> outRecord;
 
     public OutputConversionOperator(
             @Nullable RowData.FieldGetter atomicFieldGetter,
             DataStructureConverter converter,
-            int rowtimeIndex) {
+            int rowtimeIndex,
+            boolean consumeRowtimeMetadata) {
         this.atomicFieldGetter = atomicFieldGetter;
         this.converter = converter;
         this.rowtimeIndex = rowtimeIndex;
+        this.consumeRowtimeMetadata = consumeRowtimeMetadata;
     }
 
     @Override
@@ -65,7 +69,10 @@ public class OutputConversionOperator extends TableStreamOperator<Object>
     public void processElement(StreamRecord<RowData> element) throws Exception {
         final RowData rowData = element.getValue();
 
-        if (rowtimeIndex != -1) {
+        if (consumeRowtimeMetadata) {
+            final long rowtime = rowData.getTimestamp(rowData.getArity() - 1, 3).getMillisecond();
+            outRecord.setTimestamp(rowtime);
+        } else if (rowtimeIndex != -1) {
             final long rowtime = rowData.getTimestamp(rowtimeIndex, 3).getMillisecond();
             outRecord.setTimestamp(rowtime);
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/source/InputConversionOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/source/InputConversionOperator.java
@@ -45,7 +45,7 @@ public final class InputConversionOperator<E> extends TableStreamOperator<RowDat
 
     private final boolean requiresWrapping;
 
-    private final boolean attachRowtime;
+    private final boolean produceRowtimeMetadata;
 
     private final boolean propagateWatermark;
 
@@ -56,12 +56,12 @@ public final class InputConversionOperator<E> extends TableStreamOperator<RowDat
     public InputConversionOperator(
             DataStructureConverter converter,
             boolean requiresWrapping,
-            boolean attachRowtime,
+            boolean produceRowtimeMetadata,
             boolean propagateWatermark,
             boolean isInsertOnly) {
         this.converter = converter;
         this.requiresWrapping = requiresWrapping;
-        this.attachRowtime = attachRowtime;
+        this.produceRowtimeMetadata = produceRowtimeMetadata;
         this.propagateWatermark = propagateWatermark;
         this.isInsertOnly = isInsertOnly;
     }
@@ -124,7 +124,7 @@ public final class InputConversionOperator<E> extends TableStreamOperator<RowDat
                             kind));
         }
 
-        if (!attachRowtime) {
+        if (!produceRowtimeMetadata) {
             output.collect(outRecord.replace(payloadRowData));
             return;
         }


### PR DESCRIPTION
## What is the purpose of the change

This adds `StreamTableEnvironment.fromChangelogStream` and `StreamTableEnvironment.toChangelogStream` mentioned in FLIP-136.

Now the following is supported:

```
DataStream<Row> dataStream =
        env.fromElements(
                Row.ofKind(RowKind.INSERT, "alice", 12),
                Row.ofKind(RowKind.UPDATE_AFTER, "alice", 13),
                Row.ofKind(RowKind.UPDATE_AFTER, "alice", 14));
tEnv
    .fromChangelogStream(
        dataStream,
        Schema.newBuilder().primaryKey("f0").build(),
        ChangelogMode.upsert()
    )
    .groupBy($("f0"))
    .select($("f0"), $("f1").sum())
    .execute()
    .print();
```


## Brief change log

- Improve the schema translator to make schema derivation work with a declared schema with writable metadata and primary keys.
- Expose API methods for Java and Scala.

## Verifying this change

This change added tests and can be verified as follows:

- `ExternalSchemaTranslatorTest`
- `DataStreamJavaITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
