### PR TITLE
[hotfix][table-planner-blink] Fix unstable itcase in OverAggregateITCase#testRowNumberOnOver.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
@@ -150,7 +150,7 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "5,3",
       "5,4",
       "5,5")
-    assertEquals(expected, sink.getAppendResults)
+    assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to correct unstable itcase in OverAggregateITCase#testRowNumberOnOver.

## Brief change log

  - correct unstable itcase in OverAggregateITCase#testRowNumberOnOver.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
