### PR TITLE
[FLINK-22476] Extend the description of the config option `execution.target`

### DIFF
--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>execution.target</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The deployment target for the execution. This can take one of the following values:<ul><li>remote</li><li>local</li><li>yarn-per-job</li><li>yarn-session</li><li>kubernetes-session</li></ul>.</td>
+            <td>The deployment target for the execution. This can take one of the following values when execute bin/flink run:<ul><li>remote</li><li>local</li><li>yarn-per-job</li><li>yarn-session</li><li>kubernetes-session</li></ul>, and can take one of the following values when execute bin/flink run-application:<ul><li>yarn-application</li><li>kubernetes-application</li></ul>.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -37,13 +37,17 @@ public class DeploymentOptions {
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The deployment target for the execution. This can take one of the following values:")
+                                            "The deployment target for the execution. This can take one of the following values "
+                                                    + "when execute bin/flink run:")
                                     .list(
                                             text("remote"),
                                             text("local"),
                                             text("yarn-per-job"),
                                             text("yarn-session"),
                                             text("kubernetes-session"))
+                                    .text(
+                                            ", and can take one of the following values when execute bin/flink run-application:")
+                                    .list(text("yarn-application"), text("kubernetes-application"))
                                     .text(".")
                                     .build());
 


### PR DESCRIPTION

## What is the purpose of the change

update the description of `execution.targets`

## Brief change log

- add `yarn-application` and `kubernetes-application` into desscription

## Verifying this change

This change is just a document update.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? applicable
