### PR TITLE
[FLINK-19519] [Runtime/Configuration] Support port range for Taskmanager data port configuration

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -27,6 +27,12 @@
             <td>Time we wait for the timers in milliseconds to finish all pending timer threads when the stream task is cancelled.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.data.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The task manager's bind port used for data exchange operations. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine. If not configured, 'taskmanager.data.port' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/common_host_port_section.html
+++ b/docs/layouts/shortcodes/generated/common_host_port_section.html
@@ -51,6 +51,12 @@
             <td>The port that the client connects to. If rest.bind-port has not been specified, then the REST server will bind to this port. Attention: This option is respected only if the high-availability configuration is NONE.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.data.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The task manager's bind port used for data exchange operations. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine. If not configured, 'taskmanager.data.port' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -11,8 +11,8 @@
         <tr>
             <td><h5>taskmanager.data.bind-port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>The task manager's bind port used for data exchange operations. If not configured, 'taskmanager.data.port' will be used.</td>
+            <td>String</td>
+            <td>The task manager's bind port used for data exchange operations. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine. If not configured, 'taskmanager.data.port' will be used.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.port</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -46,12 +46,19 @@ public class NettyShuffleEnvironmentOptions {
                             "The task manager’s external port used for data exchange operations.");
 
     /** The local network port that the task manager listen at for data exchange. */
-    public static final ConfigOption<Integer> DATA_BIND_PORT =
+    @Documentation.Section({
+        Documentation.Sections.COMMON_HOST_PORT,
+        Documentation.Sections.ALL_TASK_MANAGER
+    })
+    public static final ConfigOption<String> DATA_BIND_PORT =
             key("taskmanager.data.bind-port")
-                    .intType()
+                    .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The task manager's bind port used for data exchange operations. If not configured, '"
+                            "The task manager's bind port used for data exchange operations."
+                                    + " Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both."
+                                    + " It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine."
+                                    + " If not configured, '"
                                     + DATA_PORT.key()
                                     + "' will be used.");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -146,7 +146,8 @@ class NettyClient {
     private void initNioBootstrap() {
         // Add the server port number to the name in order to distinguish
         // multiple clients running on the same host.
-        String name = NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPort() + ")";
+        String name =
+                NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPortRange() + ")";
 
         NioEventLoopGroup nioGroup =
                 new NioEventLoopGroup(
@@ -157,7 +158,8 @@ class NettyClient {
     private void initEpollBootstrap() {
         // Add the server port number to the name in order to distinguish
         // multiple clients running on the same host.
-        String name = NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPort() + ")";
+        String name =
+                NettyConfig.CLIENT_THREAD_GROUP_NAME + " (" + config.getServerPortRange() + ")";
 
         EpollEventLoopGroup epollGroup =
                 new EpollEventLoopGroup(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -42,6 +42,8 @@ import org.junit.runners.Parameterized;
 import javax.net.ssl.SSLSessionContext;
 
 import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.apache.flink.configuration.SecurityOptions.SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT;
@@ -297,9 +299,13 @@ public class NettyClientServerSslTest extends TestLogger {
     }
 
     private static NettyConfig createNettyConfig(Configuration config) {
+        int availPort = NetUtils.getAvailablePort();
+        Iterator<Integer> portRangeIterator = Collections.singletonList(availPort).iterator();
+        String portRange = String.valueOf(availPort);
         return new NettyConfig(
                 InetAddress.getLoopbackAddress(),
-                NetUtils.getAvailablePort(),
+                portRangeIterator,
+                portRange,
                 NettyTestUtil.DEFAULT_SEGMENT_SIZE,
                 1,
                 config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,10 +49,15 @@ public class NettyConnectionManagerTest {
         // Expected number of arenas and threads
         int numberOfSlots = 2;
 
+        int availPort = NetUtils.getAvailablePort();
+        Iterator<Integer> portRangeIterator = Collections.singletonList(availPort).iterator();
+        String portRange = String.valueOf(availPort);
+
         NettyConfig config =
                 new NettyConfig(
                         InetAddress.getLocalHost(),
-                        NetUtils.getAvailablePort(),
+                        portRangeIterator,
+                        portRange,
                         1024,
                         numberOfSlots,
                         new Configuration());
@@ -111,10 +118,15 @@ public class NettyConnectionManagerTest {
         flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_CLIENT, 3);
         flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_SERVER, 4);
 
+        int availPort = NetUtils.getAvailablePort();
+        Iterator<Integer> portRangeIterator = Collections.singletonList(availPort).iterator();
+        String portRange = String.valueOf(availPort);
+
         NettyConfig config =
                 new NettyConfig(
                         InetAddress.getLocalHost(),
-                        NetUtils.getAvailablePort(),
+                        portRangeIterator,
+                        portRange,
                         1024,
                         1337,
                         flinkConfig);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Iterator;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
@@ -199,9 +201,18 @@ public class NettyPartitionRequestClientTest {
     private NettyPartitionRequestClient createPartitionRequestClient(
             Channel tcpChannel, NetworkClientHandler clientHandler) throws Exception {
         int port = NetUtils.getAvailablePort();
+        Iterator<Integer> portRangeIterator = Collections.singletonList(port).iterator();
+        String portRange = String.valueOf(port);
+
         ConnectionID connectionID = new ConnectionID(new InetSocketAddress("localhost", port), 0);
         NettyConfig config =
-                new NettyConfig(InetAddress.getLocalHost(), port, 1024, 1, new Configuration());
+                new NettyConfig(
+                        InetAddress.getLocalHost(),
+                        portRangeIterator,
+                        portRange,
+                        1024,
+                        1,
+                        new Configuration());
         NettyClient nettyClient = new NettyClient(config);
         PartitionRequestClientFactory partitionRequestClientFactory =
                 new PartitionRequestClientFactory(nettyClient);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerMultiPortsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerMultiPortsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.NetUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+public class NettyServerMultiPortsTest {
+
+    @Test
+    public void testStartMultipleNettyServerSameConfig() throws Exception {
+        int firstPort = NetUtils.getAvailablePort();
+        int secondPort = firstPort;
+        while (secondPort == firstPort) {
+            secondPort = NetUtils.getAvailablePort();
+        }
+        NettyConfig config = createNettyConfig(firstPort, secondPort);
+        NettyServer nettyServer1 = new NettyServer(config);
+        int firstBindPort = nettyServer1.init(new NoOpProtocol(), new NettyBufferPool(1));
+
+        NettyServer nettyServer2 = new NettyServer(config);
+        int secondBindPort = nettyServer2.init(new NoOpProtocol(), new NettyBufferPool(1));
+
+        assertEquals(firstPort, firstBindPort);
+        assertEquals(secondPort, secondBindPort);
+    }
+
+    private NettyConfig createNettyConfig(int firstPort, int secondPort) {
+        String portRange = String.format("%s,%s", firstPort, secondPort);
+        Iterator<Integer> portRangeIterator = NetUtils.getPortRangeFromString(portRange);
+        return new NettyConfig(
+                InetAddress.getLoopbackAddress(),
+                portRangeIterator,
+                portRange,
+                NettyTestUtil.DEFAULT_SEGMENT_SIZE,
+                1,
+                new Configuration());
+    }
+
+    private static class NoOpProtocol extends NettyProtocol {
+        NoOpProtocol() {
+            super(null, null);
+        }
+
+        @Override
+        public ChannelHandler[] getServerChannelHandlers() {
+            return new ChannelHandler[0];
+        }
+
+        @Override
+        public ChannelHandler[] getClientChannelHandlers() {
+            return new ChannelHandler[0];
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -40,6 +40,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -326,9 +328,17 @@ public class PartitionRequestClientFactoryTest {
 
     private static Tuple2<NettyServer, NettyClient> createNettyServerAndClient(
             NettyProtocol protocol) throws IOException {
+        Iterator<Integer> portRangeIterator = Collections.singletonList(SERVER_PORT).iterator();
+        String portRange = String.valueOf(SERVER_PORT);
+
         final NettyConfig config =
                 new NettyConfig(
-                        InetAddress.getLocalHost(), SERVER_PORT, 32 * 1024, 1, new Configuration());
+                        InetAddress.getLocalHost(),
+                        portRangeIterator,
+                        portRange,
+                        32 * 1024,
+                        1,
+                        new Configuration());
 
         final NettyServer server = new NettyServer(config);
         final NettyClient client = new NettyClient(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -72,6 +72,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -285,8 +286,9 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
             final NettyConfig nettyConfig =
                     new NettyConfig(
-                            socketAddress.getAddress(),
-                            socketAddress.getPort(),
+                            InetAddress.getByName(testingRpcService.getAddress()),
+                            Collections.singletonList(socketAddress.getPort()).iterator(),
+                            String.valueOf(socketAddress.getPort()),
                             ConfigurationParserUtils.getPageSize(configuration),
                             ConfigurationParserUtils.getSlot(configuration),
                             configuration);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -48,6 +48,8 @@ import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Iterator;
 
 import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
 
@@ -198,10 +200,12 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
             @SuppressWarnings("SameParameterValue") int bufferPoolSize, Configuration config)
             throws Exception {
 
+        Iterator<Integer> portRangeIterator = Collections.singletonList(0).iterator();
         final NettyConfig nettyConfig =
                 new NettyConfig(
                         LOCAL_ADDRESS,
-                        0,
+                        portRangeIterator,
+                        "0",
                         ConfigurationParserUtils.getPageSize(config),
                         // please note that the number of slots directly influences the number of
                         // netty threads!


### PR DESCRIPTION
## What is the purpose of the change
This change adds support for setting a port range for a TaskManager data port, which allows multiple TaskManager to run on the same machine without having to use a random port.

## Brief change log

- Change value type of `taskmanager.data.bind-port` from Integer to String.
- Use `NetUtils.getPortRangeFromString` to generate the list of ports that can be used from the value of `taskmanager.data.bind-port`
- When starting up TaskManager's NettyServer, try to bind to the ports from the configured range sequentially, returning on the first success.
- Add documents for previously undocumented `taskmanager.data.bind-port`

## Verifying this change

- `NetUtils.getPortRangeFromString` is reused and already covered by existing tests.
- Add basic unittest: `NettyServerMultiPortsTest`, to verify that you can start 2 NettyServer concurrently without conflict by setting multiple ports in `taskmanager.data.bind-port`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
