### PR TITLE
[FLINK-22376][runtime] RecoveredChannelStateHandler recycles the buffer if it was created inside and doesn't recycle if it was passed as parameter.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
@@ -128,7 +128,8 @@ public class InflightDataRescalingDescriptor implements Serializable {
 
         private final MappingType mappingType;
 
-        enum MappingType {
+        /** Type of mapping which should be used for this in-flight data. */
+        public enum MappingType {
             IDENTITY,
             RESCALING
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateSerializer.java
@@ -57,11 +57,12 @@ interface ChannelStateSerializer {
 /** Wrapper around various buffers to receive channel state data. */
 @Internal
 @NotThreadSafe
-interface ChannelStateByteBuffer {
+interface ChannelStateByteBuffer extends AutoCloseable {
 
     boolean isWritable();
 
-    void recycle();
+    @Override
+    void close();
 
     /**
      * Read up to <code>bytesToRead</code> bytes into this buffer from the given {@link
@@ -82,7 +83,7 @@ interface ChannelStateByteBuffer {
             }
 
             @Override
-            public void recycle() {
+            public void close() {
                 buffer.recycleBuffer();
             }
 
@@ -102,8 +103,8 @@ interface ChannelStateByteBuffer {
             }
 
             @Override
-            public void recycle() {
-                bufferBuilder.recycle();
+            public void close() {
+                bufferBuilder.close();
             }
 
             @Override
@@ -135,7 +136,7 @@ interface ChannelStateByteBuffer {
             }
 
             @Override
-            public void recycle() {}
+            public void close() {}
 
             @Override
             public int writeBytes(InputStream input, int bytesToRead) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandler.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.checkpoint.RescaleMappings;
 import org.apache.flink.runtime.io.network.api.SubtaskConnectionDescriptor;
@@ -50,11 +49,21 @@ interface RecoveredChannelStateHandler<Info, Context> extends AutoCloseable {
             this.buffer = buffer;
             this.context = context;
         }
+
+        public void close() {
+            buffer.close();
+        }
     }
 
     BufferWithContext<Context> getBuffer(Info info) throws IOException, InterruptedException;
 
-    void recover(Info info, int oldSubtaskIndex, Context context) throws IOException;
+    /**
+     * Recover the data from buffer. This method is taking over the ownership of the
+     * bufferWithContext and is fully responsible for cleaning it up both on the happy path and in
+     * case of an error.
+     */
+    void recover(Info info, int oldSubtaskIndex, BufferWithContext<Context> bufferWithContext)
+            throws IOException;
 }
 
 class InputChannelRecoveredStateHandler
@@ -83,8 +92,12 @@ class InputChannelRecoveredStateHandler
     }
 
     @Override
-    public void recover(InputChannelInfo channelInfo, int oldSubtaskIndex, Buffer buffer)
+    public void recover(
+            InputChannelInfo channelInfo,
+            int oldSubtaskIndex,
+            BufferWithContext<Buffer> bufferWithContext)
             throws IOException {
+        Buffer buffer = bufferWithContext.context;
         try {
             if (buffer.readableBytes() > 0) {
                 for (final RecoveredInputChannel channel : getMappedChannels(channelInfo)) {
@@ -142,8 +155,7 @@ class InputChannelRecoveredStateHandler
 }
 
 class ResultSubpartitionRecoveredStateHandler
-        implements RecoveredChannelStateHandler<
-                ResultSubpartitionInfo, Tuple2<BufferBuilder, BufferConsumer>> {
+        implements RecoveredChannelStateHandler<ResultSubpartitionInfo, BufferBuilder> {
 
     private final ResultPartitionWriter[] writers;
     private final boolean notifyAndBlockOnCompletion;
@@ -164,40 +176,39 @@ class ResultSubpartitionRecoveredStateHandler
     }
 
     @Override
-    public BufferWithContext<Tuple2<BufferBuilder, BufferConsumer>> getBuffer(
-            ResultSubpartitionInfo subpartitionInfo) throws IOException, InterruptedException {
+    public BufferWithContext<BufferBuilder> getBuffer(ResultSubpartitionInfo subpartitionInfo)
+            throws IOException, InterruptedException {
         // request the buffer from any mapped subpartition as they all will receive the same buffer
         final List<CheckpointedResultSubpartition> channels = getMappedChannels(subpartitionInfo);
         BufferBuilder bufferBuilder = channels.get(0).requestBufferBuilderBlocking();
-        return new BufferWithContext<>(
-                wrap(bufferBuilder),
-                Tuple2.of(bufferBuilder, bufferBuilder.createBufferConsumer()));
+        return new BufferWithContext<>(wrap(bufferBuilder), bufferBuilder);
     }
 
     @Override
     public void recover(
             ResultSubpartitionInfo subpartitionInfo,
             int oldSubtaskIndex,
-            Tuple2<BufferBuilder, BufferConsumer> bufferBuilderAndConsumer)
+            BufferWithContext<BufferBuilder> bufferWithContext)
             throws IOException {
-        try {
-            bufferBuilderAndConsumer.f0.finish();
-            if (bufferBuilderAndConsumer.f1.isDataAvailable()) {
-                final List<CheckpointedResultSubpartition> channels =
-                        getMappedChannels(subpartitionInfo);
-                for (final CheckpointedResultSubpartition channel : channels) {
-                    // channel selector is created from the downstream's point of view: the subtask
-                    // of
-                    // downstream = subpartition index of recovered buffer
-                    final SubtaskConnectionDescriptor channelSelector =
-                            new SubtaskConnectionDescriptor(
-                                    subpartitionInfo.getSubPartitionIdx(), oldSubtaskIndex);
-                    channel.addRecovered(EventSerializer.toBufferConsumer(channelSelector, false));
-                    channel.addRecovered(bufferBuilderAndConsumer.f1.copy());
+        try (BufferBuilder bufferBuilder = bufferWithContext.context) {
+            try (BufferConsumer bufferConsumer =
+                    bufferBuilder.createBufferConsumerFromBeginning()) {
+                bufferBuilder.finish();
+                if (bufferConsumer.isDataAvailable()) {
+                    final List<CheckpointedResultSubpartition> channels =
+                            getMappedChannels(subpartitionInfo);
+                    for (final CheckpointedResultSubpartition channel : channels) {
+                        // channel selector is created from the downstream's point of view: the
+                        // subtask of downstream = subpartition index of recovered buffer
+                        final SubtaskConnectionDescriptor channelSelector =
+                                new SubtaskConnectionDescriptor(
+                                        subpartitionInfo.getSubPartitionIdx(), oldSubtaskIndex);
+                        channel.addRecovered(
+                                EventSerializer.toBufferConsumer(channelSelector, false));
+                        channel.addRecovered(bufferConsumer.copy());
+                    }
                 }
             }
-        } finally {
-            bufferBuilderAndConsumer.f1.close();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -306,7 +306,9 @@ public class EventSerializer {
         MemorySegment data = MemorySegmentFactory.wrap(serializedEvent.array());
 
         return new BufferConsumer(
-                data, FreeingBufferRecycler.INSTANCE, getDataType(event, hasPriority));
+                new NetworkBuffer(
+                        data, FreeingBufferRecycler.INSTANCE, getDataType(event, hasPriority)),
+                data.size());
     }
 
     public static AbstractEvent fromBuffer(Buffer buffer, ClassLoader classLoader)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -154,11 +153,6 @@ public class BufferBuilder {
 
     public void recycle() {
         recycler.recycle(memorySegment);
-    }
-
-    @VisibleForTesting
-    public MemorySegment getMemorySegment() {
-        return memorySegment;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferConsumer.java
@@ -46,41 +46,15 @@ public class BufferConsumer implements Closeable {
 
     private int currentReaderPosition;
 
-    /** Constructs {@link BufferConsumer} instance with the initial reader position. */
-    public BufferConsumer(
-            MemorySegment memorySegment,
-            BufferRecycler recycler,
-            PositionMarker currentWriterPosition,
-            int currentReaderPosition) {
-        this(
-                new NetworkBuffer(checkNotNull(memorySegment), checkNotNull(recycler)),
-                currentWriterPosition,
-                currentReaderPosition);
-    }
-
-    /** Constructs {@link BufferConsumer} instance with static content. */
-    public BufferConsumer(
-            MemorySegment memorySegment, BufferRecycler recycler, Buffer.DataType dataType) {
-        this(memorySegment, recycler, memorySegment.size(), dataType);
-    }
-
     /** Constructs {@link BufferConsumer} instance with static content of a certain size. */
-    public BufferConsumer(
-            MemorySegment memorySegment,
-            BufferRecycler recycler,
-            int size,
-            Buffer.DataType dataType) {
-        this(
-                new NetworkBuffer(checkNotNull(memorySegment), checkNotNull(recycler), dataType),
-                () -> -size,
-                0);
-        checkState(memorySegment.size() > 0);
+    public BufferConsumer(Buffer buffer, int size) {
+        this(buffer, () -> -size, 0);
         checkState(
                 isFinished(),
                 "BufferConsumer with static size must be finished after construction!");
     }
 
-    private BufferConsumer(
+    public BufferConsumer(
             Buffer buffer,
             BufferBuilder.PositionMarker currentWriterPosition,
             int currentReaderPosition) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 
 import javax.annotation.Nullable;
@@ -85,4 +86,21 @@ public interface BufferProvider extends AvailabilityProvider {
 
     /** Returns whether the buffer provider has been destroyed. */
     boolean isDestroyed();
+
+    /**
+     * Returns a {@link MemorySegment} instance from the buffer provider.
+     *
+     * @return {@code null} if no memory segment is available or the buffer provider has been
+     *     destroyed.
+     */
+    @Nullable
+    MemorySegment requestMemorySegment();
+
+    /**
+     * Returns a {@link MemorySegment} instance from the buffer provider.
+     *
+     * <p>If there is no memory segment available, the call will block until one becomes available
+     * again or the buffer provider has been destroyed.
+     */
+    MemorySegment requestMemorySegmentBlocking() throws InterruptedException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -281,7 +281,12 @@ class LocalBufferPool implements BufferPool {
 
     @Override
     public BufferBuilder requestBufferBuilderBlocking() throws InterruptedException {
-        return toBufferBuilder(requestMemorySegmentBlocking(UNKNOWN_CHANNEL), UNKNOWN_CHANNEL);
+        return toBufferBuilder(requestMemorySegmentBlocking(), UNKNOWN_CHANNEL);
+    }
+
+    @Override
+    public MemorySegment requestMemorySegmentBlocking() throws InterruptedException {
+        return requestMemorySegmentBlocking(UNKNOWN_CHANNEL);
     }
 
     @Override
@@ -359,8 +364,8 @@ class LocalBufferPool implements BufferPool {
         return segment;
     }
 
-    @Nullable
-    private MemorySegment requestMemorySegment() {
+    @Override
+    public MemorySegment requestMemorySegment() {
         return requestMemorySegment(UNKNOWN_CHANNEL);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -349,6 +349,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
             numBytesOut.inc(bufferBuilder.finish());
             numBuffersOut.inc();
             unicastBufferBuilders[targetSubpartition] = null;
+            bufferBuilder.close();
         }
     }
 
@@ -362,6 +363,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
         if (broadcastBufferBuilder != null) {
             numBytesOut.inc(broadcastBufferBuilder.finish() * numSubpartitions);
             numBuffersOut.inc(numSubpartitions);
+            broadcastBufferBuilder.close();
             broadcastBufferBuilder = null;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -450,6 +450,10 @@ public class RemoteInputChannel extends InputChannel {
         }
     }
 
+    /**
+     * Handles the input buffer. This method is taking over the ownership of the buffer and is fully
+     * responsible for cleaning it up both on the happy path and in case of an error.
+     */
     public void onBuffer(Buffer buffer, int sequenceNumber, int backlog) throws IOException {
         boolean recycleBuffer = true;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/InputChannelRecoveredStateHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.RescaleMappings;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test of different implementation of {@link InputChannelRecoveredStateHandler}. */
+public class InputChannelRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
+    private static final int preAllocatedSegments = 3;
+    private NetworkBufferPool networkBufferPool;
+    private SingleInputGate inputGate;
+    private InputChannelRecoveredStateHandler icsHander;
+    private InputChannelInfo channelInfo;
+
+    @Before
+    public void setUp() {
+        // given: Segment provider with defined number of allocated segments.
+        networkBufferPool = new NetworkBufferPool(preAllocatedSegments, 1024);
+
+        // and: Configured input gate with recovered channel.
+        inputGate =
+                new SingleInputGateBuilder()
+                        .setChannelFactory(InputChannelBuilder::buildLocalRecoveredChannel)
+                        .setSegmentProvider(networkBufferPool)
+                        .build();
+
+        icsHander = buildInputChannelStateHandler(inputGate);
+
+        channelInfo = new InputChannelInfo(0, 0);
+    }
+
+    private InputChannelRecoveredStateHandler buildInputChannelStateHandler(
+            SingleInputGate inputGate) {
+        return new InputChannelRecoveredStateHandler(
+                new InputGate[] {inputGate},
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }));
+    }
+
+    @Test
+    public void testRecycleBufferBeforeRecoverWasCalled() throws Exception {
+        // when: Request the buffer.
+        RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
+                icsHander.getBuffer(channelInfo);
+
+        // and: Recycle buffer outside.
+        bufferWithContext.buffer.close();
+
+        // Close the gate for flushing the cached recycled buffers to the segment provider.
+        inputGate.close();
+
+        // then: All pre-allocated segments should be successfully recycled.
+        assertEquals(preAllocatedSegments, networkBufferPool.getNumberOfAvailableMemorySegments());
+    }
+
+    @Test
+    public void testRecycleBufferAfterRecoverWasCalled() throws Exception {
+        // when: Request the buffer.
+        RecoveredChannelStateHandler.BufferWithContext<Buffer> bufferWithContext =
+                icsHander.getBuffer(channelInfo);
+
+        // and: Recycle buffer outside.
+        icsHander.recover(channelInfo, 0, bufferWithContext);
+
+        // Close the gate for flushing the cached recycled buffers to the segment provider.
+        inputGate.close();
+
+        // then: All pre-allocated segments should be successfully recycled.
+        assertEquals(preAllocatedSegments, networkBufferPool.getNumberOfAvailableMemorySegments());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.junit.Test;
+
+/**
+ * Base class which contains all tests which should be implemented for every implementation of
+ * {@link InputChannelRecoveredStateHandler}.
+ */
+public abstract class RecoveredChannelStateHandlerTest {
+
+    @Test
+    public abstract void testRecycleBufferBeforeRecoverWasCalled() throws Exception;
+
+    @Test
+    public abstract void testRecycleBufferAfterRecoverWasCalled() throws Exception;
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.channel;
+
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.RescaleMappings;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test of different implementation of {@link ResultSubpartitionRecoveredStateHandler}. */
+public class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
+    private static final int preAllocatedSegments = 3;
+    private NetworkBufferPool networkBufferPool;
+    private ResultPartition partition;
+    private ResultSubpartitionRecoveredStateHandler rstHandler;
+    private ResultSubpartitionInfo channelInfo;
+
+    @Before
+    public void setUp() throws IOException {
+        // given: Segment provider with defined number of allocated segments.
+        channelInfo = new ResultSubpartitionInfo(0, 0);
+
+        networkBufferPool = new NetworkBufferPool(preAllocatedSegments, 1024);
+        partition = new ResultPartitionBuilder().setNetworkBufferPool(networkBufferPool).build();
+        partition.setup();
+
+        rstHandler = buildResultStateHandler(partition);
+    }
+
+    private ResultSubpartitionRecoveredStateHandler buildResultStateHandler(
+            ResultPartition partition) {
+        return new ResultSubpartitionRecoveredStateHandler(
+                new ResultPartitionWriter[] {partition},
+                false,
+                new InflightDataRescalingDescriptor(
+                        new InflightDataRescalingDescriptor
+                                        .InflightDataGateOrPartitionRescalingDescriptor[] {
+                            new InflightDataRescalingDescriptor
+                                    .InflightDataGateOrPartitionRescalingDescriptor(
+                                    new int[] {1},
+                                    RescaleMappings.identity(1, 1),
+                                    new HashSet<>(),
+                                    InflightDataRescalingDescriptor
+                                            .InflightDataGateOrPartitionRescalingDescriptor
+                                            .MappingType.IDENTITY)
+                        }));
+    }
+
+    @Test
+    public void testRecycleBufferBeforeRecoverWasCalled() throws Exception {
+        // when: Request the buffer.
+        RecoveredChannelStateHandler.BufferWithContext<BufferBuilder> bufferWithContext =
+                rstHandler.getBuffer(new ResultSubpartitionInfo(0, 0));
+
+        // and: Recycle buffer outside.
+        bufferWithContext.buffer.close();
+
+        // Close the partition for flushing the cached recycled buffers to the segment provider.
+        partition.close();
+
+        // then: All pre-allocated segments should be successfully recycled.
+        assertEquals(preAllocatedSegments, networkBufferPool.getNumberOfAvailableMemorySegments());
+    }
+
+    @Test
+    public void testRecycleBufferAfterRecoverWasCalled() throws Exception {
+        // when: Request the buffer.
+        RecoveredChannelStateHandler.BufferWithContext<BufferBuilder> bufferWithContext =
+                rstHandler.getBuffer(channelInfo);
+
+        // and: Pass the buffer to recovery.
+        rstHandler.recover(channelInfo, 0, bufferWithContext);
+
+        // Close the partition for flushing the cached recycled buffers to the segment provider.
+        partition.close();
+
+        // then: All pre-allocated segments should be successfully recycled.
+        assertEquals(preAllocatedSegments, networkBufferPool.getNumberOfAvailableMemorySegments());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -292,15 +292,16 @@ public class SpanningRecordSerializationTest extends TestLogger {
     }
 
     private static Buffer appendLeftOverBytes(Buffer buffer, byte[] leftOverBytes) {
-        BufferBuilder bufferBuilder =
+        try (BufferBuilder bufferBuilder =
                 new BufferBuilder(
                         MemorySegmentFactory.allocateUnpooledSegment(
                                 buffer.readableBytes() + leftOverBytes.length),
-                        FreeingBufferRecycler.INSTANCE);
-        try (BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer()) {
-            bufferBuilder.append(buffer.getNioBufferReadable());
-            bufferBuilder.appendAndCommit(ByteBuffer.wrap(leftOverBytes));
-            return bufferConsumer.build();
+                        FreeingBufferRecycler.INSTANCE)) {
+            try (BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer()) {
+                bufferBuilder.append(buffer.getNioBufferReadable());
+                bufferBuilder.appendAndCommit(ByteBuffer.wrap(leftOverBytes));
+                return bufferConsumer.build();
+            }
         }
     }
 
@@ -331,6 +332,10 @@ public class SpanningRecordSerializationTest extends TestLogger {
                 createFilledBufferBuilder(segmentSize + startingOffset, startingOffset);
         BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
         bufferConsumer.build().recycleBuffer();
+
+        // Closing the BufferBuilder here just allow to be sure that Buffer will be recovered when
+        // BufferConsumer will be closed.
+        bufferBuilder.close();
 
         bufferBuilder.appendAndCommit(serializedRecord);
         return new BufferAndSerializerResult(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -312,13 +312,14 @@ public class RecordWriterTest {
             assertTrue(recordWriter.getAvailableFuture().isDone());
 
             // request one buffer from the local pool to make it unavailable afterwards
-            final BufferBuilder bufferBuilder = localPool.requestBufferBuilder(0);
-            assertNotNull(bufferBuilder);
-            assertFalse(recordWriter.getAvailableFuture().isDone());
+            try (BufferBuilder bufferBuilder = localPool.requestBufferBuilder(0)) {
+                assertNotNull(bufferBuilder);
+                assertFalse(recordWriter.getAvailableFuture().isDone());
 
-            // recycle the buffer to make the local pool available again
-            final Buffer buffer = BufferBuilderTestUtils.buildSingleBuffer(bufferBuilder);
-            buffer.recycleBuffer();
+                // recycle the buffer to make the local pool available again
+                final Buffer buffer = BufferBuilderTestUtils.buildSingleBuffer(bufferBuilder);
+                buffer.recycleBuffer();
+            }
             assertTrue(recordWriter.getAvailableFuture().isDone());
             assertEquals(recordWriter.AVAILABLE, recordWriter.getAvailableFuture());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
-import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.memory.MemorySegment;
 
 import org.junit.Test;
 
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 
+import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSingleBuffer;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -45,6 +46,8 @@ public class BufferBuilderAndConsumerTest {
         BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
 
         assertEquals(3 * Integer.BYTES, bufferBuilder.appendAndCommit(toByteBuffer(1, 2, 3)));
+
+        bufferBuilder.close();
 
         Buffer buffer = bufferConsumer.build();
         assertFalse(buffer.isRecycled());
@@ -152,33 +155,37 @@ public class BufferBuilderAndConsumerTest {
 
     @Test
     public void buildEmptyBuffer() {
-        Buffer buffer = buildSingleBuffer(createBufferBuilder());
-        assertEquals(0, buffer.getSize());
-        assertContent(buffer, FreeingBufferRecycler.INSTANCE);
+        try (BufferBuilder bufferBuilder = createBufferBuilder()) {
+            Buffer buffer = buildSingleBuffer(bufferBuilder);
+            assertEquals(0, buffer.getSize());
+            assertContent(buffer, FreeingBufferRecycler.INSTANCE);
+        }
     }
 
     @Test
     public void buildingBufferMultipleTimes() {
-        BufferBuilder bufferBuilder = createBufferBuilder();
-        try (BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer()) {
-            bufferBuilder.appendAndCommit(toByteBuffer(0, 1));
-            bufferBuilder.appendAndCommit(toByteBuffer(2));
+        try (BufferBuilder bufferBuilder = createBufferBuilder()) {
+            try (BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer()) {
+                bufferBuilder.appendAndCommit(toByteBuffer(0, 1));
+                bufferBuilder.appendAndCommit(toByteBuffer(2));
 
-            assertContent(bufferConsumer, 0, 1, 2);
+                assertContent(bufferConsumer, 0, 1, 2);
 
-            bufferBuilder.appendAndCommit(toByteBuffer(3, 42));
-            bufferBuilder.appendAndCommit(toByteBuffer(44));
+                bufferBuilder.appendAndCommit(toByteBuffer(3, 42));
+                bufferBuilder.appendAndCommit(toByteBuffer(44));
 
-            assertContent(bufferConsumer, 3, 42, 44);
+                assertContent(bufferConsumer, 3, 42, 44);
 
-            ArrayList<Integer> originalValues = new ArrayList<>();
-            while (!bufferBuilder.isFull()) {
-                bufferBuilder.appendAndCommit(toByteBuffer(1337));
-                originalValues.add(1337);
+                ArrayList<Integer> originalValues = new ArrayList<>();
+                while (!bufferBuilder.isFull()) {
+                    bufferBuilder.appendAndCommit(toByteBuffer(1337));
+                    originalValues.add(1337);
+                }
+
+                assertContent(
+                        bufferConsumer,
+                        originalValues.stream().mapToInt(Integer::intValue).toArray());
             }
-
-            assertContent(
-                    bufferConsumer, originalValues.stream().mapToInt(Integer::intValue).toArray());
         }
     }
 
@@ -218,6 +225,43 @@ public class BufferBuilderAndConsumerTest {
         BufferBuilder bufferBuilder = createBufferBuilder();
         bufferBuilder.append(toByteBuffer(new int[bufferBuilder.getMaxCapacity()]));
         assertEquals(0, bufferBuilder.getWritableBytes());
+    }
+
+    @Test
+    public void recycleWithoutConsumer() {
+        // given: Recycler with the counter of recycle invocation.
+        CountedRecycler recycler = new CountedRecycler();
+        BufferBuilder bufferBuilder =
+                new BufferBuilder(allocateUnpooledSegment(BUFFER_SIZE), recycler);
+
+        // when: Invoke the recycle.
+        bufferBuilder.close();
+
+        // then: Recycling successfully finished.
+        assertEquals(1, recycler.recycleInvocationCounter);
+    }
+
+    @Test
+    public void recycleConsumerAndBufferBuilder() {
+        // given: Recycler with the counter of recycling invocation.
+        CountedRecycler recycler = new CountedRecycler();
+        BufferBuilder bufferBuilder =
+                new BufferBuilder(allocateUnpooledSegment(BUFFER_SIZE), recycler);
+
+        // and: One buffer consumer.
+        BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
+
+        // when: Invoke the recycle of BufferBuilder.
+        bufferBuilder.close();
+
+        // then: Nothing happened because BufferBuilder has already consumer.
+        assertEquals(0, recycler.recycleInvocationCounter);
+
+        // when: Close the consumer.
+        bufferConsumer.close();
+
+        // then: Recycling successfully finished.
+        assertEquals(1, recycler.recycleInvocationCounter);
     }
 
     private static void testIsFinished(int writes) {
@@ -283,7 +327,16 @@ public class BufferBuilderAndConsumerTest {
 
     private static BufferBuilder createBufferBuilder() {
         return new BufferBuilder(
-                MemorySegmentFactory.allocateUnpooledSegment(BUFFER_SIZE),
-                FreeingBufferRecycler.INSTANCE);
+                allocateUnpooledSegment(BUFFER_SIZE), FreeingBufferRecycler.INSTANCE);
+    }
+
+    private static class CountedRecycler implements BufferRecycler {
+        int recycleInvocationCounter;
+
+        @Override
+        public void recycle(MemorySegment memorySegment) {
+            recycleInvocationCounter++;
+            memorySegment.free();
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
@@ -39,12 +39,20 @@ public class BufferBuilderTestUtils {
         return createFilledBufferBuilder(size, 0);
     }
 
+    public static BufferBuilder createBufferBuilder(MemorySegment memorySegment) {
+        return createFilledBufferBuilder(memorySegment, 0);
+    }
+
     public static BufferBuilder createFilledBufferBuilder(int size, int dataSize) {
         checkArgument(size >= dataSize);
+        return createFilledBufferBuilder(
+                MemorySegmentFactory.allocateUnpooledSegment(size), dataSize);
+    }
+
+    public static BufferBuilder createFilledBufferBuilder(
+            MemorySegment memorySegment, int dataSize) {
         BufferBuilder bufferBuilder =
-                new BufferBuilder(
-                        MemorySegmentFactory.allocateUnpooledSegment(size),
-                        FreeingBufferRecycler.INSTANCE);
+                new BufferBuilder(memorySegment, FreeingBufferRecycler.INSTANCE);
         return fillBufferBuilder(bufferBuilder, dataSize);
     }
 
@@ -83,6 +91,7 @@ public class BufferBuilderTestUtils {
 
         if (isFinished) {
             bufferBuilder.finish();
+            bufferBuilder.close();
         }
 
         return bufferConsumer;
@@ -90,9 +99,11 @@ public class BufferBuilderTestUtils {
 
     public static BufferConsumer createEventBufferConsumer(int size, Buffer.DataType dataType) {
         return new BufferConsumer(
-                MemorySegmentFactory.allocateUnpooledSegment(size),
-                FreeingBufferRecycler.INSTANCE,
-                dataType);
+                new NetworkBuffer(
+                        MemorySegmentFactory.allocateUnpooledSegment(size),
+                        FreeingBufferRecycler.INSTANCE,
+                        dataType),
+                size);
     }
 
     public static Buffer buildBufferWithAscendingInts(int bufferSize, int numInts, int nextValue) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -514,6 +514,7 @@ public class LocalBufferPoolTest extends TestLogger {
 
         // recycle the requested buffer
         bufferBuilder.createBufferConsumer().close();
+        bufferBuilder.recycle();
         assertTrue(localBufferPool.isAvailable());
         assertTrue(availableFuture2.isDone());
     }
@@ -524,7 +525,7 @@ public class LocalBufferPoolTest extends TestLogger {
         NetworkBufferPool globalPool = new TestNetworkBufferPool(numBuffers, memorySegmentSize);
         try {
             BufferPool localPool = new LocalBufferPool(globalPool, 1);
-            MemorySegment segment = localPool.requestBufferBuilderBlocking().getMemorySegment();
+            MemorySegment segment = localPool.requestMemorySegmentBlocking();
             localPool.setNumBuffers(2);
 
             localPool.recycle(segment);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPoolTest.java
@@ -449,15 +449,15 @@ public class LocalBufferPoolTest extends TestLogger {
         assertFalse(localBufferPool.getAvailableFuture().isDone());
 
         // recycle segments
-        bufferBuilder11.getRecycler().recycle(bufferBuilder11.getMemorySegment());
+        bufferBuilder11.close();
         assertFalse(localBufferPool.getAvailableFuture().isDone());
-        bufferBuilder21.getRecycler().recycle(bufferBuilder21.getMemorySegment());
+        bufferBuilder21.close();
         assertFalse(localBufferPool.getAvailableFuture().isDone());
-        bufferBuilder02.getRecycler().recycle(bufferBuilder02.getMemorySegment());
+        bufferBuilder02.close();
         assertTrue(localBufferPool.getAvailableFuture().isDone());
-        bufferBuilder01.getRecycler().recycle(bufferBuilder01.getMemorySegment());
+        bufferBuilder01.close();
         assertTrue(localBufferPool.getAvailableFuture().isDone());
-        bufferBuilder22.getRecycler().recycle(bufferBuilder22.getMemorySegment());
+        bufferBuilder22.close();
         assertTrue(localBufferPool.getAvailableFuture().isDone());
     }
 
@@ -468,55 +468,53 @@ public class LocalBufferPoolTest extends TestLogger {
         assertTrue(localBufferPool.isAvailable());
 
         // request one buffer
-        final BufferBuilder bufferBuilder =
-                checkNotNull(localBufferPool.requestBufferBuilderBlocking());
-        CompletableFuture<?> availableFuture = localBufferPool.getAvailableFuture();
-        assertFalse(availableFuture.isDone());
+        try (BufferBuilder bufferBuilder =
+                checkNotNull(localBufferPool.requestBufferBuilderBlocking())) {
+            CompletableFuture<?> availableFuture = localBufferPool.getAvailableFuture();
+            assertFalse(availableFuture.isDone());
 
-        // set the pool size
-        final int numLocalBuffers = 5;
-        localBufferPool.setNumBuffers(numLocalBuffers);
-        assertTrue(availableFuture.isDone());
-        assertTrue(localBufferPool.isAvailable());
-
-        // drain the local buffer pool
-        final Deque<Buffer> buffers = new ArrayDeque<>(LocalBufferPoolTest.numBuffers);
-        for (int i = 0; i < numLocalBuffers - 1; i++) {
+            // set the pool size
+            final int numLocalBuffers = 5;
+            localBufferPool.setNumBuffers(numLocalBuffers);
+            assertTrue(availableFuture.isDone());
             assertTrue(localBufferPool.isAvailable());
-            buffers.add(checkNotNull(localBufferPool.requestBuffer()));
+
+            // drain the local buffer pool
+            final Deque<Buffer> buffers = new ArrayDeque<>(LocalBufferPoolTest.numBuffers);
+            for (int i = 0; i < numLocalBuffers - 1; i++) {
+                assertTrue(localBufferPool.isAvailable());
+                buffers.add(checkNotNull(localBufferPool.requestBuffer()));
+            }
+            assertFalse(localBufferPool.isAvailable());
+
+            buffers.pop().recycleBuffer();
+            assertTrue(localBufferPool.isAvailable());
+
+            // recycle the requested segments to global buffer pool
+            for (final Buffer buffer : buffers) {
+                buffer.recycleBuffer();
+            }
+            assertTrue(localBufferPool.isAvailable());
+
+            // scale down (first buffer still taken), but there should still be one segment locally
+            // available
+            localBufferPool.setNumBuffers(2);
+            assertTrue(localBufferPool.isAvailable());
+
+            final Buffer buffer2 = checkNotNull(localBufferPool.requestBuffer());
+            assertFalse(localBufferPool.isAvailable());
+
+            buffer2.recycleBuffer();
+            assertTrue(localBufferPool.isAvailable());
+
+            // reset the pool size
+            localBufferPool.setNumBuffers(1);
+            assertFalse(localBufferPool.getAvailableFuture().isDone());
+            // recycle the requested buffer
         }
-        assertFalse(localBufferPool.isAvailable());
 
-        buffers.pop().recycleBuffer();
         assertTrue(localBufferPool.isAvailable());
-
-        // recycle the requested segments to global buffer pool
-        for (final Buffer buffer : buffers) {
-            buffer.recycleBuffer();
-        }
-        assertTrue(localBufferPool.isAvailable());
-
-        // scale down (first buffer still taken), but there should still be one segment locally
-        // available
-        localBufferPool.setNumBuffers(2);
-        assertTrue(localBufferPool.isAvailable());
-
-        final Buffer buffer2 = checkNotNull(localBufferPool.requestBuffer());
-        assertFalse(localBufferPool.isAvailable());
-
-        buffer2.recycleBuffer();
-        assertTrue(localBufferPool.isAvailable());
-
-        // reset the pool size
-        localBufferPool.setNumBuffers(1);
-        CompletableFuture<?> availableFuture2 = localBufferPool.getAvailableFuture();
-        assertFalse(availableFuture2.isDone());
-
-        // recycle the requested buffer
-        bufferBuilder.createBufferConsumer().close();
-        bufferBuilder.recycle();
-        assertTrue(localBufferPool.isAvailable());
-        assertTrue(availableFuture2.isDone());
+        assertTrue(localBufferPool.getAvailableFuture().isDone());
     }
 
     /** For FLINK-20547: https://issues.apache.org/jira/browse/FLINK-20547. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -695,7 +695,7 @@ public class NetworkBufferPoolTest extends TestLogger {
 
             // recycle all the requested buffers
             for (BufferBuilder bufferBuilder : segmentsRequested) {
-                bufferBuilder.createBufferConsumer().close();
+                bufferBuilder.close();
             }
 
         } finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -67,6 +67,16 @@ public class NoOpBufferPool implements BufferPool {
     }
 
     @Override
+    public MemorySegment requestMemorySegment() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MemorySegment requestMemorySegmentBlocking() throws InterruptedException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public int getNumberOfRequiredMemorySegments() {
         throw new UnsupportedOperationException();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/UnpooledBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/UnpooledBufferPool.java
@@ -41,8 +41,14 @@ public class UnpooledBufferPool implements BufferPool {
         return new BufferBuilder(requestMemorySegment(), this);
     }
 
-    private MemorySegment requestMemorySegment() {
+    @Override
+    public MemorySegment requestMemorySegment() {
         return MemorySegmentFactory.allocateUnpooledOffHeapMemory(SEGMENT_SIZE, null);
+    }
+
+    @Override
+    public MemorySegment requestMemorySegmentBlocking() throws InterruptedException {
+        return requestMemorySegment();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
@@ -232,7 +233,9 @@ public class BoundedBlockingSubpartitionWriteReadTest {
             }
 
             partition.add(
-                    new BufferConsumer(memory, (ignored) -> {}, pos, Buffer.DataType.DATA_BUFFER));
+                    new BufferConsumer(
+                            new NetworkBuffer(memory, (ignored) -> {}, Buffer.DataType.DATA_BUFFER),
+                            pos));
 
             // we need to flush after every buffer as long as the add() contract is that
             // buffer are immediately added and can be filled further after that (for low latency

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferListener.NotificationResult;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
@@ -1237,9 +1238,11 @@ public class RemoteInputChannelTest {
             final Callable<Void> bufferPoolInteractionsTask =
                     () -> {
                         for (int i = 0; i < retries; ++i) {
-                            Buffer buffer =
-                                    buildSingleBuffer(bufferPool.requestBufferBuilderBlocking());
-                            buffer.recycleBuffer();
+                            try (BufferBuilder bufferBuilder =
+                                    bufferPool.requestBufferBuilderBlocking()) {
+                                Buffer buffer = buildSingleBuffer(bufferBuilder);
+                                buffer.recycleBuffer();
+                            }
                         }
                         return null;
                     };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestBufferFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.util;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
@@ -51,14 +52,18 @@ public class TestBufferFactory {
         this.bufferRecycler = checkNotNull(bufferRecycler);
     }
 
-    public synchronized Buffer create() {
+    public synchronized MemorySegment createMemorySegment() {
         if (numberOfCreatedBuffers >= poolSize) {
             return null;
         }
 
         numberOfCreatedBuffers++;
-        return new NetworkBuffer(
-                MemorySegmentFactory.allocateUnpooledSegment(bufferSize), bufferRecycler);
+        return MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+    }
+
+    public synchronized Buffer create() {
+        MemorySegment memorySegment = createMemorySegment();
+        return memorySegment == null ? null : new NetworkBuffer(memorySegment, bufferRecycler);
     }
 
     public synchronized int getNumberOfCreatedBuffers() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -36,9 +36,10 @@ import java.util.concurrent.LinkedBlockingDeque;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
+/** */
 public class TestPooledBufferProvider implements BufferProvider {
 
-    private final BlockingQueue<Buffer> buffers = new LinkedBlockingDeque<>();
+    private final BlockingQueue<MemorySegment> segments = new LinkedBlockingDeque<>();
 
     private final TestBufferFactory bufferFactory;
 
@@ -51,25 +52,22 @@ public class TestPooledBufferProvider implements BufferProvider {
     public TestPooledBufferProvider(int poolSize, int bufferSize) {
         checkArgument(poolSize > 0);
 
-        this.bufferRecycler = new PooledBufferProviderRecycler(buffers);
+        this.bufferRecycler = new PooledBufferProviderRecycler(segments);
         this.bufferFactory = new TestBufferFactory(poolSize, bufferSize, bufferRecycler);
     }
 
     @Override
     public Buffer requestBuffer() {
-        final Buffer buffer = buffers.poll();
-        if (buffer != null) {
-            return buffer;
-        }
+        MemorySegment memorySegment = requestMemorySegment();
 
-        return bufferFactory.create();
+        return memorySegment == null ? null : new NetworkBuffer(memorySegment, bufferRecycler);
     }
 
     @Override
     public BufferBuilder requestBufferBuilder() {
-        Buffer buffer = requestBuffer();
-        if (buffer != null) {
-            return new BufferBuilder(buffer.getMemorySegment(), buffer.getRecycler());
+        MemorySegment memorySegment = requestMemorySegment();
+        if (memorySegment != null) {
+            return new BufferBuilder(memorySegment, bufferRecycler);
         }
         return null;
     }
@@ -79,24 +77,9 @@ public class TestPooledBufferProvider implements BufferProvider {
         return requestBufferBuilder();
     }
 
-    private Buffer requestBufferBlocking() throws InterruptedException {
-        Buffer buffer = buffers.poll();
-        if (buffer != null) {
-            return buffer;
-        }
-
-        buffer = bufferFactory.create();
-        if (buffer != null) {
-            return buffer;
-        }
-
-        return buffers.take();
-    }
-
     @Override
     public BufferBuilder requestBufferBuilderBlocking() throws InterruptedException {
-        Buffer buffer = requestBufferBlocking();
-        return new BufferBuilder(buffer.getMemorySegment(), buffer.getRecycler());
+        return new BufferBuilder(requestMemorySegmentBlocking(), bufferRecycler);
     }
 
     @Override
@@ -116,49 +99,68 @@ public class TestPooledBufferProvider implements BufferProvider {
     }
 
     @Override
+    public MemorySegment requestMemorySegment() {
+        final MemorySegment buffer = segments.poll();
+        if (buffer != null) {
+            return buffer;
+        }
+
+        return bufferFactory.createMemorySegment();
+    }
+
+    @Override
+    public MemorySegment requestMemorySegmentBlocking() throws InterruptedException {
+        MemorySegment buffer = segments.poll();
+        if (buffer != null) {
+            return buffer;
+        }
+
+        buffer = bufferFactory.createMemorySegment();
+        if (buffer != null) {
+            return buffer;
+        }
+
+        return segments.take();
+    }
+
+    @Override
     public CompletableFuture<?> getAvailableFuture() {
         return AVAILABLE;
     }
 
-    public int getNumberOfAvailableBuffers() {
-        return buffers.size();
-    }
-
-    public int getNumberOfCreatedBuffers() {
-        return bufferFactory.getNumberOfCreatedBuffers();
+    public int getNumberOfAvailableSegments() {
+        return segments.size();
     }
 
     private static class PooledBufferProviderRecycler implements BufferRecycler {
 
         private final Object listenerRegistrationLock = new Object();
 
-        private final Queue<Buffer> buffers;
+        private final Queue<MemorySegment> segments;
 
         private final ConcurrentLinkedQueue<BufferListener> registeredListeners =
                 Queues.newConcurrentLinkedQueue();
 
-        public PooledBufferProviderRecycler(Queue<Buffer> buffers) {
-            this.buffers = buffers;
+        public PooledBufferProviderRecycler(Queue<MemorySegment> segments) {
+            this.segments = segments;
         }
 
         @Override
         public void recycle(MemorySegment segment) {
             synchronized (listenerRegistrationLock) {
-                final Buffer buffer = new NetworkBuffer(segment, this);
-
                 BufferListener listener = registeredListeners.poll();
 
                 if (listener == null) {
-                    buffers.add(buffer);
+                    segments.add(segment);
                 } else {
-                    listener.notifyBufferAvailable(buffer);
+                    listener.notifyBufferAvailable(new NetworkBuffer(segment, this));
                 }
             }
         }
 
         boolean registerListener(BufferListener listener) {
             synchronized (listenerRegistrationLock) {
-                if (buffers.isEmpty()) {
+                if (segments.isEmpty()) {
                     registeredListeners.add(listener);
 
                     return true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionProducer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestSubpartitionProducer.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.apache.flink.runtime.io.network.util.TestProducerSource.BufferAndChannel;
 
@@ -77,7 +78,9 @@ public class TestSubpartitionProducer implements Callable<Boolean> {
                 MemorySegment segment = MemorySegmentFactory.wrap(bufferAndChannel.getBuffer());
                 subpartition.add(
                         new BufferConsumer(
-                                segment, MemorySegment::free, Buffer.DataType.DATA_BUFFER));
+                                new NetworkBuffer(
+                                        segment, MemorySegment::free, Buffer.DataType.DATA_BUFFER),
+                                segment.size()));
 
                 // Check for interrupted flag after adding data to prevent resource leaks
                 if (Thread.interrupted()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -121,6 +121,7 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
                             BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
                             bufferBuilder.appendAndCommit(serializedRecord);
                             bufferBuilder.finish();
+                            bufferBuilder.close();
 
                             // Call getCurrentBuffer to ensure size is set
                             return Optional.of(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -236,12 +236,14 @@ public class StreamTaskNetworkInputTest {
     }
 
     private BufferOrEvent createDataBuffer() throws IOException {
-        BufferBuilder bufferBuilder = BufferBuilderTestUtils.createEmptyBufferBuilder(PAGE_SIZE);
-        BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
-        serializeRecord(42L, bufferBuilder);
-        serializeRecord(44L, bufferBuilder);
+        try (BufferBuilder bufferBuilder =
+                BufferBuilderTestUtils.createEmptyBufferBuilder(PAGE_SIZE)) {
+            BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();
+            serializeRecord(42L, bufferBuilder);
+            serializeRecord(44L, bufferBuilder);
 
-        return new BufferOrEvent(bufferConsumer.build(), new InputChannelInfo(0, 0));
+            return new BufferOrEvent(bufferConsumer.build(), new InputChannelInfo(0, 0));
+        }
     }
 
     private StreamTaskNetworkInput<Long> createStreamTaskNetworkInput(List<BufferOrEvent> buffers) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializerTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.runtime.io.recovery;
 
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -56,6 +57,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
+import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.array;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.mappings;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.rescalingDescriptor;
@@ -115,15 +117,17 @@ public class DemultiplexingRecordDeserializerTest {
 
             long start = selector.getInputSubtaskIndex() << 4 | selector.getOutputSubtaskIndex();
 
-            final BufferBuilder bufferBuilder = createBufferBuilder(128);
-            Buffer buffer = writeLongs(bufferBuilder, start + 1L, start + 2L, start + 3L);
+            MemorySegment memorySegment = allocateUnpooledSegment(128);
+            try (BufferBuilder bufferBuilder = createBufferBuilder(memorySegment)) {
+                Buffer buffer = writeLongs(bufferBuilder, start + 1L, start + 2L, start + 3L);
 
-            deserializer.select(selector);
-            deserializer.setNextBuffer(buffer);
+                deserializer.select(selector);
+                deserializer.setNextBuffer(buffer);
+            }
 
             assertEquals(
                     Arrays.asList(start + 1L, start + 2L, start + 3L), readLongs(deserializer));
-            assertTrue(bufferBuilder.getMemorySegment().isFreed());
+            assertTrue(memorySegment.isFreed());
         }
     }
 
@@ -151,23 +155,25 @@ public class DemultiplexingRecordDeserializerTest {
                 deserializer.getVirtualChannelSelectors());
 
         for (int i = 0; i < 100; i++) {
-            final BufferBuilder bufferBuilder = createBufferBuilder(128);
-            // add one even and one odd number
-            Buffer buffer = writeLongs(bufferBuilder, i, i + 1L);
+            MemorySegment memorySegment = allocateUnpooledSegment(128);
+            try (BufferBuilder bufferBuilder = createBufferBuilder(memorySegment)) {
+                // add one even and one odd number
+                Buffer buffer = writeLongs(bufferBuilder, i, i + 1L);
 
-            SubtaskConnectionDescriptor selector =
-                    Iterables.get(deserializer.getVirtualChannelSelectors(), i / 10 % 2);
-            deserializer.select(selector);
-            deserializer.setNextBuffer(buffer);
+                SubtaskConnectionDescriptor selector =
+                        Iterables.get(deserializer.getVirtualChannelSelectors(), i / 10 % 2);
+                deserializer.select(selector);
+                deserializer.setNextBuffer(buffer);
 
-            if (selector.getInputSubtaskIndex() == 41) {
-                assertEquals(Arrays.asList((long) i, i + 1L), readLongs(deserializer));
-            } else {
-                // only odd should occur in output
-                assertEquals(Arrays.asList(i / 2 * 2 + 1L), readLongs(deserializer));
+                if (selector.getInputSubtaskIndex() == 41) {
+                    assertEquals(Arrays.asList((long) i, i + 1L), readLongs(deserializer));
+                } else {
+                    // only odd should occur in output
+                    assertEquals(Arrays.asList(i / 2 * 2 + 1L), readLongs(deserializer));
+                }
             }
 
-            assertTrue(bufferBuilder.getMemorySegment().isFreed());
+            assertTrue(memorySegment.isFreed());
         }
     }
 
@@ -190,13 +196,15 @@ public class DemultiplexingRecordDeserializerTest {
                         deserializer.getVirtualChannelSelectors().iterator();
                 iterator.hasNext(); ) {
             SubtaskConnectionDescriptor selector = iterator.next();
-            final BufferBuilder bufferBuilder = createBufferBuilder(128);
-            final long ts =
-                    42L + selector.getInputSubtaskIndex() + selector.getOutputSubtaskIndex();
-            Buffer buffer = write(bufferBuilder, new Watermark(ts));
+            MemorySegment memorySegment = allocateUnpooledSegment(128);
+            try (BufferBuilder bufferBuilder = createBufferBuilder(memorySegment)) {
+                final long ts =
+                        42L + selector.getInputSubtaskIndex() + selector.getOutputSubtaskIndex();
+                Buffer buffer = write(bufferBuilder, new Watermark(ts));
 
-            deserializer.select(selector);
-            deserializer.setNextBuffer(buffer);
+                deserializer.select(selector);
+                deserializer.setNextBuffer(buffer);
+            }
 
             if (iterator.hasNext()) {
                 assertEquals(Collections.emptyList(), read(deserializer));
@@ -205,7 +213,7 @@ public class DemultiplexingRecordDeserializerTest {
                 assertEquals(Arrays.asList(new Watermark(42)), read(deserializer));
             }
 
-            assertTrue(bufferBuilder.getMemorySegment().isFreed());
+            assertTrue(memorySegment.isFreed());
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*PR organizes the order of recycling of buffer inside of RecoveredChannelStateHandler *


## Brief change log
  - *BufferBuilder is able to recycle itself if there is no consumer was created*
  - *InputChannelRecoveredStateHandler doesn't recycle buffer inside of recover*
  - *ResultSubpartitionRecoveredStateHandler create buffer consumer inside recover rather than receiving it as parameter*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests for BufferBuilder, InputChannelRecoveredStateHandler, ResultSubpartitionRecoveredStateHandler*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
