### PR TITLE
[FLINK-22640][datagen] Fix DataGen SQL Connector does not support defining fields min/max option of decimal type field.

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/RandomGeneratorVisitor.java
@@ -166,7 +166,9 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
         return DataGeneratorContainer.of(
                 new DecimalDataRandomGenerator(
                         decimalType.getPrecision(), decimalType.getScale(),
-                        config.get(min), config.get(max)));
+                        config.get(min), config.get(max)),
+                min,
+                max);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -106,6 +106,22 @@ public class DataGenTableSourceFactoryTest {
         descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
         descriptor.putString(NUMBER_OF_ROWS.key(), "10");
 
+        // add min max option for numeric types
+        descriptor.putString("fields.f4.min", "1.0");
+        descriptor.putString("fields.f4.max", "1000.0");
+        descriptor.putString("fields.f5.min", "0");
+        descriptor.putString("fields.f5.max", "127");
+        descriptor.putString("fields.f6.min", "0");
+        descriptor.putString("fields.f6.max", "32767");
+        descriptor.putString("fields.f7.min", "0");
+        descriptor.putString("fields.f7.max", "65535");
+        descriptor.putString("fields.f8.min", "0");
+        descriptor.putString("fields.f8.max", String.valueOf(Long.MAX_VALUE));
+        descriptor.putString("fields.f9.min", "0");
+        descriptor.putString("fields.f9.max", String.valueOf(Float.MAX_VALUE));
+        descriptor.putString("fields.f10.min", "0");
+        descriptor.putString("fields.f10.max", String.valueOf(Double.MAX_VALUE));
+
         List<RowData> results = runGenerator(schema, descriptor);
         Assert.assertEquals("Failed to generate all rows", 10, results.size());
 


### PR DESCRIPTION
## What is the purpose of the change

Fix DataGen SQL Connector does not support defining fields min/max option of decimal type field.


## Brief change log
  - *Fix the RandomGeneratorVisitor lost min / max option for decimal type.

## Verifying this change

This change added tests and can be verified as follows:

  - *Extended DataGenTableSourceFactoryTest to validate the fix*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
