### PR TITLE
[FLINK-22604] [table-runtime-blink] fix NPE on bundle close when task failover after a failed task open

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
@@ -18,23 +18,27 @@
 
 package org.apache.flink.table.planner.runtime.harness
 
-import java.lang.{Integer => JInt}
-import java.util.concurrent.ConcurrentLinkedQueue
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api._
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.bridge.scala.internal.StreamTableEnvironmentImpl
-import org.apache.flink.table.api.EnvironmentSettings
+import org.apache.flink.table.api.{EnvironmentSettings, _}
+import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.utils.{Top3WithMapView, Top3WithRetractInput}
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor
 import org.apache.flink.table.runtime.util.StreamRecordUtils.{deleteRecord, insertRecord}
+import org.apache.flink.table.types.logical.LogicalType
 import org.apache.flink.types.Row
+
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{Before, Test}
 
+import java.lang.{Integer => JInt}
 import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
 
 import scala.collection.mutable
 
@@ -117,22 +121,8 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
 
   @Test
   def testTableAggregateWithRetractInput(): Unit = {
-    val top3 = new Top3WithRetractInput
-    tEnv.registerFunction("top3", top3)
-    val source = env.fromCollection(data).toTable(tEnv, 'a, 'b)
-    val resultTable = source
-      .groupBy('a)
-      .select('b.sum as 'b)
-      .flatAggregate(top3('b) as ('b1, 'b2))
-      .select('b1, 'b2)
-
-    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
-    val testHarness = createHarnessTester(
-      resultTable.toRetractStream[Row], "GroupTableAggregate")
-    val assertor = new RowDataHarnessAssertor(
-      Array(
-        DataTypes.INT().getLogicalType,
-        DataTypes.INT().getLogicalType))
+    val (testHarness, outputTypes) = createTableAggregateWithRetract
+    val assertor = new RowDataHarnessAssertor(outputTypes)
 
     testHarness.open()
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
@@ -168,6 +158,34 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
 
     val result = testHarness.getOutput
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+    testHarness.close()
+  }
+
+  private def createTableAggregateWithRetract()
+    : (KeyedOneInputStreamOperatorTestHarness[RowData, RowData, RowData], Array[LogicalType]) = {
+    val top3 = new Top3WithRetractInput
+    tEnv.registerFunction("top3", top3)
+    val source = env.fromCollection(data).toTable(tEnv, 'a, 'b)
+    val resultTable = source
+        .groupBy('a)
+        .select('b.sum as 'b)
+        .flatAggregate(top3('b) as('b1, 'b2))
+        .select('b1, 'b2)
+
+    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(2))
+    val testHarness = createHarnessTester(
+      resultTable.toRetractStream[Row], "GroupTableAggregate")
+    val outputTypes = Array(
+      DataTypes.INT().getLogicalType,
+      DataTypes.INT().getLogicalType)
+    (testHarness, outputTypes)
+  }
+
+  @Test
+  def testCloseWithoutOpen(): Unit = {
+    val (testHarness, outputTypes) = createTableAggregateWithRetract
+    testHarness.setup(new RowDataSerializer(outputTypes: _*))
+    // simulate a failover after a failed task open, expect no exception happens
     testHarness.close()
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
@@ -344,20 +344,10 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
     testHarness.close()
 
     val testHarness1 = createHarnessTester(stream, "GlobalWindowAggregate")
-    // window aggregate put window properties at the end of aggs
-    val outputTypes1 = Array(
-      DataTypes.STRING().getLogicalType,
-      DataTypes.BIGINT().getLogicalType,
-      DataTypes.DOUBLE().getLogicalType,
-      DataTypes.BIGINT().getLogicalType,
-      DataTypes.TIMESTAMP_LTZ(3).getLogicalType,
-      DataTypes.TIMESTAMP_LTZ(3).getLogicalType)
-    testHarness1.setup(new RowDataSerializer(outputTypes1: _*))
+    testHarness1.setup(new RowDataSerializer(outputTypes: _*))
 
     // simulate a failover after a failed task open, expect no exception happens
     testHarness1.close()
-
-
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
@@ -19,10 +19,12 @@
 package org.apache.flink.table.planner.runtime.harness
 
 import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.data.{RowData, TimestampData}
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
@@ -280,6 +282,82 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
     testHarness.setup(new RowDataSerializer(outputTypes: _*))
     // simulate a failover after a failed task open, expect no exception happens
     testHarness.close()
+  }
+
+  /**
+   * Processing time window doesn't support two-phase, so add a single two-phase test.
+    */
+  @Test
+  def testTwoPhaseWindowAggregateCloseWithoutOpen(): Unit = {
+    val timestampDataId = TestValuesTableFactory.registerData(TestData.windowDataWithTimestamp)
+    tEnv.executeSql(
+      s"""
+         |CREATE TABLE T2 (
+         | `ts` STRING,
+         | `int` INT,
+         | `double` DOUBLE,
+         | `float` FLOAT,
+         | `bigdec` DECIMAL(10, 2),
+         | `string` STRING,
+         | `name` STRING,
+         | `rowtime` AS
+         | TO_TIMESTAMP(`ts`),
+         | WATERMARK for `rowtime` AS `rowtime` - INTERVAL '1' SECOND
+         |) WITH (
+         | 'connector' = 'values',
+         | 'data-id' = '${timestampDataId}',
+         | 'failing-source' = 'false'
+         |)
+         |""".stripMargin)
+
+    tEnv.getConfig.getConfiguration.setString(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_AGG_PHASE_STRATEGY, "TWO_PHASE")
+
+    val sql =
+      """
+        |SELECT
+        |  `name`,
+        |  window_start,
+        |  window_end,
+        |  COUNT(*),
+        |  MAX(`double`),
+        |  COUNT(DISTINCT `string`)
+        |FROM TABLE(
+        |   TUMBLE(TABLE T2, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+        |GROUP BY `name`, window_start, window_end
+      """.stripMargin
+    val t1 = tEnv.sqlQuery(sql)
+    val stream: DataStream[Row] = t1.toAppendStream[Row]
+
+    val testHarness = createHarnessTesterForNoState(stream, "LocalWindowAggregate")
+    // window aggregate put window properties at the end of aggs
+    val outputTypes = Array(
+      DataTypes.STRING().getLogicalType,
+      DataTypes.BIGINT().getLogicalType,
+      DataTypes.DOUBLE().getLogicalType,
+      DataTypes.BIGINT().getLogicalType,
+      DataTypes.TIMESTAMP_LTZ(3).getLogicalType,
+      DataTypes.TIMESTAMP_LTZ(3).getLogicalType)
+    testHarness.setup(new RowDataSerializer(outputTypes: _*))
+
+    // simulate a failover after a failed task open, expect no exception happens
+    testHarness.close()
+
+    val testHarness1 = createHarnessTester(stream, "GlobalWindowAggregate")
+    // window aggregate put window properties at the end of aggs
+    val outputTypes1 = Array(
+      DataTypes.STRING().getLogicalType,
+      DataTypes.BIGINT().getLogicalType,
+      DataTypes.DOUBLE().getLogicalType,
+      DataTypes.BIGINT().getLogicalType,
+      DataTypes.TIMESTAMP_LTZ(3).getLogicalType,
+      DataTypes.TIMESTAMP_LTZ(3).getLogicalType)
+    testHarness1.setup(new RowDataSerializer(outputTypes1: _*))
+
+    // simulate a failover after a failed task open, expect no exception happens
+    testHarness1.close()
+
+
   }
 
   /**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/LocalSlicingWindowAggOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/LocalSlicingWindowAggOperator.java
@@ -143,7 +143,9 @@ public class LocalSlicingWindowAggOperator extends AbstractStreamOperator<RowDat
         super.close();
         collector = null;
         functionsClosed = true;
-        windowBuffer.close();
+        if (windowBuffer != null) {
+            windowBuffer.close();
+        }
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/AbstractMapBundleOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/AbstractMapBundleOperator.java
@@ -131,7 +131,7 @@ public abstract class AbstractMapBundleOperator<K, V, IN, OUT> extends AbstractS
 
     @Override
     public void finishBundle() throws Exception {
-        if (!bundle.isEmpty()) {
+        if (bundle != null && !bundle.isEmpty()) {
             numOfElements = 0;
             function.finishBundle(bundle, collector);
             bundle.clear();


### PR DESCRIPTION
## What is the purpose of the change

fix NPE on bundle close when task failover after a failed task open and add case for current sql harness tests.

## Brief change log

- add null check on finishBundle for AbstractMapBundleOperator
- add close without open case for current sql harness tests.

## Verifying this change

This change added tests and can be verified as follows:

  - Extended HarnessTest for close without open

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
