### PR TITLE
[FLINK-19449][table-planner] LEAD/LAG cannot work correctly in streaming mode

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -674,10 +674,10 @@ aggregate:
   - sql: ROW_NUMER()
     description: Assigns a unique, sequential number to each row, starting with one, according to the ordering of rows within the window partition. ROW_NUMBER and RANK are similar. ROW_NUMBER numbers all rows sequentially (for example 1, 2, 3, 4, 5). RANK provides the same numeric value for ties (for example 1, 2, 2, 4, 5).
   - sql: LEAD(expression [, offset] [, default])
-    description: Returns the value of expression at the offsetth row before the current row in the window. The default value of offset is 1 and the default value of default is NULL.
-  - sql: LAG(expression [, offset] [, default])
     description: Returns the value of expression at the offsetth row after the current row in the window. The default value of offset is 1 and the default value of default is NULL.
-  - sql: FIRST_VALUE(expression) 
+  - sql: LAG(expression [, offset] [, default])
+    description: Returns the value of expression at the offsetth row before the current row in the window. The default value of offset is 1 and the default value of default is NULL.
+  - sql: FIRST_VALUE(expression)
     description: Returns the first value in an ordered set of values.
   - sql: LAST_VALUE(expression)
     description: Returns the last value in an ordered set of values.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LagAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/LagAggFunction.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.runtime.functions.aggregate.BuiltInAggregateFunction;
+import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.runtime.typeutils.LinkedListSerializer;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+/** Lag {@link AggregateFunction}. */
+public class LagAggFunction<T> extends BuiltInAggregateFunction<T, LagAggFunction.LagAcc<T>> {
+
+    private final transient DataType[] valueDataTypes;
+
+    @SuppressWarnings("unchecked")
+    public LagAggFunction(LogicalType[] valueTypes) {
+        this.valueDataTypes =
+                Arrays.stream(valueTypes)
+                        .map(DataTypeUtils::toInternalDataType)
+                        .toArray(DataType[]::new);
+        if (valueDataTypes.length == 3
+                && valueDataTypes[2].getLogicalType().getTypeRoot() != LogicalTypeRoot.NULL) {
+            if (valueDataTypes[0].getConversionClass() != valueDataTypes[2].getConversionClass()) {
+                throw new TableException(
+                        String.format(
+                                "Please explicitly cast default value %s to %s.",
+                                valueDataTypes[2], valueDataTypes[1]));
+            }
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Planning
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public List<DataType> getArgumentDataTypes() {
+        return Arrays.asList(valueDataTypes);
+    }
+
+    @Override
+    public DataType getAccumulatorDataType() {
+        return DataTypes.STRUCTURED(
+                LagAcc.class,
+                DataTypes.FIELD("offset", DataTypes.INT()),
+                DataTypes.FIELD("defaultValue", valueDataTypes[0]),
+                DataTypes.FIELD("buffer", getLinkedListType()));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private DataType getLinkedListType() {
+        TypeSerializer<T> serializer =
+                InternalSerializers.create(getOutputDataType().getLogicalType());
+        return DataTypes.RAW(
+                LinkedList.class, (TypeSerializer) new LinkedListSerializer<>(serializer));
+    }
+
+    @Override
+    public DataType getOutputDataType() {
+        return valueDataTypes[0];
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Runtime
+    // --------------------------------------------------------------------------------------------
+
+    public void accumulate(LagAcc<T> acc, T value) throws Exception {
+        acc.buffer.add(value);
+        while (acc.buffer.size() > acc.offset + 1) {
+            acc.buffer.removeFirst();
+        }
+    }
+
+    public void accumulate(LagAcc<T> acc, T value, int offset) throws Exception {
+        if (offset < 0) {
+            throw new TableException(String.format("Offset(%d) should be positive.", offset));
+        }
+
+        acc.offset = offset;
+        accumulate(acc, value);
+    }
+
+    public void accumulate(LagAcc<T> acc, T value, int offset, T defaultValue) throws Exception {
+        acc.defaultValue = defaultValue;
+        accumulate(acc, value, offset);
+    }
+
+    public void resetAccumulator(LagAcc<T> acc) throws Exception {
+        acc.offset = 1;
+        acc.defaultValue = null;
+        acc.buffer.clear();
+    }
+
+    @Override
+    public T getValue(LagAcc<T> acc) {
+        if (acc.buffer.size() < acc.offset + 1) {
+            return acc.defaultValue;
+        } else if (acc.buffer.size() == acc.offset + 1) {
+            return acc.buffer.getFirst();
+        } else {
+            throw new TableException("Too more elements: " + acc);
+        }
+    }
+
+    @Override
+    public LagAcc<T> createAccumulator() {
+        return new LagAcc<>();
+    }
+
+    /** Accumulator for LAG. */
+    public static class LagAcc<T> {
+        public int offset = 1;
+        public T defaultValue = null;
+        public LinkedList<T> buffer = new LinkedList<>();
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            LagAcc<?> lagAcc = (LagAcc<?>) o;
+            return offset == lagAcc.offset
+                    && Objects.equals(defaultValue, lagAcc.defaultValue)
+                    && Objects.equals(buffer, lagAcc.buffer);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(offset, defaultValue, buffer);
+        }
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -145,14 +145,14 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
         final SliceAssigner sliceAssigner = createSliceAssigner(windowing, shiftTimeZone);
 
         final AggregateInfoList localAggInfoList =
-                AggregateUtil.deriveWindowAggregateInfoList(
+                AggregateUtil.deriveStreamWindowAggregateInfoList(
                         localAggInputRowType, // should use original input here
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         windowing.getWindow(),
                         false); // isStateBackendDataViews
 
         final AggregateInfoList globalAggInfoList =
-                AggregateUtil.deriveWindowAggregateInfoList(
+                AggregateUtil.deriveStreamWindowAggregateInfoList(
                         localAggInputRowType, // should use original input here
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         windowing.getWindow(),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -122,7 +122,7 @@ public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBas
         final SliceAssigner sliceAssigner = createSliceAssigner(windowing, shiftTimeZone);
 
         final AggregateInfoList aggInfoList =
-                AggregateUtil.deriveWindowAggregateInfoList(
+                AggregateUtil.deriveStreamWindowAggregateInfoList(
                         inputRowType,
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         windowing.getWindow(),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -143,7 +143,7 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
         // Hopping window requires additional COUNT(*) to determine whether to register next timer
         // through whether the current fired window is empty, see SliceSharedWindowAggProcessor.
         final AggregateInfoList aggInfoList =
-                AggregateUtil.deriveWindowAggregateInfoList(
+                AggregateUtil.deriveStreamWindowAggregateInfoList(
                         inputRowType,
                         JavaScalaConversionUtil.toScala(Arrays.asList(aggCalls)),
                         windowing.getWindow(),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalWindowAggregate.scala
@@ -63,7 +63,7 @@ class StreamPhysicalGlobalWindowAggregate(
   extends SingleRel(cluster, traitSet, inputRel)
   with StreamPhysicalRel {
 
-  private lazy val aggInfoList = AggregateUtil.deriveWindowAggregateInfoList(
+  private lazy val aggInfoList = AggregateUtil.deriveStreamWindowAggregateInfoList(
     FlinkTypeFactory.toLogicalRowType(inputRowTypeOfLocalAgg),
     aggCalls,
     windowing.getWindow,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalWindowAggregate.scala
@@ -56,7 +56,7 @@ class StreamPhysicalLocalWindowAggregate(
   extends SingleRel(cluster, traitSet, inputRel)
   with StreamPhysicalRel {
 
-  private lazy val aggInfoList = AggregateUtil.deriveWindowAggregateInfoList(
+  private lazy val aggInfoList = AggregateUtil.deriveStreamWindowAggregateInfoList(
     FlinkTypeFactory.toLogicalRowType(inputRel.getRowType),
     aggCalls,
     windowing.getWindow,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregate.scala
@@ -56,7 +56,7 @@ class StreamPhysicalWindowAggregate(
   extends SingleRel(cluster, traitSet, inputRel)
   with StreamPhysicalRel {
 
-  lazy val aggInfoList: AggregateInfoList = AggregateUtil.deriveWindowAggregateInfoList(
+  lazy val aggInfoList: AggregateInfoList = AggregateUtil.deriveStreamWindowAggregateInfoList(
     FlinkTypeFactory.toLogicalRowType(inputRel.getRowType),
     aggCalls,
     windowing.getWindow,

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LagAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/LagAggFunctionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.AggregateFunction;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.table.data.StringData.fromString;
+
+/** Test for {@link LagAggFunction}. */
+public class LagAggFunctionTest
+        extends AggFunctionTestBase<StringData, LagAggFunction.LagAcc<StringData>> {
+
+    @Override
+    protected List<List<StringData>> getInputValueSets() {
+        return Arrays.asList(
+                Collections.singletonList(fromString("1")),
+                Arrays.asList(fromString("1"), null),
+                Arrays.asList(null, null),
+                Arrays.asList(null, fromString("10")));
+    }
+
+    @Override
+    protected List<StringData> getExpectedResults() {
+        return Arrays.asList(null, fromString("1"), null, null);
+    }
+
+    @Override
+    protected AggregateFunction<StringData, LagAggFunction.LagAcc<StringData>> getAggregator() {
+        return new LagAggFunction<>(
+                new LogicalType[] {new VarCharType(), new IntType(), new CharType()});
+    }
+
+    @Override
+    protected Class<?> getAccClass() {
+        return LagAggFunction.LagAcc.class;
+    }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -949,7 +949,8 @@ class FlinkRelMdHandlerTestBase {
     val aggFunctionFactory = new AggFunctionFactory(
       FlinkTypeFactory.toLogicalRowType(studentBatchScan.getRowType),
       Array.empty[Int],
-      Array.fill(aggCalls.size())(false))
+      Array.fill(aggCalls.size())(false),
+      false)
     val aggCallToAggFunction = aggCalls.zipWithIndex.map {
       case (call, index) => (call, aggFunctionFactory.createAggFunction(call, index))
     }
@@ -1157,7 +1158,8 @@ class FlinkRelMdHandlerTestBase {
     val aggFunctionFactory = new AggFunctionFactory(
       FlinkTypeFactory.toLogicalRowType(calcOnStudentScan.getRowType),
       Array.empty[Int],
-      Array.fill(aggCalls.size())(false))
+      Array.fill(aggCalls.size())(false),
+      false)
     val aggCallToAggFunction = aggCalls.zipWithIndex.map {
       case (call, index) => (call, aggFunctionFactory.createAggFunction(call, index))
     }
@@ -1324,7 +1326,8 @@ class FlinkRelMdHandlerTestBase {
     val aggFunctionFactory = new AggFunctionFactory(
       FlinkTypeFactory.toLogicalRowType(studentBatchScan.getRowType),
       Array.empty[Int],
-      Array.fill(aggCalls.size())(false))
+      Array.fill(aggCalls.size())(false),
+      false)
     val aggCallToAggFunction = aggCalls.zipWithIndex.map {
       case (call, index) => (call, aggFunctionFactory.createAggFunction(call, index))
     }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializer.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A serializer for {@link LinkedList}. The serializer relies on an element serializer for the
+ * serialization of the list's elements.
+ *
+ * @param <T> The type of element in the list.
+ */
+@Internal
+public final class LinkedListSerializer<T> extends TypeSerializer<LinkedList<T>> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The serializer for the elements of the list. */
+    private final TypeSerializer<T> elementSerializer;
+
+    /**
+     * Creates a list serializer that uses the given serializer to serialize the list's elements.
+     *
+     * @param elementSerializer The serializer for the elements of the list
+     */
+    public LinkedListSerializer(TypeSerializer<T> elementSerializer) {
+        this.elementSerializer = checkNotNull(elementSerializer);
+    }
+
+    // ------------------------------------------------------------------------
+    //  LinkedListSerializer specific properties
+    // ------------------------------------------------------------------------
+
+    /**
+     * Gets the serializer for the elements of the list.
+     *
+     * @return The serializer for the elements of the list
+     */
+    public TypeSerializer<T> getElementSerializer() {
+        return elementSerializer;
+    }
+
+    // ------------------------------------------------------------------------
+    //  Type Serializer implementation
+    // ------------------------------------------------------------------------
+
+    @Override
+    public boolean isImmutableType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<LinkedList<T>> duplicate() {
+        TypeSerializer<T> duplicateElement = elementSerializer.duplicate();
+        return duplicateElement == elementSerializer
+                ? this
+                : new LinkedListSerializer<>(duplicateElement);
+    }
+
+    @Override
+    public LinkedList<T> createInstance() {
+        return new LinkedList<>();
+    }
+
+    @Override
+    public LinkedList<T> copy(LinkedList<T> from) {
+        LinkedList<T> newList = new LinkedList<>();
+        for (T element : from) {
+            newList.add(elementSerializer.copy(element));
+        }
+        return newList;
+    }
+
+    @Override
+    public LinkedList<T> copy(LinkedList<T> from, LinkedList<T> reuse) {
+        return copy(from);
+    }
+
+    @Override
+    public int getLength() {
+        return -1; // var length
+    }
+
+    @Override
+    public void serialize(LinkedList<T> list, DataOutputView target) throws IOException {
+        target.writeInt(list.size());
+        for (T element : list) {
+            elementSerializer.serialize(element, target);
+        }
+    }
+
+    @Override
+    public LinkedList<T> deserialize(DataInputView source) throws IOException {
+        final int size = source.readInt();
+        final LinkedList<T> list = new LinkedList<>();
+        for (int i = 0; i < size; i++) {
+            list.add(elementSerializer.deserialize(source));
+        }
+        return list;
+    }
+
+    @Override
+    public LinkedList<T> deserialize(LinkedList<T> reuse, DataInputView source) throws IOException {
+        return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+        // copy number of elements
+        final int num = source.readInt();
+        target.writeInt(num);
+        for (int i = 0; i < num; i++) {
+            elementSerializer.copy(source, target);
+        }
+    }
+
+    // --------------------------------------------------------------------
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this
+                || (obj != null
+                        && obj.getClass() == getClass()
+                        && elementSerializer.equals(
+                                ((LinkedListSerializer<?>) obj).elementSerializer));
+    }
+
+    @Override
+    public int hashCode() {
+        return elementSerializer.hashCode();
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Serializer configuration snapshot & compatibility
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public TypeSerializerSnapshot<LinkedList<T>> snapshotConfiguration() {
+        return new LinkedListSerializerSnapshot<>(this);
+    }
+
+    /** Snapshot class for the {@link LinkedListSerializer}. */
+    public static class LinkedListSerializerSnapshot<T>
+            extends CompositeTypeSerializerSnapshot<LinkedList<T>, LinkedListSerializer<T>> {
+
+        private static final int CURRENT_VERSION = 1;
+
+        /** Constructor for read instantiation. */
+        public LinkedListSerializerSnapshot() {
+            super(LinkedListSerializer.class);
+        }
+
+        /** Constructor to create the snapshot for writing. */
+        public LinkedListSerializerSnapshot(LinkedListSerializer<T> listSerializer) {
+            super(listSerializer);
+        }
+
+        @Override
+        public int getCurrentOuterSnapshotVersion() {
+            return CURRENT_VERSION;
+        }
+
+        @Override
+        protected LinkedListSerializer<T> createOuterSerializerWithNestedSerializers(
+                TypeSerializer<?>[] nestedSerializers) {
+            @SuppressWarnings("unchecked")
+            TypeSerializer<T> elementSerializer = (TypeSerializer<T>) nestedSerializers[0];
+            return new LinkedListSerializer<>(elementSerializer);
+        }
+
+        @Override
+        protected TypeSerializer<?>[] getNestedSerializers(
+                LinkedListSerializer<T> outerSerializer) {
+            return new TypeSerializer<?>[] {outerSerializer.getElementSerializer()};
+        }
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.typeutils;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+
+import java.util.LinkedList;
+import java.util.Random;
+
+/** A test for the {@link LinkedListSerializer}. */
+public class LinkedListSerializerTest extends SerializerTestBase<LinkedList<Long>> {
+
+    @Override
+    protected TypeSerializer<LinkedList<Long>> createSerializer() {
+        return new LinkedListSerializer<>(LongSerializer.INSTANCE);
+    }
+
+    @Override
+    protected int getLength() {
+        return -1;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Class<LinkedList<Long>> getTypeClass() {
+        return (Class<LinkedList<Long>>) (Class<?>) LinkedList.class;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    protected LinkedList<Long>[] getTestData() {
+        final Random rnd = new Random(123654789);
+
+        // empty lists
+        final LinkedList<Long> list1 = new LinkedList<>();
+
+        // single element lists
+        final LinkedList<Long> list2 = new LinkedList<>();
+        list2.add(12345L);
+
+        // longer lists
+        final LinkedList<Long> list3 = new LinkedList<>();
+        for (int i = 0; i < rnd.nextInt(200); i++) {
+            list3.add(rnd.nextLong());
+        }
+
+        final LinkedList<Long> list4 = new LinkedList<>();
+        for (int i = 0; i < rnd.nextInt(200); i++) {
+            list4.add(rnd.nextLong());
+        }
+
+        return (LinkedList<Long>[]) new LinkedList[] {list1, list2, list3, list4};
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

Fix "LEAD/LAG cannot work correctly in streaming mode".

`LeadLagAggFunction` is only works in batch mode with `OffsetOverFrame`.
In streaming mode, it will output wrong results.

## Brief change log

- Add `LinkedListSerializer`.
- Fix wrong document for lead and lag.
- Pass isBounded to `AggFunctionFactory`.
- Implement `LagAggFunction`.
- Add Lag IT Case for streaming mode.

## Verifying this change

- OverAggregateITCase.testLagFunction
- OverAggregateITCase.testLeadFunction

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no