### PR TITLE
[FLINK-22638] Keep channels blocked on alignment timeout 

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AbstractAlternatingAlignedBarrierHandlerState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AbstractAlternatingAlignedBarrierHandlerState.java
@@ -58,8 +58,7 @@ abstract class AbstractAlternatingAlignedBarrierHandlerState implements BarrierH
         state.blockChannel(channelInfo);
         if (controller.allBarriersReceived()) {
             controller.triggerGlobalCheckpoint(checkpointBarrier);
-            state.unblockAllChannels();
-            return new AlternatingWaitingForFirstBarrier(state.getInputs());
+            return stopCheckpoint();
         } else if (controller.isTimedOut(checkpointBarrier)) {
             return alignmentTimeout(controller, checkpointBarrier)
                     .barrierReceived(controller, channelInfo, checkpointBarrier.asUnaligned());
@@ -72,7 +71,11 @@ abstract class AbstractAlternatingAlignedBarrierHandlerState implements BarrierH
 
     @Override
     public final BarrierHandlerState abort(long cancelledId) throws IOException {
+        return stopCheckpoint();
+    }
+
+    private BarrierHandlerState stopCheckpoint() throws IOException {
         state.unblockAllChannels();
-        return new AlternatingWaitingForFirstBarrier(state.getInputs());
+        return new AlternatingWaitingForFirstBarrier(state.emptyState());
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AbstractAlternatingAlignedBarrierHandlerState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AbstractAlternatingAlignedBarrierHandlerState.java
@@ -58,7 +58,7 @@ abstract class AbstractAlternatingAlignedBarrierHandlerState implements BarrierH
         state.blockChannel(channelInfo);
         if (controller.allBarriersReceived()) {
             controller.triggerGlobalCheckpoint(checkpointBarrier);
-            return stopCheckpoint();
+            return finishCheckpoint();
         } else if (controller.isTimedOut(checkpointBarrier)) {
             return alignmentTimeout(controller, checkpointBarrier)
                     .barrierReceived(controller, channelInfo, checkpointBarrier.asUnaligned());
@@ -71,10 +71,10 @@ abstract class AbstractAlternatingAlignedBarrierHandlerState implements BarrierH
 
     @Override
     public final BarrierHandlerState abort(long cancelledId) throws IOException {
-        return stopCheckpoint();
+        return finishCheckpoint();
     }
 
-    private BarrierHandlerState stopCheckpoint() throws IOException {
+    private BarrierHandlerState finishCheckpoint() throws IOException {
         state.unblockAllChannels();
         return new AlternatingWaitingForFirstBarrier(state.emptyState());
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
@@ -24,6 +24,10 @@ import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInpu
 
 import java.io.IOException;
 
+/**
+ * We are performing aligned checkpoints with time out. We have seen at least a single aligned
+ * barrier.
+ */
 final class AlternatingCollectingBarriers extends AbstractAlternatingAlignedBarrierHandlerState {
 
     AlternatingCollectingBarriers(ChannelState context) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCollectingBarriers.java
@@ -35,14 +35,13 @@ final class AlternatingCollectingBarriers extends AbstractAlternatingAlignedBarr
             Controller controller, CheckpointBarrier checkpointBarrier)
             throws IOException, CheckpointException {
         state.prioritizeAllAnnouncements();
-        state.unblockAllChannels();
         CheckpointBarrier unalignedBarrier = checkpointBarrier.asUnaligned();
         controller.initInputsCheckpoint(unalignedBarrier);
         for (CheckpointableInput input : state.getInputs()) {
             input.checkpointStarted(unalignedBarrier);
         }
         controller.triggerGlobalCheckpoint(unalignedBarrier);
-        return new CollectingBarriersUnaligned(true, state.getInputs());
+        return new AlternatingCollectingBarriersUnaligned(true, state);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrier.java
@@ -20,15 +20,13 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
-import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 
 import java.io.IOException;
 
 final class AlternatingWaitingForFirstBarrier
         extends AbstractAlternatingAlignedBarrierHandlerState {
-
-    AlternatingWaitingForFirstBarrier(CheckpointableInput[] inputs) {
-        super(new ChannelState(inputs));
+    AlternatingWaitingForFirstBarrier(ChannelState state) {
+        super(state);
     }
 
     @Override
@@ -36,8 +34,7 @@ final class AlternatingWaitingForFirstBarrier
             Controller controller, CheckpointBarrier checkpointBarrier)
             throws IOException, CheckpointException {
         state.prioritizeAllAnnouncements();
-        state.unblockAllChannels();
-        return new WaitingForFirstBarrierUnaligned(true, state.getInputs());
+        return new AlternatingWaitingForFirstBarrierUnaligned(true, state);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrier.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 
 import java.io.IOException;
 
+/** We are performing aligned checkpoints with time out. We have not seen any barriers yet. */
 final class AlternatingWaitingForFirstBarrier
         extends AbstractAlternatingAlignedBarrierHandlerState {
     AlternatingWaitingForFirstBarrier(ChannelState state) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingWaitingForFirstBarrierUnaligned.java
@@ -25,14 +25,14 @@ import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInpu
 
 import java.io.IOException;
 
-final class CollectingBarriersUnaligned implements BarrierHandlerState {
+final class AlternatingWaitingForFirstBarrierUnaligned implements BarrierHandlerState {
 
     private final boolean alternating;
-    private final CheckpointableInput[] inputs;
+    private final ChannelState channelState;
 
-    CollectingBarriersUnaligned(boolean alternating, CheckpointableInput[] inputs) {
+    AlternatingWaitingForFirstBarrierUnaligned(boolean alternating, ChannelState channelState) {
         this.alternating = alternating;
-        this.inputs = inputs;
+        this.channelState = channelState;
     }
 
     @Override
@@ -46,7 +46,7 @@ final class CollectingBarriersUnaligned implements BarrierHandlerState {
     public BarrierHandlerState announcementReceived(
             Controller controller, InputChannelInfo channelInfo, int sequenceNumber)
             throws IOException {
-        inputs[channelInfo.getGateIdx()].convertToPriorityEvent(
+        channelState.getInputs()[channelInfo.getGateIdx()].convertToPriorityEvent(
                 channelInfo.getInputChannelIdx(), sequenceNumber);
         return this;
     }
@@ -57,31 +57,39 @@ final class CollectingBarriersUnaligned implements BarrierHandlerState {
             InputChannelInfo channelInfo,
             CheckpointBarrier checkpointBarrier)
             throws CheckpointException, IOException {
+
         // we received an out of order aligned barrier, we should resume consumption for the
         // channel, as it is being blocked by the credit-based network
         if (!checkpointBarrier.getCheckpointOptions().isUnalignedCheckpoint()) {
-            inputs[channelInfo.getGateIdx()].resumeConsumption(channelInfo);
+            channelState.blockChannel(channelInfo);
         }
 
-        if (controller.allBarriersReceived()) {
-            return stopCheckpoint(checkpointBarrier.getId());
+        CheckpointBarrier unalignedBarrier = checkpointBarrier.asUnaligned();
+        controller.initInputsCheckpoint(unalignedBarrier);
+        for (CheckpointableInput input : channelState.getInputs()) {
+            input.checkpointStarted(unalignedBarrier);
         }
-        return this;
+        controller.triggerGlobalCheckpoint(unalignedBarrier);
+        if (controller.allBarriersReceived()) {
+            for (CheckpointableInput input : channelState.getInputs()) {
+                input.checkpointStopped(unalignedBarrier.getId());
+            }
+            return stopCheckpoint();
+        }
+        return new AlternatingCollectingBarriersUnaligned(alternating, channelState);
     }
 
     @Override
     public BarrierHandlerState abort(long cancelledId) throws IOException {
-        return stopCheckpoint(cancelledId);
+        return stopCheckpoint();
     }
 
-    private BarrierHandlerState stopCheckpoint(long cancelledId) {
-        for (CheckpointableInput input : inputs) {
-            input.checkpointStopped(cancelledId);
-        }
+    private BarrierHandlerState stopCheckpoint() throws IOException {
+        channelState.unblockAllChannels();
         if (alternating) {
-            return new AlternatingWaitingForFirstBarrier(inputs);
+            return new AlternatingWaitingForFirstBarrier(channelState.emptyState());
         } else {
-            return new WaitingForFirstBarrierUnaligned(false, inputs);
+            return this;
         }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/ChannelState.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.util.Preconditions.checkState;
+
 /**
  * A controller for keeping track of channels state in {@link AbstractAlignedBarrierHandlerState}
  * and {@link AbstractAlternatingAlignedBarrierHandlerState}.
@@ -81,5 +83,14 @@ final class ChannelState {
 
     public void removeSeenAnnouncement(InputChannelInfo channelInfo) {
         this.sequenceNumberInAnnouncedChannels.remove(channelInfo);
+    }
+
+    public ChannelState emptyState() {
+        checkState(
+                blockedChannels.isEmpty(),
+                "We should not reset to an empty state if there are blocked channels: %s",
+                blockedChannels);
+        sequenceNumberInAnnouncedChannels.clear();
+        return this;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CollectingBarriers.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CollectingBarriers.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
+/** We are performing aligned checkpoints. We have seen at least a single aligned * barrier. */
 final class CollectingBarriers extends AbstractAlignedBarrierHandlerState {
 
     CollectingBarriers(ChannelState context) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -123,7 +123,7 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                 checkpointCoordinator,
                 clock,
                 numOpenChannels,
-                new WaitingForFirstBarrierUnaligned(false, inputs),
+                new AlternatingWaitingForFirstBarrierUnaligned(false, new ChannelState(inputs)),
                 false,
                 registerTimer,
                 inputs);
@@ -162,7 +162,7 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
                 checkpointCoordinator,
                 clock,
                 numOpenChannels,
-                new AlternatingWaitingForFirstBarrier(inputs),
+                new AlternatingWaitingForFirstBarrier(new ChannelState(inputs)),
                 true,
                 registerTimer,
                 inputs);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/WaitingForFirstBarrier.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/WaitingForFirstBarrier.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.runtime.io.network.partition.consumer.CheckpointableInput;
 
+/** We are performing aligned checkpoints. We have not seen any barriers yet. */
 final class WaitingForFirstBarrier extends AbstractAlignedBarrierHandlerState {
 
     WaitingForFirstBarrier(CheckpointableInput[] inputs) {


### PR DESCRIPTION
## What is the purpose of the change

Improve the end to end checkpointing time in case alignment timeout occurs.

## Brief change log
See the commits

## Verifying this change

Updated tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
