### PR TITLE
[FLINK-19647][Connectors/HBase]Support the limit push down for the hb…

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/HBase1DynamicTableFactory.java
@@ -83,7 +83,8 @@ public class HBase1DynamicTableFactory
                 tableName,
                 hbaseSchema,
                 nullStringLiteral,
-                getHBaseLookupOptions(tableOptions));
+                getHBaseLookupOptions(tableOptions),
+                null);
     }
 
     @Override

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/AbstractTableInputFormat.java
@@ -147,7 +147,7 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
     }
 
     public T nextRecord(T reuse) throws IOException {
-        if (limit != null && limit >= scannedRows) {
+        if (limit != null && limit <= scannedRows) {
             endReached = true;
             return null;
         }

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseDynamicTableSource.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseDynamicTableSource.java
@@ -29,6 +29,8 @@ import org.apache.flink.table.data.RowData;
 
 import org.apache.hadoop.conf.Configuration;
 
+import javax.annotation.Nullable;
+
 /** HBase table source implementation. */
 @Internal
 public class HBaseDynamicTableSource extends AbstractHBaseDynamicTableSource {
@@ -38,19 +40,20 @@ public class HBaseDynamicTableSource extends AbstractHBaseDynamicTableSource {
             String tableName,
             HBaseTableSchema hbaseSchema,
             String nullStringLiteral,
-            HBaseLookupOptions lookupOptions) {
-        super(conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions);
+            HBaseLookupOptions lookupOptions,
+            @Nullable Long limit) {
+        super(conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions, limit);
     }
 
     @Override
     public DynamicTableSource copy() {
         return new HBaseDynamicTableSource(
-                conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions);
+                conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions, limit);
     }
 
     @Override
     public InputFormat<RowData, ?> getInputFormat() {
-        return new HBaseRowDataInputFormat(conf, tableName, hbaseSchema, nullStringLiteral);
+        return new HBaseRowDataInputFormat(conf, tableName, hbaseSchema, nullStringLiteral, limit);
     }
 
     @VisibleForTesting

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseInputFormat.java
@@ -39,7 +39,7 @@ public abstract class HBaseInputFormat<T extends Tuple> extends AbstractTableInp
      *     zookeeper.znode.parent need to be set.
      */
     public HBaseInputFormat(org.apache.hadoop.conf.Configuration hConf) {
-        super(hConf);
+        super(hConf, null);
     }
 
     /**

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseRowDataInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseRowDataInputFormat.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -52,8 +54,9 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
             org.apache.hadoop.conf.Configuration conf,
             String tableName,
             HBaseTableSchema schema,
-            String nullStringLiteral) {
-        super(conf);
+            String nullStringLiteral,
+            @Nullable Long limit) {
+        super(conf, limit);
         this.tableName = tableName;
         this.schema = schema;
         this.nullStringLiteral = nullStringLiteral;

--- a/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseRowInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/main/java/org/apache/flink/connector/hbase1/source/HBaseRowInputFormat.java
@@ -56,7 +56,8 @@ public class HBaseRowInputFormat extends AbstractTableInputFormat<Row>
 
     public HBaseRowInputFormat(
             org.apache.hadoop.conf.Configuration conf, String tableName, HBaseTableSchema schema) {
-        super(conf);
+        // we don't support limit push down for the legacy one
+        super(conf, null);
         this.tableName = tableName;
         this.schema = schema;
     }

--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -49,8 +49,6 @@ import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
-
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
@@ -124,17 +122,10 @@ public class HBaseConnectorITCase extends HBaseTestBase {
         if (isLegacyConnector) {
             return;
         }
-        List<String> expectedResultList =
-                ImmutableList.of(
-                        "+I[10, Hello-1, 100, 1.01, false, Welt-1]",
-                        "+I[20, Hello-2, 200, 2.02, true, Welt-2]",
-                        "+I[30, Hello-3, 300, 3.03, false, Welt-3]");
-        for (int i = 1; i <= expectedResultList.size(); i++) {
+        final int loopTimes = 3;
+        for (int i = 1; i <= loopTimes; i++) {
             List<Row> results = testTableSourceScanBase((long) i);
             assertEquals(i, results.size());
-            String expected =
-                    expectedResultList.subList(0, i).stream().collect(Collectors.joining("\n"));
-            TestBaseUtils.compareResultAsText(results, expected);
         }
     }
 
@@ -152,7 +143,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
             ((TableEnvironmentInternal) tEnv).registerTableSourceInternal("hTable", hbaseTable);
         } else {
             tEnv.executeSql(
-                    "CREATE TABLE hTable ("
+                    "CREATE TABLE IF NOT EXISTS hTable ("
                             + " family1 ROW<col1 INT>,"
                             + " family2 ROW<col1 STRING, col2 BIGINT>,"
                             + " family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 STRING>,"

--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -49,6 +49,8 @@ import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
+
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
@@ -56,6 +58,8 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -98,6 +102,43 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 
     @Test
     public void testTableSourceFullScan() {
+
+        List<Row> results = testTableSourceScanBase(null);
+
+        String expected =
+                "+I[10, Hello-1, 100, 1.01, false, Welt-1]\n"
+                        + "+I[20, Hello-2, 200, 2.02, true, Welt-2]\n"
+                        + "+I[30, Hello-3, 300, 3.03, false, Welt-3]\n"
+                        + "+I[40, null, 400, 4.04, true, Welt-4]\n"
+                        + "+I[50, Hello-5, 500, 5.05, false, Welt-5]\n"
+                        + "+I[60, Hello-6, 600, 6.06, true, Welt-6]\n"
+                        + "+I[70, Hello-7, 700, 7.07, false, Welt-7]\n"
+                        + "+I[80, null, 800, 8.08, true, Welt-8]\n";
+
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @Test
+    public void testTableSourceScanWithLimit() {
+        // we don't support limit push down for the legacy one.
+        if (isLegacyConnector) {
+            return;
+        }
+        List<String> expectedResultList =
+                ImmutableList.of(
+                        "+I[10, Hello-1, 100, 1.01, false, Welt-1]",
+                        "+I[20, Hello-2, 200, 2.02, true, Welt-2]",
+                        "+I[30, Hello-3, 300, 3.03, false, Welt-3]");
+        for (int i = 1; i <= expectedResultList.size(); i++) {
+            List<Row> results = testTableSourceScanBase((long) i);
+            assertEquals(i, results.size());
+            String expected =
+                    expectedResultList.subList(0, i).stream().collect(Collectors.joining("\n"));
+            TestBaseUtils.compareResultAsText(results, expected);
+        }
+    }
+
+    private List<Row> testTableSourceScanBase(@Nullable Long limit) {
         TableEnvironment tEnv = createBatchTableEnv();
         if (isLegacyConnector) {
             HBaseTableSource hbaseTable = new HBaseTableSource(getConf(), TEST_TABLE_1);
@@ -128,29 +169,22 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                             + ")");
         }
 
-        Table table =
-                tEnv.sqlQuery(
-                        "SELECT "
-                                + "  h.family1.col1, "
-                                + "  h.family2.col1, "
-                                + "  h.family2.col2, "
-                                + "  h.family3.col1, "
-                                + "  h.family3.col2, "
-                                + "  h.family3.col3 "
-                                + "FROM hTable AS h");
+        String querySql =
+                "SELECT "
+                        + "  h.family1.col1, "
+                        + "  h.family2.col1, "
+                        + "  h.family2.col2, "
+                        + "  h.family3.col1, "
+                        + "  h.family3.col2, "
+                        + "  h.family3.col3 "
+                        + "FROM hTable AS h";
 
-        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
-        String expected =
-                "+I[10, Hello-1, 100, 1.01, false, Welt-1]\n"
-                        + "+I[20, Hello-2, 200, 2.02, true, Welt-2]\n"
-                        + "+I[30, Hello-3, 300, 3.03, false, Welt-3]\n"
-                        + "+I[40, null, 400, 4.04, true, Welt-4]\n"
-                        + "+I[50, Hello-5, 500, 5.05, false, Welt-5]\n"
-                        + "+I[60, Hello-6, 600, 6.06, true, Welt-6]\n"
-                        + "+I[70, Hello-7, 700, 7.07, false, Welt-7]\n"
-                        + "+I[80, null, 800, 8.08, true, Welt-8]\n";
+        if (limit != null) {
+            querySql = querySql + " LIMIT " + limit;
+        }
+        Table table = tEnv.sqlQuery(querySql);
 
-        TestBaseUtils.compareResultAsText(results, expected);
+        return CollectionUtil.iteratorToList(table.execute().collect());
     }
 
     @Test
@@ -585,7 +619,8 @@ public class HBaseConnectorITCase extends HBaseTestBase {
         if (isLegacyConnector) {
             inputFormat = new HBaseRowInputFormat(getConf(), TEST_TABLE_1, tableSchema);
         } else {
-            inputFormat = new HBaseRowDataInputFormat(getConf(), TEST_TABLE_1, tableSchema, "null");
+            inputFormat =
+                    new HBaseRowDataInputFormat(getConf(), TEST_TABLE_1, tableSchema, "null", null);
         }
         inputFormat.open(inputFormat.createInputSplits(1)[0]);
         assertNotNull(inputFormat.getConnection());

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/HBase2DynamicTableFactory.java
@@ -82,7 +82,7 @@ public class HBase2DynamicTableFactory
         HBaseTableSchema hbaseSchema = HBaseTableSchema.fromTableSchema(tableSchema);
 
         return new HBaseDynamicTableSource(
-                hbaseConf, tableName, hbaseSchema, nullStringLiteral, lookupOptions);
+                hbaseConf, tableName, hbaseSchema, nullStringLiteral, lookupOptions, null);
     }
 
     @Override

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
@@ -152,7 +152,7 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
 
     @Override
     public T nextRecord(T reuse) throws IOException {
-        if (limit != null && limit >= scannedRows) {
+        if (limit != null && limit <= scannedRows) {
             endReached = true;
             return null;
         }

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/AbstractTableInputFormat.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hbase.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,8 +72,12 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
     // Configuration is not serializable
     protected byte[] serializedConfig;
 
-    public AbstractTableInputFormat(org.apache.hadoop.conf.Configuration hConf) {
+    @Nullable protected Long limit;
+
+    public AbstractTableInputFormat(
+            org.apache.hadoop.conf.Configuration hConf, @Nullable Long limit) {
         serializedConfig = HBaseConfigurationUtil.serializeConfiguration(hConf);
+        this.limit = limit;
     }
 
     /**
@@ -146,6 +152,11 @@ public abstract class AbstractTableInputFormat<T> extends RichInputFormat<T, Tab
 
     @Override
     public T nextRecord(T reuse) throws IOException {
+        if (limit != null && limit >= scannedRows) {
+            endReached = true;
+            return null;
+        }
+
         if (resultScanner == null) {
             throw new IOException("No table result scanner provided!");
         }

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseDynamicTableSource.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseDynamicTableSource.java
@@ -32,6 +32,8 @@ import org.apache.flink.table.data.RowData;
 
 import org.apache.hadoop.conf.Configuration;
 
+import javax.annotation.Nullable;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** HBase table source implementation. */
@@ -43,8 +45,9 @@ public class HBaseDynamicTableSource extends AbstractHBaseDynamicTableSource {
             String tableName,
             HBaseTableSchema hbaseSchema,
             String nullStringLiteral,
-            HBaseLookupOptions lookupOptions) {
-        super(conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions);
+            HBaseLookupOptions lookupOptions,
+            @Nullable Long limit) {
+        super(conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions, limit);
     }
 
     @Override
@@ -76,12 +79,12 @@ public class HBaseDynamicTableSource extends AbstractHBaseDynamicTableSource {
     @Override
     public DynamicTableSource copy() {
         return new HBaseDynamicTableSource(
-                conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions);
+                conf, tableName, hbaseSchema, nullStringLiteral, lookupOptions, limit);
     }
 
     @Override
     protected InputFormat<RowData, ?> getInputFormat() {
-        return new HBaseRowDataInputFormat(conf, tableName, hbaseSchema, nullStringLiteral);
+        return new HBaseRowDataInputFormat(conf, tableName, hbaseSchema, nullStringLiteral, limit);
     }
 
     @VisibleForTesting

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseInputFormat.java
@@ -42,7 +42,7 @@ public abstract class HBaseInputFormat<T extends Tuple> extends AbstractTableInp
      *     zookeeper.znode.parent need to be set.
      */
     public HBaseInputFormat(org.apache.hadoop.conf.Configuration hConf) {
-        super(hConf);
+        super(hConf, null);
     }
 
     /**

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseRowDataInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseRowDataInputFormat.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -51,8 +53,9 @@ public class HBaseRowDataInputFormat extends AbstractTableInputFormat<RowData> {
             org.apache.hadoop.conf.Configuration conf,
             String tableName,
             HBaseTableSchema schema,
-            String nullStringLiteral) {
-        super(conf);
+            String nullStringLiteral,
+            @Nullable Long limit) {
+        super(conf, limit);
         this.tableName = tableName;
         this.schema = schema;
         this.nullStringLiteral = nullStringLiteral;

--- a/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseRowInputFormat.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/main/java/org/apache/flink/connector/hbase2/source/HBaseRowInputFormat.java
@@ -55,7 +55,8 @@ public class HBaseRowInputFormat extends AbstractTableInputFormat<Row>
 
     public HBaseRowInputFormat(
             org.apache.hadoop.conf.Configuration conf, String tableName, HBaseTableSchema schema) {
-        super(conf);
+        // we don't support limit push down for the legacy one
+        super(conf, null);
         this.tableName = tableName;
         this.schema = schema;
     }

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -49,7 +49,6 @@ import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
-import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 
 import org.apache.hadoop.hbase.TableName;
@@ -125,17 +124,10 @@ public class HBaseConnectorITCase extends HBaseTestBase {
         if (isLegacyConnector) {
             return;
         }
-        List<String> expectedResultList =
-                ImmutableList.of(
-                        "+I[10, Hello-1, 100, 1.01, false, Welt-1]",
-                        "+I[20, Hello-2, 200, 2.02, true, Welt-2]",
-                        "+I[30, Hello-3, 300, 3.03, false, Welt-3]");
-        for (int i = 1; i <= expectedResultList.size(); i++) {
+        final int loopTimes = 3;
+        for (int i = 1; i <= loopTimes; i++) {
             List<Row> results = testTableSourceScanBase((long) i);
             assertEquals(i, results.size());
-            String expected =
-                    expectedResultList.subList(0, i).stream().collect(Collectors.joining("\n"));
-            TestBaseUtils.compareResultAsText(results, expected);
         }
     }
 
@@ -153,7 +145,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
             ((TableEnvironmentInternal) tEnv).registerTableSourceInternal("hTable", hbaseTable);
         } else {
             tEnv.executeSql(
-                    "CREATE TABLE hTable ("
+                    "CREATE TABLE IF NOT EXISTS hTable ("
                             + " family1 ROW<col1 INT>,"
                             + " family2 ROW<col1 STRING, col2 BIGINT>,"
                             + " family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 STRING>,"

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -557,7 +557,8 @@ public class HBaseConnectorITCase extends HBaseTestBase {
         if (isLegacyConnector) {
             inputFormat = new HBaseRowInputFormat(getConf(), TEST_TABLE_1, tableSchema);
         } else {
-            inputFormat = new HBaseRowDataInputFormat(getConf(), TEST_TABLE_1, tableSchema, "null", null);
+            inputFormat =
+                    new HBaseRowDataInputFormat(getConf(), TEST_TABLE_1, tableSchema, "null", null);
         }
         inputFormat.open(inputFormat.createInputSplits(1)[0]);
         assertNotNull(inputFormat.getConnection());

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -152,7 +152,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
                             + " rowkey INT,"
                             + " PRIMARY KEY (rowkey) NOT ENFORCED"
                             + ") WITH ("
-                            + " 'connector' = 'hbase-1.4',"
+                            + " 'connector' = 'hbase-2.2',"
                             + " 'table-name' = '"
                             + TEST_TABLE_1
                             + "',"


### PR DESCRIPTION
…ase connector"


## What is the purpose of the change

Support limit push down for HBase connector

## Brief change log


  -  implements `SupportLimitPushdown` in HBase1 and HBase2
  


## Verifying this change

This change added tests and can be verified as follows:

-
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes /**no**)
  - The serializers: (yes /*no* / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
