### PR TITLE
[FLINK-22479][Kinesis][Consumer] Potential lock-up under error condition (Flink 1.12)

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -217,6 +217,10 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final String SUBSCRIBE_TO_SHARD_RETRIES =
             "flink.shard.subscribetoshard.maxretries";
 
+    /** A timeout when waiting for a shard subscription to be established. */
+    public static final String SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS =
+            "flink.shard.subscribetoshard.timeout";
+
     /** The base backoff time between each subscribeToShard attempt. */
     public static final String SUBSCRIBE_TO_SHARD_BACKOFF_BASE =
             "flink.shard.subscribetoshard.backoff.base";
@@ -362,6 +366,8 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
     public static final double DEFAULT_DEREGISTER_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
     public static final int DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES = 10;
+
+    public static final Duration DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT = Duration.ofSeconds(60);
 
     public static final long DEFAULT_SUBSCRIBE_TO_SHARD_BACKOFF_BASE = 1000L;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -143,7 +143,10 @@ public class FanOutRecordPublisher implements RecordPublisher {
             final Consumer<SubscribeToShardEvent> eventConsumer) throws InterruptedException {
         FanOutShardSubscriber fanOutShardSubscriber =
                 new FanOutShardSubscriber(
-                        consumerArn, subscribedShard.getShard().getShardId(), kinesisProxy);
+                        consumerArn,
+                        subscribedShard.getShard().getShardId(),
+                        kinesisProxy,
+                        configuration.getSubscribeToShardTimeout());
         boolean complete;
 
         try {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfiguration.java
@@ -52,6 +52,9 @@ public class FanOutRecordPublisherConfiguration {
     /** Base backoff millis for the deregister stream operation. */
     private final int subscribeToShardMaxRetries;
 
+    /** A timeout when waiting for a shard subscription to be established. */
+    private final Duration subscribeToShardTimeout;
+
     /** Maximum backoff millis for the subscribe to shard operation. */
     private final long subscribeToShardMaxBackoffMillis;
 
@@ -156,6 +159,13 @@ public class FanOutRecordPublisherConfiguration {
                                         ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_RETRIES))
                         .map(Integer::parseInt)
                         .orElse(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_RETRIES);
+        this.subscribeToShardTimeout =
+                Optional.ofNullable(
+                                configProps.getProperty(
+                                        ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS))
+                        .map(Integer::parseInt)
+                        .map(Duration::ofSeconds)
+                        .orElse(ConsumerConfigConstants.DEFAULT_SUBSCRIBE_TO_SHARD_TIMEOUT);
         this.subscribeToShardBaseBackoffMillis =
                 Optional.ofNullable(
                                 configProps.getProperty(
@@ -317,6 +327,11 @@ public class FanOutRecordPublisherConfiguration {
     /** Get maximum retry attempts for the subscribe to shard operation. */
     public int getSubscribeToShardMaxRetries() {
         return subscribeToShardMaxRetries;
+    }
+
+    /** Get timeout when waiting for a shard subscription to be established. */
+    public Duration getSubscribeToShardTimeout() {
+        return subscribeToShardTimeout;
     }
 
     /** Get maximum backoff millis for the subscribe to shard operation. */

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -72,10 +72,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
-import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFORegistrationType.NONE;
-import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFO_REGISTRATION_TYPE;
-import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
-import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType.EFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -96,12 +92,13 @@ public class KinesisDataFetcherTest extends TestLogger {
         assertTrue(fetcher.isRunning());
     }
 
-    @Test
-    public void testIsRunningFalseAfterShutDown() {
+    @Test(timeout = 10000)
+    public void testIsRunningFalseAfterShutDown() throws InterruptedException {
         KinesisDataFetcher<String> fetcher =
                 createTestDataFetcherWithNoShards(10, 2, "test-stream");
 
         fetcher.shutdownFetcher();
+        fetcher.awaitTermination();
 
         assertFalse(fetcher.isRunning());
     }
@@ -990,19 +987,15 @@ public class KinesisDataFetcherTest extends TestLogger {
                 fetcher.wasInterrupted);
     }
 
-    @Test
-    public void testRecordPublisherFactoryIsTornDown() {
-        Properties config = TestUtils.getStandardProperties();
-        config.setProperty(RECORD_PUBLISHER_TYPE, EFO.name());
-        config.setProperty(EFO_REGISTRATION_TYPE, NONE.name());
-
+    @Test(timeout = 1000L)
+    public void testRecordPublisherFactoryIsTornDown() throws InterruptedException {
         KinesisProxyV2Interface kinesisV2 = mock(KinesisProxyV2Interface.class);
 
         TestableKinesisDataFetcher<String> fetcher =
                 new TestableKinesisDataFetcher<String>(
                         singletonList("fakeStream1"),
                         new TestSourceContext<>(),
-                        config,
+                        TestUtils.efoProperties(),
                         new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
                         10,
                         2,
@@ -1014,7 +1007,64 @@ public class KinesisDataFetcherTest extends TestLogger {
 
         fetcher.shutdownFetcher();
 
+        fetcher.awaitTermination();
+    }
+
+    @Test(timeout = 10000)
+    public void testRecordPublisherFactoryIsTornDownWhenDeregisterStreamConsumerThrowsException()
+            throws InterruptedException {
+        KinesisProxyV2Interface kinesisV2 = mock(KinesisProxyV2Interface.class);
+
+        TestableKinesisDataFetcher<String> fetcher =
+                new TestableKinesisDataFetcher<String>(
+                        singletonList("fakeStream1"),
+                        new TestSourceContext<>(),
+                        TestUtils.efoProperties(),
+                        new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+                        10,
+                        2,
+                        new AtomicReference<>(),
+                        new LinkedList<>(),
+                        new HashMap<>(),
+                        mock(KinesisProxyInterface.class),
+                        kinesisV2) {
+                    @Override
+                    protected void deregisterStreamConsumer() {
+                        throw new RuntimeException();
+                    }
+                };
+
+        fetcher.shutdownFetcher();
+
         verify(kinesisV2).close();
+        fetcher.awaitTermination();
+    }
+
+    @Test(timeout = 10000)
+    public void testExecutorServiceShutDownWhenCloseRecordPublisherFactoryThrowsException()
+            throws InterruptedException {
+        TestableKinesisDataFetcher<String> fetcher =
+                new TestableKinesisDataFetcher<String>(
+                        singletonList("fakeStream1"),
+                        new TestSourceContext<>(),
+                        TestUtils.efoProperties(),
+                        new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+                        10,
+                        2,
+                        new AtomicReference<>(),
+                        new LinkedList<>(),
+                        new HashMap<>(),
+                        mock(KinesisProxyInterface.class),
+                        mock(KinesisProxyV2Interface.class)) {
+                    @Override
+                    protected void closeRecordPublisherFactory() {
+                        throw new RuntimeException();
+                    }
+                };
+
+        fetcher.shutdownFetcher();
+
+        fetcher.awaitTermination();
     }
 
     private KinesisDataFetcher<String> createTestDataFetcherWithNoShards(

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfigurationTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherConfigurationTest.java
@@ -24,9 +24,6 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -46,18 +43,18 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.REGISTER_STREAM_TIMEOUT_SECONDS;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType.EFO;
+import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link FanOutRecordPublisherConfiguration}. */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FanOutRecordPublisherConfiguration.class)
 public class FanOutRecordPublisherConfigurationTest extends TestLogger {
-    @Rule private ExpectedException exception = ExpectedException.none();
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testPollingRecordPublisher() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Only efo record publisher can register a FanOutProperties.");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Only efo record publisher can register a FanOutProperties.");
 
         Properties testConfig = TestUtils.getStandardProperties();
         testConfig.setProperty(RECORD_PUBLISHER_TYPE, RecordPublisherType.POLLING.toString());
@@ -82,8 +79,8 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
     public void testEagerStrategyWithNoConsumerName() {
         String msg = "No valid enhanced fan-out consumer name is set through " + EFO_CONSUMER_NAME;
 
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(msg);
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(msg);
 
         Properties testConfig = TestUtils.getStandardProperties();
         testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
@@ -115,8 +112,8 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 
         String msg =
                 "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream1, flink.stream.efo.consumerarn.fakedstream2";
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(msg);
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(msg);
 
         Properties testConfig = TestUtils.getStandardProperties();
         testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
@@ -131,8 +128,8 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 
         String msg =
                 "Invalid efo consumer arn settings for not providing consumer arns: flink.stream.efo.consumerarn.fakedstream2";
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(msg);
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(msg);
 
         Properties testConfig = TestUtils.getStandardProperties();
         testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
@@ -168,5 +165,30 @@ public class FanOutRecordPublisherConfigurationTest extends TestLogger {
 
         assertEquals(Duration.ofSeconds(60), configuration.getRegisterStreamConsumerTimeout());
         assertEquals(Duration.ofSeconds(240), configuration.getDeregisterStreamConsumerTimeout());
+    }
+
+    @Test
+    public void testParseSubscribeToShardTimeout() {
+        Properties testConfig = TestUtils.getStandardProperties();
+        testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+        testConfig.setProperty(EFO_CONSUMER_NAME, "name");
+        testConfig.setProperty(SUBSCRIBE_TO_SHARD_TIMEOUT_SECONDS, "123");
+
+        FanOutRecordPublisherConfiguration configuration =
+                new FanOutRecordPublisherConfiguration(testConfig, Collections.emptyList());
+
+        assertEquals(Duration.ofSeconds(123), configuration.getSubscribeToShardTimeout());
+    }
+
+    @Test
+    public void testDefaultSubscribeToShardTimeout() {
+        Properties testConfig = TestUtils.getStandardProperties();
+        testConfig.setProperty(RECORD_PUBLISHER_TYPE, EFO.toString());
+        testConfig.setProperty(EFO_CONSUMER_NAME, "name");
+
+        FanOutRecordPublisherConfiguration configuration =
+                new FanOutRecordPublisherConfiguration(testConfig, Collections.emptyList());
+
+        assertEquals(Duration.ofSeconds(60), configuration.getSubscribeToShardTimeout());
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeseri
 
 import org.mockito.invocation.InvocationOnMock;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -49,6 +50,7 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
     private final OneShotLatch shutdownWaiter;
 
     private volatile boolean running;
+    private volatile boolean executorServiceShutdownNowCalled;
 
     public TestableKinesisDataFetcher(
             List<String> fakeStreams,
@@ -128,14 +130,22 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
     @Override
     protected ExecutorService createShardConsumersThreadPool(String subtaskName) {
         // this is just a dummy fetcher, so no need to create a thread pool for shard consumers
-        ExecutorService mockExecutor = mock(ExecutorService.class);
-        when(mockExecutor.isTerminated()).thenAnswer((InvocationOnMock invocation) -> !running);
+        ExecutorService mockExecutorService = mock(ExecutorService.class);
+        when(mockExecutorService.isTerminated())
+                .thenAnswer((InvocationOnMock invocation) -> !running);
+        when(mockExecutorService.shutdownNow())
+                .thenAnswer(
+                        invocationOnMock -> {
+                            executorServiceShutdownNowCalled = true;
+                            return Collections.emptyList();
+                        });
         try {
-            when(mockExecutor.awaitTermination(anyLong(), any())).thenReturn(!running);
+            when(mockExecutorService.awaitTermination(anyLong(), any()))
+                    .thenAnswer(invocationOnMock -> !running && executorServiceShutdownNowCalled);
         } catch (InterruptedException e) {
             // We're just trying to stub the method. Must acknowledge the checked exception.
         }
-        return mockExecutor;
+        return mockExecutorService;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Pull in the following fixes from AWS fork:
* Fix issue where `KinesisDataFetcher.shutdownFetcher()` hangs ([issue](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/23), [pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/24))
  
* Log error when shutting down Kinesis Data Fetcher ([issue](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/22), [pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/25))
  
* Treating TimeoutException as Recoverable Exception ([issue](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/28), [pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/issues/21))
  
* Add time-out for acquiring subscription and passing events from network to source thread to prevent deadlock ([pull request](https://github.com/awslabs/amazon-kinesis-connector-flink/pull/18)) 

## Brief change log

- Added `Timeout` when blocking on queue between source and network thread
- Catching exceptions during source teardown, to allow source to interrupt threads of executor

## Verifying this change

- Added unit tests for changes
- Verified on AWS KDA with test applications

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
