### PR TITLE
 [FLINK-22356][hive / filesystem] Fix partition-time commit failure when watermark is defined  on TIMESTAMP_LTZ column

### DIFF
--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -227,9 +227,9 @@ To define when to commit a partition, providing partition commit trigger:
     </tr>
     <tr>
         <td><h5>sink.partition-commit.watermark-time-zone</h5></td>
-        <td style="word-wrap: break-word;">0 s</td>
+        <td style="word-wrap: break-word;">UTC</td>
         <td>String</td>
-        <td>The time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.</td>
+        <td>The time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not. This option is only take effect when `sink.partition-commit.trigger` is set to 'partition-time'. If this option is not configured correctly, e.g. source rowtime is defined on TIMESTAMP_LTZ column, but this config is not configured, then users may see the partition committed after a few hours. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is the session time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.</td>
     </tr>        
   </tbody>
 </table>
@@ -444,6 +444,7 @@ FROM kafka_table;
 SELECT * FROM fs_table WHERE dt='2020-05-20' and `hour`='12';
 ```
 
+If the watermark is defined on TIMESTAMP_LTZ column and used `partition-time` to commit, the `sink.partition-commit.watermark-time-zone` is required to set to the session time zone, otherwise the partition committed may happen after a few hours.  
 ```sql
 
 CREATE TABLE kafka_table (

--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -225,6 +225,12 @@ To define when to commit a partition, providing partition commit trigger:
         <td>Duration</td>
         <td>The partition will not commit until the delay time. If it is a daily partition, should be '1 d', if it is a hourly partition, should be '1 h'.</td>
     </tr>
+    <tr>
+        <td><h5>sink.partition-commit.watermark-time-zone</h5></td>
+        <td style="word-wrap: break-word;">0 s</td>
+        <td>String</td>
+        <td>The time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.</td>
+    </tr>        
   </tbody>
 </table>
 
@@ -401,7 +407,7 @@ The parallelism of writing files into external file system (including Hive) can 
 
 ## Full Example
 
-The below shows how the file system connector can be used to write a streaming query to write data from Kafka into a file system and runs a batch query to read that data back out.
+The below examples show how the file system connector can be used to write a streaming query to write data from Kafka into a file system and runs a batch query to read that data back out.
 
 ```sql
 
@@ -409,7 +415,7 @@ CREATE TABLE kafka_table (
   user_id STRING,
   order_amount DOUBLE,
   log_ts TIMESTAMP(3),
-  WATERMARK FOR log_ts AS log_ts - INTERVAL '5' SECOND
+  WATERMARK FOR log_ts AS log_ts - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP column
 ) WITH (...);
 
 CREATE TABLE fs_table (
@@ -432,6 +438,45 @@ SELECT
     order_amount, 
     DATE_FORMAT(log_ts, 'yyyy-MM-dd'),
     DATE_FORMAT(log_ts, 'HH') 
+FROM kafka_table;
+
+-- batch sql, select with partition pruning
+SELECT * FROM fs_table WHERE dt='2020-05-20' and `hour`='12';
+```
+
+```sql
+
+CREATE TABLE kafka_table (
+  user_id STRING,
+  order_amount DOUBLE,
+  ts BIGINT, -- time in epoch milliseconds
+  ts_ltz AS TO_TIMESTAMP_LTZ(ts, 3),
+  WATERMARK FOR ts_ltz AS ts_ltz - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP_LTZ column
+) WITH (...);
+
+CREATE TABLE fs_table (
+  user_id STRING,
+  order_amount DOUBLE,
+  dt STRING,
+  `hour` STRING
+) PARTITIONED BY (dt, `hour`) WITH (
+  'connector'='filesystem',
+  'path'='...',
+  'format'='parquet',
+  'partition.time-extractor.timestamp-pattern'='$dt $hour:00:00',
+  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.trigger'='partition-time',
+  'sink.partition-commit.watermark-time-zone'='Asia/Shanghai', -- Assume user configured time zone is 'Asia/Shanghai'
+  'sink.partition-commit.policy.kind'='success-file'
+);
+
+-- streaming sql, insert into file system table
+INSERT INTO fs_table 
+SELECT 
+    user_id, 
+    order_amount, 
+    DATE_FORMAT(ts_ltz, 'yyyy-MM-dd'),
+    DATE_FORMAT(ts_ltz, 'HH') 
 FROM kafka_table;
 
 -- batch sql, select with partition pruning

--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -382,6 +382,7 @@ SELECT * FROM hive_table WHERE dt='2020-05-20' and hr='12';
 
 ```
 
+If the watermark is defined on TIMESTAMP_LTZ column and used `partition-time` to commit, the `sink.partition-commit.watermark-time-zone` is required to set to the session time zone, otherwise the partition committed may happen after a few hours.  
 ```sql
 
 SET table.sql-dialect=hive;

--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -346,7 +346,7 @@ Flink SQL> INSERT OVERWRITE myparttable PARTITION (my_type='type_1') SELECT 'Tom
 visible - incrementally. Users control when/how to trigger commits with several properties. Insert
 overwrite is not supported for streaming write.
 
-The below shows how the streaming sink can be used to write a streaming query to write data from Kafka into a Hive table with partition-commit,
+The below examples show how the streaming sink can be used to write a streaming query to write data from Kafka into a Hive table with partition-commit,
 and runs a batch query to read that data back out. 
 
 Please see the [streaming sink]({{< ref "docs/connectors/table/filesystem" >}}#streaming-sink) for a full list of available configurations.
@@ -369,7 +369,7 @@ CREATE TABLE kafka_table (
   user_id STRING,
   order_amount DOUBLE,
   log_ts TIMESTAMP(3),
-  WATERMARK FOR log_ts AS log_ts - INTERVAL '5' SECOND
+  WATERMARK FOR log_ts AS log_ts - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP column
 ) WITH (...);
 
 -- streaming sql, insert into hive table
@@ -382,6 +382,38 @@ SELECT * FROM hive_table WHERE dt='2020-05-20' and hr='12';
 
 ```
 
+```sql
+
+SET table.sql-dialect=hive;
+CREATE TABLE hive_table (
+  user_id STRING,
+  order_amount DOUBLE
+) PARTITIONED BY (dt STRING, hr STRING) STORED AS parquet TBLPROPERTIES (
+  'partition.time-extractor.timestamp-pattern'='$dt $hr:00:00',
+  'sink.partition-commit.trigger'='partition-time',
+  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.watermark-time-zone'='Asia/Shanghai', -- Assume user configured time zone is 'Asia/Shanghai'
+  'sink.partition-commit.policy.kind'='metastore,success-file'
+);
+
+SET table.sql-dialect=default;
+CREATE TABLE kafka_table (
+  user_id STRING,
+  order_amount DOUBLE,
+  ts BIGINT, -- time in epoch milliseconds
+  ts_ltz AS TO_TIMESTAMP_LTZ(ts, 3),
+  WATERMARK FOR ts_ltz AS ts_ltz - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP_LTZ column
+) WITH (...);
+
+-- streaming sql, insert into hive table
+INSERT INTO TABLE hive_table 
+SELECT user_id, order_amount, DATE_FORMAT(ts_ltz, 'yyyy-MM-dd'), DATE_FORMAT(ts_ltz, 'HH')
+FROM kafka_table;
+
+-- batch sql, select with partition pruning
+SELECT * FROM hive_table WHERE dt='2020-05-20' and hr='12';
+
+```
 
 By default, for streaming writes, Flink only supports renaming committers, meaning the S3 filesystem
 cannot support exactly-once streaming writes.

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -225,6 +225,12 @@ To define when to commit a partition, providing partition commit trigger:
         <td>Duration</td>
         <td>The partition will not commit until the delay time. If it is a daily partition, should be '1 d', if it is a hourly partition, should be '1 h'.</td>
     </tr>
+    <tr>
+        <td><h5>sink.partition-commit.watermark-time-zone</h5></td>
+        <td style="word-wrap: break-word;">0 s</td>
+        <td>String</td>
+        <td>The time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.</td>
+    </tr>    
   </tbody>
 </table>
 
@@ -401,7 +407,7 @@ The parallelism of writing files into external file system (including Hive) can 
 
 ## Full Example
 
-The below shows how the file system connector can be used to write a streaming query to write data from Kafka into a file system and runs a batch query to read that data back out.
+The below examples show how the file system connector can be used to write a streaming query to write data from Kafka into a file system and runs a batch query to read that data back out.
 
 ```sql
 
@@ -432,6 +438,45 @@ SELECT
     order_amount, 
     DATE_FORMAT(log_ts, 'yyyy-MM-dd'),
     DATE_FORMAT(log_ts, 'HH') 
+FROM kafka_table;
+
+-- batch sql, select with partition pruning
+SELECT * FROM fs_table WHERE dt='2020-05-20' and `hour`='12';
+```
+
+```sql
+
+CREATE TABLE kafka_table (
+  user_id STRING,
+  order_amount DOUBLE,
+  ts BIGINT, -- time in epoch milliseconds
+  ts_ltz AS TO_TIMESTAMP_LTZ(ts, 3),
+  WATERMARK FOR ts_ltz AS ts_ltz - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP_LTZ column
+) WITH (...);
+
+CREATE TABLE fs_table (
+  user_id STRING,
+  order_amount DOUBLE,
+  dt STRING,
+  `hour` STRING
+) PARTITIONED BY (dt, `hour`) WITH (
+  'connector'='filesystem',
+  'path'='...',
+  'format'='parquet',
+  'partition.time-extractor.timestamp-pattern'='$dt $hour:00:00',
+  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.trigger'='partition-time',
+  'sink.partition-commit.watermark-time-zone'='Asia/Shanghai', -- Assume user configured time zone is 'Asia/Shanghai'
+  'sink.partition-commit.policy.kind'='success-file'
+);
+
+-- streaming sql, insert into file system table
+INSERT INTO fs_table 
+SELECT 
+    user_id, 
+    order_amount, 
+    DATE_FORMAT(ts_ltz, 'yyyy-MM-dd'),
+    DATE_FORMAT(ts_ltz, 'HH') 
 FROM kafka_table;
 
 -- batch sql, select with partition pruning

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -227,9 +227,9 @@ To define when to commit a partition, providing partition commit trigger:
     </tr>
     <tr>
         <td><h5>sink.partition-commit.watermark-time-zone</h5></td>
-        <td style="word-wrap: break-word;">0 s</td>
+        <td style="word-wrap: break-word;">UTC</td>
         <td>String</td>
-        <td>The time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone, the the value should be the user configured local time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.</td>
+        <td>The time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not. This option is only take effect when `sink.partition-commit.trigger` is set to 'partition-time'. If this option is not configured correctly, e.g. source rowtime is defined on TIMESTAMP_LTZ column, but this config is not configured, then users may see the partition committed after a few hours. The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined. If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is the session time zone. The option value is either a full name such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.</td>
     </tr>    
   </tbody>
 </table>
@@ -444,6 +444,7 @@ FROM kafka_table;
 SELECT * FROM fs_table WHERE dt='2020-05-20' and `hour`='12';
 ```
 
+If the watermark is defined on TIMESTAMP_LTZ column and used `partition-time` to commit, the `sink.partition-commit.watermark-time-zone` is required to set to the session time zone, otherwise the partition committed may happen after a few hours.  
 ```sql
 
 CREATE TABLE kafka_table (

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -382,6 +382,7 @@ SELECT * FROM hive_table WHERE dt='2020-05-20' and hr='12';
 
 ```
 
+If the watermark is defined on TIMESTAMP_LTZ column and used `partition-time` to commit, the `sink.partition-commit.watermark-time-zone` is required to set to the session time zone, otherwise the partition committed may happen after a few hours.  
 ```sql
 
 SET table.sql-dialect=hive;

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -346,7 +346,7 @@ Flink SQL> INSERT OVERWRITE myparttable PARTITION (my_type='type_1') SELECT 'Tom
 visible - incrementally. Users control when/how to trigger commits with several properties. Insert
 overwrite is not supported for streaming write.
 
-The below shows how the streaming sink can be used to write a streaming query to write data from Kafka into a Hive table with partition-commit,
+The below examples show how the streaming sink can be used to write a streaming query to write data from Kafka into a Hive table with partition-commit,
 and runs a batch query to read that data back out. 
 
 Please see the [streaming sink]({{< ref "docs/connectors/table/filesystem" >}}#streaming-sink) for a full list of available configurations.
@@ -369,7 +369,7 @@ CREATE TABLE kafka_table (
   user_id STRING,
   order_amount DOUBLE,
   log_ts TIMESTAMP(3),
-  WATERMARK FOR log_ts AS log_ts - INTERVAL '5' SECOND
+  WATERMARK FOR log_ts AS log_ts - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP column
 ) WITH (...);
 
 -- streaming sql, insert into hive table
@@ -382,6 +382,38 @@ SELECT * FROM hive_table WHERE dt='2020-05-20' and hr='12';
 
 ```
 
+```sql
+
+SET table.sql-dialect=hive;
+CREATE TABLE hive_table (
+  user_id STRING,
+  order_amount DOUBLE
+) PARTITIONED BY (dt STRING, hr STRING) STORED AS parquet TBLPROPERTIES (
+  'partition.time-extractor.timestamp-pattern'='$dt $hr:00:00',
+  'sink.partition-commit.trigger'='partition-time',
+  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.watermark-time-zone'='Asia/Shanghai', -- Assume user configured time zone is 'Asia/Shanghai'
+  'sink.partition-commit.policy.kind'='metastore,success-file'
+);
+
+SET table.sql-dialect=default;
+CREATE TABLE kafka_table (
+  user_id STRING,
+  order_amount DOUBLE,
+  ts BIGINT, -- time in epoch milliseconds
+  ts_ltz AS TO_TIMESTAMP_LTZ(ts, 3),
+  WATERMARK FOR ts_ltz AS ts_ltz - INTERVAL '5' SECOND -- Define watermark on TIMESTAMP_LTZ column
+) WITH (...);
+
+-- streaming sql, insert into hive table
+INSERT INTO TABLE hive_table 
+SELECT user_id, order_amount, DATE_FORMAT(ts_ltz, 'yyyy-MM-dd'), DATE_FORMAT(ts_ltz, 'HH')
+FROM kafka_table;
+
+-- batch sql, select with partition pruning
+SELECT * FROM hive_table WHERE dt='2020-05-20' and hr='12';
+
+```
 
 By default, for streaming writes, Flink only supports renaming committers, meaning the S3 filesystem
 cannot support exactly-once streaming writes.

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
@@ -41,6 +42,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -221,6 +223,130 @@ public class HiveTableSinkITCase {
                                     "+I[5, x, y, 2020-05-03, 11]",
                                     "+I[6, a, b, 2020-05-03, 12]"));
                 });
+    }
+
+    @Test(timeout = 120000)
+    public void testStreamingSinkOnTimestampLtzWatermrk() throws Exception {
+        testStreamingWriteWithTimestampLtzWatermark(this::checkSuccessFiles);
+    }
+
+    private void testStreamingWriteWithTimestampLtzWatermark(Consumer<String> pathConsumer)
+            throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(100);
+        StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env);
+
+        tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+        tEnv.useCatalog(hiveCatalog.getName());
+        tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        try {
+            tEnv.executeSql("create database db1");
+            tEnv.useDatabase("db1");
+            tEnv.executeSql(
+                    "create external table sink_table ("
+                            + " a int,"
+                            + " b string,"
+                            + " c string)"
+                            + " partitioned by (d string,e string)"
+                            + " stored as parquet TBLPROPERTIES ("
+                            + " 'partition.time-extractor.timestamp-pattern'='$d $e:00:00',"
+                            + " 'sink.partition-commit.trigger'='partition-time',"
+                            + " 'sink.partition-commit.delay'='1h',"
+                            + " 'sink.partition-commit.watermark-time-zone'='Asia/Shanghai',"
+                            + " 'sink.partition-commit.policy.kind'='metastore,success-file',"
+                            + " 'sink.partition-commit.success-file.name'='_MY_SUCCESS')");
+
+            // hive dialect only works with hive tables at the moment, switch to default dialect
+            tEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+            tEnv.getConfig().setLocalTimeZone(ZoneId.of("Asia/Shanghai"));
+            // prepare source
+            // epoch mills 1588460400000L <=>  local timestamp 2020-05-03 07:00:00 in Shanghai
+            // epoch mills 1588464000000L <=>  local timestamp 2020-05-03 08:00:00 in Shanghai
+            // epoch mills 1588467600000L <=>  local timestamp 2020-05-03 09:00:00 in Shanghai
+            // epoch mills 1588471200000L <=>  local timestamp 2020-05-03 10:00:00 in Shanghai
+            // epoch mills 1588474800000L <=>  local timestamp 2020-05-03 11:00:00 in Shanghai
+            List<Row> data =
+                    Arrays.asList(
+                            Row.of(1, "a", "b", "2020-05-03", "7", 1588460400000L),
+                            Row.of(1, "a", "b", "2020-05-03", "7", 1588460400000L),
+                            Row.of(2, "p", "q", "2020-05-03", "8", 1588464000000L),
+                            Row.of(2, "p", "q", "2020-05-03", "8", 1588464000000L),
+                            Row.of(3, "x", "y", "2020-05-03", "9", 1588467600000L),
+                            Row.of(3, "x", "y", "2020-05-03", "9", 1588467600000L),
+                            Row.of(4, "x", "y", "2020-05-03", "10", 1588471200000L),
+                            Row.of(4, "x", "y", "2020-05-03", "10", 1588471200000L),
+                            Row.of(5, "x", "y", "2020-05-03", "11", 1588474800000L),
+                            Row.of(5, "x", "y", "2020-05-03", "11", 1588474800000L));
+
+            String dataId = TestValuesTableFactory.registerData(data);
+            String sourceTableDDL =
+                    String.format(
+                            "create table my_table("
+                                    + " a INT,"
+                                    + " b STRING,"
+                                    + " c STRING,"
+                                    + " d STRING,"
+                                    + " e STRING,"
+                                    + " ts BIGINT,"
+                                    + " ts_ltz AS TO_TIMESTAMP_LTZ(ts, 3),"
+                                    + " WATERMARK FOR ts_ltz as ts_ltz"
+                                    + ") with ("
+                                    + " 'connector' = 'values',"
+                                    + " 'data-id' = '%s',"
+                                    + " 'failing-source' = 'true')",
+                            dataId);
+            tEnv.executeSql(sourceTableDDL);
+            tEnv.executeSql("insert into sink_table select a, b, c, d, e from my_table").await();
+
+            assertBatch(
+                    "db1.sink_table",
+                    Arrays.asList(
+                            "+I[1, a, b, 2020-05-03, 7]",
+                            "+I[1, a, b, 2020-05-03, 7]",
+                            "+I[2, p, q, 2020-05-03, 8]",
+                            "+I[2, p, q, 2020-05-03, 8]",
+                            "+I[3, x, y, 2020-05-03, 9]",
+                            "+I[3, x, y, 2020-05-03, 9]",
+                            "+I[4, x, y, 2020-05-03, 10]",
+                            "+I[4, x, y, 2020-05-03, 10]",
+                            "+I[5, x, y, 2020-05-03, 11]",
+                            "+I[5, x, y, 2020-05-03, 11]"));
+
+            // using batch table env to query.
+            List<String> results = new ArrayList<>();
+            TableEnvironment batchTEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+            batchTEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+            batchTEnv.useCatalog(hiveCatalog.getName());
+            batchTEnv
+                    .executeSql("select * from db1.sink_table")
+                    .collect()
+                    .forEachRemaining(r -> results.add(r.toString()));
+            results.sort(String::compareTo);
+            Assert.assertEquals(
+                    Arrays.asList(
+                            "+I[1, a, b, 2020-05-03, 7]",
+                            "+I[1, a, b, 2020-05-03, 7]",
+                            "+I[2, p, q, 2020-05-03, 8]",
+                            "+I[2, p, q, 2020-05-03, 8]",
+                            "+I[3, x, y, 2020-05-03, 9]",
+                            "+I[3, x, y, 2020-05-03, 9]",
+                            "+I[4, x, y, 2020-05-03, 10]",
+                            "+I[4, x, y, 2020-05-03, 10]",
+                            "+I[5, x, y, 2020-05-03, 11]",
+                            "+I[5, x, y, 2020-05-03, 11]"),
+                    results);
+
+            pathConsumer.accept(
+                    URI.create(
+                                    hiveCatalog
+                                            .getHiveTable(ObjectPath.fromString("db1.sink_table"))
+                                            .getSd()
+                                            .getLocation())
+                            .getPath());
+        } finally {
+            tEnv.executeSql("drop database db1 cascade");
+        }
     }
 
     private void checkSuccessFiles(String path) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -226,12 +226,7 @@ public class HiveTableSinkITCase {
     }
 
     @Test(timeout = 120000)
-    public void testStreamingSinkOnTimestampLtzWatermrk() throws Exception {
-        testStreamingWriteWithTimestampLtzWatermark(this::checkSuccessFiles);
-    }
-
-    private void testStreamingWriteWithTimestampLtzWatermark(Consumer<String> pathConsumer)
-            throws Exception {
+    public void testStreamingSinkWithTimestampLtzWatermark() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         env.enableCheckpointing(100);
@@ -313,31 +308,7 @@ public class HiveTableSinkITCase {
                             "+I[5, x, y, 2020-05-03, 11]",
                             "+I[5, x, y, 2020-05-03, 11]"));
 
-            // using batch table env to query.
-            List<String> results = new ArrayList<>();
-            TableEnvironment batchTEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
-            batchTEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
-            batchTEnv.useCatalog(hiveCatalog.getName());
-            batchTEnv
-                    .executeSql("select * from db1.sink_table")
-                    .collect()
-                    .forEachRemaining(r -> results.add(r.toString()));
-            results.sort(String::compareTo);
-            Assert.assertEquals(
-                    Arrays.asList(
-                            "+I[1, a, b, 2020-05-03, 7]",
-                            "+I[1, a, b, 2020-05-03, 7]",
-                            "+I[2, p, q, 2020-05-03, 8]",
-                            "+I[2, p, q, 2020-05-03, 8]",
-                            "+I[3, x, y, 2020-05-03, 9]",
-                            "+I[3, x, y, 2020-05-03, 9]",
-                            "+I[4, x, y, 2020-05-03, 10]",
-                            "+I[4, x, y, 2020-05-03, 10]",
-                            "+I[5, x, y, 2020-05-03, 11]",
-                            "+I[5, x, y, 2020-05-03, 11]"),
-                    results);
-
-            pathConsumer.accept(
+            this.checkSuccessFiles(
                     URI.create(
                                     hiveCatalog
                                             .getHiveTable(ObjectPath.fromString("db1.sink_table"))
@@ -443,30 +414,6 @@ public class HiveTableSinkITCase {
                             "+I[4, x, y, 2020-05-03, 10]",
                             "+I[5, x, y, 2020-05-03, 11]",
                             "+I[5, x, y, 2020-05-03, 11]"));
-
-            // using batch table env to query.
-            List<String> results = new ArrayList<>();
-            TableEnvironment batchTEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
-            batchTEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
-            batchTEnv.useCatalog(hiveCatalog.getName());
-            batchTEnv
-                    .executeSql("select * from db1.sink_table")
-                    .collect()
-                    .forEachRemaining(r -> results.add(r.toString()));
-            results.sort(String::compareTo);
-            Assert.assertEquals(
-                    Arrays.asList(
-                            "+I[1, a, b, 2020-05-03, 7]",
-                            "+I[1, a, b, 2020-05-03, 7]",
-                            "+I[2, p, q, 2020-05-03, 8]",
-                            "+I[2, p, q, 2020-05-03, 8]",
-                            "+I[3, x, y, 2020-05-03, 9]",
-                            "+I[3, x, y, 2020-05-03, 9]",
-                            "+I[4, x, y, 2020-05-03, 10]",
-                            "+I[4, x, y, 2020-05-03, 10]",
-                            "+I[5, x, y, 2020-05-03, 11]",
-                            "+I[5, x, y, 2020-05-03, 11]"),
-                    results);
 
             pathConsumer.accept(
                     URI.create(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -190,6 +190,19 @@ public class FileSystemOptions {
                                     + " if it is a day partition, should be '1 d',"
                                     + " if it is a hour partition, should be '1 h'");
 
+    public static final ConfigOption<String> SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE =
+            key("sink.partition-commit.watermark-time-zone")
+                    .stringType()
+                    .defaultValue("UTC")
+                    .withDescription(
+                            "The time zone to parse the long watermark value to TIMESTAMP value,"
+                                    + " the parsed watermark timestamp is used to compare with partition time"
+                                    + " to decide the partition should commit or not."
+                                    + " The default value is 'UTC', which means the watermark is defined on TIMESTAMP column or not defined."
+                                    + " If the watermark is defined on TIMESTAMP_LTZ column, the time zone of watermark is user configured time zone,"
+                                    + " the the value should be the user configured local time zone. The option value is either a full name"
+                                    + " such as 'America/Los_Angeles', or a custom timezone id such as 'GMT-8:00'.");
+
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_KIND =
             key("sink.partition-commit.policy.kind")
                     .stringType()


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix hive/filesystem **partition-time**  commit can not work when watermark is defined on timestamp_ltz column

## Brief change log

  -  Introduce  a connector option **sink.partition-commit.watermark-time-zone** to specify the time zone of watermark long value.
  - Use the time zone to parse the long watermark value to TIMESTAMP value, the parsed watermark timestamp is used to compare with partition time to decide the partition should commit or not.

## Verifying this change

- Add unit test and ITCase to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
