### PR TITLE
[FLINK-21659][coordination] Properly expose checkpoint settings for initializing jobs

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsSnapshot.java
@@ -41,6 +41,14 @@ public class CheckpointStatsSnapshot implements Serializable {
     /** The latest restored checkpoint operation. */
     @Nullable private final RestoredCheckpointStats latestRestoredCheckpoint;
 
+    public static CheckpointStatsSnapshot empty() {
+        return new CheckpointStatsSnapshot(
+                new CheckpointStatsCounts(),
+                new CompletedCheckpointStatsSummary(),
+                new CheckpointStatsHistory(0),
+                null);
+    }
+
     /**
      * Creates a stats snapshot.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobMasterServiceLeadershipRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobMasterServiceLeadershipRunnerFactory.java
@@ -118,6 +118,7 @@ public enum JobMasterServiceLeadershipRunnerFactory implements JobManagerRunnerF
                 new DefaultJobMasterServiceProcessFactory(
                         jobGraph.getJobID(),
                         jobGraph.getName(),
+                        jobGraph.getCheckpointingSettings(),
                         initializationTimestamp,
                         jobMasterServiceFactory);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -386,6 +387,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
             String jobName,
             JobStatus jobStatus,
             @Nullable Throwable throwable,
+            @Nullable JobCheckpointingSettings checkpointingSettings,
             long initializationTimestamp) {
         Map<JobVertexID, ArchivedExecutionJobVertex> archivedTasks = Collections.emptyMap();
         List<ArchivedExecutionJobVertex> archivedVerticesInCreationOrder = Collections.emptyList();
@@ -421,9 +423,11 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                 serializedUserAccumulators,
                 new ExecutionConfig().archive(),
                 false,
-                null,
-                null,
-                null,
-                null);
+                checkpointingSettings == null
+                        ? null
+                        : checkpointingSettings.getCheckpointCoordinatorConfiguration(),
+                checkpointingSettings == null ? null : CheckpointStatsSnapshot.empty(),
+                checkpointingSettings == null ? null : "Unknown",
+                checkpointingSettings == null ? null : "Unknown");
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceProcessFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceProcessFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.jobmaster.factories;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmaster.DefaultJobMasterServiceProcess;
 import org.apache.flink.runtime.jobmaster.JobMasterServiceProcess;
 
@@ -32,6 +33,7 @@ public class DefaultJobMasterServiceProcessFactory implements JobMasterServicePr
 
     private final JobID jobId;
     private final String jobName;
+    @Nullable private final JobCheckpointingSettings checkpointingSettings;
     private final long initializationTimestamp;
 
     private final JobMasterServiceFactory jobMasterServiceFactory;
@@ -39,10 +41,12 @@ public class DefaultJobMasterServiceProcessFactory implements JobMasterServicePr
     public DefaultJobMasterServiceProcessFactory(
             JobID jobId,
             String jobName,
+            @Nullable JobCheckpointingSettings checkpointingSettings,
             long initializationTimestamp,
             JobMasterServiceFactory jobMasterServiceFactory) {
         this.jobId = jobId;
         this.jobName = jobName;
+        this.checkpointingSettings = checkpointingSettings;
         this.initializationTimestamp = initializationTimestamp;
         this.jobMasterServiceFactory = jobMasterServiceFactory;
     }
@@ -65,6 +69,6 @@ public class DefaultJobMasterServiceProcessFactory implements JobMasterServicePr
     public ArchivedExecutionGraph createArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
         return ArchivedExecutionGraph.createFromInitializingJob(
-                jobId, jobName, jobStatus, cause, initializationTimestamp);
+                jobId, jobName, jobStatus, cause, checkpointingSettings, initializationTimestamp);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -737,6 +737,7 @@ public class AdaptiveScheduler
                 jobInformation.getName(),
                 jobStatus,
                 cause,
+                jobInformation.getCheckpointingSettings(),
                 initializationTimestamp);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobGraphJobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobGraphJobInformation.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
@@ -66,6 +67,10 @@ public class JobGraphJobInformation implements JobInformation {
 
     public String getName() {
         return name;
+    }
+
+    public JobCheckpointingSettings getCheckpointingSettings() {
+        return jobGraph.getCheckpointingSettings();
     }
 
     public Iterable<JobInformation.VertexInformation> getVertices() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -418,6 +418,7 @@ public class DispatcherTest extends TestLogger {
                                         jobGraph.getName(),
                                         JobStatus.FAILED,
                                         testFailure,
+                                        jobGraph.getCheckpointingSettings(),
                                         1L)),
                         testFailure));
 
@@ -579,6 +580,7 @@ public class DispatcherTest extends TestLogger {
                                         jobGraph.getName(),
                                         JobStatus.FAILED,
                                         testException,
+                                        jobGraph.getCheckpointingSettings(),
                                         1L)),
                         testException));
 
@@ -805,6 +807,7 @@ public class DispatcherTest extends TestLogger {
                     new DefaultJobMasterServiceProcessFactory(
                             jobGraph.getJobID(),
                             jobGraph.getName(),
+                            jobGraph.getCheckpointingSettings(),
                             initializationTimestamp,
                             new TestingJobMasterServiceFactory(
                                     () -> {
@@ -882,6 +885,7 @@ public class DispatcherTest extends TestLogger {
                                                                             jobGraph.getJobID(),
                                                                             jobGraph.getName(),
                                                                             JobStatus.RUNNING,
+                                                                            null,
                                                                             null,
                                                                             1337))))
                             .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -153,10 +153,35 @@ public class ArchivedExecutionGraphTest extends TestLogger {
                         "TestJob",
                         JobStatus.SUSPENDED,
                         new Exception("Test suspension exception"),
+                        null,
                         System.currentTimeMillis());
 
         assertThat(suspendedExecutionGraph.getState(), is(JobStatus.SUSPENDED));
         assertThat(suspendedExecutionGraph.getFailureInfo(), notNullValue());
+    }
+
+    @Test
+    public void testCheckpointSettingsArchiving() {
+        final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
+                CheckpointCoordinatorConfiguration.builder().build();
+
+        final ArchivedExecutionGraph archivedGraph =
+                ArchivedExecutionGraph.createFromInitializingJob(
+                        new JobID(),
+                        "TestJob",
+                        JobStatus.INITIALIZING,
+                        null,
+                        new JobCheckpointingSettings(checkpointCoordinatorConfiguration, null),
+                        System.currentTimeMillis());
+
+        assertContainsCheckpointSettings(archivedGraph);
+    }
+
+    public static void assertContainsCheckpointSettings(ArchivedExecutionGraph archivedGraph) {
+        assertThat(archivedGraph.getCheckpointCoordinatorConfiguration(), notNullValue());
+        assertThat(archivedGraph.getCheckpointStatsSnapshot(), notNullValue());
+        assertThat(archivedGraph.getCheckpointStorageName().get(), is("Unknown"));
+        assertThat(archivedGraph.getStateBackendName().get(), is("Unknown"));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultJobMasterServiceProcessTest.java
@@ -53,7 +53,7 @@ public class DefaultJobMasterServiceProcessTest extends TestLogger {
             failedArchivedExecutionGraphFactory =
                     (throwable ->
                             ArchivedExecutionGraph.createFromInitializingJob(
-                                    jobId, "test", JobStatus.FAILED, throwable, 1337));
+                                    jobId, "test", JobStatus.FAILED, throwable, null, 1337));
 
     @Test
     public void testInitializationFailureCompletesResultFuture() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -259,6 +259,7 @@ public class JobMasterServiceLeadershipRunnerTest extends TestLogger {
                         jobGraph.getName(),
                         JobStatus.FAILED,
                         testException,
+                        null,
                         1L));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactory.java
@@ -65,7 +65,7 @@ public class TestingJobMasterServiceProcessFactory implements JobMasterServicePr
     public ArchivedExecutionGraph createArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
         return ArchivedExecutionGraph.createFromInitializingJob(
-                jobId, jobName, jobStatus, cause, initializationTimestamp);
+                jobId, jobName, jobStatus, cause, null, initializationTimestamp);
     }
 
     public static Builder newBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactoryOld.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceProcessFactoryOld.java
@@ -73,7 +73,7 @@ public class TestingJobMasterServiceProcessFactoryOld implements JobMasterServic
     public ArchivedExecutionGraph createArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
         return ArchivedExecutionGraph.createFromInitializingJob(
-                jobId, "test-job", jobStatus, cause, System.currentTimeMillis());
+                jobId, "test-job", jobStatus, cause, null, System.currentTimeMillis());
     }
 
     public static class TestingFutureJobMasterServiceFactory implements JobMasterServiceFactory {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraphTest;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
@@ -137,6 +138,22 @@ public class AdaptiveSchedulerTest extends TestLogger {
                 new AdaptiveSchedulerBuilder(createJobGraph(), mainThreadExecutor).build();
 
         assertThat(scheduler.getState(), instanceOf(Created.class));
+    }
+
+    @Test
+    public void testArchivedCheckpointingSettingsNotNullIfCheckpointingIsEnabled()
+            throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        jobGraph.setSnapshotSettings(
+                new JobCheckpointingSettings(
+                        CheckpointCoordinatorConfiguration.builder().build(), null));
+
+        final ArchivedExecutionGraph archivedExecutionGraph =
+                new AdaptiveSchedulerBuilder(jobGraph, mainThreadExecutor)
+                        .build()
+                        .getArchivedExecutionGraph(JobStatus.INITIALIZING, null);
+
+        ArchivedExecutionGraphTest.assertContainsCheckpointSettings(archivedExecutionGraph);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatedTest.java
@@ -118,7 +118,7 @@ public class CreatedTest extends TestLogger {
         public ArchivedExecutionGraph getArchivedExecutionGraph(
                 JobStatus jobStatus, @Nullable Throwable cause) {
             return ArchivedExecutionGraph.createFromInitializingJob(
-                    new JobID(), "testJob", jobStatus, cause, 0L);
+                    new JobID(), "testJob", jobStatus, cause, null, 0L);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -202,7 +202,7 @@ public class CreatingExecutionGraphTest extends TestLogger {
         public ArchivedExecutionGraph getArchivedExecutionGraph(
                 JobStatus jobStatus, @Nullable Throwable cause) {
             return ArchivedExecutionGraph.createFromInitializingJob(
-                    new JobID(), "testJob", jobStatus, cause, 0L);
+                    new JobID(), "testJob", jobStatus, cause, null, 0L);
         }
 
         @Override


### PR DESCRIPTION
Ensures that various checkpointing-related settings are written into the `ArchivedExecutionGraph` when the job is in an `INITIALIZING` state, if checkpointing is enabled.

Previously we always nulled these fields, due to which the checkpoint handlers throw exceptions claiming checkpointing to be disabled.
