### PR TITLE
[FLINK-22489][webui] Fix displaying individual subtasks backpressure-level

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
@@ -61,7 +61,7 @@
       <td>{{ subtask['subtask'] }}</td>
       <td>{{ this.prettyPrint(subtask['ratio']) }} / {{ this.prettyPrint(subtask['idleRatio']) }} / {{ this.prettyPrint(subtask['busyRatio']) }}</td>
       <td>
-        <flink-backpressure-badge [state]="backpressure['backpressure-level']"></flink-backpressure-badge>
+        <flink-backpressure-badge [state]="subtask['backpressure-level']"></flink-backpressure-badge>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Previously (incorrectly) backpressure-level from the whole task was being displayed for
each of the subtasks.

## Verifying this change

There are no WebUI tests. Change was manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
