### PR TITLE
[FLINK-22266][hotfix] Do not clean up jobs in AbstractTestBase if the MiniCluster is not running

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
@@ -70,6 +70,11 @@ public abstract class AbstractTestBase extends TestBaseUtils {
 
     @After
     public final void cleanupRunningJobs() throws Exception {
+        if (!miniClusterResource.getMiniCluster().isRunning()) {
+            // do nothing if the MiniCluster is not running
+            return;
+        }
+
         for (JobStatusMessage path : miniClusterResource.getClusterClient().listJobs().get()) {
             if (!path.getJobState().isTerminalState()) {
                 try {


### PR DESCRIPTION
## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
