### PR TITLE
[FLINK-22413][runtime-web] Hide Checkpointing page in the UI for batch jobs

### DIFF
--- a/docs/content.zh/docs/try-flink/flink-operations-playground.md
+++ b/docs/content.zh/docs/try-flink/flink-operations-playground.md
@@ -727,6 +727,7 @@ curl localhost:8081/jobs/<jod-id>
   "plan": {
     "jid": "<job-id>",
     "name": "Click Event Count",
+    "type": "STREAMING",
     "nodes": [
       {
         "id": "<vertex-id>",

--- a/docs/content/docs/try-flink/flink-operations-playground.md
+++ b/docs/content/docs/try-flink/flink-operations-playground.md
@@ -711,6 +711,7 @@ curl localhost:8081/jobs/<jod-id>
   "plan": {
     "jid": "<job-id>",
     "name": "Click Event Count",
+    "type": "STREAMING",
     "nodes": [
       {
         "id": "<vertex-id>",

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
@@ -61,6 +61,7 @@ export interface JobDetailInterface {
 interface Plan {
   jid: string;
   name: string;
+  type:  string;
   nodes: NodesItemInterface[];
 }
 
@@ -150,6 +151,7 @@ export interface JobDetailCorrectInterface extends JobDetailInterface {
   plan: {
     jid: string;
     name: string;
+    type: string;
     nodes: NodesItemCorrectInterface[];
     links: NodesItemLinkInterface[];
   };

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/status/job-status.component.ts
@@ -55,6 +55,7 @@ export class JobStatusComponent implements OnInit, OnDestroy {
       title: 'Configuration'
     }
   ];
+  checkpointIndexOfNavigation = this.checkpointIndexOfNav();
 
   webCancelEnabled = this.statusService.configuration.features["web-cancel"];
 
@@ -72,6 +73,12 @@ export class JobStatusComponent implements OnInit, OnDestroy {
     jobDetail$.subscribe(data => {
       this.jobDetail = data;
       this.cdr.markForCheck();
+      var index = this.checkpointIndexOfNav();
+      if (data.plan.type == 'STREAMING' && index == -1) {
+        this.listOfNavigation.splice(this.checkpointIndexOfNavigation, 0, {path: 'checkpoints', title: 'Checkpoints'});
+      } else if (data.plan.type == 'BATCH' && index > -1) {
+        this.listOfNavigation.splice(index, 1);
+      }
     });
     jobDetail$.pipe(distinctUntilKeyChanged('state')).subscribe(() => {
       this.statusTips = '';
@@ -81,5 +88,9 @@ export class JobStatusComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  checkpointIndexOfNav() {
+    return this.listOfNavigation.findIndex(item => item.path === 'checkpoints');
   }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java
@@ -46,6 +46,7 @@ public class JsonPlanGenerator {
             gen.writeStartObject();
             gen.writeStringField("jid", jg.getJobID().toString());
             gen.writeStringField("name", jg.getName());
+            gen.writeStringField("type", jg.getJobType().name());
             gen.writeArrayFieldStart("nodes");
 
             // info per vertex

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonGeneratorTest.java
@@ -102,6 +102,7 @@ public class JsonGeneratorTest {
             // core fields
             assertEquals(new TextNode(jg.getJobID().toString()), rootNode.get("jid"));
             assertEquals(new TextNode(jg.getName()), rootNode.get("name"));
+            assertEquals(new TextNode(jg.getJobType().name()), rootNode.get("type"));
 
             assertTrue(rootNode.path("nodes").isArray());
 

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -257,13 +257,16 @@ public class JsonJobGraphGenerationTest {
 
             JsonNode idField = rootNode.get("jid");
             JsonNode nameField = rootNode.get("name");
+            JsonNode typeField = rootNode.get("type");
             JsonNode arrayField = rootNode.get("nodes");
 
             assertNotNull(idField);
             assertNotNull(nameField);
+            assertNotNull(typeField);
             assertNotNull(arrayField);
             assertTrue(idField.isTextual());
             assertTrue(nameField.isTextual());
+            assertTrue(typeField.isTextual());
             assertTrue(arrayField.isArray());
 
             ArrayNode array = (ArrayNode) arrayField;


### PR DESCRIPTION
## What is the purpose of the change

*Batch jobs don't need a checkpointing page, because there is no information for these jobs available there. Therefore runtime web should hide the checkpointing page in the UI.*

## Brief change log

  - *The field `plan` of the response for `/jobs/:jobid` Rest API adds the `type` field which represents the job type of the job graph to identify whether the type of this job is `STREAMING` or `BATCH`.*
  - *`job-status.component.ts` hides the checkpointing page through checking the job type for the response of `/jobs/:jobid` Rest API.*

## Verifying this change

  - *`JsonGeneratorTest` and `JsonJobGraphGenerationTest` add the validation whether the `type` field value is equal to the job type of the job graph.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)