### PR TITLE
[FLINK-22557][build] Run japicmp against 1.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<japicmp.referenceVersion>1.12.3</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.12.2</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.4.2</spotless.version>
 	</properties>


### PR DESCRIPTION
1.12.3 is broken because Scala 2.12 artifacts are actually 2.11 artifacts. We now verify again against 1.12.2, and will later jump straight to 1.12.4 once it was released.
This does bear the risk that 1.12.4 may break APIs introduced in 1.12.3; ideally we make sure this doesn't happen by not touching any API.