### PR TITLE
[FLINK-20723][cassandra][tests] Retry on NoHostAvailableException 

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -47,6 +47,8 @@ import org.apache.flink.streaming.runtime.operators.WriteAheadSinkTestBase;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.testutils.junit.FailsOnJava11;
+import org.apache.flink.testutils.junit.RetryOnException;
+import org.apache.flink.testutils.junit.RetryRule;
 import org.apache.flink.types.Row;
 
 import com.datastax.driver.core.Cluster;
@@ -54,6 +56,7 @@ import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.mapping.Mapper;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.junit.AfterClass;
@@ -61,6 +64,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
@@ -92,12 +96,16 @@ import static org.junit.Assert.assertTrue;
 /** IT cases for all cassandra sinks. */
 @SuppressWarnings("serial")
 @Category(FailsOnJava11.class)
+// this test is known to be unstable, but the exact cause is unknown
+@RetryOnException(times = 2, exception = NoHostAvailableException.class)
 public class CassandraConnectorITCase
         extends WriteAheadSinkTestBase<
                 Tuple3<String, Integer, Integer>,
                 CassandraTupleWriteAheadSink<Tuple3<String, Integer, Integer>>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CassandraConnectorITCase.class);
+
+    @Rule public final RetryRule retryRule = new RetryRule();
 
     private static final boolean EMBEDDED = true;
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryOnException.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryOnException.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.testutils.junit;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -25,19 +26,26 @@ import java.lang.annotation.Target;
 /**
  * Annotation to use with {@link org.apache.flink.testutils.junit.RetryRule}.
  *
- * <p>Add the {@link org.apache.flink.testutils.junit.RetryRule} to your test and annotate tests
- * with {@link RetryOnException}.
+ * <p>Add the {@link org.apache.flink.testutils.junit.RetryRule} to your test class and annotate the
+ * class and/or tests with {@link RetryOnException}.
  *
  * <pre>
+ * {@literal @}RetryOnException(times=1, exception=IOException.class)
  * public class YourTest {
  *
  *     {@literal @}Rule
  *     public RetryRule retryRule = new RetryRule();
  *
  *     {@literal @}Test
- *     {@literal @}RetryOnException(times=1, exception=IOException.class)
  *     public void yourTest() throws Exception {
  *         // This will be retried 1 time (total runs 2) before failing the test.
+ *         throw new IOException("Failing test");
+ *     }
+ *
+ *     {@literal @}Test
+ *     {@literal @}RetryOnException(times=2, exception=IOException.class)
+ *     public void yourTest() throws Exception {
+ *         // This will be retried 2 times (total runs 3) before failing the test.
  *         throw new IOException("Failing test");
  *     }
  *
@@ -51,7 +59,7 @@ import java.lang.annotation.Target;
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(java.lang.annotation.ElementType.METHOD)
+@Target({java.lang.annotation.ElementType.METHOD, ElementType.TYPE})
 public @interface RetryOnException {
 
     int times();

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryOnFailure.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryOnFailure.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.testutils.junit;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -25,25 +26,33 @@ import java.lang.annotation.Target;
 /**
  * Annotation to use with {@link RetryRule}.
  *
- * <p>Add the {@link RetryRule} to your test and annotate tests with {@link RetryOnFailure}.
+ * <p>Add the {@link RetryRule} to your test class and annotate the class and/or tests with {@link
+ * RetryOnFailure}.
  *
  * <pre>
+ * {@literal @}RetryOnFailure(times=1)
  * public class YourTest {
  *
  *     {@literal @}Rule
  *     public RetryRule retryRule = new RetryRule();
  *
  *     {@literal @}Test
- *     {@literal @}RetryOnFailure(times=1)
  *     public void yourTest() {
  *         // This will be retried 1 time (total runs 2) before failing the test.
+ *         throw new Exception("Failing test");
+ *     }
+ *
+ *     {@literal @}Test
+ *     {@literal @}RetryOnFailure(times=2)
+ *     public void yourTest() {
+ *         // This will be retried 2 time (total runs 3) before failing the test.
  *         throw new Exception("Failing test");
  *     }
  * }
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({java.lang.annotation.ElementType.METHOD})
+@Target({java.lang.annotation.ElementType.METHOD, ElementType.TYPE})
 public @interface RetryOnFailure {
     int times();
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryRule.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryRule.java
@@ -85,8 +85,6 @@ public class RetryRule implements TestRule {
 
         private final int timesOnFailure;
 
-        private int currentRun;
-
         private final Statement statement;
 
         private RetryOnFailureStatement(int timesOnFailure, Statement statement) {
@@ -104,7 +102,7 @@ public class RetryRule implements TestRule {
          */
         @Override
         public void evaluate() throws Throwable {
-            for (currentRun = 0; currentRun <= timesOnFailure; currentRun++) {
+            for (int currentRun = 0; currentRun <= timesOnFailure; currentRun++) {
                 try {
                     statement.evaluate();
                     break; // success
@@ -130,8 +128,6 @@ public class RetryRule implements TestRule {
         private final int timesOnFailure;
         private final Statement statement;
 
-        private int currentRun;
-
         private RetryOnExceptionStatement(
                 int timesOnFailure,
                 Class<? extends Throwable> exceptionClass,
@@ -155,7 +151,7 @@ public class RetryRule implements TestRule {
          */
         @Override
         public void evaluate() throws Throwable {
-            for (currentRun = 0; currentRun <= timesOnFailure; currentRun++) {
+            for (int currentRun = 0; currentRun <= timesOnFailure; currentRun++) {
                 try {
                     statement.evaluate();
                     break; // success

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryRule.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/RetryRule.java
@@ -54,30 +54,36 @@ public class RetryRule implements TestRule {
         RetryOnFailure retryOnFailure = description.getAnnotation(RetryOnFailure.class);
         RetryOnException retryOnException = description.getAnnotation(RetryOnException.class);
 
-        // sanity check that we don't use expected exceptions with the RetryOnX annotations
-        if (retryOnFailure != null || retryOnException != null) {
-            Test test = description.getAnnotation(Test.class);
-            if (test.expected() != Test.None.class) {
-                throw new IllegalArgumentException(
-                        "You cannot combine the RetryOnFailure "
-                                + "annotation with the Test(expected) annotation.");
-            }
-        }
-
         // sanity check that we don't use both annotations
         if (retryOnFailure != null && retryOnException != null) {
             throw new IllegalArgumentException(
                     "You cannot combine the RetryOnFailure and RetryOnException annotations.");
         }
 
+        final Class<? extends Throwable> whitelistedException = getExpectedException(description);
+
         if (retryOnFailure != null) {
-            return new RetryOnFailureStatement(retryOnFailure.times(), statement);
+            return new RetryOnFailureStatement(
+                    retryOnFailure.times(), statement, whitelistedException);
         } else if (retryOnException != null) {
             return new RetryOnExceptionStatement(
-                    retryOnException.times(), retryOnException.exception(), statement);
+                    retryOnException.times(),
+                    retryOnException.exception(),
+                    statement,
+                    whitelistedException);
         } else {
             return statement;
         }
+    }
+
+    @Nullable
+    private static Class<? extends Throwable> getExpectedException(Description description) {
+        Test test = description.getAnnotation(Test.class);
+        if (test.expected() != Test.None.class) {
+            return test.expected();
+        }
+
+        return null;
     }
 
     /** Retries a test in case of a failure. */
@@ -86,8 +92,13 @@ public class RetryRule implements TestRule {
         private final int timesOnFailure;
 
         private final Statement statement;
+        @Nullable private final Class<? extends Throwable> expectedException;
 
-        private RetryOnFailureStatement(int timesOnFailure, Statement statement) {
+        private RetryOnFailureStatement(
+                int timesOnFailure,
+                Statement statement,
+                @Nullable Class<? extends Throwable> expectedException) {
+            this.expectedException = expectedException;
             if (timesOnFailure < 0) {
                 throw new IllegalArgumentException("Negatives number of retries on failure");
             }
@@ -107,6 +118,11 @@ public class RetryRule implements TestRule {
                     statement.evaluate();
                     break; // success
                 } catch (Throwable t) {
+                    if (expectedException != null
+                            && expectedException.isAssignableFrom(t.getClass())) {
+                        throw t;
+                    }
+
                     LOG.warn(
                             String.format(
                                     "Test run failed (%d/%d).", currentRun, timesOnFailure + 1),
@@ -127,11 +143,13 @@ public class RetryRule implements TestRule {
         private final Class<? extends Throwable> exceptionClass;
         private final int timesOnFailure;
         private final Statement statement;
+        @Nullable private final Class<? extends Throwable> expectedException;
 
         private RetryOnExceptionStatement(
                 int timesOnFailure,
                 Class<? extends Throwable> exceptionClass,
-                Statement statement) {
+                Statement statement,
+                @Nullable Class<? extends Throwable> expectedException) {
             if (timesOnFailure < 0) {
                 throw new IllegalArgumentException("Negatives number of retries on failure");
             }
@@ -142,6 +160,7 @@ public class RetryRule implements TestRule {
             this.exceptionClass = (exceptionClass);
             this.timesOnFailure = timesOnFailure;
             this.statement = statement;
+            this.expectedException = expectedException;
         }
 
         /**
@@ -156,6 +175,11 @@ public class RetryRule implements TestRule {
                     statement.evaluate();
                     break; // success
                 } catch (Throwable t) {
+                    if (expectedException != null
+                            && expectedException.isAssignableFrom(t.getClass())) {
+                        throw t;
+                    }
+
                     LOG.warn(
                             String.format(
                                     "Test run failed (%d/%d).", currentRun, timesOnFailure + 1),

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryRuleTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryRuleTest.java
@@ -30,10 +30,11 @@ import static org.junit.Assert.assertThat;
 
 /** Tests for the {@link RetryRule}. */
 public class RetryRuleTest extends TestLogger {
+    private static final RetryRule RETRY_RULE = new RetryRule();
 
     @Test
     public void testExpectedExceptionIgnored() throws Throwable {
-        final RetryRule retryRule = new RetryRule();
+        final int numEvaluationsToFail = 1;
 
         final Description testDescription =
                 Description.createTestDescription(
@@ -43,21 +44,97 @@ public class RetryRuleTest extends TestLogger {
                                 .getMethod("test")
                                 .getAnnotations());
 
-        final TestStatement statement = new TestStatement(1);
+        final TestStatement statement = new TestStatement(numEvaluationsToFail);
 
         try {
-            retryRule.apply(statement, testDescription).evaluate();
+            RETRY_RULE.apply(statement, testDescription).evaluate();
             Assert.fail("Should have failed.");
         } catch (RuntimeException expected) {
         }
 
-        assertThat(statement.getNumEvaluations(), is(1));
+        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail));
     }
 
     @Ignore // we don't want to actually this run as a test
     private static class TestClassWithTestExpectingRuntimeException {
         @RetryOnFailure(times = 2)
         @Test(expected = RuntimeException.class)
+        public void test() {}
+    }
+
+    @Test
+    public void testNoAnnotationResultsInZeroRetries() throws Throwable {
+        final int numEvaluationsToFail = 1;
+
+        final Description testDescription =
+                Description.createTestDescription(
+                        TestClassWithoutAnnotation.class,
+                        "test",
+                        TestClassWithAnnotation.class.getMethod("test").getAnnotations());
+
+        final TestStatement statement = new TestStatement(numEvaluationsToFail);
+
+        try {
+            RETRY_RULE.apply(statement, testDescription).evaluate();
+            Assert.fail("Should have failed.");
+        } catch (RuntimeException expected) {
+        }
+
+        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail));
+    }
+
+    @Ignore // we don't want to actually this run as a test
+    private static class TestClassWithoutAnnotation {
+        @Test
+        public void test() {}
+    }
+
+    @Test
+    public void testAnnotationOnClassUsedAsFallback() throws Throwable {
+        final int numEvaluationsToFail = 1;
+
+        final Description testDescription =
+                Description.createTestDescription(
+                        TestClassWithAnnotation.class,
+                        "test",
+                        TestClassWithAnnotation.class.getMethod("test").getAnnotations());
+
+        final TestStatement statement = new TestStatement(numEvaluationsToFail);
+
+        RETRY_RULE.apply(statement, testDescription).evaluate();
+
+        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail + 1));
+    }
+
+    @Ignore // we don't want to actually this run as a test
+    @RetryOnFailure(times = 1)
+    private static class TestClassWithAnnotation {
+        @Test
+        public void test() {}
+    }
+
+    @Test
+    public void testAnnotationOnMethodTakesPrecedence() throws Throwable {
+        final int numEvaluationsToFail = 2;
+
+        final Description testDescription =
+                Description.createTestDescription(
+                        TestClassWithAnnotationOnMethod.class,
+                        "test",
+                        TestClassWithAnnotationOnMethod.class.getMethod("test").getAnnotations());
+
+        final TestStatement statement = new TestStatement(numEvaluationsToFail);
+
+        RETRY_RULE.apply(statement, testDescription).evaluate();
+
+        assertThat(statement.getNumEvaluations(), is(numEvaluationsToFail + 1));
+    }
+
+    @Ignore // we don't want to actually this run as a test
+    @RetryOnFailure(times = 1)
+    private static class TestClassWithAnnotationOnMethod {
+        @RetryOnFailure(times = 2)
+        @Test
         public void test() {}
     }
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryRuleTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryRuleTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils.junit;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Tests for the {@link RetryRule}. */
+public class RetryRuleTest extends TestLogger {
+
+    @Test
+    public void testExpectedExceptionIgnored() throws Throwable {
+        final RetryRule retryRule = new RetryRule();
+
+        final Description testDescription =
+                Description.createTestDescription(
+                        TestClassWithTestExpectingRuntimeException.class,
+                        "test",
+                        TestClassWithTestExpectingRuntimeException.class
+                                .getMethod("test")
+                                .getAnnotations());
+
+        final TestStatement statement = new TestStatement(1);
+
+        try {
+            retryRule.apply(statement, testDescription).evaluate();
+            Assert.fail("Should have failed.");
+        } catch (RuntimeException expected) {
+        }
+
+        assertThat(statement.getNumEvaluations(), is(1));
+    }
+
+    @Ignore // we don't want to actually this run as a test
+    private static class TestClassWithTestExpectingRuntimeException {
+        @RetryOnFailure(times = 2)
+        @Test(expected = RuntimeException.class)
+        public void test() {}
+    }
+
+    private static class TestStatement extends Statement {
+        private final int numEvaluationsToFail;
+
+        private int numEvaluations = 0;
+
+        private TestStatement(int numEvaluationsToFail) {
+            this.numEvaluationsToFail = numEvaluationsToFail;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            try {
+                if (numEvaluations < numEvaluationsToFail) {
+                    throw new RuntimeException("test exception");
+                }
+            } finally {
+                numEvaluations++;
+            }
+        }
+
+        public int getNumEvaluations() {
+            return numEvaluations;
+        }
+    }
+}


### PR DESCRIPTION
Beefs up the `RetryRule` to allow configuring retries per class, and subsequently sets up retries for the entire `CassandraConnectorITCase`.

To avoid inconsistent/unexpeced behaviors when combinding class-wide retries with expected exceptions, the latter are now properly handled by the retry rule (i.e., if they occur then we don't retry and just rethrow the exception).

The existing pattern of annotating single methods was not really viable for this case because various tests are inherited from a parent class, which we could only annotated by overriding each of them.
This seemed like annoying busy work, so I fixed the root issue instead.