### PR TITLE
[FLINK-22434] Store suspended execution graphs on termination to keep…

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -501,7 +501,7 @@ function wait_job_terminal_state {
   echo "Waiting for job ($job) to reach terminal state $expected_terminal_state ..."
 
   while : ; do
-    local N=$(grep -o "Job $job reached globally terminal state .*" $FLINK_LOG_DIR/*$log_file_name*.log | tail -1 || true)
+    local N=$(grep -o "Job $job reached terminal state .*" $FLINK_LOG_DIR/*$log_file_name*.log | tail -1 || true)
     if [[ -z $N ]]; then
       sleep 1
     else

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
@@ -59,4 +59,4 @@ wait_rest_endpoint_up_k8s $jm_pod_name
 # The Flink cluster will be destroyed immediately once the job finished or failed. So we check jobmanager logs
 # instead of checking the result
 kubectl logs -f $jm_pod_name >$LOCAL_LOGS_PATH/jobmanager.log
-grep -E "Job [A-Za-z0-9]+ reached globally terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log
+grep -E "Job [A-Za-z0-9]+ reached terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
@@ -111,4 +111,4 @@ wait_rest_endpoint_up_k8s $jm_pod_name
 # The Flink cluster will be destroyed immediately once the job finished or failed. So we check jobmanager logs
 # instead of checking the result
 kubectl logs -f $jm_pod_name >$LOCAL_LOGS_PATH/jobmanager.log
-grep -E "Job [A-Za-z0-9]+ reached globally terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log
+grep -E "Job [A-Za-z0-9]+ reached terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -119,12 +119,10 @@ public class MiniDispatcher extends Dispatcher {
     }
 
     @Override
-    protected CleanupJobState jobReachedGloballyTerminalState(
-            ExecutionGraphInfo executionGraphInfo) {
+    protected CleanupJobState jobReachedTerminalState(ExecutionGraphInfo executionGraphInfo) {
         final ArchivedExecutionGraph archivedExecutionGraph =
                 executionGraphInfo.getArchivedExecutionGraph();
-        final CleanupJobState cleanupHAState =
-                super.jobReachedGloballyTerminalState(executionGraphInfo);
+        final CleanupJobState cleanupHAState = super.jobReachedTerminalState(executionGraphInfo);
 
         if (jobCancelled || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
             // shut down if job is cancelled or we don't have to wait for the execution result
@@ -139,13 +137,5 @@ public class MiniDispatcher extends Dispatcher {
         }
 
         return cleanupHAState;
-    }
-
-    @Override
-    protected void jobNotFinished(JobID jobId) {
-        super.jobNotFinished(jobId);
-        // shut down since we have done our job
-        log.info("Shutting down cluster because job not finished");
-        shutDownFuture.complete(ApplicationStatus.UNKNOWN);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -220,12 +220,12 @@ public class JobResult implements Serializable {
         final JobStatus jobStatus = accessExecutionGraph.getState();
 
         checkArgument(
-                jobStatus.isGloballyTerminalState(),
+                jobStatus.isTerminalState(),
                 "The job "
                         + accessExecutionGraph.getJobName()
                         + '('
                         + jobId
-                        + ") is not in a globally "
+                        + ") is not in a "
                         + "terminal state. It is in state "
                         + jobStatus
                         + '.');

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -65,7 +65,7 @@ class TestingDispatcher extends Dispatcher {
     }
 
     void completeJobExecution(ExecutionGraphInfo executionGraphInfo) {
-        runAsync(() -> jobReachedGloballyTerminalState(executionGraphInfo));
+        runAsync(() -> jobReachedTerminalState(executionGraphInfo));
     }
 
     CompletableFuture<Void> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -69,6 +69,7 @@ import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.apache.flink.core.testutils.FlinkMatchers.willNotComplete;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -658,13 +659,15 @@ public class JobMasterServiceLeadershipRunnerTest extends TestLogger {
                         "Result future should be completed exceptionally."));
     }
 
-    private void assertJobNotFinished(CompletableFuture<JobManagerRunnerResult> resultFuture) {
-        try {
-            resultFuture.get();
-            fail("Expect exception");
-        } catch (Throwable t) {
-            assertThat(t, containsCause(JobNotFinishedException.class));
-        }
+    private void assertJobNotFinished(CompletableFuture<JobManagerRunnerResult> resultFuture)
+            throws ExecutionException, InterruptedException {
+        final JobManagerRunnerResult jobManagerRunnerResult = resultFuture.get();
+        assertEquals(
+                jobManagerRunnerResult
+                        .getExecutionGraphInfo()
+                        .getArchivedExecutionGraph()
+                        .getState(),
+                JobStatus.SUSPENDED);
     }
 
     public JobMasterServiceLeadershipRunnerBuilder newJobMasterServiceLeadershipRunnerBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
@@ -57,9 +58,15 @@ public class TestingJobManagerRunner implements JobManagerRunner {
         this.resultFuture = resultFuture;
         this.terminationFuture = new CompletableFuture<>();
 
+        final ExecutionGraphInfo suspendedExecutionGraphInfo =
+                new ExecutionGraphInfo(
+                        ArchivedExecutionGraph.createFromInitializingJob(
+                                jobId, "TestJob", JobStatus.SUSPENDED, null, null, 0L),
+                        null);
         terminationFuture.whenComplete(
                 (ignored, ignoredThrowable) ->
-                        resultFuture.completeExceptionally(new JobNotFinishedException(jobId)));
+                        resultFuture.complete(
+                                JobManagerRunnerResult.forSuccess(suspendedExecutionGraphInfo)));
     }
 
     @Override


### PR DESCRIPTION
… them accessible

Before this change as soon as a cluster termination was initiated every
job was suspended and not accessible anymore until recovery. By storing
the execution graph they will appear as SUSPENDED they are now
accessible until the cluster is fully shutdown.

## Brief change log

  * Once the JobMasterServiceLeadershipRunner is shutdown the resultFuture describing will complete **without** an exception and return the SUSPENDED execution graph.


## Verifying this change

* Updated tests to ensure on shutdown the JobStatus is reflected correctly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
