### PR TITLE
[FLINK-22313][table-planner-blink] Redundant CAST in plan when selecting window start and window end in window agg

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/SqlGroupedWindowFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/calcite/sql/SqlGroupedWindowFunction.java
@@ -184,11 +184,7 @@ public class SqlGroupedWindowFunction extends SqlFunction {
         public WindowStartEndReturnTypeInference() {}
 
         public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
-            if (opBinding.getOperandType(0).getSqlTypeName().equals(SqlTypeName.TIMESTAMP)) {
-                return opBinding.getOperandType(0);
-            } else {
-                return explicit.inferReturnType(opBinding);
-            }
+            return explicit.inferReturnType(opBinding);
         }
     }
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerWindowEnd.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerWindowEnd.java
@@ -36,7 +36,7 @@ public class PlannerWindowEnd extends AbstractPlannerWindowProperty {
 
     @Override
     public LogicalType getResultType() {
-        return new TimestampType(3);
+        return new TimestampType(false, 3);
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerWindowStart.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerWindowStart.java
@@ -37,7 +37,7 @@ public class PlannerWindowStart extends AbstractPlannerWindowProperty {
 
     @Override
     public LogicalType getResultType() {
-        return new TimestampType(3);
+        return new TimestampType(false, 3);
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -385,14 +385,14 @@
       }, {
         "w$start" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
       }, {
         "w$end" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
@@ -427,7 +427,7 @@
       "inputIndex" : 5,
       "type" : {
         "typeName" : "TIMESTAMP",
-        "nullable" : true,
+        "nullable" : false,
         "precision" : 3
       }
     }, {
@@ -435,7 +435,7 @@
       "inputIndex" : 6,
       "type" : {
         "typeName" : "TIMESTAMP",
-        "nullable" : true,
+        "nullable" : false,
         "precision" : 3
       }
     }, {
@@ -485,14 +485,14 @@
       }, {
         "window_start" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
@@ -550,14 +550,14 @@
       }, {
         "window_start" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
       }, {
         "window_end" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
@@ -366,14 +366,14 @@
       }, {
         "w$start" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
       }, {
         "w$end" : {
           "type" : "TIMESTAMP_WITHOUT_TIME_ZONE",
-          "nullable" : true,
+          "nullable" : false,
           "precision" : 3,
           "kind" : "REGULAR"
         }
@@ -397,21 +397,8 @@
         "nullable" : true
       }
     }, {
-      "kind" : "REX_CALL",
-      "operator" : {
-        "name" : "CAST",
-        "kind" : "CAST",
-        "syntax" : "SPECIAL"
-      },
-      "operands" : [ {
-        "kind" : "INPUT_REF",
-        "inputIndex" : 3,
-        "type" : {
-          "typeName" : "TIMESTAMP",
-          "nullable" : true,
-          "precision" : 3
-        }
-      } ],
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
       "type" : {
         "typeName" : "TIMESTAMP",
         "nullable" : false,
@@ -450,7 +437,7 @@
         "EXPR$2" : "BIGINT NOT NULL"
       } ]
     },
-    "description" : "Calc(select=[b, CAST(w$end) AS window_end, EXPR$2])"
+    "description" : "Calc(select=[b, w$end AS window_end, EXPR$2])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
     "dynamicTableSink" : {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.xml
@@ -227,7 +227,7 @@ LogicalProject(name=[$0], EXPR$1=[TUMBLE_END($1)], EXPR$2=[$2])
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[name, CAST(w$end) AS EXPR$1, EXPR$2])
+Calc(select=[name, w$end AS EXPR$1, EXPR$2])
 +- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w$, proctime, 600000)], properties=[w$start, w$end, w$proctime], select=[name, AVG(val) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[hash[name]])
       +- Calc(select=[val, name, proctime], where=[(val > 100)])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/MatchRecognizeTest.xml
@@ -52,7 +52,7 @@ LogicalProject(symbol=[$0], price=[$2], rowTime=[TUMBLE_ROWTIME($1)], startTime=
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-Calc(select=[symbol, price, CAST(w$rowtime) AS rowTime, CAST(w$start) AS startTime])
+Calc(select=[symbol, price, CAST(w$rowtime) AS rowTime, w$start AS startTime])
 +- GroupWindowAggregate(groupBy=[symbol], window=[TumblingGroupWindow('w$, matchRowtime, 3000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[symbol, SUM(price) AS price, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[hash[symbol]])
       +- Calc(select=[symbol, matchRowtime, price])

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/GroupWindowTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/GroupWindowTest.xml
@@ -126,7 +126,7 @@ LogicalProject(EXPR$0=[$1], wAvg=[$2], EXPR$2=[HOP_START($0)], EXPR$3=[HOP_END($
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[EXPR$0, wAvg, CAST(w$start) AS EXPR$2, CAST(w$end) AS EXPR$3])
+Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 +- GroupWindowAggregate(window=[SlidingGroupWindow('w$, proctime, 3600000, 900000)], properties=[w$start, w$end, w$proctime], select=[COUNT(*) AS EXPR$0, weightedAvg(c, a) AS wAvg, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[single])
       +- Calc(select=[proctime, c, CAST(a) AS a])
@@ -388,7 +388,7 @@ LogicalProject(EXPR$0=[$1], wAvg=[$2], EXPR$2=[SESSION_START($0)], EXPR$3=[SESSI
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[EXPR$0, wAvg, CAST(w$start) AS EXPR$2, CAST(w$end) AS EXPR$3])
+Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 +- GroupWindowAggregate(window=[SessionGroupWindow('w$, proctime, 900000)], properties=[w$start, w$end, w$proctime], select=[COUNT(*) AS EXPR$0, weightedAvg(c, a) AS wAvg, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime])
    +- Exchange(distribution=[single])
       +- Calc(select=[proctime, c, CAST(a) AS a])


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add the following test case to org.apache.flink.table.planner.plan.stream.sql.agg.WindowAggregateTest to reproduce this bug.

```scala
@Test
def testSessionFunction(): Unit = {
  val sql =
    """
      |SELECT
      |    COUNT(*),
      |    SESSION_START(proctime, INTERVAL '15' MINUTE),
      |    SESSION_END(proctime, INTERVAL '15' MINUTE)
      |FROM MyTable
      |    GROUP BY SESSION(proctime, INTERVAL '15' MINUTE)
    """.stripMargin
  util.verifyExecPlan(sql)
}
```

The produced plan is

```
Calc(select=[EXPR$0, CAST(w$start) AS EXPR$1, CAST(w$end) AS EXPR$2])
+- GroupWindowAggregate(window=[SessionGroupWindow('w$, proctime, 900000)], properties=[w$start, w$end, w$proctime], select=[COUNT(*) AS EXPR$0, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime])
   +- Exchange(distribution=[single])
      +- Calc(select=[proctime])
         +- WatermarkAssigner(rowtime=[rowtime], watermark=[(rowtime - 1000:INTERVAL SECOND)])
            +- Calc(select=[PROCTIME() AS proctime, rowtime])
               +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[rowtime]]], fields=[rowtime])
```

This is because the nullability indicated by PlannerWindowStart#getResultType and SqlGroupedWindowFunction#WindowStartEndReturnTypeInference are different. Actually time attribute and window start / end should always be not null.

## Brief change log

- Fix nullability in `PlannerWindowStart#getResultType` and `SqlGroupedWindowFunction#WindowStartEndReturnTypeInference`.


## Verifying this change

This change is already covered by existing tests, such as `GroupWindowTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

