### PR TITLE
[FLINK-22409][runtime]Rename ResourceProfile class throwUnsupportedOperationExecptionIfUnknown method

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -174,7 +174,7 @@ public class ResourceProfile implements Serializable {
      * @return The cpu cores, 1.0 means a full cpu thread
      */
     public CPUResource getCpuCores() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return cpuCores;
     }
 
@@ -184,7 +184,7 @@ public class ResourceProfile implements Serializable {
      * @return The task heap memory
      */
     public MemorySize getTaskHeapMemory() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return taskHeapMemory;
     }
 
@@ -194,7 +194,7 @@ public class ResourceProfile implements Serializable {
      * @return The task off-heap memory
      */
     public MemorySize getTaskOffHeapMemory() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return taskOffHeapMemory;
     }
 
@@ -204,7 +204,7 @@ public class ResourceProfile implements Serializable {
      * @return The managed memory
      */
     public MemorySize getManagedMemory() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return managedMemory;
     }
 
@@ -214,7 +214,7 @@ public class ResourceProfile implements Serializable {
      * @return The network memory
      */
     public MemorySize getNetworkMemory() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return networkMemory;
     }
 
@@ -224,7 +224,7 @@ public class ResourceProfile implements Serializable {
      * @return The total memory
      */
     public MemorySize getTotalMemory() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return getOperatorsMemory().add(networkMemory);
     }
 
@@ -234,7 +234,7 @@ public class ResourceProfile implements Serializable {
      * @return The operator memory
      */
     public MemorySize getOperatorsMemory() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return taskHeapMemory.add(taskOffHeapMemory).add(managedMemory);
     }
 
@@ -244,11 +244,11 @@ public class ResourceProfile implements Serializable {
      * @return The extended resources
      */
     public Map<String, ExternalResource> getExtendedResources() {
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
         return Collections.unmodifiableMap(extendedResources);
     }
 
-    private void throwUnsupportedOperationExecptionIfUnknown() {
+    private void throwUnsupportedOperationExceptionIfUnknown() {
         if (this.equals(UNKNOWN)) {
             throw new UnsupportedOperationException();
         }
@@ -262,7 +262,7 @@ public class ResourceProfile implements Serializable {
      */
     public boolean isMatching(final ResourceProfile required) {
         checkNotNull(required, "Cannot check matching with null resources");
-        throwUnsupportedOperationExecptionIfUnknown();
+        throwUnsupportedOperationExceptionIfUnknown();
 
         if (this.equals(ANY)) {
             return true;


### PR DESCRIPTION
## What is the purpose of the change

throwUnsupportedOperationExecptionIfUnknown method has a mistake name. It should be 'throwUnsupportedOperationExceptionIfUnknown' , and All other references to this method are changed to 'throwUnsupportedOperationExceptionIfUnknown' . 


## Brief change log

rename throwUnsupportedOperationExecptionIfUnknown to throwUnsupportedOperationExceptionIfUnknown


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
