### PR TITLE
[FLINK-22511][python] Fix the bug of non-composite result type in Python TableAggregateFunction

### DIFF
--- a/flink-python/pyflink/fn_execution/table/aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/table/aggregate_fast.pxd
@@ -59,7 +59,7 @@ cdef class SimpleAggsHandleFunction(SimpleAggsHandleFunctionBase):
     cdef size_t _get_value_indexes_length
 
 cdef class SimpleTableAggsHandleFunction(SimpleAggsHandleFunctionBase):
-    pass
+    cdef list _convert_to_row(self, data)
 
 cdef class RecordCounter:
     cdef bint record_count_is_zero(self, list acc)

--- a/flink-python/pyflink/fn_execution/table/aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/aggregate_slow.py
@@ -355,12 +355,20 @@ class SimpleTableAggsHandleFunction(SimpleAggsHandleFunctionBase, TableAggsHandl
         udf = self._udfs[0]  # type: TableAggregateFunction
         results = udf.emit_value(self._accumulators[0])
         for x in results:
-            result = join_row(current_key, x._values)
+            result = join_row(current_key, self._convert_to_row(x))
             if is_retract:
                 result.set_row_kind(RowKind.DELETE)
             else:
                 result.set_row_kind(RowKind.INSERT)
             yield result
+
+    def _convert_to_row(self, data):
+        if isinstance(data, Row):
+            return data._values
+        elif isinstance(data, tuple):
+            return list(data)
+        else:
+            return [data]
 
 
 class RecordCounter(ABC):

--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -264,7 +264,7 @@ class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkStreamT
                                       (2, 'Hi', 'Hello')], ['a', 'b', 'c'])
         result = t.select(t.a, t.c) \
             .group_by(t.c) \
-            .flat_aggregate(mytop) \
+            .flat_aggregate(mytop.alias('a')) \
             .select(t.a) \
             .flat_aggregate(mytop.alias("b")) \
             .select("b") \
@@ -339,8 +339,8 @@ class CountAndSumAggregateFunction(AggregateFunction):
 class Top2(TableAggregateFunction):
 
     def emit_value(self, accumulator):
-        yield Row(accumulator[0])
-        yield Row(accumulator[1])
+        yield accumulator[0]
+        yield accumulator[1]
 
     def create_accumulator(self):
         return [None, None]
@@ -365,8 +365,7 @@ class Top2(TableAggregateFunction):
         return DataTypes.ARRAY(DataTypes.BIGINT())
 
     def get_result_type(self):
-        return DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.BIGINT())])
+        return DataTypes.BIGINT()
 
 
 class ListViewConcatTableAggregateFunction(TableAggregateFunction):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of non-composite result type in Python TableAggregateFunction*

## Brief change log

  - *Add method `_convert_to_row` to convert result data from `emit_value` in user-defined `TableAggregateFunction`*

## Verifying this change

This change added tests and can be verified as follows:

  - *IT `test_flat_aggregate`*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
