### PR TITLE
[FLINK-22113][table-planner-blink] Implement the column uniqueness checking for TableSourceTable

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.metadata
 
 import org.apache.flink.table.api.TableException
+import org.apache.flink.table.catalog.CatalogTable
 import org.apache.flink.table.planner.JBoolean
 import org.apache.flink.table.planner.expressions.PlannerNamedWindowProperty
 import org.apache.flink.table.planner.plan.nodes.FlinkRelNode
@@ -27,11 +28,10 @@ import org.apache.flink.table.planner.plan.nodes.logical._
 import org.apache.flink.table.planner.plan.nodes.physical.batch._
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalLookupJoin
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
-import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase
+import org.apache.flink.table.planner.plan.schema.{FlinkPreparingTableBase, TableSourceTable}
 import org.apache.flink.table.planner.plan.utils.{FlinkRelMdUtil, RankUtil}
 import org.apache.flink.table.runtime.operators.rank.RankType
 import org.apache.flink.table.sources.TableSource
-
 import org.apache.calcite.plan.RelOptTable
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.`type`.RelDataType
@@ -43,9 +43,8 @@ import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.util.{Bug, BuiltInMethod, ImmutableBitSet, Util}
-
 import java.util
-
+import com.google.common.collect.ImmutableSet
 import scala.collection.JavaConversions._
 
 /**
@@ -81,9 +80,29 @@ class FlinkRelMdColumnUniqueness private extends MetadataHandler[BuiltInMetadata
       return false
     }
 
-    // TODO get uniqueKeys from TableSchema of TableSource
-
     relOptTable match {
+      case sourceTable: TableSourceTable =>
+        val catalogTable = sourceTable.catalogTable
+        catalogTable match {
+          case act: CatalogTable =>
+            val schema = act.getSchema
+            val builder = ImmutableSet.builder[ImmutableBitSet]()
+            if (schema.getPrimaryKey.isPresent) {
+              val columns = schema.getFieldNames
+              val columnIndices = schema.getPrimaryKey.get().getColumns map { c =>
+                columns.indexOf(c)
+              }
+              builder.add(ImmutableBitSet.of(columnIndices: _*))
+            }
+            val uniqueSet = sourceTable.uniqueKeysSet().orElse(null)
+            if (uniqueSet != null) {
+              builder.addAll(uniqueSet)
+            }
+            val uniqueKeys = builder.build()
+            uniqueKeys.exists {
+              uniqueKey => uniqueKey.forall(columns.toArray.contains(_))
+            }
+        }
       case table: FlinkPreparingTableBase => {
         val ukOptional = table.uniqueKeysSet
         if (ukOptional.isPresent) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -623,7 +623,12 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testAreColumnsUniqueOnTableSourceTable(): Unit = {
-    Array(tableSourceTableLogicalScan, tableSourceTableFlinkLogicalScan, tableSourceTableBatchScan, tableSourceTableStreamScan)
+    Array(
+      tableSourceTableLogicalScan,
+      tableSourceTableFlinkLogicalScan,
+      tableSourceTableBatchScan,
+      tableSourceTableStreamScan
+    )
       .foreach { scan =>
         assertTrue(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1, 2, 3)))
         assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(1, 2)))
@@ -634,7 +639,12 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testAreColumnsUniqueOntableSourceTableNonKeyNonKey(): Unit = {
-    Array(tableSourceTableNonKeyLogicalScan, tableSourceTableNonKeyFlinkLogicalScan, tableSourceTableNonKeyBatchScan, tableSourceTableNonKeyStreamScan)
+    Array(
+      tableSourceTableNonKeyLogicalScan,
+      tableSourceTableNonKeyFlinkLogicalScan,
+      tableSourceTableNonKeyBatchScan,
+      tableSourceTableNonKeyStreamScan
+    )
       .foreach { scan =>
         assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1, 2, 3)))
       }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.plan.metadata
 import org.apache.flink.table.planner.plan.nodes.calcite.{LogicalExpand, LogicalRank}
 import org.apache.flink.table.planner.plan.utils.ExpandUtil
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
-
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.rel.`type`.RelDataTypeFieldImpl
 import org.apache.calcite.rel.{RelCollations, RelNode}
@@ -620,6 +619,25 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
     (0 until testRel.getRowType.getFieldCount).foreach { idx =>
       assertNull(mq.areColumnsUnique(testRel, ImmutableBitSet.of(idx)))
     }
+  }
+
+  @Test
+  def testAreColumnsUniqueOnTableSourceTable(): Unit = {
+    Array(tableSourceTableLogicalScan, tableSourceTableFlinkLogicalScan, tableSourceTableBatchScan, tableSourceTableStreamScan)
+      .foreach { scan =>
+        assertTrue(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1, 2, 3)))
+        assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(1, 2)))
+        assertTrue(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1)))
+        assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(0)))
+      }
+  }
+
+  @Test
+  def testAreColumnsUniqueOntableSourceTableNonKeyNonKey(): Unit = {
+    Array(tableSourceTableNonKeyLogicalScan, tableSourceTableNonKeyFlinkLogicalScan, tableSourceTableNonKeyBatchScan, tableSourceTableNonKeyStreamScan)
+      .foreach { scan =>
+        assertFalse(mq.areColumnsUnique(scan, ImmutableBitSet.of(0, 1, 2, 3)))
+      }
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -166,22 +166,22 @@ class FlinkRelMdHandlerTestBase {
     createDataStreamScan(ImmutableList.of("emp"), streamPhysicalTraits)
 
   protected lazy val tableSourceTableLogicalScan: LogicalTableScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), logicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable1"), logicalTraits)
   protected lazy val tableSourceTableFlinkLogicalScan: FlinkLogicalDataStreamTableScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), flinkLogicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable1"), flinkLogicalTraits)
   protected lazy val tableSourceTableBatchScan: BatchPhysicalBoundedStreamScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), batchPhysicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable1"), batchPhysicalTraits)
   protected lazy val tableSourceTableStreamScan: StreamPhysicalDataStreamScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable1"), streamPhysicalTraits)
-  
+    createTableSourceTable(ImmutableList.of("TableSourceTable1"), streamPhysicalTraits)
+
   protected lazy val tableSourceTableNonKeyLogicalScan: LogicalTableScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), logicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable3"), logicalTraits)
   protected lazy val tableSourceTableNonKeyFlinkLogicalScan: FlinkLogicalDataStreamTableScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), flinkLogicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable3"), flinkLogicalTraits)
   protected lazy val tableSourceTableNonKeyBatchScan: BatchPhysicalBoundedStreamScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), batchPhysicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable3"), batchPhysicalTraits)
   protected lazy val tableSourceTableNonKeyStreamScan: StreamPhysicalDataStreamScan =
-    createDataStreamScanForTableSourceTable(ImmutableList.of("TableSourceTable3"), streamPhysicalTraits)
+    createTableSourceTable(ImmutableList.of("TableSourceTable3"), streamPhysicalTraits)
 
   private lazy val valuesType = relBuilder.getTypeFactory
     .builder()
@@ -402,7 +402,7 @@ class FlinkRelMdHandlerTestBase {
       flinkLogicalTraits.replace(collection), studentFlinkLogicalScan, collection, offset, fetch)
 
     val batchSortLimit = new BatchPhysicalSortLimit(
-        cluster, batchPhysicalTraits.replace(collection),
+      cluster, batchPhysicalTraits.replace(collection),
       new BatchPhysicalExchange(
         cluster, batchPhysicalTraits.replace(FlinkRelDistribution.SINGLETON), studentBatchScan,
         FlinkRelDistribution.SINGLETON),
@@ -414,7 +414,7 @@ class FlinkRelMdHandlerTestBase {
       relBuilder.literal(SortUtil.getLimitEnd(offset, fetch)),
       false)
     val batchSortGlobal = new BatchPhysicalSortLimit(
-        cluster, batchPhysicalTraits.replace(collection),
+      cluster, batchPhysicalTraits.replace(collection),
       new BatchPhysicalExchange(
         cluster, batchPhysicalTraits.replace(FlinkRelDistribution.SINGLETON), batchSortLocalLimit,
         FlinkRelDistribution.SINGLETON),
@@ -1119,10 +1119,10 @@ class FlinkRelMdHandlerTestBase {
     relBuilder.push(calcOnStudentScan)
 
     def createSingleArgAggWithFilter(
-        aggFunction: SqlAggFunction,
-        argIndex: Int,
-        filterArg: Int,
-        name: String): AggregateCall = {
+                                      aggFunction: SqlAggFunction,
+                                      argIndex: Int,
+                                      filterArg: Int,
+                                      name: String): AggregateCall = {
       AggregateCall.create(
         aggFunction,
         false,
@@ -1408,7 +1408,7 @@ class FlinkRelMdHandlerTestBase {
   // only for row_time we distinguish by batch row time, for what we hard code DataTypes.TIMESTAMP,
   // which is ok here for testing.
   private lazy val windowRef: PlannerWindowReference =
-    new PlannerWindowReference("w$", new TimestampType(3))
+  new PlannerWindowReference("w$", new TimestampType(3))
 
   protected lazy val tumblingGroupWindow: LogicalWindow =
     TumblingGroupWindow(
@@ -2599,32 +2599,51 @@ class FlinkRelMdHandlerTestBase {
     .scan("MyTable2")
     .minus(false).build()
 
-  // select * from TableSourceTable1 left join TableSourceTable2 on TableSourceTable1.b = TableSourceTable2.b
+  // select * from TableSourceTable1
+  // left join TableSourceTable2 on TableSourceTable1.b = TableSourceTable2.b
   protected lazy val logicalLeftJoinOnContainedUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable2")
-    .join(JoinRelType.LEFT,
-      relBuilder.call(EQUALS, relBuilder.field(2, 0, 1), relBuilder.field(2, 1, 1)))
+    .join(
+      JoinRelType.LEFT,
+      relBuilder.call(
+        EQUALS,
+        relBuilder.field(2, 0, 1),
+        relBuilder.field(2, 1, 1)
+      )
+    )
     .build
 
   // select * from TableSourceTable1 left join TableSourceTable2 on TableSourceTable1.a = TableSourceTable2.a
   protected lazy val logicalLeftJoinOnDisjointUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable2")
-    .join(JoinRelType.LEFT,
-      relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0)))
+    .join(
+      JoinRelType.LEFT,
+      relBuilder.call(
+        EQUALS,
+        relBuilder.field(2, 0, 0),
+        relBuilder.field(2, 1, 0)
+      )
+    )
     .build
 
   // select * from TableSourceTable1 left join TableSourceTable3 on TableSourceTable1.a = TableSourceTable3.a
-  protected lazy val logicalLeftJoinWithNonKeyTableUniqueKeys: RelNode = relBuilder
+  protected lazy val logicalLeftJoinWithNoneKeyTableUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable3")
-    .join(JoinRelType.LEFT,
-      relBuilder.call(EQUALS, relBuilder.field(2, 0, 0), relBuilder.field(2, 1, 0)))
+    .join(
+      JoinRelType.LEFT,
+      relBuilder.call(
+        EQUALS,
+        relBuilder.field(2, 0, 0),
+        relBuilder.field(2, 1, 0)
+      )
+    )
     .build
 
   protected def createDataStreamScan[T](
-      tableNames: util.List[String], traitSet: RelTraitSet): T = {
+                                         tableNames: util.List[String], traitSet: RelTraitSet): T = {
     val table = relBuilder
       .getRelOptSchema
       .asInstanceOf[CalciteCatalogReader]
@@ -2650,8 +2669,8 @@ class FlinkRelMdHandlerTestBase {
     scan.asInstanceOf[T]
   }
 
-  protected def createDataStreamScanForTableSourceTable[T](
-                                         tableNames: util.List[String], traitSet: RelTraitSet): T = {
+  protected def createTableSourceTable[T](
+                                                            tableNames: util.List[String], traitSet: RelTraitSet): T = {
     val table = relBuilder
       .getRelOptSchema
       .asInstanceOf[CalciteCatalogReader]
@@ -2678,8 +2697,8 @@ class FlinkRelMdHandlerTestBase {
   }
 
   protected def createLiteralList(
-      rowType: RelDataType,
-      literalValues: Seq[String]): util.List[RexLiteral] = {
+                                   rowType: RelDataType,
+                                   literalValues: Seq[String]): util.List[RexLiteral] = {
     require(literalValues.length == rowType.getFieldCount)
     val rexBuilder = relBuilder.getRexBuilder
     literalValues.zipWithIndex.map {
@@ -2700,15 +2719,15 @@ class FlinkRelMdHandlerTestBase {
             case VARCHAR => rexBuilder.makeLiteral(v)
             case _ => throw new TableException(s"${fieldType.getSqlTypeName} is not supported!")
           }
-        }.asInstanceOf[RexLiteral]
+          }.asInstanceOf[RexLiteral]
     }.toList
   }
 
   protected def createLogicalCalc(
-      input: RelNode,
-      outputRowType: RelDataType,
-      projects: util.List[RexNode],
-      conditions: util.List[RexNode]): Calc = {
+                                   input: RelNode,
+                                   outputRowType: RelDataType,
+                                   projects: util.List[RexNode],
+                                   conditions: util.List[RexNode]): Calc = {
     val predicate: RexNode = if (conditions == null || conditions.isEmpty) {
       null
     } else {
@@ -2724,10 +2743,10 @@ class FlinkRelMdHandlerTestBase {
   }
 
   protected def makeLiteral(
-      value: Any,
-      internalType: LogicalType,
-      isNullable: Boolean = false,
-      allowCast: Boolean = true): RexNode = {
+                             value: Any,
+                             internalType: LogicalType,
+                             isNullable: Boolean = false,
+                             allowCast: Boolean = true): RexNode = {
     rexBuilder.makeLiteral(
       value,
       typeFactory.createFieldTypeFromLogicalType(internalType.copy(isNullable)),
@@ -2737,9 +2756,9 @@ class FlinkRelMdHandlerTestBase {
 }
 
 class TestRel(
-    cluster: RelOptCluster,
-    traits: RelTraitSet,
-    input: RelNode) extends SingleRel(cluster, traits, input) {
+               cluster: RelOptCluster,
+               traits: RelTraitSet,
+               input: RelNode) extends SingleRel(cluster, traits, input) {
 
   override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
     planner.getCostFactory.makeCost(1.0, 1.0, 1.0)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -2671,7 +2671,7 @@ class FlinkRelMdHandlerTestBase {
     scan.asInstanceOf[T]
   }
 
-  protected def createDataStreamScanForTableSourceTable[T](
+  protected def createTableSourceTable[T](
       tableNames: util.List[String], traitSet: RelTraitSet): T = {
     val table = relBuilder
       .getRelOptSchema

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -402,7 +402,7 @@ class FlinkRelMdHandlerTestBase {
       flinkLogicalTraits.replace(collection), studentFlinkLogicalScan, collection, offset, fetch)
 
     val batchSortLimit = new BatchPhysicalSortLimit(
-      cluster, batchPhysicalTraits.replace(collection),
+        cluster, batchPhysicalTraits.replace(collection),
       new BatchPhysicalExchange(
         cluster, batchPhysicalTraits.replace(FlinkRelDistribution.SINGLETON), studentBatchScan,
         FlinkRelDistribution.SINGLETON),
@@ -414,7 +414,7 @@ class FlinkRelMdHandlerTestBase {
       relBuilder.literal(SortUtil.getLimitEnd(offset, fetch)),
       false)
     val batchSortGlobal = new BatchPhysicalSortLimit(
-      cluster, batchPhysicalTraits.replace(collection),
+        cluster, batchPhysicalTraits.replace(collection),
       new BatchPhysicalExchange(
         cluster, batchPhysicalTraits.replace(FlinkRelDistribution.SINGLETON), batchSortLocalLimit,
         FlinkRelDistribution.SINGLETON),
@@ -1119,10 +1119,10 @@ class FlinkRelMdHandlerTestBase {
     relBuilder.push(calcOnStudentScan)
 
     def createSingleArgAggWithFilter(
-                                      aggFunction: SqlAggFunction,
-                                      argIndex: Int,
-                                      filterArg: Int,
-                                      name: String): AggregateCall = {
+        aggFunction: SqlAggFunction,
+        argIndex: Int,
+        filterArg: Int,
+        name: String): AggregateCall = {
       AggregateCall.create(
         aggFunction,
         false,
@@ -1408,7 +1408,7 @@ class FlinkRelMdHandlerTestBase {
   // only for row_time we distinguish by batch row time, for what we hard code DataTypes.TIMESTAMP,
   // which is ok here for testing.
   private lazy val windowRef: PlannerWindowReference =
-  new PlannerWindowReference("w$", new TimestampType(3))
+    new PlannerWindowReference("w$", new TimestampType(3))
 
   protected lazy val tumblingGroupWindow: LogicalWindow =
     TumblingGroupWindow(
@@ -2614,7 +2614,8 @@ class FlinkRelMdHandlerTestBase {
     )
     .build
 
-  // select * from TableSourceTable1 left join TableSourceTable2 on TableSourceTable1.a = TableSourceTable2.a
+  // select * from TableSourceTable1
+  // left join TableSourceTable2 on TableSourceTable1.a = TableSourceTable2.a
   protected lazy val logicalLeftJoinOnDisjointUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable2")
@@ -2628,7 +2629,8 @@ class FlinkRelMdHandlerTestBase {
     )
     .build
 
-  // select * from TableSourceTable1 left join TableSourceTable3 on TableSourceTable1.a = TableSourceTable3.a
+  // select * from TableSourceTable1
+  // left join TableSourceTable3 on TableSourceTable1.a = TableSourceTable3.a
   protected lazy val logicalLeftJoinWithNoneKeyTableUniqueKeys: RelNode = relBuilder
     .scan("TableSourceTable1")
     .scan("TableSourceTable3")
@@ -2643,7 +2645,7 @@ class FlinkRelMdHandlerTestBase {
     .build
 
   protected def createDataStreamScan[T](
-                                         tableNames: util.List[String], traitSet: RelTraitSet): T = {
+      tableNames: util.List[String], traitSet: RelTraitSet): T = {
     val table = relBuilder
       .getRelOptSchema
       .asInstanceOf[CalciteCatalogReader]
@@ -2669,8 +2671,8 @@ class FlinkRelMdHandlerTestBase {
     scan.asInstanceOf[T]
   }
 
-  protected def createTableSourceTable[T](
-                                                            tableNames: util.List[String], traitSet: RelTraitSet): T = {
+  protected def createDataStreamScanForTableSourceTable[T](
+      tableNames: util.List[String], traitSet: RelTraitSet): T = {
     val table = relBuilder
       .getRelOptSchema
       .asInstanceOf[CalciteCatalogReader]
@@ -2697,8 +2699,8 @@ class FlinkRelMdHandlerTestBase {
   }
 
   protected def createLiteralList(
-                                   rowType: RelDataType,
-                                   literalValues: Seq[String]): util.List[RexLiteral] = {
+      rowType: RelDataType,
+      literalValues: Seq[String]): util.List[RexLiteral] = {
     require(literalValues.length == rowType.getFieldCount)
     val rexBuilder = relBuilder.getRexBuilder
     literalValues.zipWithIndex.map {
@@ -2719,15 +2721,15 @@ class FlinkRelMdHandlerTestBase {
             case VARCHAR => rexBuilder.makeLiteral(v)
             case _ => throw new TableException(s"${fieldType.getSqlTypeName} is not supported!")
           }
-          }.asInstanceOf[RexLiteral]
+        }.asInstanceOf[RexLiteral]
     }.toList
   }
 
   protected def createLogicalCalc(
-                                   input: RelNode,
-                                   outputRowType: RelDataType,
-                                   projects: util.List[RexNode],
-                                   conditions: util.List[RexNode]): Calc = {
+      input: RelNode,
+      outputRowType: RelDataType,
+      projects: util.List[RexNode],
+      conditions: util.List[RexNode]): Calc = {
     val predicate: RexNode = if (conditions == null || conditions.isEmpty) {
       null
     } else {
@@ -2743,10 +2745,10 @@ class FlinkRelMdHandlerTestBase {
   }
 
   protected def makeLiteral(
-                             value: Any,
-                             internalType: LogicalType,
-                             isNullable: Boolean = false,
-                             allowCast: Boolean = true): RexNode = {
+      value: Any,
+      internalType: LogicalType,
+      isNullable: Boolean = false,
+      allowCast: Boolean = true): RexNode = {
     rexBuilder.makeLiteral(
       value,
       typeFactory.createFieldTypeFromLogicalType(internalType.copy(isNullable)),
@@ -2756,9 +2758,9 @@ class FlinkRelMdHandlerTestBase {
 }
 
 class TestRel(
-               cluster: RelOptCluster,
-               traits: RelTraitSet,
-               input: RelNode) extends SingleRel(cluster, traits, input) {
+    cluster: RelOptCluster,
+    traits: RelTraitSet,
+    input: RelNode) extends SingleRel(cluster, traits, input) {
 
   override def computeSelfCost(planner: RelOptPlanner, mq: RelMetadataQuery): RelOptCost = {
     planner.getCostFactory.makeCost(1.0, 1.0, 1.0)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -316,9 +316,18 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
 
   @Test
   def testGetUniqueKeysOnTableScanTable(): Unit = {
-    assertEquals(uniqueKeys(Array(0, 1), Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnContainedUniqueKeys).toSet)
-    assertEquals(uniqueKeys(Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnDisjointUniqueKeys).toSet)
-    assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalLeftJoinWithNonKeyTableUniqueKeys).toSet)
+    assertEquals(
+      uniqueKeys(Array(0, 1), Array(0, 1, 5)),
+      mq.getUniqueKeys(logicalLeftJoinOnContainedUniqueKeys).toSet
+    )
+    assertEquals(
+      uniqueKeys(Array(0, 1, 5)),
+      mq.getUniqueKeys(logicalLeftJoinOnDisjointUniqueKeys).toSet
+    )
+    assertEquals(
+      uniqueKeys(),
+      mq.getUniqueKeys(logicalLeftJoinWithNoneKeyTableUniqueKeys).toSet
+    )
   }
 
   private def uniqueKeys(keys: Array[Int]*): Set[ImmutableBitSet] = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -314,6 +314,13 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
     assertNull(mq.getUniqueKeys(testRel))
   }
 
+  @Test
+  def testGetUniqueKeysOnTableScanTable(): Unit = {
+    assertEquals(uniqueKeys(Array(0, 1), Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnContainedUniqueKeys).toSet)
+    assertEquals(uniqueKeys(Array(0, 1, 5)), mq.getUniqueKeys(logicalLeftJoinOnDisjointUniqueKeys).toSet)
+    assertEquals(uniqueKeys(), mq.getUniqueKeys(logicalLeftJoinWithNonKeyTableUniqueKeys).toSet)
+  }
+
   private def uniqueKeys(keys: Array[Int]*): Set[ImmutableBitSet] = {
     keys.map(k => ImmutableBitSet.of(k: _*)).toSet
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -58,6 +58,7 @@ object MetadataTestUtil {
     rootSchema.add("TemporalTable3", createTemporalTable3())
     rootSchema.add("TableSourceTable1", createTableSourceTable1())
     rootSchema.add("TableSourceTable2", createTableSourceTable2())
+    rootSchema.add("TableSourceTable3", createTableSourceTable3())
     rootSchema.add("projected_table_source_table", createProjectedTableSourceTable())
     rootSchema.add(
       "projected_table_source_table_with_partial_pk",
@@ -362,6 +363,44 @@ object MetadataTestUtil {
 
     new MockTableSourceTable(
       ObjectIdentifier.of("default_catalog", "default_database", "TableSourceTable2"),
+      rowType,
+      new TestTableSource(),
+      true,
+      new ResolvedCatalogTable(catalogTable, resolvedSchema),
+      Array("project=[a, b, c, d]"))
+  }
+
+  private def createTableSourceTable3(): Table = {
+    val catalogTable = CatalogTable.fromProperties(
+      Map(
+        "connector" -> "values",
+        "bounded" -> "true",
+        "schema.0.name" -> "a",
+        "schema.0.data-type" -> "BIGINT NOT NULL",
+        "schema.1.name" -> "b",
+        "schema.1.data-type" -> "INT  NOT NULL",
+        "schema.2.name" -> "c",
+        "schema.2.data-type" -> "VARCHAR(2147483647)  NOT NULL",
+        "schema.3.name" -> "d",
+        "schema.3.data-type" -> "BIGINT NOT NULL")
+    )
+
+    val resolvedSchema = new ResolvedSchema(
+      util.Arrays.asList(
+        Column.physical("a", DataTypes.BIGINT().notNull()),
+        Column.physical("b", DataTypes.INT().notNull()),
+        Column.physical("c", DataTypes.STRING().notNull()),
+        Column.physical("d", DataTypes.BIGINT().notNull())),
+      Collections.emptyList(),
+      null)
+
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem)
+    val rowType = typeFactory.buildRelNodeRowType(
+      Seq("a", "b", "c", "d"),
+      Seq(new BigIntType(false), new IntType(), new VarCharType(false, 100), new BigIntType(false)))
+
+    new MockTableSourceTable(
+      ObjectIdentifier.of("default_catalog", "default_database", "TableSourceTable3"),
       rowType,
       new TestTableSource(),
       true,


### PR DESCRIPTION
## What is the purpose of the change
Implement the column uniqueness checking to avoid losing uniqueness information during join operations.

More specifically,
```
CREATE TEMPORARY TABLE passengers (
  passenger_key STRING,
  PRIMARY KEY (passenger_key) NOT ENFORCED
) WITH (
  'connector' = 'values'
)

CREATE TEMPORARY TABLE booking_channels (
  booking_channel_key STRING,
  PRIMARY KEY (booking_channel_key) NOT ENFORCED
) WITH (
  'connector' = 'values'
)

CREATE TEMPORARY TABLE train_activities (
  passenger_key STRING,
  booking_channel_key STRING,
  PRIMARY KEY (booking_channel_key) NOT ENFORCED
) WITH (
  'connector' = 'values'
)

SELECT t.booking_channel_key as booking_channel_key, t.passenger_key as passenger_key, b.booking_channel_key as booking_channel_key_0
FROM train_activities t
LEFT JOIN booking_channels b
ON t.booking_channel_key = b.booking_channel_key
LEFT JOIN passengers p
on t.passenger_key = p.passenger_key

== Optimized Physical Plan ==
Calc(select=[booking_channel_key, passenger_key, booking_channel_key0 AS booking_channel_key_0])
+- Join(joinType=[LeftOuterJoin], where=[=(passenger_key, passenger_key0)], select=[passenger_key, booking_channel_key, booking_channel_key0, passenger_key0], leftInputSpec=[HasUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :- Exchange(distribution=[hash[passenger_key]])
   :  +- Join(joinType=[LeftOuterJoin], where=[=(booking_channel_key, booking_channel_key0)], select=[passenger_key, booking_channel_key, booking_channel_key0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :     :- Exchange(distribution=[hash[booking_channel_key]])
   :     :  +- TableSourceScan(table=[[default_catalog, default_database, train_activities]], fields=[passenger_key, booking_channel_key])
   :     +- Exchange(distribution=[hash[booking_channel_key]])
   :        +- TableSourceScan(table=[[default_catalog, default_database, booking_channels]], fields=[booking_channel_key])
   +- Exchange(distribution=[hash[passenger_key]])
      +- TableSourceScan(table=[[default_catalog, default_database, passengers]], fields=[passenger_key])
```
VS
```
SELECT t.booking_channel_key as booking_channel_key, t.passenger_key as passenger_key
FROM train_activities t
LEFT JOIN booking_channels b
ON t.booking_channel_key = b.booking_channel_key
LEFT JOIN passengers p
on t.passenger_key = p.passenger_key


== Optimized Physical Plan ==
Calc(select=[booking_channel_key, passenger_key])
+- Join(joinType=[LeftOuterJoin], where=[=(passenger_key, passenger_key0)], select=[passenger_key, booking_channel_key, passenger_key0], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :- Exchange(distribution=[hash[passenger_key]])
   :  +- Calc(select=[passenger_key, booking_channel_key])
   :     +- Join(joinType=[LeftOuterJoin], where=[=(booking_channel_key, booking_channel_key0)], select=[passenger_key, booking_channel_key, booking_channel_key0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
   :        :- Exchange(distribution=[hash[booking_channel_key]])
   :        :  +- TableSourceScan(table=[[default_catalog, default_database, train_activities]], fields=[passenger_key, booking_channel_key])
   :        +- Exchange(distribution=[hash[booking_channel_key]])
   :           +- TableSourceScan(table=[[default_catalog, default_database, booking_channels]], fields=[booking_channel_key])
   +- Exchange(distribution=[hash[passenger_key]])
      +- TableSourceScan(table=[[default_catalog, default_database, passengers]], fields=[passenger_key])

```
 

**_The only difference is that we select booking_channel_key from both left and right table in the first case and only booking_channel_key from left table in the second case. The result is one has uniqueKey and the other doesn't._**

 
`t.booking_channel_key, t.passenger_key` can be the unique key of the first join output, but it seems we lost this unique information. 

## Brief change log
- *Implement the column uniqueness checking for TableSourceTable*
- *Add some test cases of uniqueness checking and getUniqueKey for TableSourceTable*


## Verifying this change

Existing and added test cases, manually rerun the example above and the uniqueness information was remained successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
