### PR TITLE
[FLINK-22085][tests] Update TestUtils::tryExecute() to cancel the job after execution failure

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/TestUtils.java
@@ -18,41 +18,50 @@
 
 package org.apache.flink.test.util;
 
-import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.ProgramInvocationException;
-import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.client.JobInitializationException;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import static org.junit.Assert.fail;
 
 /** Test utilities. */
 public class TestUtils {
 
-    public static JobExecutionResult tryExecute(StreamExecutionEnvironment see, String name)
-            throws Exception {
+    // Execute the job and wait for the job result synchronously. The method throws exception
+    // iff one of the following conditions happens:
+    // 1) The job finishes successfully without exception
+    // 2) The job finishes with an exception that contains SuccessException.
+    public static void tryExecute(StreamExecutionEnvironment see, String name) throws Exception {
+        JobClient jobClient = null;
         try {
-            return see.execute(name);
-        } catch (ProgramInvocationException | JobExecutionException root) {
-            Throwable cause = root.getCause();
-
-            // search for nested SuccessExceptions
-            int depth = 0;
-            while (!(cause instanceof SuccessException)) {
-                if (cause == null || depth++ == 20) {
-                    root.printStackTrace();
-                    fail("Test failed: " + root.getMessage());
-                } else {
-                    cause = cause.getCause();
+            StreamGraph graph = see.getStreamGraph(name);
+            jobClient = see.executeAsync(graph);
+            jobClient.getJobExecutionResult().get();
+        } catch (Throwable root) {
+            if (jobClient != null) {
+                try {
+                    jobClient.cancel().get();
+                } catch (Exception e) {
+                    // Exception could be thrown if the job has already finished.
+                    // Ignore the exception.
                 }
             }
-        }
 
-        return null;
+            Throwable t = root;
+            while (t != null && !(t instanceof SuccessException)) {
+                t = t.getCause();
+            }
+
+            if (t == null) {
+                root.printStackTrace();
+                fail("Test failed: " + root.getMessage());
+            }
+        }
     }
 
     public static void submitJobAndWaitForResult(


### PR DESCRIPTION
## Contribution Checklist

This PR updated TestUtils::tryExecute() to cancel the job after execution failure. Otherwise, if one test has a stream job that keeps running, then even if this test fails after 60 sec due to `org.junit.runners.model.TestTimedOutException`, the next test will keep waiting for the Flink job to finish in `setClientAndEnsureNoJobIsLingering()`

## Verifying this change

Verified that `mvn test -Dtest=KafkaSourceLegacyITCase -Dcheckstyle.skip -nsu` would not hang across 30 runs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
