### PR TITLE
[FLINK-22559][table-planner] The consumed DataType of ExecSink should only consider physical columns

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.utils.LegacyRowResource;
 import org.apache.flink.types.Row;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -198,7 +197,6 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    @Ignore // FLINK-22559
     public void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -319,6 +319,6 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
     }
 
     private RowType getConsumedRowType(ResolvedSchema schema) {
-        return (RowType) schema.toSinkRowDataType().getLogicalType();
+        return (RowType) schema.toPhysicalRowDataType().getLogicalType();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fix the unstable test `UpsertKafkaTableITCase#testKafkaSourceSinkWithKeyAndFullValue` due to the consumed DataType of ExecSink has considered meta columns.

## Brief change log

  -  The consumed DataType of ExecSink should only consider physical columns

## Verifying this change

The unstable case is hard to construct, I run it N times in local env where the N >100.
![image](https://user-images.githubusercontent.com/5163645/117531258-48ac0680-b014-11eb-960c-7f6b705f22b2.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
