### PR TITLE
[FLINK-22488][hotfix] Update SubtaskGatewayImpl to specify the cause of sendEvent() failure when triggering task failover

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -891,7 +891,8 @@ public class Execution
                     new TaskNotRunningException(
                             '"'
                                     + vertex.getTaskNameWithSubtaskIndex()
-                                    + "\" is currently not running or ready."));
+                                    + "\" is not running, but in state "
+                                    + getState()));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImpl.java
@@ -78,7 +78,7 @@ class SubtaskGatewayImpl implements OperatorCoordinator.SubtaskGateway {
                                                 EVENT_LOSS_ERROR_MESSAGE,
                                                 evt,
                                                 subtaskAccess.subtaskName());
-                                subtaskAccess.triggerTaskFailover(new FlinkException(msg));
+                                subtaskAccess.triggerTaskFailover(new FlinkException(msg, failure));
                             }
                             return null;
                         },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1404,11 +1404,12 @@ public class Task
     public void deliverOperatorEvent(OperatorID operator, SerializedValue<OperatorEvent> evt)
             throws FlinkException {
         final AbstractInvokable invokable = this.invokable;
+        final ExecutionState currentState = this.executionState;
 
         if (invokable == null
-                || (executionState != ExecutionState.RUNNING
-                        && executionState != ExecutionState.INITIALIZING)) {
-            throw new TaskNotRunningException("Task is not yet running.");
+                || (currentState != ExecutionState.RUNNING
+                        && currentState != ExecutionState.INITIALIZING)) {
+            throw new TaskNotRunningException("Task is not running, but in state " + currentState);
         }
 
         try {


### PR DESCRIPTION
## Contribution Checklist

This PR updated SubtaskGatewayImpl to specify the cause of sendEvent() failure when triggering task failover. This change is useful to understand why the event could not be sent.

## Brief change log

This PR updated SubtaskGatewayImpl to specify the cause of sendEvent() failure when triggering task failover.

## Verifying this change

I manually updated SubtaskGatewayImpl::sendEvent(...) to set `failure = new FlinkException("some error")` and then run the test `KafkaSourceLegacyITCase#testOneToOneSources`. The test fails with the following stacktrace in the log:

```
...
Caused by: org.apache.flink.util.FlinkException: An OperatorEvent from an OperatorCoordinator to a task was lost. Triggering task failover to ensure consistency. Event: 'AddSplitEvents[[[B@23adb3ce]]', targetTask: Source: KafkaSource -> Map -> Map (1/5) - execution #1
	... 26 more
Caused by: org.apache.flink.util.FlinkException: some error
	at org.apache.flink.runtime.operators.coordination.SubtaskGatewayImpl.lambda$sendEvent$0(SubtaskGatewayImpl.java:75)
	... 25 more
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
