### PR TITLE
[FLINK-22596][checkpoints] Active timeout is not triggered if there were no barriers

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -213,7 +213,6 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             } else {
                 markAlignmentStart(barrier.getTimestamp());
             }
-            allBarriersReceivedFuture = new CompletableFuture<>();
         }
 
         // we must mark alignment end before calling currentState.barrierReceived which might
@@ -308,6 +307,7 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
             }
             currentCheckpointId = barrierId;
             numBarriersReceived = 0;
+            allBarriersReceivedFuture = new CompletableFuture<>();
             return true;
         }
         return false;


### PR DESCRIPTION
## What is the purpose of the change

The active timeout did not take effect if it elapsed before the first
barrier arrived. The reason is that we did not reset the future for
checkpoint complete on barrier announcement. Therefore we considered the
completed status for the previous checkpoint when evaluating the timeout for
the current checkpoint.

## Verifying this change

This change added tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
