### PR TITLE
[FLINK-22470][python] Make sure that the root cause of the exception encountered during compiling the job was exposed to users in all cases

### DIFF
--- a/flink-python/pyflink/util/exceptions.py
+++ b/flink-python/pyflink/util/exceptions.py
@@ -20,12 +20,11 @@ from py4j.protocol import Py4JJavaError
 
 
 class JavaException(Exception):
-    def __init__(self, msg, stack_trace):
-        self.msg = msg
+    def __init__(self, stack_trace: str):
         self.stack_trace = stack_trace
 
     def __str__(self):
-        return self.msg + "\n\t at " + self.stack_trace
+        return self.stack_trace
 
 
 class TableException(JavaException):
@@ -149,16 +148,7 @@ def capture_java_exception(f):
             from pyflink.java_gateway import get_gateway
             get_gateway().jvm.org.apache.flink.client.python.PythonEnvUtils\
                 .setPythonException(e.java_exception)
-            s = e.java_exception.toString()
-            stack_trace = '\n\t at '.join(map(lambda x: x.toString(),
-                                              e.java_exception.getStackTrace()))
-            for exception in exception_mapping.keys():
-                if s.startswith(exception):
-                    java_exception = \
-                        exception_mapping[exception](s.split(': ', 1)[1], stack_trace)
-                    break
-            else:
-                raise
+            java_exception = convert_py4j_exception(e)
         raise java_exception
     return deco
 
@@ -197,14 +187,9 @@ def convert_py4j_exception(e: Py4JJavaError) -> JavaException:
     """
     Convert Py4J exception to JavaException.
     """
-    def extract_java_stack_trace(java_stack_trace):
-        return '\n\t at '.join(map(lambda x: x.toString(), java_stack_trace))
-
     s = e.java_exception.toString()
-    cause = e.java_exception.getCause()
-    stack_trace = extract_java_stack_trace(e.java_exception.getStackTrace())
-    while cause is not None:
-        stack_trace += '\nCaused by: %s: %s' % (cause.getClass().getName(), cause.getMessage())
-        stack_trace += "\n\t at " + extract_java_stack_trace(cause.getStackTrace())
-        cause = cause.getCause()
-    return JavaException(s.split(': ', 1)[1], stack_trace)
+    for exception in exception_mapping.keys():
+        if s.startswith(exception):
+            return exception_mapping[exception](str(e).split(': ', 1)[1])
+    else:
+        return JavaException(str(e).split(': ', 1)[1])

--- a/flink-python/pyflink/util/exceptions.py
+++ b/flink-python/pyflink/util/exceptions.py
@@ -148,7 +148,13 @@ def capture_java_exception(f):
             from pyflink.java_gateway import get_gateway
             get_gateway().jvm.org.apache.flink.client.python.PythonEnvUtils\
                 .setPythonException(e.java_exception)
-            java_exception = convert_py4j_exception(e)
+            s = e.java_exception.toString()
+            for exception in exception_mapping.keys():
+                if s.startswith(exception):
+                    java_exception = convert_py4j_exception(e)
+                    break
+            else:
+                raise
         raise java_exception
     return deco
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the handling of exceptions encountered during compiling the job was exposed to users in all cases and makes sure that the root cause of the exception encountered during compiling the job was exposed to users in all cases*


## Verifying this change

Verified manually.

```
The exception to the problem described in the JIRA ticket will look like as following with this PR:
org.apache.flink.table.api.TableException: Failed to execute sql
	at org.apache.flink.table.api.internal.TableEnvironmentImpl.executeInternal(TableEnvironmentImpl.java:699)
	at org.apache.flink.table.api.internal.TableImpl.executeInsert(TableImpl.java:572)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.flink.api.python.shaded.py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at org.apache.flink.api.python.shaded.py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at org.apache.flink.api.python.shaded.py4j.Gateway.invoke(Gateway.java:282)
	at org.apache.flink.api.python.shaded.py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at org.apache.flink.api.python.shaded.py4j.commands.CallCommand.execute(CallCommand.java:79)
	at org.apache.flink.api.python.shaded.py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.flink.util.FlinkException: Failed to execute job 'insert-into_default_catalog.default_database.Results'.
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.executeAsync(StreamExecutionEnvironment.java:1918)
	at org.apache.flink.table.planner.delegation.ExecutorBase.executeAsync(ExecutorBase.java:55)
	at org.apache.flink.table.api.internal.TableEnvironmentImpl.executeInternal(TableEnvironmentImpl.java:681)
	... 12 more
Caused by: java.lang.RuntimeException: org.apache.flink.runtime.client.JobInitializationException: Could not instantiate JobManager.
	at org.apache.flink.util.ExceptionUtils.rethrow(ExceptionUtils.java:316)
	at org.apache.flink.util.function.FunctionUtils.lambda$uncheckedFunction$2(FunctionUtils.java:75)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:616)
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:591)
	at java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:457)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1067)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1703)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:172)
Caused by: org.apache.flink.runtime.client.JobInitializationException: Could not instantiate JobManager.
	at org.apache.flink.runtime.dispatcher.Dispatcher.lambda$createJobManagerRunner$5(Dispatcher.java:494)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.flink.runtime.client.JobExecutionException: Cannot initialize task 'Source: PythonInputFormatTableSource(text, text1) -> SourceConversion(table=[default_catalog.default_database.Unregistered_TableSource_356298953, source: [PythonInputFormatTableSource(text, text1)]], fields=[text, text1]) -> Filter -> Sink: Unnamed': Loading the input/output formats failed: 
	at org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder.buildGraph(ExecutionGraphBuilder.java:239)
	at org.apache.flink.runtime.scheduler.SchedulerBase.createExecutionGraph(SchedulerBase.java:322)
	at org.apache.flink.runtime.scheduler.SchedulerBase.createAndRestoreExecutionGraph(SchedulerBase.java:276)
	at org.apache.flink.runtime.scheduler.SchedulerBase.<init>(SchedulerBase.java:249)
	at org.apache.flink.runtime.scheduler.DefaultScheduler.<init>(DefaultScheduler.java:133)
	at org.apache.flink.runtime.scheduler.DefaultSchedulerFactory.createInstance(DefaultSchedulerFactory.java:111)
	at org.apache.flink.runtime.jobmaster.JobMaster.createScheduler(JobMaster.java:345)
	at org.apache.flink.runtime.jobmaster.JobMaster.<init>(JobMaster.java:330)
	at org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory.createJobMasterService(DefaultJobMasterServiceFactory.java:95)
	at org.apache.flink.runtime.jobmaster.factories.DefaultJobMasterServiceFactory.createJobMasterService(DefaultJobMasterServiceFactory.java:39)
	at org.apache.flink.runtime.jobmaster.JobManagerRunnerImpl.<init>(JobManagerRunnerImpl.java:162)
	at org.apache.flink.runtime.dispatcher.DefaultJobManagerRunnerFactory.createJobManagerRunner(DefaultJobManagerRunnerFactory.java:86)
	at org.apache.flink.runtime.dispatcher.Dispatcher.lambda$createJobManagerRunner$5(Dispatcher.java:478)
	... 4 more
Caused by: java.lang.Exception: Loading the input/output formats failed: 
	at org.apache.flink.runtime.jobgraph.InputOutputFormatVertex.initInputOutputformatContainer(InputOutputFormatVertex.java:172)
	at org.apache.flink.runtime.jobgraph.InputOutputFormatVertex.initializeOnMaster(InputOutputFormatVertex.java:57)
	at org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder.buildGraph(ExecutionGraphBuilder.java:235)
	... 16 more
Caused by: java.lang.RuntimeException: Deserializing the input/output formats failed: Could not read the user code wrapper: unexpected exception type
	at org.apache.flink.runtime.jobgraph.InputOutputFormatContainer.<init>(InputOutputFormatContainer.java:69)
	at org.apache.flink.runtime.jobgraph.InputOutputFormatVertex.initInputOutputformatContainer(InputOutputFormatVertex.java:168)
	... 18 more
Caused by: org.apache.flink.runtime.operators.util.CorruptConfigurationException: Could not read the user code wrapper: unexpected exception type
	at org.apache.flink.runtime.operators.util.TaskConfig.getStubWrapper(TaskConfig.java:307)
	at org.apache.flink.runtime.jobgraph.InputOutputFormatContainer.<init>(InputOutputFormatContainer.java:66)
	... 19 more
Caused by: java.io.IOException: unexpected exception type
	at java.io.ObjectStreamClass.throwMiscException(ObjectStreamClass.java:1751)
	at java.io.ObjectStreamClass.invokeReadResolve(ObjectStreamClass.java:1281)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2194)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.readArray(ObjectInputStream.java:2091)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1653)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:501)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:459)
	at java.util.HashMap.readObject(HashMap.java:1412)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1185)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2294)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.defaultReadFields(ObjectInputStream.java:2403)
	at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2327)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2185)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1665)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:501)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:459)
	at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:615)
	at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:600)
	at org.apache.flink.util.InstantiationUtil.deserializeObject(InstantiationUtil.java:587)
	at org.apache.flink.util.InstantiationUtil.readObjectFromConfig(InstantiationUtil.java:541)
	at org.apache.flink.runtime.operators.util.TaskConfig.getStubWrapper(TaskConfig.java:304)
	... 20 more
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.lang.invoke.SerializedLambda.readResolve(SerializedLambda.java:230)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.io.ObjectStreamClass.invokeReadResolve(ObjectStreamClass.java:1275)
	... 70 more
Caused by: java.lang.IllegalArgumentException: Invalid lambda deserialization
	at org.apache.flink.formats.avro.AvroFileFormatFactory$RowDataAvroWriterFactory.$deserializeLambda$(AvroFileFormatFactory.java:101)
	... 80 more
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
