### PR TITLE
[FLINK_22408]Flink Table Parsr Hive Drop Partitions Syntax unparse is Error

### DIFF
--- a/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser-hive/src/test/java/org/apache/flink/sql/parser/hive/FlinkHiveSqlParserImplTest.java
@@ -431,8 +431,16 @@ public class FlinkHiveSqlParserImplTest extends SqlParserTest {
                 .ok(
                         "ALTER TABLE `TBL`\n"
                                 + "DROP\n"
-                                + "PARTITION (`P1` = 'a', `P2` = 1)\n"
+                                + "PARTITION (`P1` = 'a', `P2` = 1),\n"
                                 + "PARTITION (`P1` = 'b', `P2` = 2)");
+        sql("alter table tbl drop partition (p1='a',p2=1), "
+                + "partition(p1='b',p2=2), partition(p1='c',p2=3)")
+                .ok(
+                        "ALTER TABLE `TBL`\n"
+                                + "DROP\n"
+                                + "PARTITION (`P1` = 'a', `P2` = 1),\n"
+                                + "PARTITION (`P1` = 'b', `P2` = 2),\n"
+                                + "PARTITION (`P1` = 'c', `P2` = 3)");
         // TODO: support IGNORE PROTECTION, PURGE
     }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropPartitions.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropPartitions.java
@@ -70,11 +70,14 @@ public class SqlDropPartitions extends SqlAlterTable {
         }
         int opLeftPrec = getOperator().getLeftPrec();
         int opRightPrec = getOperator().getRightPrec();
+        final SqlWriter.Frame frame = writer.startList("", "");
         for (SqlNodeList partSpec : partSpecs) {
+            writer.sep(",");
             writer.newlineAndIndent();
             writer.keyword("PARTITION");
             partSpec.unparse(writer, opLeftPrec, opRightPrec);
         }
+        writer.endList(frame);
     }
 
     @Nonnull


### PR DESCRIPTION
> ## What is the purpose of the change
> 
> Flink Table Enventment Parsr Hive Drop Partitions Syntax unparse is Error
> 
> ## Brief change log
> * Flink Table Parser is error Synopsis:
> * SQL：
> `alter table tbl drop partition (p1='a',p2=1), partition(p1='b',p2=2);`
> * Hive Multiple partitions unparse toSqlString is error,Missing comma in Partition SqlNodeList 
> * In Flink Table Hive Env syntax：
> `ALTER TABLE tbl
      DROP
      PARTITION (`P1` = 'a', `P2` = 1)
      PARTITION (`P1` = 'b', `P2` = 2)`

>  * The right hive syntax ：
>`ALTER TABLE tbl
      DROP
      PARTITION (`P1` = 'a', `P2` = 1),
      PARTITION (`P1` = 'b', `P2` = 2)`
> ## Verifying this change
> This change is a trivial rework / code cleanup without any test coverage.
> 
> ## Does this pull request potentially affect one of the following parts:
> * Dependencies (does it add or upgrade a dependency): no
> * The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
> * The serializers: no
> * The runtime per-record code paths (performance sensitive): no
> * Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
> * The S3 file system connector: no
> 
> ## Documentation
> * Does this pull request introduce a new feature? no
> * If yes, how is the feature documented? not applicable