### PR TITLE
[FLINK-22588][docs] Added a space between digits and unit for config options with type 'Duration' and 'MemorySize'.

### DIFF
--- a/docs/content.zh/docs/connectors/table/elasticsearch.md
+++ b/docs/content.zh/docs/connectors/table/elasticsearch.md
@@ -148,7 +148,7 @@ CREATE TABLE myUserTable (
     <tr>
       <td><h5>sink.bulk-flush.max-size</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">2mb</td>
+      <td style="word-wrap: break-word;">2 mb</td>
       <td>MemorySize</td>
       <td>每个批量请求的缓冲操作在内存中的最大值。单位必须为 MB。
       可以设置为<code>'0'</code>来禁用它。
@@ -157,7 +157,7 @@ CREATE TABLE myUserTable (
     <tr>
       <td><h5>sink.bulk-flush.interval</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">1s</td>
+      <td style="word-wrap: break-word;">1 s</td>
       <td>Duration</td>
       <td>flush 缓冲操作的间隔。
         可以设置为<code>'0'</code>来禁用它。注意，<code>'sink.bulk-flush.max-size'</code>和<code>'sink.bulk-flush.max-actions'</code>都设置为<code>'0'</code>的这种 flush 间隔设置允许对缓冲操作进行完全异步处理。

--- a/docs/content.zh/docs/connectors/table/filesystem.md
+++ b/docs/content.zh/docs/connectors/table/filesystem.md
@@ -221,7 +221,7 @@ CREATE TABLE MyUserTableWithFilepath (
   <tbody>
     <tr>
         <td><h5>sink.rolling-policy.file-size</h5></td>
-        <td style="word-wrap: break-word;">128MB</td>
+        <td style="word-wrap: break-word;">128 MB</td>
         <td>MemorySize</td>
         <td> 滚动前，part 文件最大大小。</td>
     </tr>
@@ -341,17 +341,17 @@ Flink 提供了两种类型分区提交触发器：
 
 不管分区数据是否完整而只想让下游尽快感知到分区：
 - 'sink.partition-commit.trigger'='process-time' (默认值)
-- 'sink.partition-commit.delay'='0s' (默认值)
+- 'sink.partition-commit.delay'='0 s' (默认值)
   一旦数据进入分区，将立即提交分区。注意：这个分区可能会被提交多次。
 
 如果想让下游只有在分区数据完整时才感知到分区，并且 job 中有 watermark 生成，也能从分区字段的值中提取到时间：
 - 'sink.partition-commit.trigger'='partition-time'
-- 'sink.partition-commit.delay'='1h' (根据分区类型指定，如果是按小时分区可配置为 '1h')
+- 'sink.partition-commit.delay'='1 h' (根据分区类型指定，如果是按小时分区可配置为 '1 h')
   该方式是最精准地提交分区的方式，尽力确保提交分区的数据完整。
 
 如果想让下游系统只有在数据完整时才感知到分区，但是没有 watermark，或者无法从分区字段的值中提取时间：
 - 'sink.partition-commit.trigger'='process-time' (默认值)
-- 'sink.partition-commit.delay'='1h' (根据分区类型指定，如果是按小时分区可配置为 '1h')
+- 'sink.partition-commit.delay'='1 h' (根据分区类型指定，如果是按小时分区可配置为 '1 h')
   该方式尽量精确地提交分区，但是数据延迟或者故障将导致过早提交分区。
 
 延迟数据的处理：延迟的记录会被写入到已经提交的对应分区中，且会再次触发该分区的提交。
@@ -546,7 +546,7 @@ CREATE TABLE fs_table (
   'connector'='filesystem',
   'path'='...',
   'format'='parquet',
-  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.delay'='1h',
   'sink.partition-commit.policy.kind'='success-file'
 );
 
@@ -584,7 +584,7 @@ CREATE TABLE fs_table (
   'path'='...',
   'format'='parquet',
   'partition.time-extractor.timestamp-pattern'='$dt $hour:00:00',
-  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.delay'='1h',
   'sink.partition-commit.trigger'='partition-time',
   'sink.partition-commit.watermark-time-zone'='Asia/Shanghai', -- 假设用户配置的时区为 'Asia/Shanghai'
   'sink.partition-commit.policy.kind'='success-file'

--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -132,7 +132,7 @@ ON myTopic.key = hTable.rowkey;
     <tr>
       <td><h5>sink.buffer-flush.max-size</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">2mb</td>
+      <td style="word-wrap: break-word;">2 mb</td>
       <td>MemorySize</td>
       <td>写入的参数选项。每次写入请求缓存行的最大大小。它能提升写入 HBase 数据库的性能，但是也可能增加延迟。设置为 "0" 关闭此选项。
       </td>
@@ -148,7 +148,7 @@ ON myTopic.key = hTable.rowkey;
     <tr>
       <td><h5>sink.buffer-flush.interval</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">1s</td>
+      <td style="word-wrap: break-word;">1 s</td>
       <td>Duration</td>
       <td>写入的参数选项。刷写缓存行的间隔。它能提升写入 HBase 数据库的性能，但是也可能增加延迟。设置为 "0" 关闭此选项。注意："sink.buffer-flush.max-size" 和 "sink.buffer-flush.max-rows" 同时设置为 "0"，刷写选项整个异步处理缓存行为。
       </td>

--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -268,7 +268,7 @@ Using the latest Hive table as a temporal table does not require any additional 
         <td><h5>lookup.join.cache.ttl</h5></td>
         <td style="word-wrap: break-word;">60 min</td>
         <td>Duration</td>
-        <td>The cache TTL (e.g. 10min) for the build table in lookup join. By default the TTL is 60 minutes. NOTES: The option only works when lookup bounded hive table source, if you're using streaming hive source as temporal table, please use 'streaming-source.monitor-interval' to configure the interval of data update.
+        <td>The cache TTL (e.g. 10 min) for the build table in lookup join. By default the TTL is 60 minutes. NOTES: The option only works when lookup bounded hive table source, if you're using streaming hive source as temporal table, please use 'streaming-source.monitor-interval' to configure the interval of data update.
        </td>
     </tr>
   </tbody>
@@ -364,7 +364,7 @@ CREATE TABLE hive_table (
 ) PARTITIONED BY (dt STRING, hr STRING) STORED AS parquet TBLPROPERTIES (
   'partition.time-extractor.timestamp-pattern'='$dt $hr:00:00',
   'sink.partition-commit.trigger'='partition-time',
-  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.delay'='1h',
   'sink.partition-commit.policy.kind'='metastore,success-file'
 );
 
@@ -396,7 +396,7 @@ CREATE TABLE hive_table (
 ) PARTITIONED BY (dt STRING, hr STRING) STORED AS parquet TBLPROPERTIES (
   'partition.time-extractor.timestamp-pattern'='$dt $hr:00:00',
   'sink.partition-commit.trigger'='partition-time',
-  'sink.partition-commit.delay'='1 h',
+  'sink.partition-commit.delay'='1h',
   'sink.partition-commit.watermark-time-zone'='Asia/Shanghai', -- Assume user configured time zone is 'Asia/Shanghai'
   'sink.partition-commit.policy.kind'='metastore,success-file'
 );

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -153,7 +153,7 @@ ON myTopic.key = MyUserTable.id;
     <tr>
       <td><h5>connection.max-retry-timeout</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">60s</td>
+      <td style="word-wrap: break-word;">60 s</td>
       <td>Duration</td>
       <td>最大重试超时时间，以秒为单位且不应该小于 1 秒。</td>
     </tr>
@@ -241,7 +241,7 @@ ON myTopic.key = MyUserTable.id;
     <tr>
       <td><h5>sink.buffer-flush.interval</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">1s</td>
+      <td style="word-wrap: break-word;">1 s</td>
       <td>Duration</td>
       <td>flush 间隔时间，超过该时间后异步线程将 flush 数据。可以设置为 <code>'0'</code> 来禁用它。注意, 为了完全异步地处理缓存的 flush 事件，可以将 <code>'sink.buffer-flush.max-rows'</code> 设置为 <code>'0'</code> 并配置适当的 flush 时间间隔。</td>
     </tr>

--- a/docs/content.zh/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content.zh/docs/deployment/memory/mem_setup_tm.md
@@ -190,14 +190,14 @@ Flink 会负责管理网络内存，保证其实际用量不会超过配置大�
 | :------------------------------------------- | :---------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
 | 任务堆内存                                    | [`taskmanager.memory.task.heap.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-task-heap-size)         | 无穷大                                                                        |
 | 任务堆外内存                                | [`taskmanager.memory.task.off-heap.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-task-off-heap-size) | 无穷大                                                                        |
-| 托管内存                               | [`taskmanager.memory.managed.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-size)             | 128Mb                                                                           |
-| 网络内存                               | [`taskmanager.memory.network.min`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-min) <br /> [`taskmanager.memory.network.max`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-max) | 64Mb |
+| 托管内存                               | [`taskmanager.memory.managed.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-size)             | 128 Mb                                                                           |
+| 网络内存                               | [`taskmanager.memory.network.min`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-min) <br /> [`taskmanager.memory.network.max`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-max) | 64 Mb |
 
 <br/>
 
 本地执行模式下，上面列出的所有内存部分均可以但不是必须进行配置。
 如果未配置，则会采用默认值。
-其中，[任务堆内存](#task-operator-heap-memory)和*任务堆外内存*的默认值无穷大（*Long.MAX_VALUE* 字节），以及[托管内存](#managed-memory)的默认值 128Mb 均只针对本地执行模式。
+其中，[任务堆内存](#task-operator-heap-memory)和*任务堆外内存*的默认值无穷大（*Long.MAX_VALUE* 字节），以及[托管内存](#managed-memory)的默认值 128 Mb 均只针对本地执行模式。
 
 <span class="label label-info">提示</span>
 这种情况下，任务堆内存的大小与实际的堆空间大小无关。

--- a/docs/content/docs/connectors/table/elasticsearch.md
+++ b/docs/content/docs/connectors/table/elasticsearch.md
@@ -161,7 +161,7 @@ Connector Options
       <td><h5>sink.bulk-flush.max-size</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">2mb</td>
+      <td style="word-wrap: break-word;">2 mb</td>
       <td>MemorySize</td>
       <td>Maximum size in memory of buffered actions per bulk request. Must be in MB granularity.
       Can be set to <code>'0'</code> to disable it.
@@ -171,7 +171,7 @@ Connector Options
       <td><h5>sink.bulk-flush.interval</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">1s</td>
+      <td style="word-wrap: break-word;">1 s</td>
       <td>Duration</td>
       <td>The interval to flush buffered actions.
         Can be set to <code>'0'</code> to disable it. Note, both <code>'sink.bulk-flush.max-size'</code> and <code>'sink.bulk-flush.max-actions'</code>

--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -217,7 +217,7 @@ a timeout that specifies the maximum duration for which a file can be open.
         <td><h5>sink.rolling-policy.file-size</h5></td>
         <td>optional</td>
         <td>yes</td>
-        <td style="word-wrap: break-word;">128MB</td>
+        <td style="word-wrap: break-word;">128 MB</td>
         <td>MemorySize</td>
         <td>The maximum part file size before rolling.</td>
     </tr>
@@ -350,17 +350,17 @@ hourly partition or daily partition.
 
 If you want to let downstream see the partition as soon as possible, no matter whether its data is complete or not:
 - 'sink.partition-commit.trigger'='process-time' (Default value)
-- 'sink.partition-commit.delay'='0s' (Default value)
+- 'sink.partition-commit.delay'='0 s' (Default value)
 Once there is data in the partition, it will immediately commit. Note: the partition may be committed multiple times.
 
 If you want to let downstream see the partition only when its data is complete, and your job has watermark generation, and you can extract the time from partition values:
 - 'sink.partition-commit.trigger'='partition-time'
-- 'sink.partition-commit.delay'='1h' ('1h' if your partition is hourly partition, depends on your partition type)
+- 'sink.partition-commit.delay'='1 h' ('1 h' if your partition is hourly partition, depends on your partition type)
 This is the most accurate way to commit partition, and it will try to ensure that the committed partitions are as data complete as possible.
 
 If you want to let downstream see the partition only when its data is complete, but there is no watermark, or the time cannot be extracted from partition values:
 - 'sink.partition-commit.trigger'='process-time' (Default value)
-- 'sink.partition-commit.delay'='1h' ('1h' if your partition is hourly partition, depends on your partition type)
+- 'sink.partition-commit.delay'='1 h' ('1 h' if your partition is hourly partition, depends on your partition type)
 Try to commit partition accurately, but data delay or failover will lead to premature partition commit.
 
 Late data processing: The record will be written into its partition when a record is supposed to be

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -141,7 +141,7 @@ Connector Options
       <td><h5>sink.buffer-flush.max-size</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">2mb</td>
+      <td style="word-wrap: break-word;">2 mb</td>
       <td>MemorySize</td>
       <td>Writing option, maximum size in memory of buffered rows for each writing request.
       This can improve performance for writing data to HBase database, but may increase the latency.
@@ -163,7 +163,7 @@ Connector Options
       <td><h5>sink.buffer-flush.interval</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">1s</td>
+      <td style="word-wrap: break-word;">1 s</td>
       <td>Duration</td>
       <td>Writing option, the interval to flush any buffered rows.
       This can improve performance for writing data to HBase database, but may increase the latency.

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -268,7 +268,7 @@ Using the latest Hive table as a temporal table does not require any additional 
         <td><h5>lookup.join.cache.ttl</h5></td>
         <td style="word-wrap: break-word;">60 min</td>
         <td>Duration</td>
-        <td>The cache TTL (e.g. 10min) for the build table in lookup join. By default the TTL is 60 minutes. NOTES: The option only works when lookup bounded hive table source, if you're using streaming hive source as temporal table, please use 'streaming-source.monitor-interval' to configure the interval of data update.
+        <td>The cache TTL (e.g. 10 min) for the build table in lookup join. By default the TTL is 60 minutes. NOTES: The option only works when lookup bounded hive table source, if you're using streaming hive source as temporal table, please use 'streaming-source.monitor-interval' to configure the interval of data update.
        </td>
     </tr>
   </tbody>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -155,7 +155,7 @@ Connector Options
       <td><h5>connection.max-retry-timeout</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">60s</td>
+      <td style="word-wrap: break-word;">60 s</td>
       <td>Duration</td>
       <td>Maximum timeout between retries. The timeout should be in second granularity and shouldn't be smaller than 1 second.</td>
     </tr>
@@ -255,7 +255,7 @@ Connector Options
       <td><h5>sink.buffer-flush.interval</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">1s</td>
+      <td style="word-wrap: break-word;">1 s</td>
       <td>Duration</td>
       <td>The flush interval mills, over this time, asynchronous threads will flush data. Can be set to <code>'0'</code> to disable it. Note, <code>'sink.buffer-flush.max-rows'</code> can be set to <code>'0'</code> with the flush interval set allowing for complete async processing of buffered actions.</td>
     </tr>

--- a/docs/content/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content/docs/deployment/memory/mem_setup_tm.md
@@ -174,15 +174,15 @@ then all components are ignored except for the following:
 | :------------------------------------------- | :---------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
 | Task heap                                    | [`taskmanager.memory.task.heap.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-task-heap-size)         | infinite                                                                        |
 | Task off-heap                                | [`taskmanager.memory.task.off-heap.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-task-off-heap-size) | infinite                                                                        |
-| Managed memory                               | [`taskmanager.memory.managed.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-size)             | 128Mb                                                                           |
-| Network memory                               | [`taskmanager.memory.network.min`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-min) <br /> [`taskmanager.memory.network.max`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-max) | 64Mb |
+| Managed memory                               | [`taskmanager.memory.managed.size`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-size)             | 128 Mb                                                                           |
+| Network memory                               | [`taskmanager.memory.network.min`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-min) <br /> [`taskmanager.memory.network.max`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-network-max) | 64 Mb |
 
 <br/>
 
 All of the components listed above can be but do not have to be explicitly configured for local execution.
 If they are not configured they are set to their default values. [Task heap memory](#task-operator-heap-memory) and
 *task off-heap memory* are considered to be infinite (*Long.MAX_VALUE* bytes) and [managed memory](#managed-memory)
-has a default value of 128Mb only for the local execution mode.
+has a default value of 128 Mb only for the local execution mode.
 
 <span class="label label-info">Note</span> The task heap size is not related in any way to the real heap size in this case.
 It can become relevant for future optimizations coming with next releases. The actual JVM Heap size of the started


### PR DESCRIPTION
## What is the purpose of the change

Added a space between digits and unit for config options with type 'Duration' and 'MemorySize'.

## Brief change log

Added a space between digits and unit for config options with type 'Duration' and 'MemorySize'.

Affected files:
* docs/content.zh/docs/connectors/table/elasticsearch.md
* docs/content.zh/docs/connectors/table/filesystem.md
* docs/content.zh/docs/connectors/table/hbase.md
* docs/content.zh/docs/connectors/table/hive/hive_read_write.md
* docs/content.zh/docs/connectors/table/jdbc.md
* docs/content.zh/docs/deployment/memory/mem_setup_tm.md
* docs/content/docs/connectors/table/elasticsearch.md
* docs/content/docs/connectors/table/filesystem.md
* docs/content/docs/connectors/table/hbase.md
* docs/content/docs/connectors/table/hive/hive_read_write.md
* docs/content/docs/connectors/table/jdbc.md
* docs/content/docs/deployment/memory/mem_setup_tm.md


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
