### PR TITLE
[FLINK-19164][release] Use versions-maven-plugin to properly update versions

### DIFF
--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -23,11 +23,6 @@
 RELEASE_CANDIDATE=${RELEASE_CANDIDATE:-none}
 MVN=${MVN:-mvn}
 
-if [ -z "${OLD_VERSION}" ]; then
-    echo "OLD_VERSION was not set."
-    exit 1
-fi
-
 if [ -z "${NEW_VERSION}" ]; then
     echo "NEW_VERSION was not set."
     exit 1
@@ -57,7 +52,8 @@ fi
 git checkout -b $target_branch
 
 #change version in all pom files
-find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>(.*)'$OLD_VERSION'(.*)</version>#<version>${1}'$NEW_VERSION'${2}</version>#' {} \;
+#-DprocessAllModules is required for force-shading to be picked up
+$MVN org.codehaus.mojo:versions-maven-plugin:2.8.1:set -DnewVersion=$NEW_VERSION -DprocessAllModules -DgenerateBackupPoms=false --quiet
 
 pushd tools
 ./releasing/update_japicmp_configuration.sh

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -22,11 +22,6 @@
 ##
 MVN=${MVN:-mvn}
 
-if [ -z "${OLD_VERSION}" ]; then
-    echo "OLD_VERSION was not set."
-    exit 1
-fi
-
 if [ -z "${NEW_VERSION}" ]; then
     echo "NEW_VERSION was not set."
     exit 1
@@ -49,7 +44,9 @@ fi
 cd ..
 
 #change version in all pom files
-find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>(.*)'$OLD_VERSION'(.*)</version>#<version>${1}'$NEW_VERSION'${2}</version>#' {} \;
+#-DprocessAllModules is required for force-shading to be picked up
+$MVN org.codehaus.mojo:versions-maven-plugin:2.8.1:set -DnewVersion=$NEW_VERSION -DprocessAllModules -DgenerateBackupPoms=false --quiet
+
 
 #change version of documentation
 cd docs


### PR DESCRIPTION
## What is the purpose of the change

"update_branch_version" & "create_release_branch" scripts used for releasing unintentionally break other dependency versions if the Flink version exactly matches the dependency version. 

This PR uses "versions-maven-plugin" to properly update **only** the version of the project.

## Brief change log

  - *Use versions-maven-plugin to properly update versions*

## Verifying this change

This change is a trivial fix for the release scripts without any test coverage.

How to run the scripts (optional OLD_VERSION -> default value = current version):
OLD_VERSION=1.14-SNAPSHOT NEW_VERSION=1.14 ./releasing/update_branch_version.sh
OLD_VERSION=1.14-SNAPSHOT NEW_VERSION=1.14 ./releasing/create_release_branch.sh

How to see the change actually works:
Assuming being checked out on the current master branch, try changing "maven-dependency-analyzer" version from 1.11.1 to 1.14-SNAPSHOT (same as the project version) just for testing and see running the old script changes/breaks it (which happened with our fork for 1.11.1 release as described in the issue) whereas the new script won't touch it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
