### PR TITLE
[FLINK-22378][table] Fix timestamp handling in toDataStream

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.delegation.hive;
 
 import org.apache.flink.connectors.hive.FlinkHiveException;
 import org.apache.flink.table.api.SqlParserException;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogManager;
@@ -36,7 +35,6 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ddl.CreateTableASOperation;
 import org.apache.flink.table.operations.ddl.CreateTableOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverter;
 import org.apache.flink.table.planner.delegation.ParserImpl;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveASTParseException;
@@ -80,7 +78,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** A Parser that uses Hive's planner to parse a statement. */
@@ -176,13 +173,12 @@ public class HiveParser extends ParserImpl {
             CatalogManager catalogManager,
             Supplier<FlinkPlannerImpl> validatorSupplier,
             Supplier<CalciteParser> calciteParserSupplier,
-            Function<TableSchema, SqlExprToRexConverter> sqlExprToRexConverterCreator,
             PlannerContext plannerContext) {
         super(
                 catalogManager,
                 validatorSupplier,
                 calciteParserSupplier,
-                sqlExprToRexConverterCreator);
+                plannerContext.getSqlExprToRexConverterFactory());
         this.plannerContext = plannerContext;
         this.catalogReader =
                 plannerContext.createCatalogReader(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.descriptors.DescriptorProperties;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 import org.apache.flink.table.planner.delegation.ParserFactory;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 
@@ -36,8 +35,6 @@ public class HiveParserFactory implements ParserFactory {
 
     @Override
     public Parser create(CatalogManager catalogManager, PlannerContext plannerContext) {
-        SqlExprToRexConverterFactory sqlExprToRexConverterFactory =
-                plannerContext::createSqlExprToRexConverter;
         return new HiveParser(
                 catalogManager,
                 () ->
@@ -45,9 +42,6 @@ public class HiveParserFactory implements ParserFactory {
                                 catalogManager.getCurrentCatalog(),
                                 catalogManager.getCurrentDatabase()),
                 plannerContext::createCalciteParser,
-                tableSchema ->
-                        sqlExprToRexConverterFactory.create(
-                                plannerContext.getTypeFactory().buildRelNodeRowType(tableSchema)),
                 plannerContext);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -261,9 +261,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                                 return Optional.empty();
                             }
                         },
-                        (sqlExpression, inputSchema) -> {
+                        (sqlExpression, inputRowType, outputType) -> {
                             try {
-                                return getParser().parseSqlExpression(sqlExpression, inputSchema);
+                                return getParser()
+                                        .parseSqlExpression(
+                                                sqlExpression, inputRowType, outputType);
                             } catch (Throwable t) {
                                 throw new ValidationException(
                                         String.format("Invalid SQL expression: %s", sqlExpression),

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Parser.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Parser.java
@@ -19,11 +19,14 @@
 package org.apache.flink.table.delegation;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -58,11 +61,13 @@ public interface Parser {
      * Entry point for parsing SQL expressions expressed as a String.
      *
      * @param sqlExpression the SQL expression to parse
-     * @param inputSchema the schema of the fields in sql expression
+     * @param inputRowType the fields available in the SQL expression
+     * @param outputType expected top-level output type if available
      * @return resolved expression
      * @throws org.apache.flink.table.api.SqlParserException when failed to parse the sql expression
      */
-    ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema);
+    ResolvedExpression parseSqlExpression(
+            String sqlExpression, RowType inputRowType, @Nullable LogicalType outputType);
 
     /**
      * Returns completion hints for the given statement at the given cursor position. The completion

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/SqlExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/SqlExpressionResolver.java
@@ -19,14 +19,18 @@
 package org.apache.flink.table.expressions.resolver;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
 
 /** Translates a SQL expression string into a {@link ResolvedExpression}. */
 @Internal
 public interface SqlExpressionResolver {
 
     /** Translates the given SQL expression string or throws a {@link ValidationException}. */
-    ResolvedExpression resolveExpression(String sqlExpression, TableSchema inputSchema);
+    ResolvedExpression resolveExpression(
+            String sqlExpression, RowType inputRowType, @Nullable LogicalType outputType);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.expressions.resolver.SqlExpressionResolver;
 import org.apache.flink.table.expressions.resolver.lookups.FieldReferenceLookup;
 import org.apache.flink.table.expressions.resolver.lookups.TableReferenceLookup;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
 
 import java.util.List;
 import java.util.Optional;
@@ -86,6 +87,9 @@ public interface ResolverRule {
 
         /** Access to available local references. */
         List<LocalReferenceExpression> getLocalReferences();
+
+        /** Access to the expected top-level output data type. */
+        Optional<DataType> getOutputDataType();
 
         /** Access to available local over windows. */
         Optional<LocalOverWindow> getOverWindow(Expression alias);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -26,10 +26,14 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
 import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 import org.apache.flink.table.utils.ExpressionResolverMocks;
 
 import org.junit.Test;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -268,7 +272,7 @@ public class CatalogBaseTableResolutionTest {
     }
 
     private static ResolvedExpression resolveSqlExpression(
-            String sqlExpression, TableSchema inputSchema) {
+            String sqlExpression, RowType inputRowType, @Nullable LogicalType outputType) {
         switch (sqlExpression) {
             case COMPUTED_SQL:
                 return COMPUTED_COLUMN_RESOLVED;

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/resolver/ExpressionResolverTest.java
@@ -332,7 +332,7 @@ public class ExpressionResolverTest {
                             name -> Optional.empty(),
                             new FunctionLookupMock(functions),
                             new DataTypeFactoryMock(),
-                            (sqlExpression, inputSchema) -> {
+                            (sqlExpression, inputRowType, outputType) -> {
                                 throw new UnsupportedOperationException();
                             },
                             Arrays.stream(schemas)

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/utils/ValuesOperationTreeBuilderTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/operations/utils/ValuesOperationTreeBuilderTest.java
@@ -496,7 +496,7 @@ public class ValuesOperationTreeBuilderTest {
                     new FunctionLookupMock(Collections.emptyMap()),
                     new DataTypeFactoryMock(),
                     name -> Optional.empty(), // do not support
-                    (sqlExpression, inputSchema) -> {
+                    (sqlExpression, inputRowType, outputType) -> {
                         throw new UnsupportedOperationException();
                     },
                     true);

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExpressionResolverMocks.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExpressionResolverMocks.java
@@ -47,7 +47,7 @@ public final class ExpressionResolverMocks {
 
     public static ExpressionResolverBuilder dummyResolver() {
         return forSqlExpression(
-                (sqlExpression, inputSchema) -> {
+                (sqlExpression, inputRowType, outputType) -> {
                     throw new UnsupportedOperationException();
                 });
     }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ParserMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ParserMock.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.table.utils;
 
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 
@@ -39,7 +42,8 @@ public class ParserMock implements Parser {
     }
 
     @Override
-    public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
+    public ResolvedExpression parseSqlExpression(
+            String sqlExpression, RowType inputRowType, @Nullable LogicalType outputType) {
         return null;
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.connector.sink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.connector.RuntimeConverter;
@@ -96,8 +96,7 @@ public interface DynamicTableSink {
      * interfaces might be located in other Flink modules.
      *
      * <p>Independent of the provider interface, the table runtime expects that a sink
-     * implementation accepts internal data structures (see {@link
-     * org.apache.flink.table.data.RowData} for more information).
+     * implementation accepts internal data structures (see {@link RowData} for more information).
      *
      * <p>The given {@link Context} offers utilities by the planner for creating runtime
      * implementation with minimal dependencies to internal data structures.
@@ -146,7 +145,7 @@ public interface DynamicTableSink {
          * Creates type information describing the internal data structures of the given {@link
          * DataType}.
          *
-         * @see TableSchema#toPhysicalRowDataType()
+         * @see ResolvedSchema#toPhysicalRowDataType()
          */
         <T> TypeInformation<T> createTypeInformation(DataType consumedDataType);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -117,7 +117,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("SOURCE_WATERMARK")
                     .kind(SCALAR)
                     .inputTypeStrategy(NO_ARGS)
-                    .outputTypeStrategy(explicit(DataTypes.TIMESTAMP(3)))
+                    .outputTypeStrategy(TypeStrategies.SOURCE_WATERMARK)
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.SourceWatermarkFunction")
                     .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
@@ -69,6 +69,7 @@ public final class TypeStrategies {
     /** Placeholder for a missing type strategy. */
     public static final TypeStrategy MISSING = new MissingTypeStrategy();
 
+    /** Type strategy that returns a common, least restrictive type of all arguments. */
     public static final TypeStrategy COMMON = new CommonTypeStrategy();
 
     /** Type strategy that returns a fixed {@link DataType}. */
@@ -416,6 +417,21 @@ public final class TypeStrategies {
                     return Optional.of(inputDataType);
                 }
                 return Optional.of(nullReplacementDataType);
+            };
+
+    /** Type strategy specific for source watermarks that depend on the output type. */
+    public static final TypeStrategy SOURCE_WATERMARK =
+            callContext -> {
+                final DataType timestampDataType =
+                        callContext
+                                .getOutputDataType()
+                                .filter(
+                                        dt ->
+                                                hasFamily(
+                                                        dt.getLogicalType(),
+                                                        LogicalTypeFamily.TIMESTAMP))
+                                .orElse(DataTypes.TIMESTAMP_LTZ(3));
+                return Optional.of(timestampDataType);
             };
 
     /**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -42,6 +42,7 @@ import org.apache.calcite.util.Static;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
 
@@ -49,12 +50,28 @@ import static org.apache.calcite.sql.type.SqlTypeName.DECIMAL;
 @Internal
 public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
 
+    // Enables CallContext#getOutputDataType() when validating SQL expressions.
+    private SqlNode sqlNodeForExpectedOutputType;
+    private RelDataType expectedOutputType;
+
     public FlinkCalciteSqlValidator(
             SqlOperatorTable opTab,
             SqlValidatorCatalogReader catalogReader,
             RelDataTypeFactory typeFactory,
             SqlValidator.Config config) {
         super(opTab, catalogReader, typeFactory, config);
+    }
+
+    public void setExpectedOutputType(SqlNode sqlNode, RelDataType expectedOutputType) {
+        this.sqlNodeForExpectedOutputType = sqlNode;
+        this.expectedOutputType = expectedOutputType;
+    }
+
+    public Optional<RelDataType> getExpectedOutputType(SqlNode sqlNode) {
+        if (sqlNode == sqlNodeForExpectedOutputType) {
+            return Optional.of(expectedOutputType);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.planner.calcite;
 
+import org.apache.flink.annotation.Internal;
+
 import org.apache.calcite.rex.RexNode;
 
 /** Converts SQL expressions to {@link RexNode}. */
+@Internal
 public interface SqlExprToRexConverter {
 
     /**

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterFactory.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterFactory.java
@@ -18,13 +18,28 @@
 
 package org.apache.flink.table.planner.calcite;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+
+import javax.annotation.Nullable;
 
 /** Factory to create {@link SqlExprToRexConverter}. */
+@Internal
 public interface SqlExprToRexConverterFactory {
 
     /**
-     * Creates a new instance of {@link SqlExprToRexConverter} to convert SQL expression to RexNode.
+     * Creates a new instance of {@link SqlExprToRexConverter} to convert SQL expression to {@link
+     * RexNode}.
      */
-    SqlExprToRexConverter create(RelDataType tableRowType);
+    SqlExprToRexConverter create(RelDataType inputRowType, @Nullable RelDataType outputType);
+
+    /**
+     * Creates a new instance of {@link SqlExprToRexConverter} to convert SQL expression to {@link
+     * RexNode}.
+     */
+    SqlExprToRexConverter create(RowType inputRowType, @Nullable LogicalType outputType);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/DefaultParserFactory.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/DefaultParserFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.descriptors.DescriptorProperties;
-import org.apache.flink.table.planner.calcite.SqlExprToRexConverterFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,8 +32,6 @@ import java.util.Map;
 public class DefaultParserFactory implements ParserFactory {
     @Override
     public Parser create(CatalogManager catalogManager, PlannerContext plannerContext) {
-        SqlExprToRexConverterFactory sqlExprToRexConverterFactory =
-                plannerContext::createSqlExprToRexConverter;
         return new ParserImpl(
                 catalogManager,
                 () ->
@@ -42,9 +39,7 @@ public class DefaultParserFactory implements ParserFactory {
                                 catalogManager.getCurrentCatalog(),
                                 catalogManager.getCurrentDatabase()),
                 plannerContext::createCalciteParser,
-                tableSchema ->
-                        sqlExprToRexConverterFactory.create(
-                                plannerContext.getTypeFactory().buildRelNodeRowType(tableSchema)));
+                plannerContext.getSqlExprToRexConverterFactory());
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
@@ -52,7 +52,7 @@ public class CallExpressionResolver {
                                                             "We should not need to lookup any expressions at this point");
                                                 }),
                                 context.getCatalogManager().getDataTypeFactory(),
-                                (sqlExpression, inputSchema) -> {
+                                (sqlExpression, inputRowType, outputType) -> {
                                     throw new TableException(
                                             "SQL expression parsing is not supported at this location.");
                                 })

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceReturnInference.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/TypeInferenceReturnInference.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.calcite.FlinkCalciteSqlValidator;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.TypeInference;
@@ -29,8 +30,11 @@ import org.apache.flink.table.types.inference.TypeInferenceUtil;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+
+import javax.annotation.Nullable;
 
 import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTypeFactory;
 import static org.apache.flink.table.types.inference.TypeInferenceUtil.createInvalidCallException;
@@ -63,7 +67,11 @@ public final class TypeInferenceReturnInference implements SqlReturnTypeInferenc
     @Override
     public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
         final CallContext callContext =
-                new OperatorBindingCallContext(dataTypeFactory, definition, opBinding, null);
+                new OperatorBindingCallContext(
+                        dataTypeFactory,
+                        definition,
+                        opBinding,
+                        extractExpectedOutputType(opBinding));
         try {
             return inferReturnTypeOrError(unwrapTypeFactory(opBinding), callContext);
         } catch (ValidationException e) {
@@ -74,6 +82,16 @@ public final class TypeInferenceReturnInference implements SqlReturnTypeInferenc
     }
 
     // --------------------------------------------------------------------------------------------
+
+    private @Nullable RelDataType extractExpectedOutputType(SqlOperatorBinding opBinding) {
+        if (opBinding instanceof SqlCallBinding) {
+            final SqlCallBinding binding = (SqlCallBinding) opBinding;
+            final FlinkCalciteSqlValidator validator =
+                    (FlinkCalciteSqlValidator) binding.getValidator();
+            return validator.getExpectedOutputType(binding.getCall()).orElse(null);
+        }
+        return null;
+    }
 
     private RelDataType inferReturnTypeOrError(
             FlinkTypeFactory typeFactory, CallContext callContext) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/abilities/source/FilterPushDownSpec.java
@@ -106,7 +106,7 @@ public class FilterPushDownSpec extends SourceAbilitySpecBase {
                                                                 "We should not need to lookup any expressions at this point");
                                                     }),
                                     context.getCatalogManager().getDataTypeFactory(),
-                                    (sqlExpression, inputSchema) -> {
+                                    (sqlExpression, inputRowType, outputType) -> {
                                         throw new TableException(
                                                 "SQL expression parsing is not supported at this location.");
                                     })

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -92,11 +92,6 @@ abstract class PlannerBase(
   // temporary utility until we don't use planner expressions anymore
   functionCatalog.setPlannerTypeInferenceUtil(PlannerTypeInferenceUtilImpl.INSTANCE)
 
-  private val sqlExprToRexConverterFactory = new SqlExprToRexConverterFactory {
-    override def create(tableRowType: RelDataType): SqlExprToRexConverter =
-      plannerContext.createSqlExprToRexConverter(tableRowType)
-  }
-
   private var parser: Parser = _
   private var currentDialect: SqlDialect = getTableConfig.getSqlDialect
 
@@ -109,6 +104,8 @@ abstract class PlannerBase(
       asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
       getTraitDefs.toList
     )
+
+  private val sqlExprToRexConverterFactory = plannerContext.getSqlExprToRexConverterFactory
 
   /** Returns the [[FlinkRelBuilder]] of this TableEnvironment. */
   private[flink] def getRelBuilder: FlinkRelBuilder = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/LegacyCatalogSourceTable.scala
@@ -135,7 +135,7 @@ class LegacyCatalogSourceTable[T](
             s"`$name`"
           }
         }.toArray
-      val rexNodes = toRexFactory.create(newRelTable.getRowType).convertToRexNodes(fieldExprs)
+      val rexNodes = toRexFactory.create(newRelTable.getRowType, null).convertToRexNodes(fieldExprs)
       relBuilder.projectNamed(rexNodes.toList, fieldNames, true)
     }
 
@@ -158,7 +158,7 @@ class LegacyCatalogSourceTable[T](
       }
       val rowtimeIndex = fieldNames.indexOf(rowtime)
       val watermarkRexNode = toRexFactory
-        .create(actualRowType)
+        .create(actualRowType, null)
         .convertToRexNode(watermarkSpec.get.getWatermarkExpr)
       relBuilder.watermark(rowtimeIndex, watermarkRexNode)
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/ParserImplTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/delegation/ParserImplTest.java
@@ -76,9 +76,7 @@ public class ParserImplTest {
                     catalogManager,
                     plannerSupplier,
                     () -> plannerSupplier.get().parser(),
-                    t ->
-                            plannerContext.createSqlExprToRexConverter(
-                                    plannerContext.getTypeFactory().buildRelNodeRowType(t)));
+                    plannerContext.getSqlExprToRexConverterFactory());
 
     private static final List<TestSpec> TEST_SPECS =
             Arrays.asList(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -129,17 +129,6 @@ public class SqlToOperationConverterTest {
                             .createFlinkPlanner(
                                     catalogManager.getCurrentCatalog(),
                                     catalogManager.getCurrentDatabase());
-    private final Parser parser =
-            new ParserImpl(
-                    catalogManager,
-                    plannerSupplier,
-                    () -> plannerSupplier.get().parser(),
-                    t ->
-                            getPlannerContext()
-                                    .createSqlExprToRexConverter(
-                                            getPlannerContext()
-                                                    .getTypeFactory()
-                                                    .buildRelNodeRowType(t)));
     private final PlannerContext plannerContext =
             new PlannerContext(
                     tableConfig,
@@ -147,6 +136,13 @@ public class SqlToOperationConverterTest {
                     catalogManager,
                     asRootSchema(new CatalogManagerCalciteSchema(catalogManager, isStreamingMode)),
                     Collections.emptyList());
+
+    private final Parser parser =
+            new ParserImpl(
+                    catalogManager,
+                    plannerSupplier,
+                    () -> plannerSupplier.get().parser(),
+                    getPlannerContext().getSqlExprToRexConverterFactory());
 
     private PlannerContext getPlannerContext() {
         return plannerContext;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DataStreamJavaITCase.java
@@ -28,11 +28,13 @@ import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.Column;
@@ -48,6 +50,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Collector;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +60,8 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -246,7 +251,7 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                 tableEnv.fromDataStream(
                         dataStream,
                         Schema.newBuilder()
-                                .columnByMetadata("rowtime", "TIMESTAMP(3)")
+                                .columnByMetadata("rowtime", "TIMESTAMP_LTZ(3)")
                                 .watermark("rowtime", "SOURCE_WATERMARK()")
                                 .build());
 
@@ -257,12 +262,14 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                                 Column.physical("f0", DataTypes.BIGINT().notNull()),
                                 Column.physical("f1", DataTypes.INT().notNull()),
                                 Column.physical("f2", DataTypes.STRING()),
-                                Column.metadata("rowtime", DataTypes.TIMESTAMP(3), null, false)),
+                                Column.metadata(
+                                        "rowtime", DataTypes.TIMESTAMP_LTZ(3), null, false)),
                         Collections.singletonList(
                                 WatermarkSpec.of(
                                         "rowtime",
                                         ResolvedExpressionMock.of(
-                                                DataTypes.TIMESTAMP(3), "`SOURCE_WATERMARK`()"))),
+                                                DataTypes.TIMESTAMP_LTZ(3),
+                                                "`SOURCE_WATERMARK`()"))),
                         null));
 
         tableEnv.createTemporaryView("t", table);
@@ -305,7 +312,7 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                 tableEnv.fromChangelogStream(
                         changelogStream,
                         Schema.newBuilder()
-                                .columnByMetadata("rowtime", DataTypes.TIMESTAMP(3))
+                                .columnByMetadata("rowtime", DataTypes.TIMESTAMP_LTZ(3))
                                 .watermark("rowtime", "SOURCE_WATERMARK()")
                                 .build());
         tableEnv.createTemporaryView("t", table);
@@ -429,6 +436,62 @@ public class DataStreamJavaITCase extends AbstractTestBase {
                         Schema.newBuilder().primaryKey("f0").build(),
                         ChangelogMode.upsert()),
                 getOutput(inputOrOutput));
+    }
+
+    @Test
+    public void testToDataStreamCustomEventTime() throws Exception {
+        final TableConfig config = tableEnv.getConfig();
+
+        // session time zone should not have an impact on the conversion
+        final ZoneId originalZone = config.getLocalTimeZone();
+        config.setLocalTimeZone(ZoneId.of("Europe/Berlin"));
+
+        final LocalDateTime localDateTime1 = LocalDateTime.parse("1970-01-01T00:00:00.000");
+        final LocalDateTime localDateTime2 = LocalDateTime.parse("1970-01-01T01:00:00.000");
+
+        final DataStream<Tuple2<LocalDateTime, String>> dataStream =
+                env.fromElements(
+                        new Tuple2<>(localDateTime1, "alice"), new Tuple2<>(localDateTime2, "bob"));
+
+        final Table table =
+                tableEnv.fromDataStream(
+                        dataStream,
+                        Schema.newBuilder()
+                                .column("f0", "TIMESTAMP(3)")
+                                .column("f1", "STRING")
+                                .watermark("f0", "SOURCE_WATERMARK()")
+                                .build());
+
+        testSchema(
+                table,
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("f0", DataTypes.TIMESTAMP(3)),
+                                Column.physical("f1", DataTypes.STRING())),
+                        Collections.singletonList(
+                                WatermarkSpec.of(
+                                        "f0",
+                                        ResolvedExpressionMock.of(
+                                                DataTypes.TIMESTAMP(3), "`SOURCE_WATERMARK`()"))),
+                        null));
+
+        final DataStream<Long> rowtimeStream =
+                tableEnv.toDataStream(table)
+                        .process(
+                                new ProcessFunction<Row, Long>() {
+                                    @Override
+                                    public void processElement(
+                                            Row value, Context ctx, Collector<Long> out) {
+                                        out.collect(ctx.timestamp());
+                                    }
+                                });
+
+        testResult(
+                rowtimeStream,
+                localDateTime1.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli(),
+                localDateTime2.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli());
+
+        config.setLocalTimeZone(originalZone);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
@@ -59,9 +59,7 @@ public class PlannerMocks {
                         catalogManager,
                         () -> planner,
                         planner::parser,
-                        t ->
-                                plannerContext.createSqlExprToRexConverter(
-                                        plannerContext.getTypeFactory().buildRelNodeRowType(t)));
+                        plannerContext.getSqlExprToRexConverterFactory());
         catalogManager.initSchemaResolver(
                 isStreamingMode,
                 ExpressionResolver.resolverFor(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -251,7 +251,7 @@ class FlinkRelMdHandlerTestBase {
       .unwrap(classOf[FlinkContext])
     val watermarkRexNode = flinkContext
       .getSqlExprToRexConverterFactory
-      .create(scan.getTable.getRowType)
+      .create(scan.getTable.getRowType, null)
       .convertToRexNode("rowtime - INTERVAL '10' SECOND")
 
     relBuilder.push(scan)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner;
 
 import org.apache.flink.table.api.TableException;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
@@ -29,11 +28,15 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.parse.CalciteParser;
 import org.apache.flink.table.parse.ExtendedParser;
 import org.apache.flink.table.sqlexec.SqlToOperationConverter;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.advise.SqlAdvisor;
 import org.apache.calcite.sql.advise.SqlAdvisorValidator;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,7 +108,8 @@ public class ParserImpl implements Parser {
     }
 
     @Override
-    public ResolvedExpression parseSqlExpression(String sqlExpression, TableSchema inputSchema) {
+    public ResolvedExpression parseSqlExpression(
+            String sqlExpression, RowType inputRowType, @Nullable LogicalType outputType) {
         throw new UnsupportedOperationException(
                 "Computed columns is only supported by the Blink planner.");
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -44,6 +44,7 @@ import org.apache.flink.table.parse.CalciteParser
 import org.apache.flink.table.planner.{ParserImpl, PlanningConfigurationBuilder}
 import org.apache.flink.table.sinks.{BatchSelectTableSink, BatchTableSink, OutputFormatTableSink, OverwritableTableSink, PartitionableTableSink, TableSink, TableSinkUtils}
 import org.apache.flink.table.sources.TableSource
+import org.apache.flink.table.types.logical.{LogicalType, RowType}
 import org.apache.flink.table.types.{AbstractDataType, DataType}
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.table.utils.PrintUtils
@@ -112,7 +113,10 @@ abstract class TableEnvImpl(
     catalogManager.getDataTypeFactory,
     tableLookup,
     new SqlExpressionResolver {
-      override def resolveExpression(sqlExpression: String, inputSchema: TableSchema)
+      override def resolveExpression(
+          sqlExpression: String,
+          inputRowType: RowType,
+          outputType: LogicalType)
         : ResolvedExpression = {
             throw new UnsupportedOperationException(
               "SQL expression parsing is only supported in the Blink planner.")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sink/OutputConversionOperator.java
@@ -70,9 +70,11 @@ public class OutputConversionOperator extends TableStreamOperator<Object>
         final RowData rowData = element.getValue();
 
         if (consumeRowtimeMetadata) {
+            // timestamp is TIMESTAMP_LTZ
             final long rowtime = rowData.getTimestamp(rowData.getArity() - 1, 3).getMillisecond();
             outRecord.setTimestamp(rowtime);
         } else if (rowtimeIndex != -1) {
+            // timestamp might be TIMESTAMP or TIMESTAMP_LTZ
             final long rowtime = rowData.getTimestamp(rowtimeIndex, 3).getMillisecond();
             outRecord.setTimestamp(rowtime);
         }


### PR DESCRIPTION
## What is the purpose of the change

This allows to support both TIMESTAMP and TIMESTAMP_LTZ as output for `toDataStream`. It also updates `SOURCE_WATERMARK` to derive either TIMESTAMP_LTZ or TIMESTAMP.

## Brief change log

- Support `CallContext.getOutputDataType` in schema resolution
- Update `SOURCE_WATERMARK` definition

## Verifying this change

This change added tests and can be verified as follows: `DataStreamJavaITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
