### PR TITLE
[hotfix][docs] Removed duplicate 'is'

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -563,7 +563,7 @@ val counts: DataStream[(String, Int)] = stream
 
 ## Operator State
 
-*Operator State* (or *non-keyed state*) is state that is is bound to one
+*Operator State* (or *non-keyed state*) is state that is bound to one
 parallel operator instance. The [Kafka Connector]({{< ref "docs/connectors/datastream/kafka" >}}) is a good motivating example for the use of
 Operator State in Flink. Each parallel instance of the Kafka consumer maintains
 a map of topic partitions and offsets as its Operator State.

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -624,7 +624,7 @@ val counts: DataStream[(String, Int)] = stream
 
 ## Operator State
 
-*Operator State* (or *non-keyed state*) is state that is is bound to one
+*Operator State* (or *non-keyed state*) is state that is bound to one
 parallel operator instance. The [Kafka Connector]({{< ref "docs/connectors/datastream/kafka" >}}) is a good motivating example for the use of
 Operator State in Flink. Each parallel instance of the Kafka consumer maintains
 a map of topic partitions and offsets as its Operator State.


### PR DESCRIPTION

## What is the purpose of the change

* Document correction 

## Brief change log

* Removed duplicate `is` in doc 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? ( **not applicable** / docs / JavaDocs / not documented)
