### PR TITLE
[FLINK-22598][examples] Update deprecated forms of writeAsText in examples

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/iteration/IterateExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/iteration/IterateExample.java
@@ -18,14 +18,17 @@
 package org.apache.flink.streaming.examples.iteration;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
@@ -103,7 +106,10 @@ public class IterateExample {
 
         // emit results
         if (params.has("output")) {
-            numbers.writeAsText(params.get("output"));
+            numbers.addSink(StreamingFileSink.forRowFormat(
+                    new Path(params.get("output")),
+                    new SimpleStringEncoder<Tuple2<Tuple2<Integer, Integer>, Integer>>("UTF-8"))
+                    .build());
         } else {
             System.out.println("Printing result to stdout. Use --output to specify output path.");
             numbers.print();

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/twitter/TwitterExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/twitter/TwitterExample.java
@@ -18,10 +18,13 @@
 package org.apache.flink.streaming.examples.twitter;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.connectors.twitter.TwitterSource;
 import org.apache.flink.streaming.examples.twitter.util.TwitterExampleData;
 import org.apache.flink.util.Collector;
@@ -100,7 +103,10 @@ public class TwitterExample {
 
         // emit result
         if (params.has("output")) {
-            tweets.writeAsText(params.get("output"));
+            tweets.addSink(StreamingFileSink.forRowFormat(
+                    new Path(params.get("output")),
+                    new SimpleStringEncoder<Tuple2<String, Integer>>("UTF-8"))
+                    .build());
         } else {
             System.out.println("Printing result to stdout. Use --output to specify output path.");
             tweets.print();

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/SessionWindowing.java
@@ -17,10 +17,13 @@
 
 package org.apache.flink.streaming.examples.windowing;
 
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows;
@@ -85,7 +88,10 @@ public class SessionWindowing {
                         .sum(2);
 
         if (fileOutput) {
-            aggregated.writeAsText(params.get("output"));
+            aggregated.addSink(StreamingFileSink.forRowFormat(
+                    new Path(params.get("output")),
+                    new SimpleStringEncoder<Tuple3<String, Long, Integer>>("UTF-8"))
+                    .build());
         } else {
             System.out.println("Printing result to stdout. Use --output to specify output path.");
             aggregated.print();

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/WindowWordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/windowing/WindowWordCount.java
@@ -17,10 +17,13 @@
 
 package org.apache.flink.streaming.examples.windowing;
 
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.examples.wordcount.WordCount;
 import org.apache.flink.streaming.examples.wordcount.util.WordCountData;
 
@@ -84,7 +87,10 @@ public class WindowWordCount {
 
         // emit result
         if (params.has("output")) {
-            counts.writeAsText(params.get("output"));
+            counts.addSink(StreamingFileSink.forRowFormat(
+                    new Path(params.get("output")),
+                    new SimpleStringEncoder<Tuple2<String, Integer>>("UTF-8"))
+                    .build());
         } else {
             System.out.println("Printing result to stdout. Use --output to specify output path.");
             counts.print();

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/WordCount.java
@@ -18,10 +18,13 @@
 package org.apache.flink.streaming.examples.wordcount;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.MultipleParameterTool;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.examples.wordcount.util.WordCountData;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
@@ -88,7 +91,10 @@ public class WordCount {
 
         // emit result
         if (params.has("output")) {
-            counts.writeAsText(params.get("output"));
+            counts.addSink(StreamingFileSink.forRowFormat(
+                    new Path(params.get("output")),
+                    new SimpleStringEncoder<Tuple2<String, Integer>>("UTF-8"))
+                    .build());
         } else {
             System.out.println("Printing result to stdout. Use --output to specify output path.");
             counts.print();

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/wordcount/WordCount.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/wordcount/WordCount.scala
@@ -18,7 +18,10 @@
 
 package org.apache.flink.streaming.scala.examples.wordcount
 
+import org.apache.flink.api.common.serialization.SimpleStringEncoder
 import org.apache.flink.api.java.utils.ParameterTool
+import org.apache.flink.core.fs.Path
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.streaming.examples.wordcount.util.WordCountData
 
@@ -79,7 +82,10 @@ object WordCount {
 
     // emit result
     if (params.has("output")) {
-      counts.writeAsText(params.get("output"))
+      counts.addSink(StreamingFileSink.forRowFormat(
+        new Path(params.get("output")),
+        new SimpleStringEncoder[(String, Int)]("UTF-8"))
+        .build())
     } else {
       println("Printing result to stdout. Use --output to specify output path.")
       counts.print()


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The `writeAsText` usage of the examples is no longer recommended, so update to the latest usage. This PR only updates DataStream examples.


## Brief change log

[3b42ff5](https://github.com/apache/flink/commit/3b42ff5c62b287157d954cfdc3258def7a258c67): In the java class of this examples, update the `writeAsText` call to `addSink(SinkFunction)` and use the default `StreamingFileSink`
[64bc3ce](https://github.com/apache/flink/pull/15860/commits/64bc3ced1182b56e493bea0d2d64a028eed739f6): In the scala class, it is also similar to [3b42ff5]

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
