### PR TITLE
[FLINK-22475][table-common][table-api-java-bridge] Provide placeholder options (*.'#'.*) for datagen connector

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenOptions.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/DataGenOptions.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** {@link ConfigOption}s for {@link DataGenTableSourceFactory}. */
+@Internal
+public class DataGenOptions {
+
+    public static final Long ROWS_PER_SECOND_DEFAULT_VALUE = 10000L;
+
+    public static final String FIELDS = "fields";
+    public static final String KIND = "kind";
+    public static final String START = "start";
+    public static final String END = "end";
+    public static final String MIN = "min";
+    public static final String MAX = "max";
+    public static final String LENGTH = "length";
+
+    public static final String SEQUENCE = "sequence";
+    public static final String RANDOM = "random";
+
+    public static final ConfigOption<Long> ROWS_PER_SECOND =
+            key("rows-per-second")
+                    .longType()
+                    .defaultValue(ROWS_PER_SECOND_DEFAULT_VALUE)
+                    .withDescription("Rows per second to control the emit rate.");
+
+    public static final ConfigOption<Long> NUMBER_OF_ROWS =
+            key("number-of-rows")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Total number of rows to emit. By default, the source is unbounded.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<String> FIELD_KIND =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, KIND))
+                    .stringType()
+                    .defaultValue("random")
+                    .withDescription("Generator of this '#' field. Can be 'sequence' or 'random'.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<String> FIELD_MIN =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, MIN))
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Minimum value to generate for fields of kind 'random'. Minimum value possible for the type of the field.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<String> FIELD_MAX =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, MAX))
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Maximum value to generate for fields of kind 'random'. Maximum value possible for the type of the field.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<Integer> FIELD_LENGTH =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, LENGTH))
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription(
+                            "Size or length of the collection for generating char/varchar/string/array/map/multiset types.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<String> FIELD_START =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, START))
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Start value of sequence generator.");
+
+    /** Placeholder {@link ConfigOption}. Not used for retrieving values. */
+    public static final ConfigOption<String> FIELD_END =
+            ConfigOptions.key(String.format("%s.#.%s", FIELDS, END))
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("End value of sequence generator.");
+
+    private DataGenOptions() {}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/RandomGeneratorVisitor.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.factories.DataGenOptions;
 import org.apache.flink.table.factories.datagen.types.DataGeneratorMapper;
 import org.apache.flink.table.factories.datagen.types.DecimalDataRandomGenerator;
 import org.apache.flink.table.factories.datagen.types.RowDataGenerator;
@@ -55,10 +56,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.FIELDS;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.LENGTH;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.MAX;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.MIN;
 
 /** Creates a random {@link DataGeneratorContainer} for a particular logical type. */
 @Internal
@@ -76,8 +73,8 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     public RandomGeneratorVisitor(String name, ReadableConfig config) {
         super(name, config);
 
-        this.minKey = key(FIELDS + "." + name + "." + MIN);
-        this.maxKey = key(FIELDS + "." + name + "." + MAX);
+        this.minKey = key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.MIN);
+        this.maxKey = key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.MAX);
     }
 
     @Override
@@ -88,7 +85,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     @Override
     public DataGeneratorContainer visit(CharType booleanType) {
         ConfigOption<Integer> lenOption =
-                key(FIELDS + "." + name + "." + LENGTH)
+                key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_STRING_LENGTH_DEFAULT);
         return DataGeneratorContainer.of(
@@ -98,7 +95,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     @Override
     public DataGeneratorContainer visit(VarCharType booleanType) {
         ConfigOption<Integer> lenOption =
-                key(FIELDS + "." + name + "." + LENGTH)
+                key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_STRING_LENGTH_DEFAULT);
         return DataGeneratorContainer.of(
@@ -188,7 +185,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     @Override
     public DataGeneratorContainer visit(ArrayType arrayType) {
         ConfigOption<Integer> lenOption =
-                key(FIELDS + "." + name + "." + LENGTH)
+                key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_COLLECTION_LENGTH_DEFAULT);
 
@@ -206,7 +203,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     @Override
     public DataGeneratorContainer visit(MultisetType multisetType) {
         ConfigOption<Integer> lenOption =
-                key(FIELDS + "." + name + "." + LENGTH)
+                key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_COLLECTION_LENGTH_DEFAULT);
 
@@ -228,7 +225,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     @Override
     public DataGeneratorContainer visit(MapType mapType) {
         ConfigOption<Integer> lenOption =
-                key(FIELDS + "." + name + "." + LENGTH)
+                key(DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.LENGTH)
                         .intType()
                         .defaultValue(RANDOM_COLLECTION_LENGTH_DEFAULT);
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/SequenceGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/SequenceGeneratorVisitor.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.functions.source.datagen.RandomGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.SequenceGenerator;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.factories.DataGenOptions;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.CharType;
@@ -38,9 +39,6 @@ import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.END;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.FIELDS;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.START;
 
 /** Creates a sequential {@link DataGeneratorContainer} for a particular logical type. */
 @Internal
@@ -65,8 +63,8 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
 
         this.config = config;
 
-        this.startKeyStr = FIELDS + "." + name + "." + START;
-        this.endKeyStr = FIELDS + "." + name + "." + END;
+        this.startKeyStr = DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.START;
+        this.endKeyStr = DataGenOptions.FIELDS + "." + name + "." + DataGenOptions.END;
 
         ConfigOptions.OptionBuilder startKey = key(startKeyStr);
         ConfigOptions.OptionBuilder endKey = key(endKeyStr);

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -44,17 +44,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.END;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.FIELDS;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.KIND;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.LENGTH;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.MAX;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.MIN;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.NUMBER_OF_ROWS;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.RANDOM;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.ROWS_PER_SECOND;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.SEQUENCE;
-import static org.apache.flink.table.factories.DataGenTableSourceFactory.START;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.junit.Assert.assertTrue;
 
@@ -104,7 +93,7 @@ public class DataGenTableSourceFactoryTest {
 
         DescriptorProperties descriptor = new DescriptorProperties();
         descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-        descriptor.putString(NUMBER_OF_ROWS.key(), "10");
+        descriptor.putString(DataGenOptions.NUMBER_OF_ROWS.key(), "10");
 
         List<RowData> results = runGenerator(schema, descriptor);
         Assert.assertEquals("Failed to generate all rows", 10, results.size());
@@ -122,18 +111,21 @@ public class DataGenTableSourceFactoryTest {
     public void testSource() throws Exception {
         DescriptorProperties descriptor = new DescriptorProperties();
         descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-        descriptor.putLong(ROWS_PER_SECOND.key(), 100);
+        descriptor.putLong(DataGenOptions.ROWS_PER_SECOND.key(), 100);
 
-        descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
-        descriptor.putLong(FIELDS + ".f0." + LENGTH, 20);
+        descriptor.putString(
+                DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.RANDOM);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f0." + DataGenOptions.LENGTH, 20);
 
-        descriptor.putString(FIELDS + ".f1." + KIND, RANDOM);
-        descriptor.putLong(FIELDS + ".f1." + MIN, 10);
-        descriptor.putLong(FIELDS + ".f1." + MAX, 100);
+        descriptor.putString(
+                DataGenOptions.FIELDS + ".f1." + DataGenOptions.KIND, DataGenOptions.RANDOM);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f1." + DataGenOptions.MIN, 10);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f1." + DataGenOptions.MAX, 100);
 
-        descriptor.putString(FIELDS + ".f2." + KIND, SEQUENCE);
-        descriptor.putLong(FIELDS + ".f2." + START, 50);
-        descriptor.putLong(FIELDS + ".f2." + END, 60);
+        descriptor.putString(
+                DataGenOptions.FIELDS + ".f2." + DataGenOptions.KIND, DataGenOptions.SEQUENCE);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f2." + DataGenOptions.START, 50);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f2." + DataGenOptions.END, 60);
 
         List<RowData> results = runGenerator(SCHEMA, descriptor);
 
@@ -175,9 +167,10 @@ public class DataGenTableSourceFactoryTest {
     public void testSequenceCheckpointRestore() throws Exception {
         DescriptorProperties descriptor = new DescriptorProperties();
         descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-        descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
-        descriptor.putLong(FIELDS + ".f0." + START, 0);
-        descriptor.putLong(FIELDS + ".f0." + END, 100);
+        descriptor.putString(
+                DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.SEQUENCE);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f0." + DataGenOptions.START, 0);
+        descriptor.putLong(DataGenOptions.FIELDS + ".f0." + DataGenOptions.END, 100);
 
         DynamicTableSource dynamicTableSource =
                 createTableSource(
@@ -209,8 +202,9 @@ public class DataGenTableSourceFactoryTest {
         try {
             DescriptorProperties descriptor = new DescriptorProperties();
             descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-            descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
-            descriptor.putLong(FIELDS + ".f0." + END, 100);
+            descriptor.putString(
+                    DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.SEQUENCE);
+            descriptor.putLong(DataGenOptions.FIELDS + ".f0." + DataGenOptions.END, 100);
 
             createTableSource(
                     ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
@@ -233,8 +227,9 @@ public class DataGenTableSourceFactoryTest {
         try {
             DescriptorProperties descriptor = new DescriptorProperties();
             descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-            descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
-            descriptor.putLong(FIELDS + ".f0." + START, 0);
+            descriptor.putString(
+                    DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.SEQUENCE);
+            descriptor.putLong(DataGenOptions.FIELDS + ".f0." + DataGenOptions.START, 0);
 
             createTableSource(
                     ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
@@ -278,8 +273,9 @@ public class DataGenTableSourceFactoryTest {
         try {
             DescriptorProperties descriptor = new DescriptorProperties();
             descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-            descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
-            descriptor.putLong(FIELDS + ".f0." + START, 0);
+            descriptor.putString(
+                    DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.RANDOM);
+            descriptor.putLong(DataGenOptions.FIELDS + ".f0." + DataGenOptions.START, 0);
 
             createTableSource(
                     ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
@@ -300,8 +296,9 @@ public class DataGenTableSourceFactoryTest {
         try {
             DescriptorProperties descriptor = new DescriptorProperties();
             descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-            descriptor.putString(FIELDS + ".f0." + KIND, RANDOM);
-            descriptor.putInt(FIELDS + ".f0." + LENGTH, 100);
+            descriptor.putString(
+                    DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.RANDOM);
+            descriptor.putInt(DataGenOptions.FIELDS + ".f0." + DataGenOptions.LENGTH, 100);
 
             createTableSource(
                     ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
@@ -322,9 +319,10 @@ public class DataGenTableSourceFactoryTest {
         try {
             DescriptorProperties descriptor = new DescriptorProperties();
             descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-            descriptor.putString(FIELDS + ".f0." + KIND, SEQUENCE);
-            descriptor.putString(FIELDS + ".f0." + START, "Wrong");
-            descriptor.putString(FIELDS + ".f0." + END, "Wrong");
+            descriptor.putString(
+                    DataGenOptions.FIELDS + ".f0." + DataGenOptions.KIND, DataGenOptions.SEQUENCE);
+            descriptor.putString(DataGenOptions.FIELDS + ".f0." + DataGenOptions.START, "Wrong");
+            descriptor.putString(DataGenOptions.FIELDS + ".f0." + DataGenOptions.END, "Wrong");
 
             createTableSource(
                     ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/Factory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/Factory.java
@@ -52,6 +52,8 @@ import java.util.Set;
  *   <li>In case of a hierarchy, try not to use the higher level again in the key name (e.g. do
  *       {@code sink.partitioner} instead of {@code sink.sink-partitioner}) to <b>keep the keys
  *       short</b>.
+ *   <li>Key names which can be templated, e.g. to refer to a specific column, should be listed
+ *       using '#' as the placeholder symbol. For example, use {@code fields.#.min}.
  * </ul>
  */
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -108,6 +108,12 @@ public final class FactoryUtil {
     public static final String FORMAT_SUFFIX = ".format";
 
     /**
+     * The placeholder symbol to be used for keys of options which can be templated. See {@link
+     * Factory} for details.
+     */
+    public static final String PLACEHOLDER_SYMBOL = "#";
+
+    /**
      * Creates a {@link DynamicTableSource} from a {@link CatalogTable}.
      *
      * <p>It considers {@link Catalog#getFactory()} if provided.
@@ -362,6 +368,9 @@ public final class FactoryUtil {
 
         final List<String> missingRequiredOptions =
                 requiredOptions.stream()
+                        // Templated options will never appear with their template key, so we need
+                        // to ignore them as required properties here
+                        .filter(option -> !option.key().contains(PLACEHOLDER_SYMBOL))
                         .filter(option -> readOption(options, option) == null)
                         .map(ConfigOption::key)
                         .sorted()
@@ -384,7 +393,7 @@ public final class FactoryUtil {
             String factoryIdentifier, Set<String> allOptionKeys, Set<String> consumedOptionKeys) {
         final Set<String> remainingOptionKeys = new HashSet<>(allOptionKeys);
         remainingOptionKeys.removeAll(consumedOptionKeys);
-        if (remainingOptionKeys.size() > 0) {
+        if (!remainingOptionKeys.isEmpty()) {
             throw new ValidationException(
                     String.format(
                             "Unsupported options found for '%s'.\n\n"

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.factories;
 
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
@@ -37,9 +40,11 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
@@ -275,6 +280,14 @@ public class FactoryUtilTest {
                     "Connector 'source-only' can only be used as a source. It cannot be used as a sink.";
             assertThat(e, containsCause(new ValidationException(errorMsg)));
         }
+    }
+
+    @Test
+    public void testRequiredPlaceholderOption() {
+        final Set<ConfigOption<?>> requiredOptions = new HashSet<>();
+        requiredOptions.add(ConfigOptions.key("fields.#.min").intType().noDefaultValue());
+
+        FactoryUtil.validateFactoryOptions(requiredOptions, new HashSet<>(), new Configuration());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This PR lets the datagen connector properly report its "placeholder" options (e.g. `fields.#.kind`) through the `Factory` interface. At the same time, we introduce this as a documented pattern and thus reserve `#` as a character for it, and ignore required options containing such a character when checking for missing required options.

Further work could be done when it comes to the validation, though that seems unnecessarily complex.

## Brief change log

* Document the usage of `#` as a special character on the `Factory` interface.
* Extend the datagen factory to report its placeholder options.
* Update the validation helper in `FactoryUtil` to respect such options.

## Verifying this change

This is mostly covered by existing tests, but I have added one case to ensure required placeholder properties are not reported as missing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
