### PR TITLE
[FLINK-22577][tests] Harden KubernetesLeaderElectionAndRetrievalITCase

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHighAvailabilityTestBase.java
@@ -122,6 +122,7 @@ public class KubernetesHighAvailabilityTestBase extends TestLogger {
             electionEventHandler.init(leaderElectionDriver);
             testMethod.run();
 
+            electionEventHandler.close();
             leaderElectionDriver.close();
             leaderRetrievalDriver.close();
         }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -52,9 +52,10 @@ public class KubernetesLeaderElectionAndRetrievalITCase extends TestLogger {
         KubernetesLeaderElectionDriver leaderElectionDriver = null;
         KubernetesLeaderRetrievalDriver leaderRetrievalDriver = null;
 
+        final TestingLeaderElectionEventHandler electionEventHandler =
+                new TestingLeaderElectionEventHandler(LEADER_INFORMATION);
+
         try {
-            final TestingLeaderElectionEventHandler electionEventHandler =
-                    new TestingLeaderElectionEventHandler(LEADER_INFORMATION);
             leaderElectionDriver =
                     new KubernetesLeaderElectionDriver(
                             kubernetesResource.getFlinkKubeClient(),
@@ -88,6 +89,7 @@ public class KubernetesLeaderElectionAndRetrievalITCase extends TestLogger {
             assertThat(
                     retrievalEventHandler.getAddress(), is(LEADER_INFORMATION.getLeaderAddress()));
         } finally {
+            electionEventHandler.close();
             if (leaderElectionDriver != null) {
                 leaderElectionDriver.close();
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
@@ -32,6 +32,8 @@ import java.util.function.Consumer;
 public class TestingLeaderElectionEventHandler extends TestingLeaderBase
         implements LeaderElectionEventHandler {
 
+    private final Object lock = new Object();
+
     private final LeaderInformation leaderInformation;
 
     private final OneShotLatch initializationLatch;
@@ -39,6 +41,8 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
     @Nullable private LeaderElectionDriver initializedLeaderElectionDriver = null;
 
     private LeaderInformation confirmedLeaderInformation = LeaderInformation.empty();
+
+    private boolean running = true;
 
     public TestingLeaderElectionEventHandler(LeaderInformation leaderInformation) {
         this.leaderInformation = leaderInformation;
@@ -51,35 +55,53 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
         initializationLatch.trigger();
     }
 
+    private void ifRunning(Runnable action) {
+        synchronized (lock) {
+            if (running) {
+                action.run();
+            }
+        }
+    }
+
     @Override
     public void onGrantLeadership() {
-        waitForInitialization(
-                leaderElectionDriver -> {
-                    confirmedLeaderInformation = leaderInformation;
-                    leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
-                    leaderEventQueue.offer(confirmedLeaderInformation);
-                });
+        ifRunning(
+                () ->
+                        waitForInitialization(
+                                leaderElectionDriver -> {
+                                    confirmedLeaderInformation = leaderInformation;
+                                    leaderElectionDriver.writeLeaderInformation(
+                                            confirmedLeaderInformation);
+                                    leaderEventQueue.offer(confirmedLeaderInformation);
+                                }));
     }
 
     @Override
     public void onRevokeLeadership() {
-        waitForInitialization(
-                (leaderElectionDriver) -> {
-                    confirmedLeaderInformation = LeaderInformation.empty();
-                    leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
-                    leaderEventQueue.offer(confirmedLeaderInformation);
-                });
+        ifRunning(
+                () ->
+                        waitForInitialization(
+                                (leaderElectionDriver) -> {
+                                    confirmedLeaderInformation = LeaderInformation.empty();
+                                    leaderElectionDriver.writeLeaderInformation(
+                                            confirmedLeaderInformation);
+                                    leaderEventQueue.offer(confirmedLeaderInformation);
+                                }));
     }
 
     @Override
     public void onLeaderInformationChange(LeaderInformation leaderInformation) {
-        waitForInitialization(
-                leaderElectionDriver -> {
-                    if (confirmedLeaderInformation.getLeaderSessionID() != null
-                            && !this.confirmedLeaderInformation.equals(leaderInformation)) {
-                        leaderElectionDriver.writeLeaderInformation(confirmedLeaderInformation);
-                    }
-                });
+        ifRunning(
+                () ->
+                        waitForInitialization(
+                                leaderElectionDriver -> {
+                                    if (confirmedLeaderInformation.getLeaderSessionID() != null
+                                            && !this.confirmedLeaderInformation.equals(
+                                                    leaderInformation)) {
+                                        leaderElectionDriver.writeLeaderInformation(
+                                                confirmedLeaderInformation);
+                                    }
+                                }));
     }
 
     private void waitForInitialization(Consumer<? super LeaderElectionDriver> operation) {
@@ -94,6 +116,14 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
     }
 
     public LeaderInformation getConfirmedLeaderInformation() {
-        return confirmedLeaderInformation;
+        synchronized (lock) {
+            return confirmedLeaderInformation;
+        }
+    }
+
+    public void close() {
+        synchronized (lock) {
+            running = false;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -154,6 +154,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     is(TEST_LEADER.getLeaderSessionID()));
             assertThat(retrievalEventHandler.getAddress(), is(TEST_LEADER.getLeaderAddress()));
         } finally {
+            electionEventHandler.close();
             if (leaderElectionDriver != null) {
                 leaderElectionDriver.close();
             }
@@ -401,6 +402,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     is(TEST_LEADER.getLeaderSessionID()));
             assertThat(retrievalEventHandler.getAddress(), is(TEST_LEADER.getLeaderAddress()));
         } finally {
+            electionEventHandler.close();
             if (leaderElectionDriver != null) {
                 leaderElectionDriver.close();
             }
@@ -450,6 +452,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                             .isPresent(),
                     is(true));
         } finally {
+            electionEventHandler.close();
             if (leaderElectionDriver != null) {
                 leaderElectionDriver.close();
             }
@@ -528,6 +531,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                 // that was expected
             }
         } finally {
+            electionEventHandler.close();
             if (leaderRetrievalDriver != null) {
                 leaderRetrievalDriver.close();
             }
@@ -577,6 +581,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     is(TEST_LEADER.getLeaderSessionID()));
             assertThat(retrievalEventHandler.getAddress(), is(TEST_LEADER.getLeaderAddress()));
         } finally {
+            electionEventHandler.close();
             if (leaderElectionDriver != null) {
                 leaderElectionDriver.close();
             }


### PR DESCRIPTION
This commit introduces closing logic to the TestingLeaderElectionEventHandler which would
otherwise forward calls after the KubernetesLeaderElectionDriver is closed.