### PR TITLE
[FLINK-22548][network] Remove illegal unsynchronized access to PipelinedSubpartition#buffers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -130,20 +130,12 @@ public class PipelinedSubpartition extends ResultSubpartition
     @Override
     public void addRecovered(BufferConsumer bufferConsumer) throws IOException {
         NetworkActionsLogger.traceRecover(
-                "ResultSubpartitionRecoveredStateHandler#recover",
+                "PipelinedSubpartition#addRecovered",
                 bufferConsumer,
                 parent.getOwningTaskName(),
                 subpartitionInfo);
         if (!add(bufferConsumer, Integer.MIN_VALUE)) {
             throw new IOException("Buffer consumer couldn't be added to ResultSubpartition");
-        }
-        BufferConsumerWithPartialRecordLength last = buffers.peekLast();
-        if (last != null) {
-            NetworkActionsLogger.traceRecover(
-                    "PipelinedSubpartition#addRecover",
-                    last.getBufferConsumer(),
-                    parent.getOwningTaskName(),
-                    subpartitionInfo);
         }
     }
 


### PR DESCRIPTION
After peeking last buffer, this last buffer could have been processed
and recycled by the task thread, before NetworkActionsLogger.traceRecover
would manage to check it's content causing IllegalReferenceCount exceptions.

Further more, this log seemed excessive and was accidentally added after
debugging session, so it's ok to remove it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
