### PR TITLE
[FLINK-22234][runtime] Read savepoint before creating ExecutionGraph

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -70,6 +70,7 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingResultPartition;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
@@ -392,6 +393,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
             CompletedCheckpointStore checkpointStore,
             StateBackend checkpointStateBackend,
             CheckpointStorage checkpointStorage,
+            CheckpointStorageCoordinatorView checkpointStorageView,
             CheckpointStatsTracker statsTracker,
             CheckpointsCleaner checkpointsCleaner) {
 
@@ -438,7 +440,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                         operatorCoordinators,
                         checkpointIDCounter,
                         checkpointStore,
-                        checkpointStorage,
+                        checkpointStorageView,
                         ioExecutor,
                         checkpointsCleaner,
                         new ScheduledExecutorServiceAdapter(checkpointCoordinatorTimer),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.OptionalFailure;
 
@@ -87,6 +88,7 @@ public interface ExecutionGraph extends AccessExecutionGraph {
             CompletedCheckpointStore checkpointStore,
             StateBackend checkpointStateBackend,
             CheckpointStorage checkpointStorage,
+            CheckpointStorageCoordinatorView checkpointStorageView,
             CheckpointStatsTracker statsTracker,
             CheckpointsCleaner checkpointsCleaner);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.StringSerializer;
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.buildCheckpointStorageView;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -483,7 +484,7 @@ public class CheckpointCoordinatorMasterHooksTest {
                 Collections.emptyList(),
                 new StandaloneCheckpointIDCounter(),
                 new StandaloneCompletedCheckpointStore(10),
-                new MemoryStateBackend(),
+                buildCheckpointStorageView(new MemoryStateBackend(), graph.getJobID()),
                 executor,
                 new CheckpointsCleaner(),
                 testingScheduledExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -71,7 +71,12 @@ public class CheckpointMetadataLoadingTest {
                 createTasks(operatorId, parallelism, parallelism);
 
         final CompletedCheckpoint loaded =
-                Checkpoints.loadAndValidateCheckpoint(jobId, tasks, testSavepoint, cl, false);
+                Checkpoints.validateCheckpoint(
+                        jobId,
+                        tasks,
+                        testSavepoint,
+                        false,
+                        Checkpoints.loadCheckpoint(testSavepoint, cl));
 
         assertEquals(jobId, loaded.getJobId());
         assertEquals(checkpointId, loaded.getCheckpointID());
@@ -89,7 +94,12 @@ public class CheckpointMetadataLoadingTest {
                 createTasks(operatorId, parallelism, parallelism + 1);
 
         try {
-            Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+            Checkpoints.validateCheckpoint(
+                    new JobID(),
+                    tasks,
+                    testSavepoint,
+                    false,
+                    Checkpoints.loadCheckpoint(testSavepoint, cl));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
@@ -109,7 +119,12 @@ public class CheckpointMetadataLoadingTest {
         final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
 
         try {
-            Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+            Checkpoints.validateCheckpoint(
+                    new JobID(),
+                    tasks,
+                    testSavepoint,
+                    false,
+                    Checkpoints.loadCheckpoint(testSavepoint, cl));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));
@@ -129,7 +144,12 @@ public class CheckpointMetadataLoadingTest {
         final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
 
         final CompletedCheckpoint loaded =
-                Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, true);
+                Checkpoints.validateCheckpoint(
+                        new JobID(),
+                        tasks,
+                        testSavepoint,
+                        true,
+                        Checkpoints.loadCheckpoint(testSavepoint, cl));
 
         assertTrue(loaded.getOperatorStates().isEmpty());
     }
@@ -152,7 +172,12 @@ public class CheckpointMetadataLoadingTest {
         final Map<JobVertexID, ExecutionJobVertex> tasks = Collections.emptyMap();
 
         try {
-            Checkpoints.loadAndValidateCheckpoint(new JobID(), tasks, testSavepoint, cl, false);
+            Checkpoints.validateCheckpoint(
+                    new JobID(),
+                    tasks,
+                    testSavepoint,
+                    false,
+                    Checkpoints.loadCheckpoint(testSavepoint, cl));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.buildCheckpointStorageView;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -79,7 +80,7 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
                         Collections.emptyList(),
                         new StandaloneCheckpointIDCounter(),
                         new StandaloneCompletedCheckpointStore(1),
-                        new MemoryStateBackend(),
+                        buildCheckpointStorageView(new MemoryStateBackend(), graph.getJobID()),
                         Executors.directExecutor(),
                         new CheckpointsCleaner(),
                         manualThreadExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -164,27 +164,31 @@ public class TestingDefaultExecutionGraphBuilder {
 
     public DefaultExecutionGraph build() throws JobException, JobExecutionException {
         return DefaultExecutionGraphBuilder.buildGraph(
-                jobGraph,
-                jobMasterConfig,
-                futureExecutor,
-                ioExecutor,
-                userClassLoader,
-                completedCheckpointStore,
-                new CheckpointsCleaner(),
-                checkpointIdCounter,
-                rpcTimeout,
-                metricGroup,
-                blobWriter,
-                LOG,
-                shuffleMaster,
-                partitionTracker,
-                TaskDeploymentDescriptorFactory.PartitionLocationConstraint.fromJobType(
-                        jobGraph.getJobType()),
-                executionDeploymentListener,
-                executionStateUpdateListener,
-                System.currentTimeMillis(),
-                new DefaultVertexAttemptNumberStore(),
-                Optional.ofNullable(vertexParallelismStore)
-                        .orElseGet(() -> SchedulerBase.computeVertexParallelismStore(jobGraph)));
+                        jobGraph,
+                        jobMasterConfig,
+                        futureExecutor,
+                        ioExecutor,
+                        userClassLoader,
+                        completedCheckpointStore,
+                        new CheckpointsCleaner(),
+                        checkpointIdCounter,
+                        rpcTimeout,
+                        metricGroup,
+                        blobWriter,
+                        LOG,
+                        shuffleMaster,
+                        partitionTracker,
+                        TaskDeploymentDescriptorFactory.PartitionLocationConstraint.fromJobType(
+                                jobGraph.getJobType()),
+                        executionDeploymentListener,
+                        executionStateUpdateListener,
+                        System.currentTimeMillis(),
+                        new DefaultVertexAttemptNumberStore(),
+                        Optional.ofNullable(vertexParallelismStore)
+                                .orElseGet(
+                                        () ->
+                                                SchedulerBase.computeVertexParallelismStore(
+                                                        jobGraph)))
+                .f0;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.SerializedValue;
@@ -258,6 +259,7 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
             CompletedCheckpointStore checkpointStore,
             StateBackend checkpointStateBackend,
             CheckpointStorage checkpointStorage,
+            CheckpointStorageCoordinatorView checkpointStorageView,
             CheckpointStatsTracker statsTracker,
             CheckpointsCleaner checkpointsCleaner) {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
## What is the purpose of the change

*Savepoints are currently read when the `ExecutionGraph` is created. This is causing problems when determining the (max) parallelism the job is run with, because the savepoint may impose additional restrictions. This caused quite a few headaches in FLINK-21844, and further requires the execution vertices to have a mutable max parallelism. `DefaultExecutionGraphFactory` should load the savepoint and then extract from it potential constraints for the `ExecutionGraph` creation.*

## Brief change log

  - *Separate `Checkpoints.loadAndValidateCheckpoint` into `Checkpoints.loadCheckpoint` and `Checkpoints.validateCheckpoint` for loading the savepoint before the `ExecutionGraph` creation.*

## Verifying this change

  - *`CheckpointMetadataLoadingTest` updates `Checkpoints.loadAndValidateCheckpoint` to `Checkpoints.loadCheckpoint` and `Checkpoints.validateCheckpoint`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)