### PR TITLE
[BP-1.12][FLINK-22597] Make JobMaster restartable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -174,7 +174,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
 
     // --------- ResourceManager --------
 
-    private final LeaderRetrievalService resourceManagerLeaderRetriever;
+    @Nullable private LeaderRetrievalService resourceManagerLeaderRetriever;
 
     // --------- TaskManagers --------
 
@@ -300,9 +300,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
         final JobID jid = jobGraph.getJobID();
 
         log.info("Initializing job {} ({}).", jobName, jid);
-
-        resourceManagerLeaderRetriever =
-                highAvailabilityServices.getResourceManagerLeaderRetriever();
 
         this.slotPool = checkNotNull(slotPoolFactory).createSlotPool(jid);
 
@@ -910,6 +907,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
         //   - activate leader retrieval for the resource manager
         //   - on notification of the leader, the connection will be established and
         //     the slot pool will start requesting slots
+        if (resourceManagerLeaderRetriever != null) {
+            resourceManagerLeaderRetriever.stop();
+        }
+        resourceManagerLeaderRetriever =
+                highAvailabilityServices.getResourceManagerLeaderRetriever();
         resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
     }
 
@@ -956,7 +958,10 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
         setFencingToken(null);
 
         try {
-            resourceManagerLeaderRetriever.stop();
+            if (resourceManagerLeaderRetriever != null) {
+                resourceManagerLeaderRetriever.stop();
+                resourceManagerLeaderRetriever = null;
+            }
             resourceManagerAddress = null;
         } catch (Throwable t) {
             log.warn("Failed to stop resource manager leader retriever when suspending.", t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/DefaultLeaderRetrievalService.java
@@ -87,8 +87,7 @@ public class DefaultLeaderRetrievalService
     public void start(LeaderRetrievalListener listener) throws Exception {
         checkNotNull(listener, "Listener must not be null.");
         Preconditions.checkState(
-                leaderListener == null,
-                "DefaultLeaderRetrievalService can " + "only be started once.");
+                leaderListener == null, "DefaultLeaderRetrievalService can only be started once.");
 
         synchronized (lock) {
             leaderListener = listener;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -69,6 +69,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaServices;
 import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -2291,6 +2292,26 @@ public class JobMasterTest extends TestLogger {
                             testingTimeout);
 
             assertThat(registrationResponse.get(), instanceOf(JMTMRegistrationRejection.class));
+        } finally {
+            RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
+        }
+    }
+
+    /** Tests that the JobMaster can be restarted multiple times. See FLINK-22597. */
+    @Test
+    public void testMultipleStartsWork() throws Exception {
+        final JobMaster jobMaster =
+                new JobMasterBuilder(jobGraph, rpcService)
+                        .withHighAvailabilityServices(
+                                new StandaloneHaServices("localhost", "localhost", "localhost"))
+                        .createJobMaster();
+
+        try {
+            jobMaster.start(JobMasterId.generate()).join();
+
+            jobMaster.suspend(new FlinkException("Test exception."));
+
+            jobMaster.start(JobMasterId.generate()).join();
         } finally {
             RpcUtils.terminateRpcEndpoint(jobMaster, testingTimeout);
         }


### PR DESCRIPTION
The problem is that the DefaultLeaderRetrievalService for the ResourceManager is reused by
the JobMaster. Since the DefaultLeaderRetrievalService is only usable once, this means that
the JobMaster can only be started once even though the JobManagerRunnerImpl restarts it in
case of a regained leadership.