### PR TITLE
[FLINK-22355][docs] Fix simple task manager memory model image

### DIFF
--- a/docs/content/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content/docs/deployment/memory/mem_setup_tm.md
@@ -44,9 +44,8 @@ The *total process memory* of Flink JVM processes consists of memory consumed by
 and by the JVM to run the process. The *total Flink memory* consumption includes usage of JVM Heap,
 *managed memory* (managed by Flink) and other direct (or native) memory.
 
-<center>
-  <img src="/fig/simple_mem_model.svg" width="300px" alt="Simple TaskManager Memory Model" usemap="#simple-mem-model">
-</center>
+{{< img src="/fig/simple_mem_model.svg" width="300px" alt="Simple TaskManager Memory Model" usemap="#simple-mem-model" >}}
+
 <br />
 
 If you run Flink locally (e.g. from your IDE) without creating a cluster, then only a subset of the memory configuration


### PR DESCRIPTION
## What is the purpose of the change

Fix the broken image in https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/memory/mem_setup_tm/

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
