### PR TITLE
[FLINK-22407][build] Bump log4j to 2.24.1

### DIFF
--- a/docs/content.zh/docs/dev/datastream/project-configuration.md
+++ b/docs/content.zh/docs/dev/datastream/project-configuration.md
@@ -331,7 +331,7 @@ ext {
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
     slf4jVersion = '1.7.15'
-    log4jVersion = '2.12.1'
+    log4jVersion = '2.14.1'
 }
 
 

--- a/docs/content/docs/dev/datastream/project-configuration.md
+++ b/docs/content/docs/dev/datastream/project-configuration.md
@@ -330,7 +330,7 @@ ext {
     flinkVersion = '1.13-SNAPSHOT'
     scalaBinaryVersion = '2.11'
     slf4jVersion = '1.7.15'
-    log4jVersion = '2.12.1'
+    log4jVersion = '2.14.1'
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ under the License.
 		<akka.version>2.5.21</akka.version>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.15</slf4j.version>
-		<log4j.version>2.12.1</log4j.version>
+		<log4j.version>2.14.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 Intellij is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -8,10 +8,10 @@ Copyright 2014-2021 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.12.1
-- org.apache.logging.log4j:log4j-core:2.12.1
-- org.apache.logging.log4j:log4j-slf4j-impl:2.12.1
-- org.apache.logging.log4j:log4j-1.2-api:2.12.1
+- org.apache.logging.log4j:log4j-api:2.14.1
+- org.apache.logging.log4j:log4j-core:2.14.1
+- org.apache.logging.log4j:log4j-slf4j-impl:2.14.1
+- org.apache.logging.log4j:log4j-1.2-api:2.14.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
Fixes CVE-2020-9488 and a layout issue a user runs into.

