### PR TITLE
[hotfix][core] Fix typo in FileUtils

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -689,7 +689,7 @@ public final class FileUtils {
 
     /**
      * Converts the given {@link java.nio.file.Path} into a file {@link URL}. The resulting url is
-     * relative iff the given path is relative.
+     * relative if the given path is relative.
      *
      * @param path to convert into a {@link URL}.
      * @return URL


### PR DESCRIPTION
## What is the purpose of the change

Comments in FileUtils#toURL method has a typo.

## Brief change log

Alter 'iff' to 'if'.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
