### PR TITLE
[FLINK-22586][table] Improve the precision dedivation for decimal ari…

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
@@ -197,7 +197,7 @@ public class TypeStrategiesTest {
                         .expectDataType(DataTypes.DECIMAL(11, 8).notNull()),
                 TestSpec.forStrategy("Find a decimal product", TypeStrategies.DECIMAL_TIMES)
                         .inputTypes(DataTypes.DECIMAL(5, 4), DataTypes.DECIMAL(3, 2))
-                        .expectDataType(DataTypes.DECIMAL(8, 6).notNull()),
+                        .expectDataType(DataTypes.DECIMAL(9, 6).notNull()),
                 TestSpec.forStrategy("Find a decimal modulo", TypeStrategies.DECIMAL_MOD)
                         .inputTypes(DataTypes.DECIMAL(5, 4), DataTypes.DECIMAL(3, 2))
                         .expectDataType(DataTypes.DECIMAL(5, 4).notNull()),

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/AvgAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/AvgAggFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -72,7 +73,7 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
     @Override
     public Expression[] accumulateExpressions() {
         return new Expression[] {
-            /* sum = */ ifThenElse(isNull(operand(0)), sum, plus(sum, operand(0))),
+            /* sum = */ adjustSumType(ifThenElse(isNull(operand(0)), sum, plus(sum, operand(0)))),
             /* count = */ ifThenElse(isNull(operand(0)), count, plus(count, literal(1L))),
         };
     }
@@ -80,7 +81,7 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
     @Override
     public Expression[] retractExpressions() {
         return new Expression[] {
-            /* sum = */ ifThenElse(isNull(operand(0)), sum, minus(sum, operand(0))),
+            /* sum = */ adjustSumType(ifThenElse(isNull(operand(0)), sum, minus(sum, operand(0)))),
             /* count = */ ifThenElse(isNull(operand(0)), count, minus(count, literal(1L))),
         };
     }
@@ -88,8 +89,13 @@ public abstract class AvgAggFunction extends DeclarativeAggregateFunction {
     @Override
     public Expression[] mergeExpressions() {
         return new Expression[] {
-            /* sum = */ plus(sum, mergeOperand(sum)), /* count = */ plus(count, mergeOperand(count))
+            /* sum = */ adjustSumType(plus(sum, mergeOperand(sum))),
+            /* count = */ plus(count, mergeOperand(count))
         };
+    }
+
+    private UnresolvedCallExpression adjustSumType(UnresolvedCallExpression sumExpr) {
+        return cast(sumExpr, typeLiteral(getSumType()));
     }
 
     /** If all input are nulls, count will be 0 and we will get null after the division. */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Sum0AggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/Sum0AggFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.functions.aggfunctions;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -28,11 +29,13 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 import java.math.BigDecimal;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.cast;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.isNull;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.literal;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.minus;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.typeLiteral;
 
 /** built-in sum0 aggregate function. */
 public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
@@ -56,20 +59,25 @@ public abstract class Sum0AggFunction extends DeclarativeAggregateFunction {
     @Override
     public Expression[] accumulateExpressions() {
         return new Expression[] {
-            /* sum0 = */ ifThenElse(isNull(operand(0)), sum0, plus(sum0, operand(0)))
+            /* sum0 = */ adjustSumType(ifThenElse(isNull(operand(0)), sum0, plus(sum0, operand(0))))
         };
     }
 
     @Override
     public Expression[] retractExpressions() {
         return new Expression[] {
-            /* sum0 = */ ifThenElse(isNull(operand(0)), sum0, minus(sum0, operand(0)))
+            /* sum0 = */ adjustSumType(
+                    ifThenElse(isNull(operand(0)), sum0, minus(sum0, operand(0))))
         };
     }
 
     @Override
     public Expression[] mergeExpressions() {
-        return new Expression[] {/* sum0 = */ plus(sum0, mergeOperand(sum0))};
+        return new Expression[] {/* sum0 = */ adjustSumType(plus(sum0, mergeOperand(sum0)))};
+    }
+
+    private UnresolvedCallExpression adjustSumType(UnresolvedCallExpression sumExpr) {
+        return cast(sumExpr, typeLiteral(getResultType()));
     }
 
     @Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -88,7 +88,7 @@ public class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").times(6),
                                 "f0 * 6",
                                 new BigDecimal("9086137920000"),
-                                DataTypes.DECIMAL(29, 0))
+                                DataTypes.DECIMAL(30, 0))
                         // DECIMAL(19, 0) * DECIMAL(19, 0) => DECIMAL(38, 0)
                         .testResult(
                                 $("f0").times($("f0")),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
@@ -410,32 +410,28 @@ class DecimalTypeTest extends ExpressionTestBase {
       "f3 + f7",
       "127.65")
 
-    // our result type precision is capped at 38
-    // SQL2003 $6.26 -- result scale is dictated as max(s1,s2). no approximation allowed.
-    // calcite -- scale is not reduced; integral part may be reduced. overflow may occur
-    //   (38,10)+(38,28)=>(57,28)=>(38,28)
     // T-SQL -- scale may be reduced to keep the integral part. approximation may occur
     //   (38,10)+(38,28)=>(57,28)=>(38,9)
     testAllApis(
       'f15 + 'f16,
       "f15 + f16",
-      "300.0246913578012345678901234567")
+      "300.024691358")
 
     testAllApis(
       'f15 - 'f16,
       "f15 - f16",
-      "-100.0000000000012345678901234567")
+      "-100.000000000")
 
     // 10 digits integral part
     testAllApis(
       'f17 + 'f18,
       "f17 + f18",
-      "null")
+      "10000000000.000000000")
 
     testAllApis(
       'f17 - 'f18,
       "f17 - f18",
-      "null")
+      "10000000000.000000000")
 
     // requires 39 digits
     testAllApis(
@@ -456,7 +452,6 @@ class DecimalTypeTest extends ExpressionTestBase {
     // see calcite ReturnTypes.DECIMAL_PRODUCT
     // s = s1+s2, p = p1+p2
     // both p&s are capped at 38
-    // if s>38, result is rounded to s=38, and the integral part can only be zero
     testAllApis(
       'f20 * 'f20,
       "f20 * f20",
@@ -489,33 +484,31 @@ class DecimalTypeTest extends ExpressionTestBase {
       "f23 * f20",
       "3.14")
 
-    // precision is capped at 38; scale will not be reduced (unless over 38)
-    // similar to plus&minus, and calcite behavior is different from T-SQL.
+    // (60,12) => (38,6), minimum scale 6 is preserved
+    // while sacrificing scale for more space for integral part
     testAllApis(
       'f24 * 'f24,
       "f24 * f24",
-      "1.000000000000")
+      "1.000000")
 
     testAllApis(
       'f24 * 'f25,
       "f24 * f25",
-      "2.0000000000000000")
+      "2.000000")
 
     testAllApis(
       'f26 * 'f26,
       "f26 * f26",
-      "0.00010000000000000000000000000000000000"
+      "0.00010000000000000"
     )
 
-    // scalastyle:off
-    // we don't have this ridiculous behavior:
-    //   https://blogs.msdn.microsoft.com/sqlprogrammability/2006/03/29/multiplication-and-division-with-numerics/
-    // scalastyle:on
-
+    // (76, 20) -> (38, 6), 0.0000006 is rounding to 0.000001
+    // refer "https://blogs.msdn.microsoft.com/sqlprogrammability/
+    // 2006/03/29/multiplication-and-division-with-numerics/"
     testAllApis(
       'f27 * 'f28,
       "f27 * f28",
-      "0.00000060000000000000"
+      "0.000001"
     )
 
     // result overflow
@@ -525,11 +518,11 @@ class DecimalTypeTest extends ExpressionTestBase {
       "null"
     )
 
-    //(60,40)=>(38,38), no space for integral part
+    //(60,40) => (38,17), scale part is reduced to make more space for integral part
     testAllApis(
       'f30 * 'f30,
       "f30 * f30",
-      "null"
+      "1.00000000000000000"
     )
   }
 


### PR DESCRIPTION
…thmetics

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently the precision and scale derivation is not properly for decimal data arithmetics, e.g,

considering the following example:

select cast('10.1' as decimal(38, 19)) * cast('10.2' as decimal(38, 19)) from T
the result is `null`, which may confuses use a lot, because the result is actually not that big.

The root cause is the precision derivation for the above multiplication is:

(38, 19) * (38, 19) -> (38, 38)

So there is no space for integral digits, and the result may overflow easily, which leads to null result.

This pr aims to adjust precision/scale properly when the precision is out of range. (The derivation rules basically follow 
 https://docs.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql)


## Brief change log

  - Modify precision derivation rules for `FlinkTypeSystem` and `LogicalTypeMerging`.


## Verifying this change
This change added tests and can be verified as follows:
  -  Unit test for decimal arithmetics are covered by `DecimalTypeTest`.
  -  integration testing covered by `MathFunctionsITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
