### PR TITLE
[FLINK-22275][table] Support random past for timestamp types in datagen connector

### DIFF
--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -125,6 +125,13 @@ CREATE TABLE datagen (
       <td>随机生成器的最大值，适用于数字类型。</td>
     </tr>
     <tr>
+      <td><h5>fields.#.max-past</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">0</td>
+      <td>Duration</td>
+      <td>随机生成器生成相对当前时间向过去偏移的最大值，适用于 Timestamp 类型.</td>
+    </tr>
+    <tr>
       <td><h5>fields.#.length</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">100</td>

--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -129,7 +129,7 @@ CREATE TABLE datagen (
       <td>可选</td>
       <td style="word-wrap: break-word;">0</td>
       <td>Duration</td>
-      <td>随机生成器生成相对当前时间向过去偏移的最大值，适用于 Timestamp 类型.</td>
+      <td>随机生成器生成相对当前时间向过去偏移的最大值，适用于 timestamp 类型。</td>
     </tr>
     <tr>
       <td><h5>fields.#.length</h5></td>

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -157,12 +157,18 @@ Types
         <tr>
             <td>TIMESTAMP</td>
             <td>random</td>
-            <td>Always resolves to the current timestamp of the local machine.</td>
+            <td>
+                Resolves a past timestamp relative to the current timestamp of the local machine.
+                The max past is specified by the 'max-past' option.
+            </td>
         </tr>
         <tr>
             <td>TIMESTAMP_LTZ</td>
             <td>random</td>
-            <td>Always resolves to the current timestamp of the local machine.</td>
+            <td>
+                Resolves a past timestamp relative to the current timestamp of the local machine.
+                The max past is specified by the 'max-past' option.
+            </td>
         </tr>
         <tr>
             <td>INTERVAL YEAR TO MONTH</td>
@@ -252,6 +258,13 @@ Connector Options
       <td style="word-wrap: break-word;">(Maximum value of type)</td>
       <td>(Type of field)</td>
       <td>Maximum value of random generator, work for numeric types.</td>
+    </tr>
+    <tr>
+      <td><h5>fields.#.max-past</h5></td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">0</td>
+      <td>Duration</td>
+      <td>Maximum past of timestamp random generator， work for timestamp types.</td>
     </tr>
     <tr>
       <td><h5>fields.#.length</h5></td>

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -159,7 +159,7 @@ Types
             <td>random</td>
             <td>
                 Resolves a past timestamp relative to the current timestamp of the local machine.
-                The max past is specified by the 'max-past' option.
+                The max past can be specified by the 'max-past' option.
             </td>
         </tr>
         <tr>
@@ -167,7 +167,7 @@ Types
             <td>random</td>
             <td>
                 Resolves a past timestamp relative to the current timestamp of the local machine.
-                The max past is specified by the 'max-past' option.
+                The max past can be specified by the 'max-past' option.
             </td>
         </tr>
         <tr>
@@ -264,7 +264,7 @@ Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">0</td>
       <td>Duration</td>
-      <td>Maximum past of timestamp random generator， work for timestamp types.</td>
+      <td>Maximum past of timestamp random generator, only works for timestamp types.</td>
     </tr>
     <tr>
       <td><h5>fields.#.length</h5></td>

--- a/flink-table/flink-sql-client/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/table.q
@@ -350,6 +350,7 @@ fields.amount.min
 fields.product.kind
 fields.product.length
 fields.ts.kind
+fields.ts.max-past
 fields.user.kind
 fields.user.max
 fields.user.min

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptions.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptions.java
@@ -22,12 +22,15 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
+import java.time.Duration;
+
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.END;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.FIELDS;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.KIND;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.LENGTH;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.MAX;
+import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.MAX_PAST;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.MIN;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.ROWS_PER_SECOND_DEFAULT_VALUE;
 import static org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil.START;
@@ -75,6 +78,14 @@ public class DataGenConnectorOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Maximum value to generate for fields of kind 'random'. Maximum value possible for the type of the field.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<Duration> FIELD_MAX_PAST =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, MAX_PAST))
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Maximum past relative to the current timestamp of the local machine to generate for timestamp fields of kind 'random'.");
 
     /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
     public static final ConfigOption<Integer> FIELD_LENGTH =

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptionsUtil.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenConnectorOptionsUtil.java
@@ -32,6 +32,7 @@ public class DataGenConnectorOptionsUtil {
     public static final String END = "end";
     public static final String MIN = "min";
     public static final String MAX = "max";
+    public static final String MAX_PAST = "max-past";
     public static final String LENGTH = "length";
 
     public static final String SEQUENCE = "sequence";

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSourceFactory.java
@@ -65,6 +65,7 @@ public class DataGenTableSourceFactory implements DynamicTableSourceFactory {
         options.add(DataGenConnectorOptions.FIELD_KIND);
         options.add(DataGenConnectorOptions.FIELD_MIN);
         options.add(DataGenConnectorOptions.FIELD_MAX);
+        options.add(DataGenConnectorOptions.FIELD_MAX_PAST);
         options.add(DataGenConnectorOptions.FIELD_LENGTH);
         options.add(DataGenConnectorOptions.FIELD_START);
         options.add(DataGenConnectorOptions.FIELD_END);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenVisitorBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenVisitorBase.java
@@ -24,13 +24,9 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.DateType;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimeType;
-import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.types.logical.ZonedTimestampType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 
 import java.io.Serializable;
@@ -64,24 +60,6 @@ public abstract class DataGenVisitorBase extends LogicalTypeDefaultVisitor<DataG
     @Override
     public DataGeneratorContainer visit(TimeType timeType) {
         return DataGeneratorContainer.of(TimeGenerator.of(() -> LocalTime.now().get(MILLI_OF_DAY)));
-    }
-
-    @Override
-    public DataGeneratorContainer visit(TimestampType timestampType) {
-        return DataGeneratorContainer.of(
-                TimeGenerator.of(() -> TimestampData.fromEpochMillis(System.currentTimeMillis())));
-    }
-
-    @Override
-    public DataGeneratorContainer visit(ZonedTimestampType zonedTimestampType) {
-        return DataGeneratorContainer.of(
-                TimeGenerator.of(() -> TimestampData.fromEpochMillis(System.currentTimeMillis())));
-    }
-
-    @Override
-    public DataGeneratorContainer visit(LocalZonedTimestampType localZonedTimestampType) {
-        return DataGeneratorContainer.of(
-                TimeGenerator.of(() -> TimestampData.fromEpochMillis(System.currentTimeMillis())));
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/RandomGeneratorVisitor.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -40,15 +41,19 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,6 +74,8 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
 
     private final ConfigOptions.OptionBuilder maxKey;
 
+    private final ConfigOptions.OptionBuilder maxPastKey;
+
     public RandomGeneratorVisitor(String name, ReadableConfig config) {
         super(name, config);
 
@@ -86,6 +93,13 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
                                 + name
                                 + "."
                                 + DataGenConnectorOptionsUtil.MAX);
+        this.maxPastKey =
+                key(
+                        DataGenConnectorOptionsUtil.FIELDS
+                                + "."
+                                + name
+                                + "."
+                                + DataGenConnectorOptionsUtil.MAX_PAST);
     }
 
     @Override
@@ -201,6 +215,33 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         ConfigOption<Long> max = maxKey.longType().defaultValue(Long.MAX_VALUE);
         return DataGeneratorContainer.of(
                 RandomGenerator.longGenerator(config.get(min), config.get(max)), min, max);
+    }
+
+    @Override
+    public DataGeneratorContainer visit(TimestampType timestampType) {
+        ConfigOption<Duration> maxPastOption =
+                maxPastKey.durationType().defaultValue(Duration.ZERO);
+
+        return DataGeneratorContainer.of(
+                getRandomPastTimestampGenerator(config.get(maxPastOption)), maxPastOption);
+    }
+
+    @Override
+    public DataGeneratorContainer visit(ZonedTimestampType zonedTimestampType) {
+        ConfigOption<Duration> maxPastOption =
+                maxPastKey.durationType().defaultValue(Duration.ZERO);
+
+        return DataGeneratorContainer.of(
+                getRandomPastTimestampGenerator(config.get(maxPastOption)), maxPastOption);
+    }
+
+    @Override
+    public DataGeneratorContainer visit(LocalZonedTimestampType localZonedTimestampType) {
+        ConfigOption<Duration> maxPastOption =
+                maxPastKey.durationType().defaultValue(Duration.ZERO);
+
+        return DataGeneratorContainer.of(
+                getRandomPastTimestampGenerator(config.get(maxPastOption)), maxPastOption);
     }
 
     @Override
@@ -322,6 +363,18 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
             @Override
             public StringData next() {
                 return StringData.fromString(random.nextHexString(length));
+            }
+        };
+    }
+
+    private static RandomGenerator<TimestampData> getRandomPastTimestampGenerator(
+            Duration maxPast) {
+        return new RandomGenerator<TimestampData>() {
+            @Override
+            public TimestampData next() {
+                long maxPastMillis = maxPast.toMillis();
+                long past = maxPastMillis > 0 ? random.nextLong(0, maxPastMillis) : 0;
+                return TimestampData.fromEpochMillis(System.currentTimeMillis() - past);
             }
         };
     }

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -57,7 +58,8 @@ public class DataGenTableSourceFactoryTest {
             ResolvedSchema.of(
                     Column.physical("f0", DataTypes.STRING()),
                     Column.physical("f1", DataTypes.BIGINT()),
-                    Column.physical("f2", DataTypes.BIGINT()));
+                    Column.physical("f2", DataTypes.BIGINT()),
+                    Column.physical("f3", DataTypes.TIMESTAMP()));
 
     @Test
     public void testDataTypeCoverage() throws Exception {
@@ -156,7 +158,16 @@ public class DataGenTableSourceFactoryTest {
         descriptor.putLong(
                 DataGenConnectorOptionsUtil.FIELDS + ".f2." + DataGenConnectorOptionsUtil.END, 60);
 
+        descriptor.putString(
+                DataGenConnectorOptionsUtil.FIELDS + ".f3." + DataGenConnectorOptionsUtil.KIND,
+                DataGenConnectorOptionsUtil.RANDOM);
+        descriptor.putString(
+                DataGenConnectorOptionsUtil.FIELDS + ".f3." + DataGenConnectorOptionsUtil.MAX_PAST,
+                "5s");
+
+        final long begin = System.currentTimeMillis();
         List<RowData> results = runGenerator(SCHEMA, descriptor);
+        final long end = System.currentTimeMillis();
 
         Assert.assertEquals(11, results.size());
         for (int i = 0; i < results.size(); i++) {
@@ -165,6 +176,8 @@ public class DataGenTableSourceFactoryTest {
             long f1 = row.getLong(1);
             Assert.assertTrue(f1 >= 10 && f1 <= 100);
             Assert.assertEquals(i + 50, row.getLong(2));
+            final TimestampData f3 = row.getTimestamp(3, 3);
+            Assert.assertTrue(f3.getMillisecond() >= begin - 5000 && f3.getMillisecond() <= end);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Introduce a `max-past` duration option for timestamp type fields. If the `max-past` is specified, it will resolve a past timestamp relative to the current timestamp of the local machine.

You can use it to achieve the out-of-order effect.


## Brief change log

  - Add a `max-past` option for timestamp types in datagen connector.


## Verifying this change

This change added tests and can be verified as follows:

  - Added test that validates that the `max-past` option is available.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
