### PR TITLE
[FLINK-22636] Group job specific zNodes under /jobs zNode

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
+++ b/docs/layouts/shortcodes/generated/expert_high_availability_zk_section.html
@@ -39,34 +39,10 @@
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
-            <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
-            <td style="word-wrap: break-word;">"/checkpoint-counter"</td>
-            <td>String</td>
-            <td>ZooKeeper root path (ZNode) for checkpoint counters.</td>
-        </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.checkpoints</h5></td>
-            <td style="word-wrap: break-word;">"/checkpoints"</td>
-            <td>String</td>
-            <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
-        </tr>
-        <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
             <td style="word-wrap: break-word;">"/jobgraphs"</td>
             <td>String</td>
             <td>ZooKeeper root path (ZNode) for job graphs</td>
-        </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.latch</h5></td>
-            <td style="word-wrap: break-word;">"/leaderlatch"</td>
-            <td>String</td>
-            <td>Defines the znode of the leader latch which is used to elect the leader.</td>
-        </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.leader</h5></td>
-            <td style="word-wrap: break-word;">"/leader"</td>
-            <td>String</td>
-            <td>Defines the znode of the leader which contains the URL to the leader and the current leader session ID.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.mesos-workers</h5></td>

--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -63,34 +63,10 @@
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
-            <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
-            <td style="word-wrap: break-word;">"/checkpoint-counter"</td>
-            <td>String</td>
-            <td>ZooKeeper root path (ZNode) for checkpoint counters.</td>
-        </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.checkpoints</h5></td>
-            <td style="word-wrap: break-word;">"/checkpoints"</td>
-            <td>String</td>
-            <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
-        </tr>
-        <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
             <td style="word-wrap: break-word;">"/jobgraphs"</td>
             <td>String</td>
             <td>ZooKeeper root path (ZNode) for job graphs</td>
-        </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.latch</h5></td>
-            <td style="word-wrap: break-word;">"/leaderlatch"</td>
-            <td>String</td>
-            <td>Defines the znode of the leader latch which is used to elect the leader.</td>
-        </tr>
-        <tr>
-            <td><h5>high-availability.zookeeper.path.leader</h5></td>
-            <td style="word-wrap: break-word;">"/leader"</td>
-            <td>String</td>
-            <td>Defines the znode of the leader which contains the URL to the leader and the current leader session ID.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.mesos-workers</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1013,7 +1013,7 @@ public final class ConfigConstants {
     public static final String HA_ZOOKEEPER_NAMESPACE_KEY =
             "high-availability.zookeeper.path.namespace";
 
-    /** @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_LATCH_PATH}. */
+    /** @deprecated no longer used. */
     @PublicEvolving @Deprecated
     public static final String HA_ZOOKEEPER_LATCH_PATH = "high-availability.zookeeper.path.latch";
 
@@ -1026,14 +1026,14 @@ public final class ConfigConstants {
     public static final String HA_ZOOKEEPER_JOBGRAPHS_PATH =
             "high-availability.zookeeper.path.jobgraphs";
 
-    /** @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_LEADER_PATH}. */
+    /** @deprecated no longer used. */
     @PublicEvolving @Deprecated
     public static final String HA_ZOOKEEPER_LEADER_PATH = "high-availability.zookeeper.path.leader";
 
     /**
      * ZooKeeper root path (ZNode) for completed checkpoints.
      *
-     * @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_CHECKPOINTS_PATH}.
+     * @deprecated no longer used.
      */
     @PublicEvolving @Deprecated
     public static final String HA_ZOOKEEPER_CHECKPOINTS_PATH =
@@ -1042,7 +1042,7 @@ public final class ConfigConstants {
     /**
      * ZooKeeper root path (ZNode) for checkpoint counters.
      *
-     * @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH}.
+     * @deprecated no longer used.
      */
     @PublicEvolving @Deprecated
     public static final String HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH =
@@ -1691,21 +1691,19 @@ public final class ConfigConstants {
     /** @deprecated in favor of {@link HighAvailabilityOptions#HA_CLUSTER_ID}. */
     @Deprecated public static final String DEFAULT_ZOOKEEPER_NAMESPACE_KEY = "/default";
 
-    /** @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_LATCH_PATH}. */
+    /** @deprecated no longer used. */
     @Deprecated public static final String DEFAULT_ZOOKEEPER_LATCH_PATH = "/leaderlatch";
 
-    /** @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_LEADER_PATH}. */
+    /** @deprecated no longer used. */
     @Deprecated public static final String DEFAULT_ZOOKEEPER_LEADER_PATH = "/leader";
 
     /** @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_JOBGRAPHS_PATH}. */
     @Deprecated public static final String DEFAULT_ZOOKEEPER_JOBGRAPHS_PATH = "/jobgraphs";
 
-    /** @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_CHECKPOINTS_PATH}. */
+    /** @deprecated no longer used. */
     @Deprecated public static final String DEFAULT_ZOOKEEPER_CHECKPOINTS_PATH = "/checkpoints";
 
-    /**
-     * @deprecated in favor of {@link HighAvailabilityOptions#HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH}
-     */
+    /** @deprecated no longer used. */
     @Deprecated
     public static final String DEFAULT_ZOOKEEPER_CHECKPOINT_COUNTER_PATH = "/checkpoint-counter";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -115,14 +115,6 @@ public class HighAvailabilityOptions {
                     .withDescription(
                             "The root path under which Flink stores its entries in ZooKeeper.");
 
-    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
-    public static final ConfigOption<String> HA_ZOOKEEPER_LATCH_PATH =
-            key("high-availability.zookeeper.path.latch")
-                    .defaultValue("/leaderlatch")
-                    .withDeprecatedKeys("recovery.zookeeper.path.latch")
-                    .withDescription(
-                            "Defines the znode of the leader latch which is used to elect the leader.");
-
     /** ZooKeeper root path (ZNode) for job graphs. */
     @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
     public static final ConfigOption<String> HA_ZOOKEEPER_JOBGRAPHS_PATH =
@@ -130,31 +122,6 @@ public class HighAvailabilityOptions {
                     .defaultValue("/jobgraphs")
                     .withDeprecatedKeys("recovery.zookeeper.path.jobgraphs")
                     .withDescription("ZooKeeper root path (ZNode) for job graphs");
-
-    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
-    public static final ConfigOption<String> HA_ZOOKEEPER_LEADER_PATH =
-            key("high-availability.zookeeper.path.leader")
-                    .defaultValue("/leader")
-                    .withDeprecatedKeys("recovery.zookeeper.path.leader")
-                    .withDescription(
-                            "Defines the znode of the leader which contains the URL to the leader and the current"
-                                    + " leader session ID.");
-
-    /** ZooKeeper root path (ZNode) for completed checkpoints. */
-    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
-    public static final ConfigOption<String> HA_ZOOKEEPER_CHECKPOINTS_PATH =
-            key("high-availability.zookeeper.path.checkpoints")
-                    .defaultValue("/checkpoints")
-                    .withDeprecatedKeys("recovery.zookeeper.path.checkpoints")
-                    .withDescription("ZooKeeper root path (ZNode) for completed checkpoints.");
-
-    /** ZooKeeper root path (ZNode) for checkpoint counters. */
-    @Documentation.Section(Documentation.Sections.EXPERT_ZOOKEEPER_HIGH_AVAILABILITY)
-    public static final ConfigOption<String> HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH =
-            key("high-availability.zookeeper.path.checkpoint-counter")
-                    .defaultValue("/checkpoint-counter")
-                    .withDeprecatedKeys("recovery.zookeeper.path.checkpoint-counter")
-                    .withDescription("ZooKeeper root path (ZNode) for checkpoint counters.");
 
     /** ZooKeeper root path (ZNode) for Mesos workers. */
     @PublicEvolving

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
@@ -112,20 +112,20 @@ public class KubernetesHaServices extends AbstractHaServices {
                 kubeClient,
                 configuration,
                 ioExecutor,
-                this::getLeaderNameForJobManager,
+                this::getLeaderPathForJobManager,
                 lockIdentity);
     }
 
     @Override
     public JobGraphStore createJobGraphStore() throws Exception {
         return KubernetesUtils.createJobGraphStore(
-                configuration, kubeClient, getLeaderNameForDispatcher(), lockIdentity);
+                configuration, kubeClient, getLeaderPathForDispatcher(), lockIdentity);
     }
 
     @Override
     public RunningJobsRegistry createRunningJobsRegistry() {
         return new KubernetesRunningJobsRegistry(
-                kubeClient, getLeaderNameForDispatcher(), lockIdentity);
+                kubeClient, getLeaderPathForDispatcher(), lockIdentity);
     }
 
     @Override
@@ -144,25 +144,25 @@ public class KubernetesHaServices extends AbstractHaServices {
 
     @Override
     public void internalCleanupJobData(JobID jobID) throws Exception {
-        kubeClient.deleteConfigMap(getLeaderNameForJobManager(jobID)).get();
+        kubeClient.deleteConfigMap(getLeaderPathForJobManager(jobID)).get();
     }
 
     @Override
-    protected String getLeaderNameForResourceManager() {
+    protected String getLeaderPathForResourceManager() {
         return getLeaderName(RESOURCE_MANAGER_NAME);
     }
 
     @Override
-    protected String getLeaderNameForDispatcher() {
+    protected String getLeaderPathForDispatcher() {
         return getLeaderName(DISPATCHER_NAME);
     }
 
-    public String getLeaderNameForJobManager(final JobID jobID) {
+    public String getLeaderPathForJobManager(final JobID jobID) {
         return getLeaderName(jobID.toString() + NAME_SEPARATOR + JOB_MANAGER_NAME);
     }
 
     @Override
-    protected String getLeaderNameForRestServer() {
+    protected String getLeaderPathForRestServer() {
         return getLeaderName(REST_SERVER_NAME);
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServicesTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServicesTest.java
@@ -94,7 +94,7 @@ public class KubernetesHaServicesTest extends KubernetesHighAvailabilityTestBase
                                             new VoidBlobStore());
                             JobID jobID = new JobID();
                             String configMapName =
-                                    kubernetesHaServices.getLeaderNameForJobManager(jobID);
+                                    kubernetesHaServices.getLeaderPathForJobManager(jobID);
                             final KubernetesConfigMap configMap =
                                     new TestingFlinkKubeClient.MockKubernetesConfigMap(
                                             configMapName);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounter.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.recipes.shared.SharedCount;
@@ -76,14 +78,11 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
      * Creates a {@link ZooKeeperCheckpointIDCounter} instance.
      *
      * @param client Curator ZooKeeper client
-     * @param counterPath ZooKeeper path for the counter. It's sufficient to have a path per-job.
      */
     public ZooKeeperCheckpointIDCounter(
-            CuratorFramework client,
-            String counterPath,
-            LastStateConnectionStateListener connectionStateListener) {
+            CuratorFramework client, LastStateConnectionStateListener connectionStateListener) {
         this.client = checkNotNull(client, "Curator client");
-        this.counterPath = checkNotNull(counterPath, "Counter path");
+        this.counterPath = ZooKeeperUtils.getCheckpointIdCounterPath();
         this.sharedCount = new SharedCount(client, counterPath, 1);
         this.connectionStateListener = connectionStateListener;
     }
@@ -175,5 +174,10 @@ public class ZooKeeperCheckpointIDCounter implements CheckpointIDCounter {
                         throw new IllegalStateException("Connection state: " + lastState);
                     }
                 });
+    }
+
+    @VisibleForTesting
+    String getPath() {
+        return counterPath;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointRecoveryFactory.java
@@ -51,11 +51,17 @@ public class ZooKeeperCheckpointRecoveryFactory implements CheckpointRecoveryFac
             throws Exception {
 
         return ZooKeeperUtils.createCompletedCheckpoints(
-                client, config, jobId, maxNumberOfCheckpointsToRetain, executor);
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        client, ZooKeeperUtils.getPathForJob(jobId)),
+                config,
+                maxNumberOfCheckpointsToRetain,
+                executor);
     }
 
     @Override
     public CheckpointIDCounter createCheckpointIDCounter(JobID jobID) throws Exception {
-        return ZooKeeperUtils.createCheckpointIDCounter(client, config, jobID);
+        return ZooKeeperUtils.createCheckpointIDCounter(
+                ZooKeeperUtils.useNamespaceAndEnsurePath(
+                        client, ZooKeeperUtils.getPathForJob(jobID)));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
@@ -38,9 +38,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Abstract high availability services based on distributed system(e.g. Zookeeper, Kubernetes). It
  * will help with creating all the leader election/retrieval services and the cleanup. Please return
- * a proper leader name int the implementation of {@link #getLeaderNameForResourceManager}, {@link
- * #getLeaderNameForDispatcher}, {@link #getLeaderNameForJobManager}, {@link
- * #getLeaderNameForRestServer}. The returned leader name is the ConfigMap name in Kubernetes and
+ * a proper leader name int the implementation of {@link #getLeaderPathForResourceManager}, {@link
+ * #getLeaderPathForDispatcher}, {@link #getLeaderPathForJobManager}, {@link
+ * #getLeaderPathForRestServer}. The returned leader name is the ConfigMap name in Kubernetes and
  * child path in Zookeeper.
  *
  * <p>{@link #close()} and {@link #closeAndCleanupAllData()} should be implemented to destroy the
@@ -75,17 +75,17 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
 
     @Override
     public LeaderRetrievalService getResourceManagerLeaderRetriever() {
-        return createLeaderRetrievalService(getLeaderNameForResourceManager());
+        return createLeaderRetrievalService(getLeaderPathForResourceManager());
     }
 
     @Override
     public LeaderRetrievalService getDispatcherLeaderRetriever() {
-        return createLeaderRetrievalService(getLeaderNameForDispatcher());
+        return createLeaderRetrievalService(getLeaderPathForDispatcher());
     }
 
     @Override
     public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID) {
-        return createLeaderRetrievalService(getLeaderNameForJobManager(jobID));
+        return createLeaderRetrievalService(getLeaderPathForJobManager(jobID));
     }
 
     @Override
@@ -96,31 +96,31 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
 
     @Override
     public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
-        return createLeaderRetrievalService(getLeaderNameForRestServer());
+        return createLeaderRetrievalService(getLeaderPathForRestServer());
     }
 
     @Override
     public LeaderElectionService getResourceManagerLeaderElectionService() {
-        return createLeaderElectionService(getLeaderNameForResourceManager());
+        return createLeaderElectionService(getLeaderPathForResourceManager());
     }
 
     @Override
     public LeaderElectionService getDispatcherLeaderElectionService() {
-        return createLeaderElectionService(getLeaderNameForDispatcher());
+        return createLeaderElectionService(getLeaderPathForDispatcher());
     }
 
     @Override
     public LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) {
-        return createLeaderElectionService(getLeaderNameForJobManager(jobID));
+        return createLeaderElectionService(getLeaderPathForJobManager(jobID));
     }
 
     @Override
     public LeaderElectionService getClusterRestEndpointLeaderElectionService() {
-        return createLeaderElectionService(getLeaderNameForRestServer());
+        return createLeaderElectionService(getLeaderPathForRestServer());
     }
 
     @Override
-    public CheckpointRecoveryFactory getCheckpointRecoveryFactory() {
+    public CheckpointRecoveryFactory getCheckpointRecoveryFactory() throws Exception {
         return createCheckpointRecoveryFactory();
     }
 
@@ -233,7 +233,7 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
      *
      * @return Checkpoint recovery factory
      */
-    protected abstract CheckpointRecoveryFactory createCheckpointRecoveryFactory();
+    protected abstract CheckpointRecoveryFactory createCheckpointRecoveryFactory() throws Exception;
 
     /**
      * Create the submitted job graph store for the job manager.
@@ -277,35 +277,35 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
     protected abstract void internalCleanupJobData(JobID jobID) throws Exception;
 
     /**
-     * Get the leader name for ResourceManager.
+     * Get the leader path for ResourceManager.
      *
      * @return Return the ResourceManager leader name. It is ConfigMap name in Kubernetes or child
      *     node path in Zookeeper.
      */
-    protected abstract String getLeaderNameForResourceManager();
+    protected abstract String getLeaderPathForResourceManager();
 
     /**
-     * Get the leader name for Dispatcher.
+     * Get the leader path for Dispatcher.
      *
      * @return Return the Dispatcher leader name. It is ConfigMap name in Kubernetes or child node
      *     path in Zookeeper.
      */
-    protected abstract String getLeaderNameForDispatcher();
+    protected abstract String getLeaderPathForDispatcher();
 
     /**
-     * Get the leader name for specific JobManager.
+     * Get the leader path for specific JobManager.
      *
      * @param jobID job id
      * @return Return the JobManager leader name for specified job id. It is ConfigMap name in
      *     Kubernetes or child node path in Zookeeper.
      */
-    protected abstract String getLeaderNameForJobManager(final JobID jobID);
+    protected abstract String getLeaderPathForJobManager(final JobID jobID);
 
     /**
-     * Get the leader name for RestServer.
+     * Get the leader path for RestServer.
      *
      * @return Return the RestServer leader name. It is ConfigMap name in Kubernetes or child node
      *     path in Zookeeper.
      */
-    protected abstract String getLeaderNameForRestServer();
+    protected abstract String getLeaderPathForRestServer();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -158,7 +158,7 @@ public interface HighAvailabilityServices extends ClientHighAvailabilityServices
      *
      * @return Checkpoint recovery factory
      */
-    CheckpointRecoveryFactory getCheckpointRecoveryFactory();
+    CheckpointRecoveryFactory getCheckpointRecoveryFactory() throws Exception;
 
     /**
      * Gets the submitted job graph store for the job manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -140,7 +140,7 @@ public class HighAvailabilityServicesUtils {
                 return new StandaloneClientHAServices(webMonitorAddress);
             case ZOOKEEPER:
                 final CuratorFramework client = ZooKeeperUtils.startCuratorFramework(configuration);
-                return new ZooKeeperClientHAServices(client, configuration);
+                return new ZooKeeperClientHAServices(client);
             case FACTORY_CLASS:
                 return createCustomClientHAServices(configuration);
             default:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperClientHAServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperClientHAServices.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.highavailability.zookeeper;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.ClientHighAvailabilityServices;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -30,21 +29,16 @@ import javax.annotation.Nonnull;
 /** ZooKeeper based implementation for {@link ClientHighAvailabilityServices}. */
 public class ZooKeeperClientHAServices implements ClientHighAvailabilityServices {
 
-    private static final String REST_SERVER_LEADER_PATH = "/rest_server_lock";
-
     private final CuratorFramework client;
-    private final Configuration configuration;
 
-    public ZooKeeperClientHAServices(
-            @Nonnull CuratorFramework client, @Nonnull Configuration configuration) {
+    public ZooKeeperClientHAServices(@Nonnull CuratorFramework client) {
         this.client = client;
-        this.configuration = configuration;
     }
 
     @Override
     public LeaderRetrievalService getClusterRestEndpointLeaderRetriever() {
         return ZooKeeperUtils.createLeaderRetrievalService(
-                client, configuration, REST_SERVER_LEADER_PATH);
+                client, ZooKeeperUtils.getLeaderPathForRestServer());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriverFactory.java
@@ -27,15 +27,11 @@ public class ZooKeeperLeaderElectionDriverFactory implements LeaderElectionDrive
 
     private final CuratorFramework client;
 
-    private final String latchPath;
+    private final String path;
 
-    private final String leaderPath;
-
-    public ZooKeeperLeaderElectionDriverFactory(
-            CuratorFramework client, String latchPath, String leaderPath) {
+    public ZooKeeperLeaderElectionDriverFactory(CuratorFramework client, String path) {
         this.client = client;
-        this.latchPath = latchPath;
-        this.leaderPath = leaderPath;
+        this.path = path;
     }
 
     @Override
@@ -45,11 +41,6 @@ public class ZooKeeperLeaderElectionDriverFactory implements LeaderElectionDrive
             String leaderContenderDescription)
             throws Exception {
         return new ZooKeeperLeaderElectionDriver(
-                client,
-                latchPath,
-                leaderPath,
-                leaderEventHandler,
-                fatalErrorHandler,
-                leaderContenderDescription);
+                client, path, leaderEventHandler, fatalErrorHandler, leaderContenderDescription);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriverFa
 import org.apache.flink.runtime.persistence.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.persistence.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator4.org.apache.curator.framework.CuratorFrameworkFactory;
@@ -62,10 +61,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -80,6 +83,60 @@ public class ZooKeeperUtils {
     /** The prefix of the completed checkpoint file. */
     public static final String HA_STORAGE_COMPLETED_CHECKPOINT = "completedCheckpoint";
 
+    private static final String RESOURCE_MANAGER_LEADER = "/resource_manager";
+
+    private static final String DISPATCHER_LEADER = "/dispatcher";
+
+    private static final String LEADER_NODE = "/leader";
+
+    private static final String REST_SERVER_LEADER = "/rest_server";
+
+    public static String getLeaderPathForResourceManager() {
+        return getLeaderPath(RESOURCE_MANAGER_LEADER);
+    }
+
+    public static String getLeaderPathForDispatcher() {
+        return getLeaderPath(DISPATCHER_LEADER);
+    }
+
+    public static String getLeaderPathForRestServer() {
+        return getLeaderPath(REST_SERVER_LEADER);
+    }
+
+    public static String getLeaderPathForJobManager(JobID jobId) {
+        return generateZookeeperPath(getLeaderPathForJob(jobId), LEADER_NODE);
+    }
+
+    @Nonnull
+    public static String getLeaderPathForJob(JobID jobId) {
+        return generateZookeeperPath(getJobsPath(), getPathForJob(jobId));
+    }
+
+    public static String getJobsPath() {
+        return "/jobs";
+    }
+
+    private static String getCheckpointsPath() {
+        return "/checkpoints";
+    }
+
+    public static String getCheckpointIdCounterPath() {
+        return "/checkpoint_id_counter";
+    }
+
+    private static String getLeaderPath(String suffix) {
+        return generateZookeeperPath(LEADER_NODE, suffix);
+    }
+
+    @Nonnull
+    public static String generateConnectionInformationPath(String path) {
+        return generateZookeeperPath(path, "connection_info");
+    }
+
+    public static String generateLeaderLatchPath(String path) {
+        return generateZookeeperPath(path, "latch");
+    }
+
     /**
      * Starts a {@link CuratorFramework} instance and connects it to the given ZooKeeper quorum.
      *
@@ -87,7 +144,7 @@ public class ZooKeeperUtils {
      * @return {@link CuratorFramework} instance
      */
     public static CuratorFramework startCuratorFramework(Configuration configuration) {
-        Preconditions.checkNotNull(configuration, "configuration");
+        checkNotNull(configuration, "configuration");
         String zkQuorum = configuration.getValue(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM);
 
         if (zkQuorum == null || StringUtils.isBlank(zkQuorum)) {
@@ -123,7 +180,7 @@ public class ZooKeeperUtils {
         if (disableSaslClient && aclMode == ZkClientACLMode.CREATOR) {
             String errorMessage =
                     "Cannot set ACL role to "
-                            + aclMode
+                            + ZkClientACLMode.CREATOR
                             + "  since SASL authentication is "
                             + "disabled through the "
                             + SecurityOptions.ZOOKEEPER_SASL_DISABLE.key()
@@ -152,10 +209,7 @@ public class ZooKeeperUtils {
                         .retryPolicy(new ExponentialBackoffRetry(retryWait, maxRetryAttempts))
                         // Curator prepends a '/' manually and throws an Exception if the
                         // namespace starts with a '/'.
-                        .namespace(
-                                rootWithNamespace.startsWith("/")
-                                        ? rootWithNamespace.substring(1)
-                                        : rootWithNamespace)
+                        .namespace(trimStartingSlash(rootWithNamespace))
                         .aclProvider(aclProvider)
                         .build();
 
@@ -193,12 +247,11 @@ public class ZooKeeperUtils {
      * ZooKeeperLeaderRetrievalDriver}.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
      * @return {@link DefaultLeaderRetrievalService} instance.
      */
     public static DefaultLeaderRetrievalService createLeaderRetrievalService(
-            final CuratorFramework client, final Configuration configuration) {
-        return createLeaderRetrievalService(client, configuration, "");
+            final CuratorFramework client) {
+        return createLeaderRetrievalService(client, "");
     }
 
     /**
@@ -206,46 +259,35 @@ public class ZooKeeperUtils {
      * ZooKeeperLeaderRetrievalDriver}.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
-     * @param pathSuffix The path suffix which we want to append
+     * @param path The path for the leader retrieval
      * @return {@link DefaultLeaderRetrievalService} instance.
      */
     public static DefaultLeaderRetrievalService createLeaderRetrievalService(
-            final CuratorFramework client,
-            final Configuration configuration,
-            final String pathSuffix) {
-        return new DefaultLeaderRetrievalService(
-                createLeaderRetrievalDriverFactory(client, configuration, pathSuffix));
+            final CuratorFramework client, final String path) {
+        return new DefaultLeaderRetrievalService(createLeaderRetrievalDriverFactory(client, path));
     }
 
     /**
      * Creates a {@link LeaderRetrievalDriverFactory} implemented by ZooKeeper.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
      * @return {@link LeaderRetrievalDriverFactory} instance.
      */
     public static ZooKeeperLeaderRetrievalDriverFactory createLeaderRetrievalDriverFactory(
-            final CuratorFramework client, final Configuration configuration) {
-        return createLeaderRetrievalDriverFactory(client, configuration, "");
+            final CuratorFramework client) {
+        return createLeaderRetrievalDriverFactory(client, "");
     }
 
     /**
      * Creates a {@link LeaderRetrievalDriverFactory} implemented by ZooKeeper.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
-     * @param pathSuffix The path suffix which we want to append
+     * @param path The path for the leader zNode
      * @return {@link LeaderRetrievalDriverFactory} instance.
      */
     public static ZooKeeperLeaderRetrievalDriverFactory createLeaderRetrievalDriverFactory(
-            final CuratorFramework client,
-            final Configuration configuration,
-            final String pathSuffix) {
-        final String leaderPath =
-                configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_LEADER_PATH)
-                        + pathSuffix;
-        return new ZooKeeperLeaderRetrievalDriverFactory(client, leaderPath);
+            final CuratorFramework client, final String path) {
+        return new ZooKeeperLeaderRetrievalDriverFactory(client, path);
     }
 
     /**
@@ -253,13 +295,12 @@ public class ZooKeeperUtils {
      * ZooKeeperLeaderElectionDriver}.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
      * @return {@link DefaultLeaderElectionService} instance.
      */
     public static DefaultLeaderElectionService createLeaderElectionService(
-            CuratorFramework client, Configuration configuration) {
+            CuratorFramework client) {
 
-        return createLeaderElectionService(client, configuration, "");
+        return createLeaderElectionService(client, "");
     }
 
     /**
@@ -267,50 +308,35 @@ public class ZooKeeperUtils {
      * ZooKeeperLeaderElectionDriver}.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
-     * @param pathSuffix The path suffix which we want to append
+     * @param path The path for the leader election
      * @return {@link DefaultLeaderElectionService} instance.
      */
     public static DefaultLeaderElectionService createLeaderElectionService(
-            final CuratorFramework client,
-            final Configuration configuration,
-            final String pathSuffix) {
-        return new DefaultLeaderElectionService(
-                createLeaderElectionDriverFactory(client, configuration, pathSuffix));
+            final CuratorFramework client, final String path) {
+        return new DefaultLeaderElectionService(createLeaderElectionDriverFactory(client, path));
     }
 
     /**
      * Creates a {@link LeaderElectionDriverFactory} implemented by ZooKeeper.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
      * @return {@link LeaderElectionDriverFactory} instance.
      */
     public static ZooKeeperLeaderElectionDriverFactory createLeaderElectionDriverFactory(
-            final CuratorFramework client, final Configuration configuration) {
-        return createLeaderElectionDriverFactory(client, configuration, "");
+            final CuratorFramework client) {
+        return createLeaderElectionDriverFactory(client, "");
     }
 
     /**
      * Creates a {@link LeaderElectionDriverFactory} implemented by ZooKeeper.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object containing the configuration values
-     * @param pathSuffix The path suffix which we want to append
+     * @param path The path suffix which we want to append
      * @return {@link LeaderElectionDriverFactory} instance.
      */
     public static ZooKeeperLeaderElectionDriverFactory createLeaderElectionDriverFactory(
-            final CuratorFramework client,
-            final Configuration configuration,
-            final String pathSuffix) {
-        final String latchPath =
-                configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_LATCH_PATH)
-                        + pathSuffix;
-        final String leaderPath =
-                configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_LEADER_PATH)
-                        + pathSuffix;
-
-        return new ZooKeeperLeaderElectionDriverFactory(client, latchPath, leaderPath);
+            final CuratorFramework client, final String path) {
+        return new ZooKeeperLeaderElectionDriverFactory(client, path);
     }
 
     /**
@@ -359,7 +385,6 @@ public class ZooKeeperUtils {
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
      * @param configuration {@link Configuration} object
-     * @param jobId ID of job to create the instance for
      * @param maxNumberOfCheckpointsToRetain The maximum number of checkpoints to retain
      * @param executor to run ZooKeeper callbacks
      * @return {@link DefaultCompletedCheckpointStore} instance
@@ -368,23 +393,17 @@ public class ZooKeeperUtils {
     public static CompletedCheckpointStore createCompletedCheckpoints(
             CuratorFramework client,
             Configuration configuration,
-            JobID jobId,
             int maxNumberOfCheckpointsToRetain,
             Executor executor)
             throws Exception {
 
         checkNotNull(configuration, "Configuration");
 
-        String checkpointsPath =
-                configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_CHECKPOINTS_PATH);
-
         RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage =
                 createFileSystemStateStorage(configuration, HA_STORAGE_COMPLETED_CHECKPOINT);
 
-        checkpointsPath += getPathForJob(jobId);
-
         final ZooKeeperStateHandleStore<CompletedCheckpoint> completedCheckpointStateHandleStore =
-                createZooKeeperStateHandleStore(client, checkpointsPath, stateStorage);
+                createZooKeeperStateHandleStore(client, getCheckpointsPath(), stateStorage);
         final CompletedCheckpointStore zooKeeperCompletedCheckpointStore =
                 new DefaultCompletedCheckpointStore<>(
                         maxNumberOfCheckpointsToRetain,
@@ -396,7 +415,7 @@ public class ZooKeeperUtils {
                 "Initialized {} in '{}' with {}.",
                 DefaultCompletedCheckpointStore.class.getSimpleName(),
                 completedCheckpointStateHandleStore,
-                checkpointsPath);
+                getCheckpointsPath());
         return zooKeeperCompletedCheckpointStore;
     }
 
@@ -431,21 +450,11 @@ public class ZooKeeperUtils {
      * Creates a {@link ZooKeeperCheckpointIDCounter} instance.
      *
      * @param client The {@link CuratorFramework} ZooKeeper client to use
-     * @param configuration {@link Configuration} object
-     * @param jobId ID of job to create the instance for
      * @return {@link ZooKeeperCheckpointIDCounter} instance
      */
-    public static ZooKeeperCheckpointIDCounter createCheckpointIDCounter(
-            CuratorFramework client, Configuration configuration, JobID jobId) {
-
-        String checkpointIdCounterPath =
-                configuration.getString(
-                        HighAvailabilityOptions.HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH);
-
-        checkpointIdCounterPath += getPathForJob(jobId);
-
+    public static ZooKeeperCheckpointIDCounter createCheckpointIDCounter(CuratorFramework client) {
         return new ZooKeeperCheckpointIDCounter(
-                client, checkpointIdCounterPath, new DefaultLastStateConnectionStateListener());
+                client, new DefaultLastStateConnectionStateListener());
     }
 
     /**
@@ -466,20 +475,38 @@ public class ZooKeeperUtils {
                 prefix);
     }
 
-    public static String generateZookeeperPath(String root, String namespace) {
-        if (!namespace.startsWith("/")) {
-            namespace = '/' + namespace;
+    /** Creates a ZooKeeper path of the form "/root/child". */
+    public static String generateZookeeperPath(String root, String child) {
+        final String result =
+                Stream.of(root, child)
+                        .map(ZooKeeperUtils::trimSlashes)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.joining("/", "/", ""));
+
+        return result;
+    }
+
+    private static String trimStartingSlash(String path) {
+        return path.startsWith("/") ? path.substring(1) : path;
+    }
+
+    private static String trimSlashes(String input) {
+        int left = 0;
+        int right = input.length() - 1;
+
+        while (left <= right && input.charAt(left) == '/') {
+            left++;
         }
 
-        if (namespace.endsWith("/")) {
-            namespace = namespace.substring(0, namespace.length() - 1);
+        while (right >= left && input.charAt(right) == '/') {
+            right--;
         }
 
-        if (root.endsWith("/")) {
-            root = root.substring(0, root.length() - 1);
+        if (left <= right) {
+            return input.substring(left, right + 1);
+        } else {
+            return "";
         }
-
-        return root + namespace;
     }
 
     /**
@@ -493,14 +520,18 @@ public class ZooKeeperUtils {
      */
     public static CuratorFramework useNamespaceAndEnsurePath(
             final CuratorFramework client, final String path) throws Exception {
-        Preconditions.checkNotNull(client, "client must not be null");
-        Preconditions.checkNotNull(path, "path must not be null");
+        checkNotNull(client, "client must not be null");
+        checkNotNull(path, "path must not be null");
 
         // Ensure that the checkpoints path exists
         client.newNamespaceAwareEnsurePath(path).ensure(client.getZookeeperClient());
 
         // All operations will have the path as root
-        return client.usingNamespace(generateZookeeperPath(client.getNamespace(), path));
+        final String newNamespace = generateZookeeperPath(client.getNamespace(), path);
+        return client.usingNamespace(
+                // Curator prepends a '/' manually and throws an Exception if the
+                // namespace starts with a '/'.
+                trimStartingSlash(newNamespace));
     }
 
     /** Secure {@link ACLProvider} implementation. */
@@ -530,10 +561,10 @@ public class ZooKeeperUtils {
          */
         public static ZkClientACLMode fromConfig(Configuration config) {
             String aclMode = config.getString(HighAvailabilityOptions.ZOOKEEPER_CLIENT_ACL);
-            if (aclMode == null || aclMode.equalsIgnoreCase(ZkClientACLMode.OPEN.name())) {
-                return ZkClientACLMode.OPEN;
-            } else if (aclMode.equalsIgnoreCase(ZkClientACLMode.CREATOR.name())) {
-                return ZkClientACLMode.CREATOR;
+            if (aclMode == null || aclMode.equalsIgnoreCase(OPEN.name())) {
+                return OPEN;
+            } else if (aclMode.equalsIgnoreCase(CREATOR.name())) {
+                return CREATOR;
             } else {
                 String message = "Unsupported ACL option: [" + aclMode + "] provided";
                 LOG.error(message);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
@@ -64,7 +64,7 @@ public final class ZKCheckpointIDCounterMultiServersTest extends TestLogger {
                             connectionLossLatch, reconnectedLatch);
 
             ZooKeeperCheckpointIDCounter idCounter =
-                    new ZooKeeperCheckpointIDCounter(client, "/checkpoint-id-counter", listener);
+                    new ZooKeeperCheckpointIDCounter(client, listener);
             idCounter.start();
 
             AtomicLong localCounter = new AtomicLong(1L);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCheckpointIDCounterITCase.java
@@ -51,34 +51,32 @@ public class ZooKeeperCheckpointIDCounterITCase extends CheckpointIDCounterTestB
     /** Tests that counter node is removed from ZooKeeper after shutdown. */
     @Test
     public void testShutdownRemovesState() throws Exception {
-        CheckpointIDCounter counter = createCheckpointIdCounter();
+        ZooKeeperCheckpointIDCounter counter = createCheckpointIdCounter();
         counter.start();
 
         CuratorFramework client = ZooKeeper.getClient();
-        assertNotNull(client.checkExists().forPath("/checkpoint-id-counter"));
+        assertNotNull(client.checkExists().forPath(counter.getPath()));
 
         counter.shutdown(JobStatus.FINISHED);
-        assertNull(client.checkExists().forPath("/checkpoint-id-counter"));
+        assertNull(client.checkExists().forPath(counter.getPath()));
     }
 
     /** Tests that counter node is NOT removed from ZooKeeper after suspend. */
     @Test
     public void testSuspendKeepsState() throws Exception {
-        CheckpointIDCounter counter = createCheckpointIdCounter();
+        ZooKeeperCheckpointIDCounter counter = createCheckpointIdCounter();
         counter.start();
 
         CuratorFramework client = ZooKeeper.getClient();
-        assertNotNull(client.checkExists().forPath("/checkpoint-id-counter"));
+        assertNotNull(client.checkExists().forPath(counter.getPath()));
 
         counter.shutdown(JobStatus.SUSPENDED);
-        assertNotNull(client.checkExists().forPath("/checkpoint-id-counter"));
+        assertNotNull(client.checkExists().forPath(counter.getPath()));
     }
 
     @Override
-    protected CheckpointIDCounter createCheckpointIdCounter() throws Exception {
+    protected ZooKeeperCheckpointIDCounter createCheckpointIdCounter() throws Exception {
         return new ZooKeeperCheckpointIDCounter(
-                ZooKeeper.getClient(),
-                "/checkpoint-id-counter",
-                new DefaultLastStateConnectionStateListener());
+                ZooKeeper.getClient(), new DefaultLastStateConnectionStateListener());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -149,9 +149,7 @@ public class ZooKeeperDefaultDispatcherRunnerTest extends TestLogger {
                                 new ZooKeeperRunningJobsRegistry(client, configuration))
                         .setDispatcherLeaderElectionService(dispatcherLeaderElectionService)
                         .setJobMasterLeaderRetrieverFunction(
-                                jobId ->
-                                        ZooKeeperUtils.createLeaderRetrievalService(
-                                                client, configuration))
+                                jobId -> ZooKeeperUtils.createLeaderRetrievalService(client))
                         .build()) {
 
             final PartialDispatcherServices partialDispatcherServices =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -240,22 +240,22 @@ public class AbstractHaServicesTest extends TestLogger {
         }
 
         @Override
-        protected String getLeaderNameForResourceManager() {
+        protected String getLeaderPathForResourceManager() {
             throw new UnsupportedOperationException("Not supported by this test implementation.");
         }
 
         @Override
-        protected String getLeaderNameForDispatcher() {
+        protected String getLeaderPathForDispatcher() {
             throw new UnsupportedOperationException("Not supported by this test implementation.");
         }
 
         @Override
-        protected String getLeaderNameForJobManager(JobID jobID) {
+        protected String getLeaderPathForJobManager(JobID jobID) {
             throw new UnsupportedOperationException("Not supported by this test implementation.");
         }
 
         @Override
-        protected String getLeaderNameForRestServer() {
+        protected String getLeaderPathForRestServer() {
             throw new UnsupportedOperationException("Not supported by this test implementation.");
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -201,7 +201,7 @@ public class LeaderElectionTest extends TestLogger {
 
         @Override
         public LeaderElectionService createLeaderElectionService() throws Exception {
-            return ZooKeeperUtils.createLeaderElectionService(client, configuration);
+            return ZooKeeperUtils.createLeaderElectionService(client);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionConnectionHandlingTest.java
@@ -95,7 +95,7 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
         LeaderRetrievalDriver leaderRetrievalDriver = null;
         try {
             leaderRetrievalDriver =
-                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(zooKeeperClient, config)
+                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(zooKeeperClient)
                             .createLeaderRetrievalDriver(
                                     queueLeaderElectionListener, fatalErrorHandler);
 
@@ -126,12 +126,12 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
     @Test
     public void testConnectionSuspendedHandling() throws Exception {
-        final String retrievalPath = "/testConnectionSuspendedHandling/leaderAddress";
+        final String retrievalPath = "/testConnectionSuspendedHandling";
         final String leaderAddress = "localhost";
 
         final QueueLeaderElectionListener queueLeaderElectionListener =
                 new QueueLeaderElectionListener(1);
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
         try {
             leaderRetrievalDriver =
                     new ZooKeeperLeaderRetrievalDriver(
@@ -140,7 +140,10 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
                             queueLeaderElectionListener,
                             fatalErrorHandler);
 
-            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, UUID.randomUUID());
+            writeLeaderInformationToZooKeeper(
+                    leaderRetrievalDriver.getConnectionInformationPath(),
+                    leaderAddress,
+                    UUID.randomUUID());
 
             // do the testing
             CompletableFuture<String> firstAddress = queueLeaderElectionListener.next();
@@ -166,11 +169,10 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
     @Test
     public void testSameLeaderAfterReconnectTriggersListenerNotification() throws Exception {
-        final String retrievalPath =
-                "/testSameLeaderAfterReconnectTriggersListenerNotification/leaderAddress";
+        final String retrievalPath = "/testSameLeaderAfterReconnectTriggersListenerNotification";
         final QueueLeaderElectionListener queueLeaderElectionListener =
                 new QueueLeaderElectionListener(1);
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
         try {
             leaderRetrievalDriver =
                     new ZooKeeperLeaderRetrievalDriver(
@@ -181,7 +183,8 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
             final String leaderAddress = "foobar";
             final UUID sessionId = UUID.randomUUID();
-            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, sessionId);
+            writeLeaderInformationToZooKeeper(
+                    leaderRetrievalDriver.getConnectionInformationPath(), leaderAddress, sessionId);
 
             // pop new leader
             queueLeaderElectionListener.next();
@@ -233,12 +236,11 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
     @Test
     public void testNewLeaderAfterReconnectTriggersListenerNotification() throws Exception {
-        final String retrievalPath =
-                "/testNewLeaderAfterReconnectTriggersListenerNotification/leaderAddress";
+        final String retrievalPath = "/testNewLeaderAfterReconnectTriggersListenerNotification";
         final QueueLeaderElectionListener queueLeaderElectionListener =
                 new QueueLeaderElectionListener(1);
 
-        LeaderRetrievalDriver leaderRetrievalDriver = null;
+        ZooKeeperLeaderRetrievalDriver leaderRetrievalDriver = null;
         try {
             leaderRetrievalDriver =
                     new ZooKeeperLeaderRetrievalDriver(
@@ -249,7 +251,8 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
             final String leaderAddress = "foobar";
             final UUID sessionId = UUID.randomUUID();
-            writeLeaderInformationToZooKeeper(retrievalPath, leaderAddress, sessionId);
+            writeLeaderInformationToZooKeeper(
+                    leaderRetrievalDriver.getConnectionInformationPath(), leaderAddress, sessionId);
 
             // pop new leader
             queueLeaderElectionListener.next();
@@ -266,7 +269,10 @@ public class ZooKeeperLeaderElectionConnectionHandlingTest extends TestLogger {
 
             final String newLeaderAddress = "barfoo";
             final UUID newSessionId = UUID.randomUUID();
-            writeLeaderInformationToZooKeeper(retrievalPath, newLeaderAddress, newSessionId);
+            writeLeaderInformationToZooKeeper(
+                    leaderRetrievalDriver.getConnectionInformationPath(),
+                    newLeaderAddress,
+                    newSessionId);
 
             // check that we find the new leader information eventually
             CommonTestUtils.waitUntilCondition(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -140,7 +140,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             leaderElectionDriver = createAndInitLeaderElectionDriver(client, electionEventHandler);
             leaderRetrievalDriver =
-                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client, configuration)
+                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client)
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
@@ -183,16 +183,14 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         TestingListener listener = new TestingListener();
 
         try {
-            leaderRetrievalService =
-                    ZooKeeperUtils.createLeaderRetrievalService(client, configuration);
+            leaderRetrievalService = ZooKeeperUtils.createLeaderRetrievalService(client);
 
             LOG.debug("Start leader retrieval service for the TestingListener.");
 
             leaderRetrievalService.start(listener);
 
             for (int i = 0; i < num; i++) {
-                leaderElectionService[i] =
-                        ZooKeeperUtils.createLeaderElectionService(client, configuration);
+                leaderElectionService[i] = ZooKeeperUtils.createLeaderElectionService(client);
                 contenders[i] = new TestingContender(createAddress(i), leaderElectionService[i]);
 
                 LOG.debug("Start leader election service for contender #{}.", i);
@@ -273,14 +271,12 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         TestingListener listener = new TestingListener();
 
         try {
-            leaderRetrievalService =
-                    ZooKeeperUtils.createLeaderRetrievalService(client, configuration);
+            leaderRetrievalService = ZooKeeperUtils.createLeaderRetrievalService(client);
 
             leaderRetrievalService.start(listener);
 
             for (int i = 0; i < num; i++) {
-                leaderElectionService[i] =
-                        ZooKeeperUtils.createLeaderElectionService(client, configuration);
+                leaderElectionService[i] = ZooKeeperUtils.createLeaderElectionService(client);
                 contenders[i] =
                         new TestingContender(TEST_URL + "_" + i + "_0", leaderElectionService[i]);
 
@@ -308,7 +304,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     leaderElectionService[index].stop();
                     // create new leader election service which takes part in the leader election
                     leaderElectionService[index] =
-                            ZooKeeperUtils.createLeaderElectionService(client, configuration);
+                            ZooKeeperUtils.createLeaderElectionService(client);
                     contenders[index] =
                             new TestingContender(
                                     TEST_URL + "_" + index + "_" + (lastTry + 1),
@@ -341,16 +337,13 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     @Test
     public void testLeaderShouldBeCorrectedWhenOverwritten() throws Exception {
         final String faultyContenderUrl = "faultyContender";
-        final String leaderPath = "/leader";
-
-        configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_LEADER_PATH, leaderPath);
 
         final TestingLeaderElectionEventHandler electionEventHandler =
                 new TestingLeaderElectionEventHandler(TEST_LEADER);
         final TestingLeaderRetrievalEventHandler retrievalEventHandler =
                 new TestingLeaderRetrievalEventHandler();
 
-        LeaderElectionDriver leaderElectionDriver = null;
+        ZooKeeperLeaderElectionDriver leaderElectionDriver = null;
         LeaderRetrievalDriver leaderRetrievalDriver = null;
 
         CuratorFramework anotherClient = null;
@@ -375,11 +368,14 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             // overwrite the current leader address, the leader should notice that
             boolean dataWritten = false;
 
+            final String connectionInformationPath =
+                    leaderElectionDriver.getConnectionInformationPath();
+
             while (!dataWritten) {
-                anotherClient.delete().forPath(leaderPath);
+                anotherClient.delete().forPath(connectionInformationPath);
 
                 try {
-                    anotherClient.create().forPath(leaderPath, baos.toByteArray());
+                    anotherClient.create().forPath(connectionInformationPath, baos.toByteArray());
 
                     dataWritten = true;
                 } catch (KeeperException.NodeExistsException e) {
@@ -389,7 +385,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             // The faulty leader should be corrected on ZooKeeper
             leaderRetrievalDriver =
-                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client, configuration)
+                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client)
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
@@ -470,7 +466,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
      */
     @Test
     public void testEphemeralZooKeeperNodes() throws Exception {
-        LeaderElectionDriver leaderElectionDriver = null;
+        ZooKeeperLeaderElectionDriver leaderElectionDriver = null;
         LeaderRetrievalDriver leaderRetrievalDriver = null;
         final TestingLeaderElectionEventHandler electionEventHandler =
                 new TestingLeaderElectionEventHandler(TEST_LEADER);
@@ -487,13 +483,11 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
 
             leaderElectionDriver = createAndInitLeaderElectionDriver(client, electionEventHandler);
             leaderRetrievalDriver =
-                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client2, configuration)
+                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client2)
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
-            final String leaderPath =
-                    configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_LEADER_PATH);
-            cache = new NodeCache(client2, leaderPath);
+            cache = new NodeCache(client2, leaderElectionDriver.getConnectionInformationPath());
 
             ExistsCacheListener existsListener = new ExistsCacheListener(cache);
             DeletedCacheListener deletedCacheListener = new DeletedCacheListener(cache);
@@ -570,7 +564,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                     is(LeaderInformation.empty()));
             // The data on ZooKeeper it not be cleared
             leaderRetrievalDriver =
-                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client, configuration)
+                    ZooKeeperUtils.createLeaderRetrievalDriverFactory(client)
                             .createLeaderRetrievalDriver(
                                     retrievalEventHandler, retrievalEventHandler::handleError);
 
@@ -646,7 +640,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             throws Exception {
 
         final ZooKeeperLeaderElectionDriver leaderElectionDriver =
-                ZooKeeperUtils.createLeaderElectionDriverFactory(client, configuration)
+                ZooKeeperUtils.createLeaderElectionDriverFactory(client)
                         .createLeaderElectionDriver(
                                 electionEventHandler, electionEventHandler::handleError, TEST_URL);
         electionEventHandler.init(leaderElectionDriver);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ZooKeeperUtilsTest extends TestLogger {
+
+    @Test
+    public void testZookeeperPathGeneration() {
+        runZookeeperPathGenerationTest("root", "namespace", "/root/namespace");
+        runZookeeperPathGenerationTest("/root/", "/namespace/", "/root/namespace");
+        runZookeeperPathGenerationTest("//root//", "//namespace//", "/root/namespace");
+        runZookeeperPathGenerationTest("////", "namespace", "/namespace");
+        runZookeeperPathGenerationTest("//a//", "/b/", "/a/b");
+        runZookeeperPathGenerationTest("", "", "/");
+        runZookeeperPathGenerationTest("root", "////", "/root");
+    }
+
+    private void runZookeeperPathGenerationTest(
+            String root, String namespace, String expectedValue) {
+        final String result = ZooKeeperUtils.generateZookeeperPath(root, namespace);
+
+        assertThat(result, is(expectedValue));
+    }
+}


### PR DESCRIPTION
In order to better clean up job specific HA services, this commit changes the layout of the
zNode structure so that the JobMaster leader, checkpoints and checkpoint counter is no grouped
below the jobs zNode.

Moreover, this commit groups the leaders of the cluster components (Dispatcher, ResourceManager,
RestServer) under /leader.

The new layout looks like:

```
clusterID -> jobgraphs -> <job-id>
          -> jobs -> <job-id> -> checkpoints -> checkpoint-1
                              -> checkpoint_id_counter -> counter
                              -> leader -> latch
                                        -> connection_info
          -> leader -> dispatcher -> latch
                                  -> connection_info
                    -> resource_manager -> latch
                                        -> connection_info
```
