### PR TITLE
1.11 backport [FLINK-22424][network] Prevent releasing PipelinedSubpartition while Task can still write to it

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/UnpooledBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/UnpooledBufferPool.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Implementation of {@link BufferPool} that works on un-pooled memory segments. */
+public class UnpooledBufferPool implements BufferPool {
+
+    private static final int SEGMENT_SIZE = 1024;
+
+    @Override
+    public void lazyDestroy() {}
+
+    @Override
+    public Buffer requestBuffer() {
+        return new NetworkBuffer(requestMemorySegment(), this);
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilder() {
+        return new BufferBuilder(requestMemorySegment(), this);
+    }
+
+    private MemorySegment requestMemorySegment() {
+        return MemorySegmentFactory.allocateUnpooledOffHeapMemory(SEGMENT_SIZE, null);
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilderBlocking() throws InterruptedException {
+        return requestBufferBuilder();
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilder(int targetChannel) {
+        return requestBufferBuilder();
+    }
+
+    @Override
+    public BufferBuilder requestBufferBuilderBlocking(int targetChannel)
+            throws InterruptedException {
+        return requestBufferBuilder();
+    }
+
+    @Override
+    public boolean addBufferListener(BufferListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getNumberOfRequiredMemorySegments() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int getMaxNumberOfMemorySegments() {
+        return -1;
+    }
+
+    @Override
+    public int getNumBuffers() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void setNumBuffers(int numBuffers) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getNumberOfAvailableMemorySegments() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int bestEffortGetNumOfUsedBuffers() {
+        return 0;
+    }
+
+    @Override
+    public BufferRecycler[] getSubpartitionBufferRecyclers() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void recycle(MemorySegment memorySegment) {
+        memorySegment.free();
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return AVAILABLE;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -484,6 +484,7 @@ public class PartitionRequestQueueTest {
         assertFalse(queue.getAvailableReaders().contains(reader));
         // the partition and its reader view should all be released
         assertTrue(reader.isReleased());
+        partition.close();
         assertTrue(partition.isReleased());
         for (ResultSubpartition subpartition : partition.getAllPartitions()) {
             assertTrue(subpartition.isReleased());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartitionTest.java
@@ -17,9 +17,13 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.io.network.buffer.UnpooledBufferPool;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -43,6 +47,25 @@ public class ReleaseOnConsumptionResultPartitionTest extends TestLogger {
         assertFalse(partition.isReleased());
 
         partition.onConsumedSubpartition(1);
+        partition.close();
+        assertTrue(partition.isReleased());
+    }
+
+    @Test
+    public void testConsumptionBeforePartitionClose() throws IOException, InterruptedException {
+        final ResultPartition partition =
+                new ResultPartitionBuilder()
+                        .setResultPartitionType(ResultPartitionType.PIPELINED)
+                        .setNumberOfSubpartitions(1)
+                        .setBufferPoolFactory(ignored -> new UnpooledBufferPool())
+                        .build();
+
+        partition.setup();
+        partition.getBufferBuilder(0).append(ByteBuffer.allocate(16));
+        partition.onConsumedSubpartition(0);
+        assertFalse(partition.isReleased());
+        partition.getBufferBuilder(0).append(ByteBuffer.allocate(16));
+        partition.close();
         assertTrue(partition.isReleased());
     }
 
@@ -77,7 +100,7 @@ public class ReleaseOnConsumptionResultPartitionTest extends TestLogger {
         partition.onConsumedSubpartition(0);
         partition.onConsumedSubpartition(0);
         partition.onConsumedSubpartition(1);
-
+        partition.close();
         assertTrue(partition.isReleased());
     }
 }


### PR DESCRIPTION
this is a backport of https://github.com/apache/flink/pull/15734