### PR TITLE
[BP-1.12][FLINK-22385][runtime] Fixes type cast error

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -285,7 +285,7 @@ public class NetworkBufferPool
     }
 
     public long getTotalMemory() {
-        return getTotalNumberOfMemorySegments() * memorySegmentSize;
+        return (long) getTotalNumberOfMemorySegments() * memorySegmentSize;
     }
 
     public int getNumberOfAvailableMemorySegments() {
@@ -295,7 +295,7 @@ public class NetworkBufferPool
     }
 
     public long getAvailableMemory() {
-        return getNumberOfAvailableMemorySegments() * memorySegmentSize;
+        return (long) getNumberOfAvailableMemorySegments() * memorySegmentSize;
     }
 
     public int getNumberOfUsedMemorySegments() {
@@ -303,7 +303,7 @@ public class NetworkBufferPool
     }
 
     public long getUsedMemory() {
-        return getNumberOfUsedMemorySegments() * memorySegmentSize;
+        return (long) getNumberOfUsedMemorySegments() * memorySegmentSize;
     }
 
     public int getNumberOfRegisteredBufferPools() {


### PR DESCRIPTION
## What is the purpose of the change

Fixes missing cast from `int` to `long`.

`1.12` Backport of #15693

## Brief change log

* Adds cast to `long`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
