### PR TITLE
[FLINK-22424][network] Prevent releasing PipelinedSubpartition while Task can still write to it

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
@@ -61,6 +61,4 @@ public interface BufferPool extends BufferProvider, BufferRecycler {
 
     /** Returns the number of used buffers of this buffer pool. */
     int bestEffortGetNumOfUsedBuffers();
-
-    BufferRecycler[] getSubpartitionBufferRecyclers();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.BufferListener.NotificationResult;
 import org.apache.flink.util.ExceptionUtils;
@@ -657,12 +656,6 @@ class LocalBufferPool implements BufferPool {
 
     private boolean isRequestedSizeReached() {
         return numberOfRequestedMemorySegments >= currentPoolSize;
-    }
-
-    @VisibleForTesting
-    @Override
-    public BufferRecycler[] getSubpartitionBufferRecyclers() {
-        return subpartitionBufferRecyclers;
     }
 
     private static class SubpartitionBufferRecycler implements BufferRecycler {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -22,8 +22,6 @@ package org.apache.flink.runtime.io.network.buffer;
 
 import org.apache.flink.core.memory.MemorySegment;
 
-import javax.annotation.Nullable;
-
 import java.util.concurrent.CompletableFuture;
 
 /** No-op implementation of {@link BufferPool}. */
@@ -96,12 +94,6 @@ public class NoOpBufferPool implements BufferPool {
     @Override
     public int bestEffortGetNumOfUsedBuffers() {
         throw new UnsupportedOperationException();
-    }
-
-    @Nullable
-    @Override
-    public BufferRecycler[] getSubpartitionBufferRecyclers() {
-        return new BufferRecycler[0];
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/UnpooledBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/UnpooledBufferPool.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Implementation of {@link BufferPool} that works on un-pooled memory segments. */
+public class UnpooledBufferPool implements BufferPool {
+
+    private static final int SEGMENT_SIZE = 1024;
+
+    @Override
+    public void lazyDestroy() {}
+
+    @Override
+    public Buffer requestBuffer() {
+        return new NetworkBuffer(requestMemorySegment(), this);
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilder() {
+        return new BufferBuilder(requestMemorySegment(), this);
+    }
+
+    private MemorySegment requestMemorySegment() {
+        return MemorySegmentFactory.allocateUnpooledOffHeapMemory(SEGMENT_SIZE, null);
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilderBlocking() throws InterruptedException {
+        return requestBufferBuilder();
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilder(int targetChannel) {
+        return requestBufferBuilder();
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilderBlocking(int targetChannel)
+            throws InterruptedException {
+        return requestBufferBuilder();
+    }
+
+    @Override
+    public boolean addBufferListener(BufferListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getNumberOfRequiredMemorySegments() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int getMaxNumberOfMemorySegments() {
+        return -1;
+    }
+
+    @Override
+    public int getNumBuffers() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void setNumBuffers(int numBuffers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getNumberOfAvailableMemorySegments() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int bestEffortGetNumOfUsedBuffers() {
+        return 0;
+    }
+
+    @Override
+    public void recycle(MemorySegment memorySegment) {
+        memorySegment.free();
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return AVAILABLE;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -106,6 +106,7 @@ public class PipelinedSubpartitionWithReadViewTest {
     @Test
     public void testRelease() {
         readView.releaseAllResources();
+        resultPartition.close();
         assertFalse(
                 resultPartition
                         .getPartitionManager()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -83,16 +83,6 @@ public class ResultPartitionFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testReleaseOnConsumptionForPipelinedPartition() {
-        final ResultPartition resultPartition =
-                createResultPartition(ResultPartitionType.PIPELINED);
-
-        resultPartition.onConsumedSubpartition(0);
-
-        assertTrue(resultPartition.isReleased());
-    }
-
-    @Test
     public void testNoReleaseOnConsumptionForBoundedBlockingPartition() {
         final ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING);
 


### PR DESCRIPTION
This bug was happening when a downstream tasks were failing over or being cancelled. If all
of the downstream tasks released subpartition views, underlying memory segments/buffers could
have been recycled, while upstream task was still writting some records.

The problem is fixed by adding the writer (result partition) itself as one more reference
counted user of the result partition

## Verifying this change

This change adds new test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
