### PR TITLE
[FLINK-22618][runtime] Fix incorrect free resource metrics of task ma…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -644,7 +644,7 @@ public class FineGrainedSlotManager implements SlotManager {
 
     @Override
     public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
-        return taskManagerTracker.getRegisteredResourceOf(instanceID);
+        return taskManagerTracker.getFreeResourceOf(instanceID);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -40,7 +40,6 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -750,8 +749,10 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         final SlotID slotId2 = new SlotID(resourceId2, 0);
         final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1, 10);
         final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2, 20);
-        final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile1, new JobID(), new AllocationID());
-        final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile2, new JobID(), new AllocationID());
+        final SlotStatus slotStatus1 =
+                new SlotStatus(slotId1, resourceProfile1, new JobID(), new AllocationID());
+        final SlotStatus slotStatus2 =
+                new SlotStatus(slotId2, resourceProfile2, new JobID(), new AllocationID());
         final SlotReport slotReport1 = new SlotReport(slotStatus1);
         final SlotReport slotReport2 = new SlotReport(slotStatus2);
 
@@ -766,18 +767,19 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                             runInMainThread(
                                     () -> {
                                         registerTaskManagerFuture1.complete(
-                                                getSlotManager().registerTaskManager(
-                                                taskExecutorConnection1,
-                                                slotReport1,
-                                                resourceProfile1.multiply(2),
-                                                resourceProfile1));
+                                                getSlotManager()
+                                                        .registerTaskManager(
+                                                                taskExecutorConnection1,
+                                                                slotReport1,
+                                                                resourceProfile1.multiply(2),
+                                                                resourceProfile1));
                                         registerTaskManagerFuture2.complete(
-                                                getSlotManager().registerTaskManager(
-                                                        taskExecutorConnection2,
-                                                        slotReport2,
-                                                        resourceProfile2.multiply(2),
-                                                        resourceProfile2)
-                                        );
+                                                getSlotManager()
+                                                        .registerTaskManager(
+                                                                taskExecutorConnection2,
+                                                                slotReport2,
+                                                                resourceProfile2.multiply(2),
+                                                                resourceProfile2));
                                     });
                             assertThat(
                                     assertFutureCompleteAndReturn(registerTaskManagerFuture1),
@@ -789,19 +791,27 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                     getSlotManager().getFreeResource(),
                                     equalTo(resourceProfile1.merge(resourceProfile2)));
                             assertThat(
-                                    getSlotManager().getFreeResourceOf(taskExecutorConnection1.getInstanceID()),
+                                    getSlotManager()
+                                            .getFreeResourceOf(
+                                                    taskExecutorConnection1.getInstanceID()),
                                     equalTo(resourceProfile1));
                             assertThat(
-                                    getSlotManager().getFreeResourceOf(taskExecutorConnection2.getInstanceID()),
+                                    getSlotManager()
+                                            .getFreeResourceOf(
+                                                    taskExecutorConnection2.getInstanceID()),
                                     equalTo(resourceProfile2));
                             assertThat(
                                     getSlotManager().getRegisteredResource(),
                                     equalTo(resourceProfile1.merge(resourceProfile2).multiply(2)));
                             assertThat(
-                                    getSlotManager().getRegisteredResourceOf(taskExecutorConnection1.getInstanceID()),
+                                    getSlotManager()
+                                            .getRegisteredResourceOf(
+                                                    taskExecutorConnection1.getInstanceID()),
                                     equalTo(resourceProfile1.multiply(2)));
                             assertThat(
-                                    getSlotManager().getRegisteredResourceOf(taskExecutorConnection2.getInstanceID()),
+                                    getSlotManager()
+                                            .getRegisteredResourceOf(
+                                                    taskExecutorConnection2.getInstanceID()),
                                     equalTo(resourceProfile2.multiply(2)));
                         });
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnect
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 
@@ -39,6 +40,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -735,6 +737,75 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
         testMaxTotalResourceExceededAllocateResource(maxTotalResourceSetter);
         testMaxTotalResourceExceededRegisterResource(maxTotalResourceSetter);
+    }
+
+    @Test
+    public void testGetResourceOverview() throws Exception {
+        final TaskExecutorConnection taskExecutorConnection1 = createTaskExecutorConnection();
+        final TaskExecutorConnection taskExecutorConnection2 = createTaskExecutorConnection();
+        final ResourceID resourceId1 = ResourceID.generate();
+        final ResourceID resourceId2 = ResourceID.generate();
+
+        final SlotID slotId1 = new SlotID(resourceId1, 0);
+        final SlotID slotId2 = new SlotID(resourceId2, 0);
+        final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1, 10);
+        final ResourceProfile resourceProfile2 = ResourceProfile.fromResources(2, 20);
+        final SlotStatus slotStatus1 = new SlotStatus(slotId1, resourceProfile1, new JobID(), new AllocationID());
+        final SlotStatus slotStatus2 = new SlotStatus(slotId2, resourceProfile2, new JobID(), new AllocationID());
+        final SlotReport slotReport1 = new SlotReport(slotStatus1);
+        final SlotReport slotReport2 = new SlotReport(slotStatus2);
+
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            final CompletableFuture<Boolean> registerTaskManagerFuture1 =
+                                    new CompletableFuture<>();
+                            final CompletableFuture<Boolean> registerTaskManagerFuture2 =
+                                    new CompletableFuture<>();
+                            runInMainThread(
+                                    () -> {
+                                        registerTaskManagerFuture1.complete(
+                                                getSlotManager().registerTaskManager(
+                                                taskExecutorConnection1,
+                                                slotReport1,
+                                                resourceProfile1.multiply(2),
+                                                resourceProfile1));
+                                        registerTaskManagerFuture2.complete(
+                                                getSlotManager().registerTaskManager(
+                                                        taskExecutorConnection2,
+                                                        slotReport2,
+                                                        resourceProfile2.multiply(2),
+                                                        resourceProfile2)
+                                        );
+                                    });
+                            assertThat(
+                                    assertFutureCompleteAndReturn(registerTaskManagerFuture1),
+                                    is(true));
+                            assertThat(
+                                    assertFutureCompleteAndReturn(registerTaskManagerFuture2),
+                                    is(true));
+                            assertThat(
+                                    getSlotManager().getFreeResource(),
+                                    equalTo(resourceProfile1.merge(resourceProfile2)));
+                            assertThat(
+                                    getSlotManager().getFreeResourceOf(taskExecutorConnection1.getInstanceID()),
+                                    equalTo(resourceProfile1));
+                            assertThat(
+                                    getSlotManager().getFreeResourceOf(taskExecutorConnection2.getInstanceID()),
+                                    equalTo(resourceProfile2));
+                            assertThat(
+                                    getSlotManager().getRegisteredResource(),
+                                    equalTo(resourceProfile1.merge(resourceProfile2).multiply(2)));
+                            assertThat(
+                                    getSlotManager().getRegisteredResourceOf(taskExecutorConnection1.getInstanceID()),
+                                    equalTo(resourceProfile1.multiply(2)));
+                            assertThat(
+                                    getSlotManager().getRegisteredResourceOf(taskExecutorConnection2.getInstanceID()),
+                                    equalTo(resourceProfile2.multiply(2)));
+                        });
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION


## What is the purpose of the change

Fix incorrect free resource metrics of task managers

## Brief change log

Changed method "getFreeResourceOf" in flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java by invoking the correct method in taskManagerTracker.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
