### PR TITLE
[FLINK-22438][metrics] Add numRecordsOut metric for Async IO

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -154,7 +154,7 @@ public class AsyncWaitOperator<IN, OUT>
                 throw new IllegalStateException("Unknown async mode: " + outputMode + '.');
         }
 
-        this.timestampedCollector = new TimestampedCollector<>(output);
+        this.timestampedCollector = new TimestampedCollector<>(super.output);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*In Flink WebUI,there is no numRecordsOut metric in Async IO operator while other operator have, this makes it difficult to monitor Async IO operator and can cause confusion for users.The commit is about to fix it. see https://issues.apache.org/jira/browse/FLINK-22438*

## Brief change log

  - *Use the `output` field in the super class of `AsyncWaitOperator` to update numRecordsOut metric.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
