### PR TITLE
[FLINK-22646] Unregister DeclarativeSlotManager metrics, before suspending

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -236,9 +236,8 @@ public class DeclarativeSlotManager implements SlotManager {
     @Override
     public void close() throws Exception {
         LOG.info("Closing the slot manager.");
-
-        suspend();
         slotManagerMetricGroup.close();
+        suspend();
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -211,6 +211,9 @@ public class DeclarativeSlotManager implements SlotManager {
 
         LOG.info("Suspending the slot manager.");
 
+        // un-register metrics
+        slotManagerMetricGroup.close();
+
         resourceTracker.clear();
         if (taskExecutorManager != null) {
             taskExecutorManager.close();
@@ -236,7 +239,6 @@ public class DeclarativeSlotManager implements SlotManager {
     @Override
     public void close() throws Exception {
         LOG.info("Closing the slot manager.");
-        slotManagerMetricGroup.close();
         suspend();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -218,6 +218,9 @@ public class FineGrainedSlotManager implements SlotManager {
 
         LOG.info("Suspending the slot manager.");
 
+        // un-register metrics
+        slotManagerMetricGroup.close();
+
         // stop the timeout checks for the TaskManagers
         if (taskManagerTimeoutsCheck != null) {
             taskManagerTimeoutsCheck.cancel(false);
@@ -247,9 +250,7 @@ public class FineGrainedSlotManager implements SlotManager {
     @Override
     public void close() throws Exception {
         LOG.info("Closing the slot manager.");
-
         suspend();
-        slotManagerMetricGroup.close();
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -137,7 +137,7 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
         private final SlotStatusSyncer slotStatusSyncer =
                 new DefaultSlotStatusSyncer(Time.seconds(10L));
         private final SlotManagerMetricGroup slotManagerMetricGroup =
-                UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
+                createSlotManagerMetricGroup();
         private final ScheduledExecutor scheduledExecutor = TestingUtils.defaultScheduledExecutor();
         private final Executor mainThreadExecutor = MAIN_THREAD_EXECUTOR;
         private FineGrainedSlotManager slotManager;
@@ -150,6 +150,10 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
                 new TestingResourceActionsBuilder();
         final SlotManagerConfigurationBuilder slotManagerConfigurationBuilder =
                 SlotManagerConfigurationBuilder.newBuilder();
+
+        SlotManagerMetricGroup createSlotManagerMetricGroup() {
+            return UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
+        }
 
         FineGrainedSlotManager getSlotManager() {
             return slotManager;


### PR DESCRIPTION
## What is the purpose of the change

Accessing DeclarativeSlotManager metrics during unregister throws NPE

## Brief change log

- Unregister DeclarativeSlotManager metrics, before suspending DeclarativeSlotManager

## Verifying this change

This change added tests and can be verified as follows:

- Added a failing test case, that access values of all gauges during un-register

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
