### PR TITLE
[FLINK-22494][ha] Introduce PossibleInconsistentStateException

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -290,13 +291,17 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                                                                                             Throwable
                                                                                                     throwable) {
                                                                                         LOG.debug(
-                                                                                                "Failed to update ConfigMap {} with data {} because of concurrent "
-                                                                                                        + "modifications. Trying again.",
+                                                                                                "Failed to update ConfigMap {} with data {}. Trying again.",
                                                                                                 configMap
                                                                                                         .getName(),
                                                                                                 configMap
                                                                                                         .getData());
-                                                                                        throw throwable;
+                                                                                        // the
+                                                                                        // client
+                                                                                        // implementation does not expose the different kind of error causes to a degree that we could do a more fine-grained error handling here
+                                                                                        throw new CompletionException(
+                                                                                                new PossibleInconsistentStateException(
+                                                                                                        throwable));
                                                                                     }
                                                                                     return true;
                                                                                 })

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
+import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 
 import java.io.File;
 import java.util.List;
@@ -151,7 +152,12 @@ public interface FlinkKubeClient extends AutoCloseable {
      *     one. If the returned optional is empty, we will not do the update.
      * @return Return the ConfigMap update future. The boolean result indicates whether the
      *     ConfigMap is updated. The returned future will be completed exceptionally if the
-     *     ConfigMap does not exist.
+     *     ConfigMap does not exist. A failure during the update operation will result in the future
+     *     failing with a {@link PossibleInconsistentStateException} indicating that no clear
+     *     decision can be made on whether the update was successful or not. The {@code
+     *     PossibleInconsistentStateException} not being present indicates that the failure happened
+     *     before writing the updated ConfigMap to Kubernetes. For the latter case, it can be
+     *     assumed that the ConfigMap was not updated.
      */
     CompletableFuture<Boolean> checkAndUpdateConfigMap(
             String configMapName,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/MixedKubernetesServer.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/MixedKubernetesServer.java
@@ -50,7 +50,7 @@ public class MixedKubernetesServer extends ExternalResource {
     }
 
     public void before() {
-        HashMap<ServerRequest, Queue<ServerResponse>> response = new HashMap<>();
+        final HashMap<ServerRequest, Queue<ServerResponse>> response = new HashMap<>();
         mock =
                 crudMode
                         ? new KubernetesMockServer(
@@ -75,6 +75,10 @@ public class MixedKubernetesServer extends ExternalResource {
 
     public RecordedRequest takeRequest(long timeout, TimeUnit unit) throws Exception {
         return mockWebServer.takeRequest(timeout, unit);
+    }
+
+    public int getRequestCount() {
+        return mockWebServer.getRequestCount();
     }
 
     public MockServerExpectation expect() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreITCase.java
@@ -68,8 +68,8 @@ public class KubernetesStateHandleStoreITCase extends TestLogger {
                 new TestingLeaderCallbackHandler[leaderNum];
 
         @SuppressWarnings("unchecked")
-        final KubernetesStateHandleStore<Long>[] stateHandleStores =
-                new KubernetesStateHandleStore[leaderNum];
+        final KubernetesStateHandleStore<TestingLongStateHandleHelper.LongStateHandle>[]
+                stateHandleStores = new KubernetesStateHandleStore[leaderNum];
 
         try {
             for (int i = 0; i < leaderNum; i++) {
@@ -103,17 +103,19 @@ public class KubernetesStateHandleStoreITCase extends TestLogger {
                 if (leaderCallbackHandlers[i].getLockIdentity().equals(lockIdentity)) {
                     expectedState = (long) i;
                 }
-                stateHandleStores[i].addAndLock(KEY, (long) i);
+                stateHandleStores[i].addAndLock(
+                        KEY, new TestingLongStateHandleHelper.LongStateHandle(i));
             }
 
             // Only the leader could add successfully
             assertThat(expectedState, is(notNullValue()));
             assertThat(stateHandleStores[0].getAllAndLock().size(), is(1));
             assertThat(
-                    stateHandleStores[0].getAllAndLock().get(0).f0.retrieveState(),
+                    stateHandleStores[0].getAllAndLock().get(0).f0.retrieveState().getValue(),
                     is(expectedState));
             assertThat(stateHandleStores[0].getAllAndLock().get(0).f1, is(KEY));
         } finally {
+            TestingLongStateHandleHelper.clearGlobalState();
             // Cleanup the resources
             for (int i = 0; i < leaderNum; i++) {
                 if (leaderElectors[i] != null) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStoreTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesLeaderElector;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.persistence.StringResourceVersion;
 import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper;
-import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper.LongRetrievableStateHandle;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.FunctionUtils;
 
@@ -36,6 +35,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -49,14 +49,16 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
     private static final String PREFIX = "test-prefix-";
     private final String key = PREFIX + JobID.generate();
     private final Predicate<String> filter = k -> k.startsWith(PREFIX);
-    private final Long state = 12345L;
+    private final TestingLongStateHandleHelper.LongStateHandle state =
+            new TestingLongStateHandleHelper.LongStateHandle(12345L);
 
-    private TestingLongStateHandleHelper longStateStorage;
+    private final TestingLongStateHandleHelper longStateStorage =
+            new TestingLongStateHandleHelper();
 
     @Before
     public void setup() {
         super.setup();
-        longStateStorage = new TestingLongStateHandleHelper();
+        TestingLongStateHandleHelper.clearGlobalState();
     }
 
     @Test
@@ -67,13 +69,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             store.addAndLock(key, state);
                             assertThat(store.getAllAndLock().size(), is(1));
                             assertThat(store.getAndLock(key).retrieveState(), is(state));
@@ -92,13 +96,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
 
                             getLeaderConfigMap().getData().put(key, "existing data");
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
 
                             try {
                                 store.addAndLock(key, state);
@@ -110,12 +116,10 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                                                 key, LEADER_CONFIGMAP_NAME);
                                 assertThat(ex, FlinkMatchers.containsMessage(msg));
                             }
-                            assertThat(longStateStorage.getStateHandles().size(), is(1));
+                            assertThat(TestingLongStateHandleHelper.getGlobalStorageSize(), is(1));
                             assertThat(
-                                    longStateStorage
-                                            .getStateHandles()
-                                            .get(0)
-                                            .getNumberOfDiscardCalls(),
+                                    TestingLongStateHandleHelper
+                                            .getDiscardCallCountForStateHandleByIndex(0),
                                     is(1));
                         });
             }
@@ -128,13 +132,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
             {
                 runTest(
                         () -> {
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
 
                             try {
                                 store.addAndLock(key, state);
@@ -146,12 +152,10 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                                                 LEADER_CONFIGMAP_NAME);
                                 assertThat(ex, FlinkMatchers.containsMessage(msg));
                             }
-                            assertThat(longStateStorage.getStateHandles().size(), is(1));
+                            assertThat(TestingLongStateHandleHelper.getGlobalStorageSize(), is(1));
                             assertThat(
-                                    longStateStorage
-                                            .getStateHandles()
-                                            .get(0)
-                                            .getNumberOfDiscardCalls(),
+                                    TestingLongStateHandleHelper
+                                            .getDiscardCallCountForStateHandleByIndex(0),
                                     is(1));
                         });
             }
@@ -166,17 +170,20 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
 
                             store.addAndLock(key, state);
 
-                            final Long newState = 23456L;
+                            final TestingLongStateHandleHelper.LongStateHandle newState =
+                                    new TestingLongStateHandleHelper.LongStateHandle(23456L);
                             final StringResourceVersion resourceVersion = store.exists(key);
                             store.replace(key, resourceVersion, newState);
 
@@ -195,14 +202,17 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
-                            final Long newState = 23456L;
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
+                            final TestingLongStateHandleHelper.LongStateHandle newState =
+                                    new TestingLongStateHandleHelper.LongStateHandle(23456L);
 
                             try {
                                 assertThat(
@@ -230,14 +240,17 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
-                            final Long newState = 23456L;
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
+                            final TestingLongStateHandleHelper.LongStateHandle newState =
+                                    new TestingLongStateHandleHelper.LongStateHandle(23456L);
 
                             store.addAndLock(key, state);
                             // Lost leadership
@@ -253,18 +266,14 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                             // The state do not change
                             assertThat(store.getAndLock(key).retrieveState(), is(state));
 
-                            assertThat(longStateStorage.getStateHandles().size(), is(2));
+                            assertThat(TestingLongStateHandleHelper.getGlobalStorageSize(), is(2));
                             assertThat(
-                                    longStateStorage
-                                            .getStateHandles()
-                                            .get(0)
-                                            .getNumberOfDiscardCalls(),
+                                    TestingLongStateHandleHelper
+                                            .getDiscardCallCountForStateHandleByIndex(0),
                                     is(0));
                             assertThat(
-                                    longStateStorage
-                                            .getStateHandles()
-                                            .get(1)
-                                            .getNumberOfDiscardCalls(),
+                                    TestingLongStateHandleHelper
+                                            .getDiscardCallCountForStateHandleByIndex(1),
                                     is(1));
                         });
             }
@@ -280,13 +289,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             store.addAndLock(key, state);
 
                             final FlinkKubeClient anotherFlinkKubeClient =
@@ -296,15 +307,18 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                                                         throw updateException;
                                                     })
                                             .build();
-                            final KubernetesStateHandleStore<Long> anotherStore =
-                                    new KubernetesStateHandleStore<>(
-                                            anotherFlinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    anotherStore =
+                                            new KubernetesStateHandleStore<>(
+                                                    anotherFlinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
 
-                            final Long newState = 23456L;
+                            final TestingLongStateHandleHelper.LongStateHandle newState =
+                                    new TestingLongStateHandleHelper.LongStateHandle(23456L);
                             final StringResourceVersion resourceVersion = anotherStore.exists(key);
                             assertThat(resourceVersion.isExisting(), is(true));
                             try {
@@ -318,18 +332,14 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                             // The state do not change
                             assertThat(anotherStore.getAndLock(key).retrieveState(), is(state));
 
-                            assertThat(longStateStorage.getStateHandles().size(), is(2));
+                            assertThat(TestingLongStateHandleHelper.getGlobalStorageSize(), is(2));
                             assertThat(
-                                    longStateStorage
-                                            .getStateHandles()
-                                            .get(0)
-                                            .getNumberOfDiscardCalls(),
+                                    TestingLongStateHandleHelper
+                                            .getDiscardCallCountForStateHandleByIndex(0),
                                     is(0));
                             assertThat(
-                                    longStateStorage
-                                            .getStateHandles()
-                                            .get(1)
-                                            .getNumberOfDiscardCalls(),
+                                    TestingLongStateHandleHelper
+                                            .getDiscardCallCountForStateHandleByIndex(1),
                                     is(1));
                         });
             }
@@ -344,13 +354,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             store.addAndLock(key, state);
                             assertThat(
                                     store.exists(key),
@@ -369,13 +381,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             final String nonExistingKey = "non-existing-key";
                             store.addAndLock(key, state);
                             assertThat(
@@ -404,26 +418,37 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             final List<Long> expected = Arrays.asList(3L, 2L, 1L);
 
                             for (Long each : expected) {
-                                store.addAndLock(key + each, each);
+                                store.addAndLock(
+                                        key + each,
+                                        new TestingLongStateHandleHelper.LongStateHandle(each));
                             }
-                            final Long[] actual =
+                            final TestingLongStateHandleHelper.LongStateHandle[] actual =
                                     store.getAllAndLock().stream()
                                             .map(
                                                     FunctionUtils.uncheckedFunction(
                                                             e -> e.f0.retrieveState()))
-                                            .toArray(Long[]::new);
+                                            .toArray(
+                                                    TestingLongStateHandleHelper.LongStateHandle[]
+                                                            ::new);
                             assertThat(
-                                    Arrays.asList(actual), containsInAnyOrder(expected.toArray()));
+                                    Arrays.stream(actual)
+                                            .map(
+                                                    TestingLongStateHandleHelper.LongStateHandle
+                                                            ::getValue)
+                                            .collect(Collectors.toList()),
+                                    containsInAnyOrder(expected.toArray()));
                         });
             }
         };
@@ -437,13 +462,15 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                         () -> {
                             leaderCallbackGrantLeadership();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             final List<String> expected = Arrays.asList(key + 3, key + 2, key + 1);
 
                             for (String each : expected) {
@@ -465,24 +492,23 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                 runTest(
                         () -> {
                             leaderCallbackGrantLeadership();
-                            LongRetrievableStateHandle.clearNumberOfGlobalDiscardCalls();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             store.addAndLock(key, state);
                             assertThat(store.getAllAndLock().size(), is(1));
                             assertThat(store.releaseAndTryRemove(key), is(true));
                             assertThat(store.getAllAndLock().size(), is(0));
 
                             // State should also be discarded.
-                            assertThat(
-                                    LongRetrievableStateHandle.getNumberOfGlobalDiscardCalls(),
-                                    is(1));
+                            assertThat(TestingLongStateHandleHelper.getGlobalDiscardCount(), is(1));
                         });
             }
         };
@@ -495,15 +521,16 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                 runTest(
                         () -> {
                             leaderCallbackGrantLeadership();
-                            LongRetrievableStateHandle.clearNumberOfGlobalDiscardCalls();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
 
                             store.addAndLock(key, state);
                             // Lost leadership
@@ -516,9 +543,7 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                             assertThat(store.releaseAndTryRemove(key), is(false));
                             assertThat(store.getAllAndLock().size(), is(1));
 
-                            assertThat(
-                                    LongRetrievableStateHandle.getNumberOfGlobalDiscardCalls(),
-                                    is(0));
+                            assertThat(TestingLongStateHandleHelper.getGlobalDiscardCount(), is(0));
                         });
             }
         };
@@ -531,23 +556,24 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                 runTest(
                         () -> {
                             leaderCallbackGrantLeadership();
-                            LongRetrievableStateHandle.clearNumberOfGlobalDiscardCalls();
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             store.addAndLock(key, state);
-                            store.addAndLock(key + "1", 2L);
+                            store.addAndLock(
+                                    key + "1",
+                                    new TestingLongStateHandleHelper.LongStateHandle(2L));
                             assertThat(store.getAllAndLock().size(), is(2));
                             store.releaseAndTryRemoveAll();
                             assertThat(store.getAllAndLock().size(), is(0));
-                            assertThat(
-                                    LongRetrievableStateHandle.getNumberOfGlobalDiscardCalls(),
-                                    is(2));
+                            assertThat(TestingLongStateHandleHelper.getGlobalDiscardCount(), is(2));
                         });
             }
         };
@@ -560,26 +586,27 @@ public class KubernetesStateHandleStoreTest extends KubernetesHighAvailabilityTe
                 runTest(
                         () -> {
                             leaderCallbackGrantLeadership();
-                            LongRetrievableStateHandle.clearNumberOfGlobalDiscardCalls();
 
                             final String anotherKey = "key-not-with-prefix";
                             getLeaderConfigMap().getData().put(anotherKey, "value");
 
-                            final KubernetesStateHandleStore<Long> store =
-                                    new KubernetesStateHandleStore<>(
-                                            flinkKubeClient,
-                                            LEADER_CONFIGMAP_NAME,
-                                            longStateStorage,
-                                            filter,
-                                            LOCK_IDENTITY);
+                            final KubernetesStateHandleStore<
+                                            TestingLongStateHandleHelper.LongStateHandle>
+                                    store =
+                                            new KubernetesStateHandleStore<>(
+                                                    flinkKubeClient,
+                                                    LEADER_CONFIGMAP_NAME,
+                                                    longStateStorage,
+                                                    filter,
+                                                    LOCK_IDENTITY);
                             store.addAndLock(key, state);
-                            store.addAndLock(key + "1", 2L);
+                            store.addAndLock(
+                                    key + "1",
+                                    new TestingLongStateHandleHelper.LongStateHandle(2L));
                             assertThat(store.getAllAndLock().size(), is(2));
                             store.clearEntries();
                             assertThat(store.getAllAndLock().size(), is(0));
-                            assertThat(
-                                    LongRetrievableStateHandle.getNumberOfGlobalDiscardCalls(),
-                                    is(0));
+                            assertThat(TestingLongStateHandleHelper.getGlobalDiscardCount(), is(0));
 
                             // Should only remove the key with specified prefix.
                             assertThat(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1209,20 +1209,7 @@ public class CheckpointCoordinator {
                         completedCheckpoint, checkpointsCleaner, this::scheduleTriggerRequest);
             } catch (Exception exception) {
                 // we failed to store the completed checkpoint. Let's clean up
-                executor.execute(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    completedCheckpoint.discardOnFailedStoring();
-                                } catch (Throwable t) {
-                                    LOG.warn(
-                                            "Could not properly discard completed checkpoint {}.",
-                                            completedCheckpoint.getCheckpointID(),
-                                            t);
-                                }
-                            }
-                        });
+                checkpointsCleaner.cleanCheckpointOnFailedStoring(completedCheckpoint, executor);
 
                 sendAbortedMessages(
                         pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorInfo;
+import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageCoordinatorView;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
@@ -1208,8 +1209,16 @@ public class CheckpointCoordinator {
                 completedCheckpointStore.addCheckpoint(
                         completedCheckpoint, checkpointsCleaner, this::scheduleTriggerRequest);
             } catch (Exception exception) {
-                // we failed to store the completed checkpoint. Let's clean up
-                checkpointsCleaner.cleanCheckpointOnFailedStoring(completedCheckpoint, executor);
+                if (exception instanceof PossibleInconsistentStateException) {
+                    LOG.warn(
+                            "An error occurred while writing checkpoint {} to the underlying metadata store. Flink was not able to determine whether the metadata was successfully persisted. The corresponding state located at '{}' won't be discarded and needs to be cleaned up manually.",
+                            completedCheckpoint.getCheckpointID(),
+                            completedCheckpoint.getExternalPointer());
+                } else {
+                    // we failed to store the completed checkpoint. Let's clean up
+                    checkpointsCleaner.cleanCheckpointOnFailedStoring(
+                            completedCheckpoint, executor);
+                }
 
                 sendAbortedMessages(
                         pendingCheckpoint.getCheckpointPlan().getTasksToCommitTo(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStore.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.persistence.ResourceVersion;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
@@ -212,6 +213,9 @@ public class DefaultCompletedCheckpointStore<R extends ResourceVersion<R>>
      * older ones.
      *
      * @param checkpoint Completed checkpoint to add.
+     * @throws PossibleInconsistentStateException if adding the checkpoint failed and leaving the
+     *     system in an possibly inconsistent state, i.e. it's uncertain whether the checkpoint
+     *     metadata was fully written to the underlying systems or not.
      */
     @Override
     public void addCheckpoint(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/PossibleInconsistentStateException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/PossibleInconsistentStateException.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.persistence;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.FlinkException;
 
 /**
@@ -27,6 +28,11 @@ import org.apache.flink.util.FlinkException;
 public class PossibleInconsistentStateException extends FlinkException {
 
     private static final long serialVersionUID = 364105635349022882L;
+
+    @VisibleForTesting
+    public PossibleInconsistentStateException() {
+        super("The system might be in an inconsistent state.");
+    }
 
     public PossibleInconsistentStateException(String message, Throwable cause) {
         super(message, cause);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/PossibleInconsistentStateException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/PossibleInconsistentStateException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.persistence;
+
+import org.apache.flink.util.FlinkException;
+
+/**
+ * {@code PossibleInconsistentStateException} represents errors that might have lead to an
+ * inconsistent state within the HA resources.
+ */
+public class PossibleInconsistentStateException extends FlinkException {
+
+    private static final long serialVersionUID = 364105635349022882L;
+
+    public PossibleInconsistentStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PossibleInconsistentStateException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/RetrievableStateStorageHelper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/RetrievableStateStorageHelper.java
@@ -19,13 +19,12 @@
 package org.apache.flink.runtime.persistence;
 
 import org.apache.flink.runtime.state.RetrievableStateHandle;
-import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 
 import java.io.Serializable;
 
 /**
- * State storage helper which is used by {@link ZooKeeperStateHandleStore} to persist state before
- * the state handle is written to ZooKeeper.
+ * State storage helper which is used by {@link StateHandleStore} to persist state before the state
+ * handle is written to the underlying system.
  *
  * @param <T> The type of the data that can be stored by this storage helper.
  */
@@ -36,7 +35,7 @@ public interface RetrievableStateStorageHelper<T extends Serializable> {
      *
      * @param state State to be stored
      * @return State handle to the stored state
-     * @throws Exception
+     * @throws Exception if an error occurred while storing the state.
      */
     RetrievableStateHandle<T> store(T state) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/persistence/StateHandleStore.java
@@ -50,9 +50,14 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
      * @param name Key name in ConfigMap or child path name in ZooKeeper
      * @param state State to be added
      * @throws AlreadyExistException if the name already exists
+     * @throws PossibleInconsistentStateException if the write operation failed. This indicates that
+     *     it's not clear whether the new state was successfully written to distributed coordination
+     *     system or not. No state was discarded. Proper error handling has to be applied on the
+     *     caller's side.
      * @throws Exception if persisting state or writing state handle failed
      */
-    RetrievableStateHandle<T> addAndLock(String name, T state) throws Exception;
+    RetrievableStateHandle<T> addAndLock(String name, T state)
+            throws PossibleInconsistentStateException, Exception;
 
     /**
      * Replaces a state handle in the distributed coordination system and discards the old state
@@ -64,9 +69,13 @@ public interface StateHandleStore<T extends Serializable, R extends ResourceVers
      *     operation snuck in.
      * @param state State to be replace with
      * @throws NotExistException if the name does not exist
+     * @throws PossibleInconsistentStateException if a failure occurred during the update operation
+     *     for which it's unclear whether the operation actually succeeded or not. No state was
+     *     discarded. The method's caller should handle this case properly.
      * @throws Exception if persisting state or writing state handle failed
      */
-    void replace(String name, R resourceVersion, T state) throws Exception;
+    void replace(String name, R resourceVersion, T state)
+            throws PossibleInconsistentStateException, Exception;
 
     /**
      * Returns resource version of state handle with specific name on the underlying storage.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/StateHandleStoreUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/StateHandleStoreUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.runtime.persistence.StateHandleStore;
+import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * {@code StateHandleStoreUtils} collects utility methods that might be usefule for any {@link
+ * StateHandleStore} implementation.
+ */
+public class StateHandleStoreUtils {
+
+    /**
+     * Serializes the passed {@link StateObject} and discards the state in case of failure.
+     *
+     * @param stateObject the {@code StateObject} that shall be serialized.
+     * @return The serialized version of the passed {@code StateObject}.
+     * @throws Exception if an error occurred during the serialization. The corresponding {@code
+     *     StateObject} will be discarded in that case.
+     */
+    public static byte[] serializeOrDiscard(StateObject stateObject) throws Exception {
+        try {
+            return InstantiationUtil.serializeObject(stateObject);
+        } catch (Exception e) {
+            try {
+                stateObject.discardState();
+            } catch (Exception discardException) {
+                e.addSuppressed(discardException);
+            }
+
+            ExceptionUtils.rethrowException(e);
+        }
+
+        // will never happen but is added to please the compiler
+        return new byte[0];
+    }
+
+    /**
+     * Deserializes the passed data into a {@link RetrievableStateHandle}.
+     *
+     * @param data The data that shall be deserialized.
+     * @param <T> The type of data handled by the deserialized {@code RetrievableStateHandle}.
+     * @return The {@code RetrievableStateHandle} instance.
+     * @throws IOException Any of the usual Input/Output related exceptions.
+     * @throws ClassNotFoundException If the data couldn't be deserialized into a {@code
+     *     RetrievableStateHandle} referring to the expected type {@code <T>}.
+     */
+    public static <T extends Serializable> T deserialize(byte[] data)
+            throws IOException, ClassNotFoundException {
+        return InstantiationUtil.deserializeObject(
+                data, Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -289,7 +289,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * @return All state handles from ZooKeeper.
      * @throws Exception If a ZooKeeper or state handle operation fails
      */
-    @SuppressWarnings("unchecked")
     @Override
     public List<Tuple2<RetrievableStateHandle<T>, String>> getAllAndLock() throws Exception {
         final List<Tuple2<RetrievableStateHandle<T>, String>> stateHandles = new ArrayList<>();
@@ -493,7 +492,6 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * @throws IOException Thrown if the method failed to deserialize the stored state handle
      * @throws Exception Thrown if a ZooKeeper operation failed
      */
-    @SuppressWarnings("unchecked")
     private RetrievableStateHandle<T> get(String pathInZooKeeper, boolean lock) throws Exception {
         checkNotNull(pathInZooKeeper, "Path in ZooKeeper");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.runtime.zookeeper;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.persistence.IntegerResourceVersion;
+import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator4.org.apache.curator.utils.ZKPaths;
@@ -41,8 +42,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
+import static org.apache.flink.runtime.util.StateHandleStoreUtils.deserialize;
+import static org.apache.flink.runtime.util.StateHandleStoreUtils.serializeOrDiscard;
+import static org.apache.flink.shaded.guava18.com.google.common.collect.Sets.newHashSet;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -81,6 +86,19 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         implements StateHandleStore<T, IntegerResourceVersion> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperStateHandleStore.class);
+
+    @VisibleForTesting
+    static final Set<Class<? extends KeeperException>> PRE_COMMIT_EXCEPTIONS =
+            newHashSet(
+                    KeeperException.NodeExistsException.class,
+                    KeeperException.BadArgumentsException.class,
+                    KeeperException.NoNodeException.class,
+                    KeeperException.NoAuthException.class,
+                    KeeperException.BadVersionException.class,
+                    KeeperException.AuthFailedException.class,
+                    KeeperException.InvalidACLException.class,
+                    KeeperException.SessionMovedException.class,
+                    KeeperException.NotReadOnlyException.class);
 
     /** Curator ZooKeeper client. */
     private final CuratorFramework client;
@@ -126,10 +144,14 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
      * @param pathInZooKeeper Destination path in ZooKeeper (expected to *not* exist yet)
      * @param state State to be added
      * @return The Created {@link RetrievableStateHandle}.
+     * @throws PossibleInconsistentStateException if the write-to-ZooKeeper operation failed. This
+     *     indicates that it's not clear whether the new state was successfully written to ZooKeeper
+     *     or not. Proper error handling has to be applied on the caller's side.
      * @throws Exception If a ZooKeeper or state handle operation fails
      */
     @Override
-    public RetrievableStateHandle<T> addAndLock(String pathInZooKeeper, T state) throws Exception {
+    public RetrievableStateHandle<T> addAndLock(String pathInZooKeeper, T state)
+            throws PossibleInconsistentStateException, Exception {
         checkNotNull(pathInZooKeeper, "Path in ZooKeeper");
         checkNotNull(state, "State");
 
@@ -137,43 +159,49 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
 
         RetrievableStateHandle<T> storeHandle = storage.store(state);
 
-        boolean success = false;
+        byte[] serializedStoreHandle = serializeOrDiscard(storeHandle);
 
         try {
-            // Serialize the state handle. This writes the state to the backend.
-            byte[] serializedStoreHandle = InstantiationUtil.serializeObject(storeHandle);
-
-            // Write state handle (not the actual state) to ZooKeeper. This is expected to be
-            // smaller than the state itself. This level of indirection makes sure that data in
-            // ZooKeeper is small, because ZooKeeper is designed for data in the KB range, but
-            // the state can be larger.
-            // Create the lock node in a transaction with the actual state node. That way we can
-            // prevent
-            // race conditions with a concurrent delete operation.
-            client.inTransaction()
-                    .create()
-                    .withMode(CreateMode.PERSISTENT)
-                    .forPath(path, serializedStoreHandle)
-                    .and()
-                    .create()
-                    .withMode(CreateMode.EPHEMERAL)
-                    .forPath(getLockPath(path))
-                    .and()
-                    .commit();
-
-            success = true;
+            writeStoreHandleTransactionally(path, serializedStoreHandle);
             return storeHandle;
-        } catch (KeeperException.NodeExistsException e) {
-            // We wrap the exception here so that it could be caught in DefaultJobGraphStore
-            throw new AlreadyExistException("ZooKeeper node " + path + " already exists.", e);
-        } finally {
-            if (!success) {
-                // Cleanup the state handle if it was not written to ZooKeeper.
-                if (storeHandle != null) {
-                    storeHandle.discardState();
-                }
+        } catch (Exception e) {
+            if (indicatesPossiblyInconsistentState(e)) {
+                throw new PossibleInconsistentStateException(e);
             }
+
+            // in any other failure case: discard the state
+            storeHandle.discardState();
+
+            // We wrap the exception here so that it could be caught in DefaultJobGraphStore
+            throw ExceptionUtils.findThrowable(e, KeeperException.NodeExistsException.class)
+                    .map(
+                            nee ->
+                                    new AlreadyExistException(
+                                            "ZooKeeper node " + path + " already exists.", nee))
+                    .orElseThrow(() -> e);
         }
+    }
+
+    // this method is provided for the sole purpose of easier testing
+    @VisibleForTesting
+    protected void writeStoreHandleTransactionally(String path, byte[] serializedStoreHandle)
+            throws Exception {
+        // Write state handle (not the actual state) to ZooKeeper. This is expected to be
+        // smaller than the state itself. This level of indirection makes sure that data in
+        // ZooKeeper is small, because ZooKeeper is designed for data in the KB range, but
+        // the state can be larger.
+        // Create the lock node in a transaction with the actual state node. That way we can
+        // prevent race conditions with a concurrent delete operation.
+        client.inTransaction()
+                .create()
+                .withMode(CreateMode.PERSISTENT)
+                .forPath(path, serializedStoreHandle)
+                .and()
+                .create()
+                .withMode(CreateMode.EPHEMERAL)
+                .forPath(getLockPath(path))
+                .and()
+                .commit();
     }
 
     /**
@@ -196,27 +224,53 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
 
         RetrievableStateHandle<T> newStateHandle = storage.store(state);
 
-        boolean success = false;
+        final byte[] serializedStateHandle = serializeOrDiscard(newStateHandle);
 
+        // initialize flags to serve the failure case
+        boolean discardOldState = false;
+        boolean discardNewState = true;
         try {
-            // Serialize the new state handle. This writes the state to the backend.
-            byte[] serializedStateHandle = InstantiationUtil.serializeObject(newStateHandle);
+            setStateHandle(path, serializedStateHandle, expectedVersion.getValue());
 
-            // Replace state handle in ZooKeeper.
-            client.setData()
-                    .withVersion(expectedVersion.getValue())
-                    .forPath(path, serializedStateHandle);
-            success = true;
-        } catch (KeeperException.NoNodeException e) {
+            // swap subject for deletion in case of success
+            discardOldState = true;
+            discardNewState = false;
+        } catch (Exception e) {
+            if (indicatesPossiblyInconsistentState(e)) {
+                // it's unclear whether the state handle metadata was written to ZooKeeper -
+                // hence, we don't discard any data
+                discardNewState = false;
+                throw new PossibleInconsistentStateException(e);
+            }
+
             // We wrap the exception here so that it could be caught in DefaultJobGraphStore
-            throw new NotExistException("ZooKeeper node " + path + " does not exist.", e);
+            throw ExceptionUtils.findThrowable(e, KeeperException.NoNodeException.class)
+                    .map(
+                            nnee ->
+                                    new NotExistException(
+                                            "ZooKeeper node " + path + " does not exist.", nnee))
+                    .orElseThrow(() -> e);
         } finally {
-            if (success) {
+            if (discardOldState) {
                 oldStateHandle.discardState();
-            } else {
+            }
+
+            if (discardNewState) {
                 newStateHandle.discardState();
             }
         }
+    }
+
+    // this method is provided for the sole purpose of easier testing
+    @VisibleForTesting
+    protected void setStateHandle(String path, byte[] serializedStateHandle, int expectedVersion)
+            throws Exception {
+        // Replace state handle in ZooKeeper.
+        client.setData().withVersion(expectedVersion).forPath(path, serializedStateHandle);
+    }
+
+    private boolean indicatesPossiblyInconsistentState(Exception e) {
+        return !PRE_COMMIT_EXCEPTIONS.contains(e.getClass());
     }
 
     /**
@@ -516,9 +570,7 @@ public class ZooKeeperStateHandleStore<T extends Serializable>
         try {
             byte[] data = client.getData().forPath(path);
 
-            RetrievableStateHandle<T> retrievableStateHandle =
-                    InstantiationUtil.deserializeObject(
-                            data, Thread.currentThread().getContextClassLoader());
+            RetrievableStateHandle<T> retrievableStateHandle = deserialize(data);
 
             success = true;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -23,26 +23,35 @@ import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.Che
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.persistence.PossibleInconsistentStateException;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -52,6 +61,8 @@ import static org.mockito.Mockito.when;
 
 /** Tests for failure of checkpoint coordinator. */
 public class CheckpointCoordinatorFailureTest extends TestLogger {
+
+    @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     /**
      * Tests that a failure while storing a completed checkpoint in the completed checkpoint store
@@ -75,7 +86,10 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
         CheckpointCoordinator coord =
                 new CheckpointCoordinatorBuilder()
                         .setExecutionGraph(testGraph)
-                        .setCompletedCheckpointStore(new FailingCompletedCheckpointStore())
+                        .setCompletedCheckpointStore(
+                                new FailingCompletedCheckpointStore(
+                                        new Exception(
+                                                "The failing completed checkpoint store failed again... :-(")))
                         .setTimer(manuallyTriggeredScheduledExecutor)
                         .build();
 
@@ -160,7 +174,85 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
                 .discardState();
     }
 
+    @Test
+    public void testCleanupForGenericFailure() throws Exception {
+        testStoringFailureHandling(new FlinkRuntimeException("Expected exception"), 1);
+    }
+
+    @Test
+    public void testCleanupOmissionForPossibleInconsistentStateException() throws Exception {
+        testStoringFailureHandling(new PossibleInconsistentStateException(), 0);
+    }
+
+    private void testStoringFailureHandling(Exception failure, int expectedCleanupCalls)
+            throws Exception {
+        final JobVertexID jobVertexID1 = new JobVertexID();
+
+        final ExecutionGraph graph =
+                new CheckpointCoordinatorTestingUtils.CheckpointExecutionGraphBuilder()
+                        .addJobVertex(jobVertexID1)
+                        .build();
+
+        final ExecutionVertex vertex = graph.getJobVertex(jobVertexID1).getTaskVertices()[0];
+        final ExecutionAttemptID attemptId = vertex.getCurrentExecutionAttempt().getAttemptId();
+
+        final StandaloneCheckpointIDCounter checkpointIDCounter =
+                new StandaloneCheckpointIDCounter();
+
+        final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
+                new ManuallyTriggeredScheduledExecutor();
+
+        final CompletedCheckpointStore completedCheckpointStore =
+                new FailingCompletedCheckpointStore(failure);
+
+        final AtomicInteger cleanupCallCount = new AtomicInteger(0);
+        final CheckpointCoordinator checkpointCoordinator =
+                new CheckpointCoordinatorBuilder()
+                        .setExecutionGraph(graph)
+                        .setCheckpointIDCounter(checkpointIDCounter)
+                        .setCheckpointsCleaner(
+                                new CheckpointsCleaner() {
+
+                                    private static final long serialVersionUID =
+                                            2029876992397573325L;
+
+                                    @Override
+                                    public void cleanCheckpointOnFailedStoring(
+                                            CompletedCheckpoint completedCheckpoint,
+                                            Executor executor) {
+                                        cleanupCallCount.incrementAndGet();
+                                        super.cleanCheckpointOnFailedStoring(
+                                                completedCheckpoint, executor);
+                                    }
+                                })
+                        .setCompletedCheckpointStore(completedCheckpointStore)
+                        .setTimer(manuallyTriggeredScheduledExecutor)
+                        .build();
+        checkpointCoordinator.triggerSavepoint(tmpFolder.newFolder().getAbsolutePath());
+        manuallyTriggeredScheduledExecutor.triggerAll();
+
+        try {
+            checkpointCoordinator.receiveAcknowledgeMessage(
+                    new AcknowledgeCheckpoint(
+                            graph.getJobID(), attemptId, checkpointIDCounter.getLast()),
+                    "unknown location");
+            fail("CheckpointException should have been thrown.");
+        } catch (CheckpointException e) {
+            assertThat(
+                    e.getCheckpointFailureReason(),
+                    is(CheckpointFailureReason.FINALIZE_CHECKPOINT_FAILURE));
+        }
+
+        assertThat(cleanupCallCount.get(), is(expectedCleanupCalls));
+    }
+
     private static final class FailingCompletedCheckpointStore implements CompletedCheckpointStore {
+
+        private final Exception addCheckpointFailure;
+
+        public FailingCompletedCheckpointStore(Exception addCheckpointFailure) {
+            this.addCheckpointFailure = addCheckpointFailure;
+        }
 
         @Override
         public void recover() throws Exception {
@@ -173,7 +265,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
                 CheckpointsCleaner checkpointsCleaner,
                 Runnable postCleanup)
                 throws Exception {
-            throw new Exception("The failing completed checkpoint store failed again... :-(");
+            throw addCheckpointFailure;
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -695,6 +695,12 @@ public class CheckpointCoordinatorTestingUtils {
             return this;
         }
 
+        public CheckpointCoordinatorBuilder setCheckpointsCleaner(
+                CheckpointsCleaner checkpointsCleaner) {
+            this.checkpointsCleaner = checkpointsCleaner;
+            return this;
+        }
+
         public CheckpointCoordinatorBuilder setCheckpointIDCounter(
                 CheckpointIDCounter checkpointIDCounter) {
             this.checkpointIDCounter = checkpointIDCounter;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingLongStateHandleHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/persistence/TestingLongStateHandleHelper.java
@@ -19,72 +19,122 @@
 package org.apache.flink.runtime.persistence;
 
 import org.apache.flink.runtime.state.RetrievableStateHandle;
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.AbstractID;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.StringJoiner;
 
 /**
  * Testing implementation for {@link RetrievableStateStorageHelper} and {@link
  * RetrievableStateHandle} with type {@link Long}.
  */
-public class TestingLongStateHandleHelper implements RetrievableStateStorageHelper<Long> {
+public class TestingLongStateHandleHelper
+        implements RetrievableStateStorageHelper<TestingLongStateHandleHelper.LongStateHandle> {
 
-    private final List<LongRetrievableStateHandle> stateHandles = new ArrayList<>();
+    private static final List<LongStateHandle> STATE_STORAGE = new ArrayList<>();
 
     @Override
-    public RetrievableStateHandle<Long> store(Long state) {
-        final LongRetrievableStateHandle stateHandle = new LongRetrievableStateHandle(state);
-        stateHandles.add(stateHandle);
+    public RetrievableStateHandle<LongStateHandle> store(LongStateHandle state) {
+        final int pos = STATE_STORAGE.size();
+        STATE_STORAGE.add(state);
 
-        return stateHandle;
+        return new LongRetrievableStateHandle(pos);
     }
 
-    public List<LongRetrievableStateHandle> getStateHandles() {
-        return stateHandles;
+    public static LongStateHandle createState(long value) {
+        return new LongStateHandle(value);
     }
 
-    /** Testing {@link RetrievableStateStorageHelper} implementation with {@link Long}. */
-    public static class LongRetrievableStateHandle implements RetrievableStateHandle<Long> {
+    public static long getStateHandleValueByIndex(int index) {
+        return STATE_STORAGE.get(index).getValue();
+    }
 
-        private static final long serialVersionUID = -3555329254423838912L;
+    public static int getDiscardCallCountForStateHandleByIndex(int index) {
+        return STATE_STORAGE.get(index).getNumberOfDiscardCalls();
+    }
 
-        private static AtomicInteger numberOfGlobalDiscardCalls = new AtomicInteger(0);
+    public static int getGlobalStorageSize() {
+        return STATE_STORAGE.size();
+    }
 
-        private final Long state;
+    public static void clearGlobalState() {
+        STATE_STORAGE.clear();
+    }
+
+    public static int getGlobalDiscardCount() {
+        return STATE_STORAGE.stream().mapToInt(LongStateHandle::getNumberOfDiscardCalls).sum();
+    }
+
+    /**
+     * {@code LongStateHandle} implements {@link StateObject} to monitor the {@link
+     * StateObject#discardState()} calls.
+     */
+    public static class LongStateHandle implements StateObject {
+
+        private static final long serialVersionUID = -5752042587113549855L;
+
+        private final Long value;
 
         private int numberOfDiscardCalls = 0;
 
-        public LongRetrievableStateHandle(Long state) {
-            this.state = state;
+        public LongStateHandle(long value) {
+            this.value = value;
         }
 
-        @Override
-        public Long retrieveState() {
-            return state;
+        public long getValue() {
+            return value;
         }
 
         @Override
         public void discardState() {
-            numberOfGlobalDiscardCalls.incrementAndGet();
             numberOfDiscardCalls++;
-        }
-
-        @Override
-        public long getStateSize() {
-            return 0;
         }
 
         public int getNumberOfDiscardCalls() {
             return numberOfDiscardCalls;
         }
 
-        public static int getNumberOfGlobalDiscardCalls() {
-            return numberOfGlobalDiscardCalls.get();
+        @Override
+        public long getStateSize() {
+            return 8L;
         }
 
-        public static void clearNumberOfGlobalDiscardCalls() {
-            numberOfGlobalDiscardCalls.set(0);
+        @Override
+        public String toString() {
+            return new StringJoiner(", ", LongStateHandle.class.getSimpleName() + "[", "]")
+                    .add("value=" + value)
+                    .add("numberOfDiscardCalls=" + numberOfDiscardCalls)
+                    .toString();
+        }
+    }
+
+    /** Testing {@link RetrievableStateStorageHelper} implementation with {@link Long}. */
+    public static class LongRetrievableStateHandle
+            implements RetrievableStateHandle<LongStateHandle> {
+
+        private static final long serialVersionUID = -3555329254423838912L;
+
+        private final int stateReference;
+
+        public LongRetrievableStateHandle(int stateReference) {
+            this.stateReference = stateReference;
+        }
+
+        @Override
+        public LongStateHandle retrieveState() {
+            return STATE_STORAGE.get(stateReference);
+        }
+
+        @Override
+        public void discardState() {
+            STATE_STORAGE.get(stateReference).discardState();
+        }
+
+        @Override
+        public long getStateSize() {
+            return AbstractID.SIZE;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/StateHandleStoreUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/StateHandleStoreUtilsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper;
+import org.apache.flink.runtime.state.StateObject;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.RunnableWithException;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * {@code StateHandleStoreUtilsTest} tests the utility classes collected in {@link
+ * StateHandleStoreUtils}.
+ */
+public class StateHandleStoreUtilsTest extends TestLogger {
+
+    @Test
+    public void testSerializationAndDeserialization() throws Exception {
+        final TestingLongStateHandleHelper.LongStateHandle original =
+                new TestingLongStateHandleHelper.LongStateHandle(42L);
+        byte[] serializedData = StateHandleStoreUtils.serializeOrDiscard(original);
+
+        final TestingLongStateHandleHelper.LongStateHandle deserializedInstance =
+                StateHandleStoreUtils.deserialize(serializedData);
+        assertThat(deserializedInstance.getStateSize(), is(original.getStateSize()));
+        assertThat(deserializedInstance.getValue(), is(original.getValue()));
+    }
+
+    @Test
+    public void testSerializeOrDiscardFailureHandling() throws Exception {
+        final AtomicBoolean discardCalled = new AtomicBoolean(false);
+        final StateObject original =
+                new FailingSerializationStateObject(() -> discardCalled.set(true));
+
+        try {
+            StateHandleStoreUtils.serializeOrDiscard(original);
+            fail("An IOException is expected to be thrown.");
+        } catch (IOException e) {
+            // IOException is expected
+        }
+
+        assertThat(discardCalled.get(), is(true));
+    }
+
+    @Test
+    public void testSerializationOrDiscardWithDiscardFailure() throws Exception {
+        final Exception discardException =
+                new IllegalStateException(
+                        "Expected IllegalStateException that should be suppressed.");
+        final StateObject original =
+                new FailingSerializationStateObject(
+                        () -> {
+                            throw discardException;
+                        });
+
+        try {
+            StateHandleStoreUtils.serializeOrDiscard(original);
+            fail("An IOException is expected to be thrown.");
+        } catch (IOException e) {
+            // IOException is expected
+            assertThat(e.getSuppressed().length, is(1));
+            assertThat(e.getSuppressed()[0], is(discardException));
+        }
+    }
+
+    private static class FailingSerializationStateObject implements StateObject {
+
+        private static final long serialVersionUID = 6382458109061973983L;
+        private final RunnableWithException discardStateRunnable;
+
+        public FailingSerializationStateObject(RunnableWithException discardStateRunnable) {
+            this.discardStateRunnable = discardStateRunnable;
+        }
+
+        private void writeObject(ObjectOutputStream outputStream) throws IOException {
+            throw new IOException("Expected IOException to test serialization error.");
+        }
+
+        @Override
+        public void discardState() throws Exception {
+            discardStateRunnable.run();
+        }
+
+        @Override
+        public long getStateSize() {
+            return 0;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.persistence.IntegerResourceVersion;
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper;
-import org.apache.flink.runtime.persistence.TestingLongStateHandleHelper.LongRetrievableStateHandle;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.InstantiationUtil;
@@ -82,26 +81,27 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     @Before
     public void cleanUp() throws Exception {
         ZOOKEEPER.deleteAll();
+        TestingLongStateHandleHelper.clearGlobalState();
     }
 
     /** Tests add operation with lock. */
     @Test
     public void testAddAndLock() throws Exception {
         final TestingLongStateHandleHelper longStateStorage = new TestingLongStateHandleHelper();
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
         // Config
         final String pathInZooKeeper = "/testAdd";
-        final Long state = 1239712317L;
+        final long state = 1239712317L;
 
         // Test
-        store.addAndLock(pathInZooKeeper, state);
+        store.addAndLock(pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(state));
 
         // Verify
         // State handle created
         assertEquals(1, store.getAllAndLock().size());
-        assertEquals(state, store.getAndLock(pathInZooKeeper).retrieveState());
+        assertEquals(state, store.getAndLock(pathInZooKeeper).retrieveState().getValue());
 
         // Path created and is persistent
         Stat stat = ZOOKEEPER.getClient().checkExists().forPath(pathInZooKeeper);
@@ -121,12 +121,13 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         // Data is equal
         @SuppressWarnings("unchecked")
-        Long actual =
-                ((RetrievableStateHandle<Long>)
+        final long actual =
+                ((RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>)
                                 InstantiationUtil.deserializeObject(
                                         ZOOKEEPER.getClient().getData().forPath(pathInZooKeeper),
                                         ClassLoader.getSystemClassLoader()))
-                        .retrieveState();
+                        .retrieveState()
+                        .getValue();
 
         assertEquals(state, actual);
     }
@@ -136,23 +137,25 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testAddAlreadyExistingPath() throws Exception {
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         ZOOKEEPER.getClient().create().forPath("/testAddAlreadyExistingPath");
 
-        store.addAndLock("/testAddAlreadyExistingPath", 1L);
+        store.addAndLock(
+                "/testAddAlreadyExistingPath",
+                new TestingLongStateHandleHelper.LongStateHandle(1L));
 
         // writing to the state storage should have succeeded
-        assertEquals(1, stateHandleProvider.getStateHandles());
+        assertEquals(1, TestingLongStateHandleHelper.getGlobalStorageSize());
 
         // the created state handle should have been cleaned up if the add operation failed
-        assertEquals(1, stateHandleProvider.getStateHandles().get(0).getNumberOfDiscardCalls());
+        assertEquals(1, TestingLongStateHandleHelper.getDiscardCallCountForStateHandleByIndex(0));
     }
 
     /** Tests that the created state handle is discarded if ZooKeeper create fails. */
     @Test
-    public void testAddDiscardStateHandleAfterFailure() throws Exception {
+    public void testAddDiscardStateHandleAfterFailure() {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
@@ -160,25 +163,26 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         when(client.inTransaction().create())
                 .thenThrow(new RuntimeException("Expected test Exception."));
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(client, stateHandleProvider);
 
         // Config
         final String pathInZooKeeper = "/testAddDiscardStateHandleAfterFailure";
-        final Long state = 81282227L;
+        final long state = 81282227L;
 
         try {
             // Test
-            store.addAndLock(pathInZooKeeper, state);
+            store.addAndLock(
+                    pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(state));
             fail("Did not throw expected exception");
         } catch (Exception ignored) {
         }
 
         // Verify
         // State handle created and discarded
-        assertEquals(1, stateHandleProvider.getStateHandles().size());
-        assertEquals(state, stateHandleProvider.getStateHandles().get(0).retrieveState());
-        assertEquals(1, stateHandleProvider.getStateHandles().get(0).getNumberOfDiscardCalls());
+        assertEquals(1, TestingLongStateHandleHelper.getGlobalStorageSize());
+        assertEquals(state, TestingLongStateHandleHelper.getStateHandleValueByIndex(0));
+        assertEquals(1, TestingLongStateHandleHelper.getDiscardCallCountForStateHandleByIndex(0));
     }
 
     /** Tests that a state handle is replaced. */
@@ -187,23 +191,27 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         // Config
         final String pathInZooKeeper = "/testReplace";
-        final Long initialState = 30968470898L;
-        final Long replaceState = 88383776661L;
+        final long initialState = 30968470898L;
+        final long replaceState = 88383776661L;
 
         // Test
-        store.addAndLock(pathInZooKeeper, initialState);
-        store.replace(pathInZooKeeper, IntegerResourceVersion.valueOf(0), replaceState);
+        store.addAndLock(
+                pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(initialState));
+        store.replace(
+                pathInZooKeeper,
+                IntegerResourceVersion.valueOf(0),
+                new TestingLongStateHandleHelper.LongStateHandle(replaceState));
 
         // Verify
         // State handles created
-        assertEquals(2, stateHandleProvider.getStateHandles().size());
-        assertEquals(initialState, stateHandleProvider.getStateHandles().get(0).retrieveState());
-        assertEquals(replaceState, stateHandleProvider.getStateHandles().get(1).retrieveState());
+        assertEquals(2, TestingLongStateHandleHelper.getGlobalStorageSize());
+        assertEquals(initialState, TestingLongStateHandleHelper.getStateHandleValueByIndex(0));
+        assertEquals(replaceState, TestingLongStateHandleHelper.getStateHandleValueByIndex(1));
 
         // Path created and is persistent
         Stat stat = ZOOKEEPER.getClient().checkExists().forPath(pathInZooKeeper);
@@ -212,12 +220,13 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         // Data is equal
         @SuppressWarnings("unchecked")
-        Long actual =
-                ((RetrievableStateHandle<Long>)
+        final long actual =
+                ((RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>)
                                 InstantiationUtil.deserializeObject(
                                         ZOOKEEPER.getClient().getData().forPath(pathInZooKeeper),
                                         ClassLoader.getSystemClassLoader()))
-                        .retrieveState();
+                        .retrieveState()
+                        .getValue();
 
         assertEquals(replaceState, actual);
     }
@@ -225,12 +234,16 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     /** Tests that a non existing path throws an Exception. */
     @Test(expected = Exception.class)
     public void testReplaceNonExistingPath() throws Exception {
-        final RetrievableStateStorageHelper<Long> stateStorage = new TestingLongStateHandleHelper();
+        final RetrievableStateStorageHelper<TestingLongStateHandleHelper.LongStateHandle>
+                stateStorage = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateStorage);
 
-        store.replace("/testReplaceNonExistingPath", IntegerResourceVersion.valueOf(0), 1L);
+        store.replace(
+                "/testReplaceNonExistingPath",
+                IntegerResourceVersion.valueOf(0),
+                new TestingLongStateHandleHelper.LongStateHandle(1L));
     }
 
     /** Tests that the replace state handle is discarded if ZooKeeper setData fails. */
@@ -242,38 +255,43 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         CuratorFramework client = spy(ZOOKEEPER.getClient());
         when(client.setData()).thenThrow(new RuntimeException("Expected test Exception."));
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(client, stateHandleProvider);
 
         // Config
         final String pathInZooKeeper = "/testReplaceDiscardStateHandleAfterFailure";
-        final Long initialState = 30968470898L;
-        final Long replaceState = 88383776661L;
+        final long initialState = 30968470898L;
+        final long replaceState = 88383776661L;
 
         // Test
-        store.addAndLock(pathInZooKeeper, initialState);
+        store.addAndLock(
+                pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(initialState));
 
         try {
-            store.replace(pathInZooKeeper, IntegerResourceVersion.valueOf(0), replaceState);
+            store.replace(
+                    pathInZooKeeper,
+                    IntegerResourceVersion.valueOf(0),
+                    new TestingLongStateHandleHelper.LongStateHandle(replaceState));
             fail("Did not throw expected exception");
         } catch (Exception ignored) {
         }
 
         // Verify
         // State handle created and discarded
-        assertEquals(2, stateHandleProvider.getStateHandles().size());
-        assertEquals(initialState, stateHandleProvider.getStateHandles().get(0).retrieveState());
-        assertEquals(replaceState, stateHandleProvider.getStateHandles().get(1).retrieveState());
-        assertEquals(1, stateHandleProvider.getStateHandles().get(1).getNumberOfDiscardCalls());
+        assertEquals(2, TestingLongStateHandleHelper.getGlobalStorageSize());
+        assertEquals(initialState, TestingLongStateHandleHelper.getStateHandleValueByIndex(0));
+        assertEquals(replaceState, TestingLongStateHandleHelper.getStateHandleValueByIndex(1));
+        assertEquals(1, TestingLongStateHandleHelper.getDiscardCallCountForStateHandleByIndex(1));
 
         // Initial value
         @SuppressWarnings("unchecked")
-        Long actual =
-                ((RetrievableStateHandle<Long>)
+        final long actual =
+                ((RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>)
                                 InstantiationUtil.deserializeObject(
                                         ZOOKEEPER.getClient().getData().forPath(pathInZooKeeper),
                                         ClassLoader.getSystemClassLoader()))
-                        .retrieveState();
+                        .retrieveState()
+                        .getValue();
 
         assertEquals(initialState, actual);
     }
@@ -284,21 +302,22 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         // Config
         final String pathInZooKeeper = "/testGetAndExists";
-        final Long state = 311222268470898L;
+        final long state = 311222268470898L;
 
         // Test
         assertThat(store.exists(pathInZooKeeper).isExisting(), is(false));
 
-        store.addAndLock(pathInZooKeeper, state);
-        RetrievableStateHandle<Long> actual = store.getAndLock(pathInZooKeeper);
+        store.addAndLock(pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(state));
+        RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle> actual =
+                store.getAndLock(pathInZooKeeper);
 
         // Verify
-        assertEquals(state, actual.retrieveState());
+        assertEquals(state, actual.retrieveState().getValue());
         assertTrue(store.exists(pathInZooKeeper).getValue() >= 0);
     }
 
@@ -307,7 +326,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testGetNonExistingPath() throws Exception {
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         store.getAndLock("/testGetNonExistingPath");
@@ -319,7 +338,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         // Config
@@ -333,11 +352,13 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         // Test
         for (long val : expected) {
-            store.addAndLock(pathInZooKeeper + val, val);
+            store.addAndLock(
+                    pathInZooKeeper + val, new TestingLongStateHandleHelper.LongStateHandle(val));
         }
 
-        for (Tuple2<RetrievableStateHandle<Long>, String> val : store.getAllAndLock()) {
-            assertTrue(expected.remove(val.f0.retrieveState()));
+        for (Tuple2<RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>, String>
+                val : store.getAllAndLock()) {
+            assertTrue(expected.remove(val.f0.retrieveState().getValue()));
         }
         assertEquals(0, expected.size());
     }
@@ -348,7 +369,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         // Config
@@ -359,10 +380,12 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Test
         for (long val : expected) {
             final String pathInZooKeeper = String.format("%s%016d", basePath, val);
-            store.addAndLock(pathInZooKeeper, val);
+            store.addAndLock(
+                    pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(val));
         }
 
-        List<Tuple2<RetrievableStateHandle<Long>, String>> actual = store.getAllAndLock();
+        List<Tuple2<RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>, String>>
+                actual = store.getAllAndLock();
         assertEquals(expected.length, actual.size());
 
         // bring the elements in sort order
@@ -370,7 +393,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         Collections.sort(actual, Comparator.comparing(o -> o.f1));
 
         for (int i = 0; i < expected.length; i++) {
-            assertEquals(expected[i], actual.get(i).f0.retrieveState());
+            assertEquals(expected[i], (Long) actual.get(i).f0.retrieveState().getValue());
         }
     }
 
@@ -380,17 +403,16 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         // Config
         final String pathInZooKeeper = "/testRemove";
-        final Long state = 27255442L;
 
-        store.addAndLock(pathInZooKeeper, state);
+        store.addAndLock(
+                pathInZooKeeper, new TestingLongStateHandleHelper.LongStateHandle(27255442L));
 
-        final int numberOfGlobalDiscardCalls =
-                LongRetrievableStateHandle.getNumberOfGlobalDiscardCalls();
+        final int numberOfGlobalDiscardCalls = TestingLongStateHandleHelper.getGlobalDiscardCount();
 
         // Test
         store.releaseAndTryRemove(pathInZooKeeper);
@@ -399,7 +421,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         assertEquals(0, ZOOKEEPER.getClient().getChildren().forPath("/").size());
         assertEquals(
                 numberOfGlobalDiscardCalls + 1,
-                LongRetrievableStateHandle.getNumberOfGlobalDiscardCalls());
+                TestingLongStateHandleHelper.getGlobalDiscardCount());
     }
 
     /** Tests that all state handles are correctly discarded. */
@@ -408,7 +430,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         // Setup
         final TestingLongStateHandleHelper stateHandleProvider = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateHandleProvider);
 
         // Config
@@ -422,7 +444,8 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
         // Test
         for (long val : expected) {
-            store.addAndLock(pathInZooKeeper + val, val);
+            store.addAndLock(
+                    pathInZooKeeper + val, new TestingLongStateHandleHelper.LongStateHandle(val));
         }
 
         store.releaseAndTryRemoveAll();
@@ -439,7 +462,7 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testCorruptedData() throws Exception {
         final TestingLongStateHandleHelper stateStorage = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> store =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> store =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), stateStorage);
 
         final Collection<Long> input = new HashSet<>();
@@ -448,21 +471,23 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         input.add(3L);
 
         for (Long aLong : input) {
-            store.addAndLock("/" + aLong, aLong);
+            store.addAndLock("/" + aLong, new TestingLongStateHandleHelper.LongStateHandle(aLong));
         }
 
         // corrupt one of the entries
         ZOOKEEPER.getClient().setData().forPath("/" + 2, new byte[2]);
 
-        List<Tuple2<RetrievableStateHandle<Long>, String>> allEntries = store.getAllAndLock();
+        List<Tuple2<RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>, String>>
+                allEntries = store.getAllAndLock();
 
         Collection<Long> expected = new HashSet<>(input);
         expected.remove(2L);
 
         Collection<Long> actual = new HashSet<>(expected.size());
 
-        for (Tuple2<RetrievableStateHandle<Long>, String> entry : allEntries) {
-            actual.add(entry.f0.retrieveState());
+        for (Tuple2<RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle>, String>
+                entry : allEntries) {
+            actual.add(entry.f0.retrieveState().getValue());
         }
 
         assertEquals(expected, actual);
@@ -478,23 +503,24 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testConcurrentDeleteOperation() throws Exception {
         final TestingLongStateHandleHelper longStateStorage = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> zkStore1 =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore1 =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
-        ZooKeeperStateHandleStore<Long> zkStore2 =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore2 =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
         final String statePath = "/state";
 
-        zkStore1.addAndLock(statePath, 42L);
-        RetrievableStateHandle<Long> stateHandle = zkStore2.getAndLock(statePath);
+        zkStore1.addAndLock(statePath, new TestingLongStateHandleHelper.LongStateHandle(42L));
+        RetrievableStateHandle<TestingLongStateHandleHelper.LongStateHandle> stateHandle =
+                zkStore2.getAndLock(statePath);
 
         // this should not remove the referenced node because we are still holding a state handle
         // reference via zkStore2
         zkStore1.releaseAndTryRemove(statePath);
 
         // sanity check
-        assertEquals(42L, (long) stateHandle.retrieveState());
+        assertEquals(42L, stateHandle.retrieveState().getValue());
 
         Stat nodeStat = ZOOKEEPER.getClient().checkExists().forPath(statePath);
 
@@ -521,15 +547,15 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testLockCleanupWhenGetAndLockFails() throws Exception {
         final TestingLongStateHandleHelper longStateStorage = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> zkStore1 =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore1 =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
-        ZooKeeperStateHandleStore<Long> zkStore2 =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore2 =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
         final String path = "/state";
 
-        zkStore1.addAndLock(path, 42L);
+        zkStore1.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(42L));
 
         final byte[] corruptedData = {1, 2};
 
@@ -581,12 +607,12 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
         try (CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
                 CuratorFramework client2 = ZooKeeperUtils.startCuratorFramework(configuration)) {
 
-            ZooKeeperStateHandleStore<Long> zkStore =
+            ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
                     new ZooKeeperStateHandleStore<>(client, longStateStorage);
 
             final String path = "/state";
 
-            zkStore.addAndLock(path, 42L);
+            zkStore.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(42L));
 
             // this should delete all ephemeral nodes
             client.close();
@@ -612,12 +638,12 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testRelease() throws Exception {
         final TestingLongStateHandleHelper longStateStorage = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> zkStore =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
         final String path = "/state";
 
-        zkStore.addAndLock(path, 42L);
+        zkStore.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(42L));
 
         final String lockPath = zkStore.getLockPath(path);
 
@@ -648,13 +674,13 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
     public void testReleaseAll() throws Exception {
         final TestingLongStateHandleHelper longStateStorage = new TestingLongStateHandleHelper();
 
-        ZooKeeperStateHandleStore<Long> zkStore =
+        ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
                 new ZooKeeperStateHandleStore<>(ZOOKEEPER.getClient(), longStateStorage);
 
         final Collection<String> paths = Arrays.asList("/state1", "/state2", "/state3");
 
         for (String path : paths) {
-            zkStore.addAndLock(path, 42L);
+            zkStore.addAndLock(path, new TestingLongStateHandleHelper.LongStateHandle(42L));
         }
 
         for (String path : paths) {
@@ -680,12 +706,12 @@ public class ZooKeeperStateHandleStoreTest extends TestLogger {
 
     @Test
     public void testRemoveAllHandlesShouldRemoveAllPaths() throws Exception {
-        final ZooKeeperStateHandleStore<Long> zkStore =
+        final ZooKeeperStateHandleStore<TestingLongStateHandleHelper.LongStateHandle> zkStore =
                 new ZooKeeperStateHandleStore<>(
                         ZooKeeperUtils.useNamespaceAndEnsurePath(ZOOKEEPER.getClient(), "/path"),
                         new TestingLongStateHandleHelper());
 
-        zkStore.addAndLock("/state", 1L);
+        zkStore.addAndLock("/state", new TestingLongStateHandleHelper.LongStateHandle(1L));
         zkStore.clearEntries();
 
         assertThat(zkStore.getAllHandles(), is(empty()));


### PR DESCRIPTION
## What is the purpose of the change

Updating the Checkpoint Metadata store of ZooKeeper and Kubernetes might lead into situations where the data was actually written but the request still failed (due to network issue for instance). In these cases, we end up in an inconsistent state where a reference exists in ZooKeeper or the k8s ConfigMap but the corresponding Checkpoint's state is discarded due to the failure. That might cause problems during recovery.

I rejected the idea of doing the cleanup entirely in the `CheckpointCoordinator` since we also use the `StateHandleStore` implementations in the `DefaultJobGraphStore`.

## Brief change log

* Introduces `PossibleInconsistentStateException`
* `Fabric8FlinkKubeClient` translates network issues into `PossibleInconsistentStateException`
* `StateHandleStore` and its implementing classes handle and forward `PossibleInconsistentStateException`
* Extends `TestingLongStateHandleHelper` to work with reference instead of saving the state in the handle itself. The previous implementation caused problems when deserializing the StateHandles not referencing the actual data but providing a copy of the state.
* `CheckpointCoordinator` handles `PossibleInconsistentStateException`

## Verifying this change

The following tests were extended:
* `CheckpointCoordinatorFailureTest` checks the failure handling for `PossibleInconsistentStateException` and another exception
* `KubernetesStateHandleStoreTest` and `ZooKeeperStateHandleStoreTest` were extended to cover the relevant exceptions
* `Fabric8FlinkKubeClientTest` was extended to cover both failure cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
