### PR TITLE
[FLINK-21389] determine parquet schema from file instead of taking it from user

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetMapInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetMapInputFormat.java
@@ -35,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * An implementation of {@link ParquetInputFormat} to read {@link Map} records from Parquet files.
  */
@@ -42,6 +44,11 @@ public class ParquetMapInputFormat extends ParquetInputFormat<Map> {
 
     public ParquetMapInputFormat(Path path, MessageType messageType) {
         super(path, messageType);
+        checkNotNull(messageType, "messageType");
+    }
+
+    public ParquetMapInputFormat(Path path) {
+        this(path, null);
     }
 
     @Override

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetPojoInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetPojoInputFormat.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /** An implementation of {@link ParquetInputFormat} to read POJO records from Parquet files. */
 public class ParquetPojoInputFormat<E> extends ParquetInputFormat<E> {
 
@@ -49,11 +51,16 @@ public class ParquetPojoInputFormat<E> extends ParquetInputFormat<E> {
     public ParquetPojoInputFormat(
             Path filePath, MessageType messageType, PojoTypeInfo<E> pojoTypeInfo) {
         super(filePath, messageType);
+        checkNotNull(messageType, "messageType");
         this.pojoTypeClass = pojoTypeInfo.getTypeClass();
         this.typeSerializer = pojoTypeInfo.createSerializer(new ExecutionConfig());
         final Map<String, Field> fieldMap = new HashMap<>();
         findAllFields(pojoTypeClass, fieldMap);
         selectFields(fieldMap.keySet().toArray(new String[0]));
+    }
+
+    public ParquetPojoInputFormat(Path filePath, PojoTypeInfo<E> pojoTypeInfo) {
+        this(filePath, null, pojoTypeInfo);
     }
 
     @Override

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetRowInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetRowInputFormat.java
@@ -26,6 +26,8 @@ import org.apache.flink.types.Row;
 
 import org.apache.parquet.schema.MessageType;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * An implementation of {@link ParquetInputFormat} to read {@link Row} records from Parquet files.
  */
@@ -35,6 +37,11 @@ public class ParquetRowInputFormat extends ParquetInputFormat<Row>
 
     public ParquetRowInputFormat(Path path, MessageType messageType) {
         super(path, messageType);
+        checkNotNull(messageType, "messageType");
+    }
+
+    public ParquetRowInputFormat(Path path) {
+        this(path, null);
     }
 
     @Override

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetInputFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetInputFormatTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.utils.TestUtil;
+import org.apache.flink.types.Row;
+
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.parquet.avro.AvroSchemaConverter;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/** Test cases for reading from Parquet files. */
+@RunWith(Parameterized.class)
+public class ParquetInputFormatTest extends TestUtil {
+    private static final AvroSchemaConverter SCHEMA_CONVERTER = new AvroSchemaConverter();
+
+    @ClassRule public static TemporaryFolder tempRoot = new TemporaryFolder();
+
+    public ParquetInputFormatTest(boolean useLegacyMode) {
+        super(useLegacyMode);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testReadWithoutParquetSchemaSpecified() throws IOException {
+        Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> tuple =
+                TestUtil.getSimpleRecordTestData();
+        Path path =
+                createTempParquetFile(
+                        tempRoot.getRoot(),
+                        SIMPLE_SCHEMA,
+                        Collections.singletonList(tuple.f1),
+                        getConfiguration());
+
+        ParquetInputFormat<Row> inputFormat =
+                new ParquetInputFormat(path, null) {
+                    @Override
+                    protected Row convert(Row row) {
+                        return row;
+                    }
+                };
+        inputFormat.setRuntimeContext(getMockRuntimeContext());
+
+        FileInputSplit[] splits = inputFormat.createInputSplits(1);
+        assertEquals(1, splits.length);
+        inputFormat.open(splits[0]);
+
+        final Row record = inputFormat.nextRecord(null);
+        assertNotNull(record);
+        assertEquals(1L, record.getField(0));
+        assertEquals("test_simple", record.getField(1));
+        Long[] longArray = {1L};
+        assertEquals(longArray, (Long[]) record.getField(2));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-21389] determine parquet schema from file instead of taking it from user

## Brief change log

deprecate ParquetInputFormat constructors that take schema as parameter and create a constructor without parquet schema as parameter. Determine the schema from the file in the constructor instead

## Verifying this change



This change added tests and can be verified as follows:
Added ParquetInputFormatTest for low level tests.
This change can be tested by ParquetInputFormatTest#testReadWithoutParquetSchemaSpecified()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes deprecation
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes (avoid user having to pass parque schema to parquet input format)
  - If yes, how is the feature documented? deprecation in javadocs
