### PR TITLE
[FLINK-22469][runtime-web] Fix NoSuchFileException in HistoryServer

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -188,6 +188,11 @@ public class HistoryServer {
                             + UUID.randomUUID();
         }
         webDir = new File(webDirectory);
+        if (!webDir.exists() && !webDir.mkdirs()) {
+            throw new IOException(
+                    "Failed to create local directory " + webDir.getAbsoluteFile() + ".");
+        }
+        LOG.info("Using directory {} as local cache.", webDir);
 
         boolean cleanupExpiredArchives =
                 config.getBoolean(HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS);
@@ -265,16 +270,8 @@ public class HistoryServer {
         synchronized (startupShutdownLock) {
             LOG.info("Starting history server.");
 
-            Files.createDirectories(webDir.toPath());
-            LOG.info("Using directory {} as local cache.", webDir);
-
             Router router = new Router();
             router.addGet("/:*", new HistoryServerStaticFileServerHandler(webDir));
-
-            if (!webDir.exists() && !webDir.mkdirs()) {
-                throw new IOException(
-                        "Failed to create local directory " + webDir.getAbsoluteFile() + ".");
-            }
 
             createDashboardConfigFile();
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -188,11 +188,6 @@ public class HistoryServer {
                             + UUID.randomUUID();
         }
         webDir = new File(webDirectory);
-        if (!webDir.exists() && !webDir.mkdirs()) {
-            throw new IOException(
-                    "Failed to create local directory " + webDir.getAbsoluteFile() + ".");
-        }
-        LOG.info("Using directory {} as local cache.", webDir);
 
         boolean cleanupExpiredArchives =
                 config.getBoolean(HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS);
@@ -269,6 +264,9 @@ public class HistoryServer {
     void start() throws IOException, InterruptedException {
         synchronized (startupShutdownLock) {
             LOG.info("Starting history server.");
+
+            Files.createDirectories(webDir.toPath());
+            LOG.info("Using directory {} as local cache.", webDir);
 
             Router router = new Router();
             router.addGet("/:*", new HistoryServerStaticFileServerHandler(webDir));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -195,17 +195,9 @@ class HistoryServerArchiveFetcher {
             this.cachedArchives = new HashSet<>();
             this.webDir = checkNotNull(webDir);
             this.webJobDir = new File(webDir, "jobs");
-            if (!webJobDir.exists() && !webJobDir.mkdirs()) {
-                throw new IOException(
-                        "Failed to create local directory " + webJobDir.getAbsoluteFile() + ".");
-            }
+            Files.createDirectories(webJobDir.toPath());
             this.webOverviewDir = new File(webDir, "overviews");
-            if (!webOverviewDir.exists() && !webOverviewDir.mkdirs()) {
-                throw new IOException(
-                        "Failed to create local directory "
-                                + webOverviewDir.getAbsoluteFile()
-                                + ".");
-            }
+            Files.createDirectories(webOverviewDir.toPath());
             updateJobOverview(webOverviewDir, webDir);
         }
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -119,7 +119,8 @@ class HistoryServerArchiveFetcher {
             File webDir,
             Consumer<ArchiveEvent> jobArchiveEventListener,
             boolean cleanupExpiredArchives,
-            int maxHistorySize) {
+            int maxHistorySize)
+            throws IOException {
         this.refreshIntervalMillis = refreshIntervalMillis;
         this.fetcherTask =
                 new JobArchiveFetcherTask(
@@ -184,7 +185,8 @@ class HistoryServerArchiveFetcher {
                 File webDir,
                 Consumer<ArchiveEvent> jobArchiveEventListener,
                 boolean processExpiredArchiveDeletion,
-                int maxHistorySize) {
+                int maxHistorySize)
+                throws IOException {
             this.refreshDirs = checkNotNull(refreshDirs);
             this.jobArchiveEventListener = jobArchiveEventListener;
             this.processExpiredArchiveDeletion = processExpiredArchiveDeletion;
@@ -193,9 +195,17 @@ class HistoryServerArchiveFetcher {
             this.cachedArchives = new HashSet<>();
             this.webDir = checkNotNull(webDir);
             this.webJobDir = new File(webDir, "jobs");
-            webJobDir.mkdir();
+            if (!webJobDir.exists() && !webJobDir.mkdirs()) {
+                throw new IOException(
+                        "Failed to create local directory " + webJobDir.getAbsoluteFile() + ".");
+            }
             this.webOverviewDir = new File(webDir, "overviews");
-            webOverviewDir.mkdir();
+            if (!webOverviewDir.exists() && !webOverviewDir.mkdirs()) {
+                throw new IOException(
+                        "Failed to create local directory "
+                                + webOverviewDir.getAbsoluteFile()
+                                + ".");
+            }
             updateJobOverview(webOverviewDir, webDir);
         }
 


### PR DESCRIPTION
## What is the purpose of the change

When history server started initially it throws the following exception:
```
2021-04-23 23:25:17,487 ERROR org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher [] - Failed to update job overview.
java.nio.file.NoSuchFileException: /var/folders/jd/35_sh46s7zq0qc6khfw8hc800000gn/T/flink-web-history-35a77053-0e52-4cb3-8d22-626e3ce3cbd7/jobs/overview.json
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86) ~[?:1.8.0_282]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102) ~[?:1.8.0_282]
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107) ~[?:1.8.0_282]
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214) ~[?:1.8.0_282]
	at java.nio.file.Files.newByteChannel(Files.java:361) ~[?:1.8.0_282]
	at java.nio.file.Files.createFile(Files.java:632) ~[?:1.8.0_282]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer.createOrGetFile(HistoryServer.java:324) ~[flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher.updateJobOverview(HistoryServerArchiveFetcher.java:464) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher.access$000(HistoryServerArchiveFetcher.java:74) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher$JobArchiveFetcherTask.<init>(HistoryServerArchiveFetcher.java:199) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher.<init>(HistoryServerArchiveFetcher.java:124) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer.<init>(HistoryServer.java:230) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer.<init>(HistoryServer.java:146) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer$1.call(HistoryServer.java:130) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer$1.call(HistoryServer.java:127) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.security.contexts.NoOpSecurityContext.runSecured(NoOpSecurityContext.java:28) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
	at org.apache.flink.runtime.webmonitor.history.HistoryServer.main(HistoryServer.java:126) [flink-dist_2.11-1.14-SNAPSHOT.jar:1.14-SNAPSHOT]
```
The issue is that `webDir` not yet created by `HistoryServer` when `HistoryServerArchiveFetcher` tries to reach `jobs/overview.json` file in it. The directory will be created later on so this PR is to eliminate the initial issue.

## Brief change log

* `HistoryServerArchiveFetcher` now creates directories including parents with `Files.createDirectories` and throws `IOException` if `webJobDir` or `webOverviewDir` creation failed.
* Double `webDir` creation in `HistoryServer.start` is eliminated

## Verifying this change

This change added tests and can be verified as follows:
  - Manually verified the change by running the following command locally and double checked there is no exception
```
bin/historyserver.sh start-foreground
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
