### PR TITLE
[FLINK-22301][runtime] Statebackend and CheckpointStorage type is not shown in the Web UI

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -115,6 +115,8 @@ export interface CheckPointConfigInterface {
     enabled: boolean;
     delete_on_cancellation: boolean;
   };
+  state_backend: any;
+  checkpoint_storage: any;
   unaligned_checkpoints: boolean;
   tolerable_failed_checkpoints: number;
 }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -115,8 +115,8 @@ export interface CheckPointConfigInterface {
     enabled: boolean;
     delete_on_cancellation: boolean;
   };
-  state_backend: any;
-  checkpoint_storage: any;
+  state_backend: string;
+  checkpoint_storage: string;
   unaligned_checkpoints: boolean;
   tolerable_failed_checkpoints: number;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -224,6 +224,14 @@
             <td *ngIf="checkPointConfig['mode'] != 'exactly_once'">At Least Once</td>
           </tr>
           <tr>
+            <td>Checkpoint Storage</td>
+            <td>{{ checkPointConfig['checkpoint_storage'] }}</td>
+          </tr>
+          <tr>
+            <td>State Backend</td>
+            <td>{{ checkPointConfig['state_backend'] }}</td>
+          </tr>
+          <tr>
             <td>Interval</td>
             <td *ngIf="checkPointConfig['interval'] == '0x7fffffffffffffff'">Periodic checkpoints disabled</td>
             <td *ngIf="checkPointConfig['interval'] != '0x7fffffffffffffff'">{{ checkPointConfig['interval'] | humanizeDuration}}</td>


### PR DESCRIPTION
## What is the purpose of the change

*Currently we have already have the Rest API /jobs/:jobid/checkpoints/config that returns the statebackend name and checkpoint storage type:*
```
{
    "mode":"exactly_once",
    "interval":20,
    "timeout":600000,
    "min_pause":0,
    "max_concurrent":1,
    "externalization":{
        "enabled":false,
        "delete_on_cancellation":true
    },
    "state_backend":"EmbeddedRocksDBStateBackend",
    "checkpoint_storage":"FileSystemCheckpointStorage",
    "unaligned_checkpoints":false,
    "tolerable_failed_checkpoints":0
}
```
*But the two fields does not shown in the Web UI of checkpoint configuration. `job-checkpoints.component.html` should add the above mentioned fields for show.*

## Brief change log

  - *`job-checkpoints.component.html` adds two rows for the show of `state_backend` and `checkpoint_storage` fields.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)