### PR TITLE
[FLINK-22462][jdbc] Fix connection leak and stabilize JdbcExactlyOnceSinkE2eTest

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -160,6 +160,19 @@ under the License.
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>1.4.200</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.15.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
+			<version>1.15.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
1. Close pooled and physical connections in `XaFacadeImpl` (tolerate close errors for MySQL)
2. Harden test by adding MySql
3. Prevent sources from waiting on cancellation
4. Prevent sources from using a latch from a different attempt