### PR TITLE
[FLINK-22444][docs] Drop async checkpoint description of state backends in Chinese docs

### DIFF
--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -55,13 +55,6 @@ Flink 内置了以下这些开箱即用的 state backends ：
 
 在 CheckPoint 时，State Backend 对状态进行快照，并将快照信息作为 CheckPoint 应答消息的一部分发送给 JobManager(master)，同时 JobManager 也将快照信息存储在堆内存中。
 
-MemoryStateBackend 能配置异步快照。强烈建议使用异步快照来防止数据流阻塞，注意，异步快照默认是开启的。
-用户可以在实例化 `MemoryStateBackend` 的时候，将相应布尔类型的构造参数设置为 `false` 来关闭异步快照（仅在 debug 的时候使用），例如：
-
-```java
-new MemoryStateBackend(MAX_MEM_STATE_SIZE, false);
-```
-
 MemoryStateBackend 的限制：
 
   - 默认情况下，每个独立的状态大小限制是 5 MB。在 MemoryStateBackend 的构造器中可以增加其大小。
@@ -82,13 +75,6 @@ MemoryStateBackend 适用场景：
 FsStateBackend 将正在运行中的状态数据保存在 TaskManager 的内存中。CheckPoint 时，将状态快照写入到配置的文件系统目录中。
 少量的元数据信息存储到 JobManager 的内存中（高可用模式下，将其写入到 CheckPoint 的元数据文件中）。
 
-FsStateBackend 默认使用异步快照来防止 CheckPoint 写状态时对数据处理造成阻塞。
-用户可以在实例化 `FsStateBackend` 的时候，将相应布尔类型的构造参数设置为 `false` 来关闭异步快照，例如：
-
-```java
-new FsStateBackend(path, false);
-```
-
 FsStateBackend 适用场景:
 
   - 状态比较大、窗口比较长、key/value 状态比较大的 Job。
@@ -107,8 +93,6 @@ Unlike storing java objects in `HashMapStateBackend`, data is stored as serializ
 
 CheckPoint 时，整个 RocksDB 数据库被 checkpoint 到配置的文件系统目录中。
 少量的元数据信息存储到 JobManager 的内存中（高可用模式下，将其存储到 CheckPoint 的元数据文件中）。 
-
-RocksDBStateBackend 只支持异步快照。
 
 RocksDBStateBackend 的限制：
 


### PR DESCRIPTION
## What is the purpose of the change

We should remove async checkpoint description of state backends in Chinese documentation as FLINK-21935 had removed "state.backend.async" option. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
