### PR TITLE
[FLINK-22419][coordination][tests] Rework RpcEndpoint delay tests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -410,16 +410,13 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
             this.mainThreadCheck = Preconditions.checkNotNull(mainThreadCheck);
         }
 
-        public void runAsync(Runnable runnable) {
-            gateway.runAsync(runnable);
-        }
-
-        public void scheduleRunAsync(Runnable runnable, long delayMillis) {
+        private void scheduleRunAsync(Runnable runnable, long delayMillis) {
             gateway.scheduleRunAsync(runnable, delayMillis);
         }
 
+        @Override
         public void execute(@Nonnull Runnable command) {
-            runAsync(command);
+            gateway.runAsync(command);
         }
 
         @Override


### PR DESCRIPTION
Several `RpcEndpoint` tests were verifying the handling of delays based via various `schedule*` methods by checking how long it took for a schedule unit to be exected
Such tests are well known to be unstable because it is not really possible to define sane upper bounds for how long it might take for the unit to be executed.

These tests have been reworked to instead check what delay is in the end passed to `MainThreadExecutable#scheduleRunAsync`.