### PR TITLE
[BP-1.12][FLINK-20695][ha] Clean ha data for job if globally terminated

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServices.java
@@ -143,6 +143,11 @@ public class KubernetesHaServices extends AbstractHaServices {
     }
 
     @Override
+    public void internalCleanupJobData(JobID jobID) throws Exception {
+        kubeClient.deleteConfigMap(getLeaderNameForJobManager(jobID)).get();
+    }
+
+    @Override
     protected String getLeaderNameForResourceManager() {
         return getLeaderName(RESOURCE_MANAGER_NAME);
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServicesTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesHaServicesTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.kubernetes.highavailability;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.kubernetes.kubeclient.TestingFlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesConfigMap;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 
 import org.junit.Test;
@@ -72,6 +75,37 @@ public class KubernetesHaServicesTest extends KubernetesHighAvailabilityTestBase
                             assertThat(
                                     labels.get(LABEL_CONFIGMAP_TYPE_KEY),
                                     is(LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY));
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testInternalJobCleanupShouldCleanupConfigMaps() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            final KubernetesHaServices kubernetesHaServices =
+                                    new KubernetesHaServices(
+                                            flinkKubeClient,
+                                            executorService,
+                                            configuration,
+                                            new VoidBlobStore());
+                            JobID jobID = new JobID();
+                            String configMapName =
+                                    kubernetesHaServices.getLeaderNameForJobManager(jobID);
+                            final KubernetesConfigMap configMap =
+                                    new TestingFlinkKubeClient.MockKubernetesConfigMap(
+                                            configMapName);
+                            flinkKubeClient.createConfigMap(configMap);
+                            assertThat(
+                                    flinkKubeClient.getConfigMap(configMapName).isPresent(),
+                                    is(true));
+                            kubernetesHaServices.internalCleanupJobData(jobID);
+                            assertThat(
+                                    flinkKubeClient.getConfigMap(configMapName).isPresent(),
+                                    is(false));
                         });
             }
         };

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -767,13 +767,14 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
     private void cleanUpJobData(JobID jobId, boolean cleanupHA) {
         jobManagerMetricGroup.removeJob(jobId);
 
-        boolean cleanupHABlobs = false;
+        boolean jobGraphRemoved = false;
         if (cleanupHA) {
             try {
                 jobGraphWriter.removeJobGraph(jobId);
 
-                // only clean up the HA blobs if we could remove the job from HA storage
-                cleanupHABlobs = true;
+                // only clean up the HA blobs and ha service data for the particular job
+                // if we could remove the job from HA storage
+                jobGraphRemoved = true;
             } catch (Exception e) {
                 log.warn(
                         "Could not properly remove job {} from submitted job graph store.",
@@ -789,6 +790,17 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                         jobId,
                         e);
             }
+
+            if (jobGraphRemoved) {
+                try {
+                    highAvailabilityServices.cleanupJobData(jobId);
+                } catch (Exception e) {
+                    log.warn(
+                            "Could not properly clean data for job {} stored by ha services",
+                            jobId,
+                            e);
+                }
+            }
         } else {
             try {
                 jobGraphWriter.releaseJobGraph(jobId);
@@ -800,7 +812,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
             }
         }
 
-        blobServer.cleanupJob(jobId, cleanupHABlobs);
+        blobServer.cleanupJob(jobId, jobGraphRemoved);
     }
 
     /** Terminate all currently running {@link DispatcherJob}s. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
@@ -205,6 +205,13 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
         logger.info("Finished cleaning up the high availability data.");
     }
 
+    @Override
+    public void cleanupJobData(JobID jobID) throws Exception {
+        logger.info("Clean up the high availability data for job {}.", jobID);
+        internalCleanupJobData(jobID);
+        logger.info("Finished cleaning up the high availability data for job {}.", jobID);
+    }
+
     /**
      * Create leader election service with specified leaderName.
      *
@@ -259,6 +266,15 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
      * @throws Exception when do the cleanup operation on external storage.
      */
     protected abstract void internalCleanup() throws Exception;
+
+    /**
+     * Clean up the meta data in the distributed system(e.g. Zookeeper, Kubernetes ConfigMap) for
+     * the specified Job.
+     *
+     * @param jobID The identifier of the job to cleanup.
+     * @throws Exception when do the cleanup operation on external storage.
+     */
+    protected abstract void internalCleanupJobData(JobID jobID) throws Exception;
 
     /**
      * Get the leader name for ResourceManager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -237,4 +237,12 @@ public interface HighAvailabilityServices extends ClientHighAvailabilityServices
      *     up data stored by them.
      */
     void closeAndCleanupAllData() throws Exception;
+
+    /**
+     * Deletes all data for specified job stored by these services in external stores.
+     *
+     * @param jobID The identifier of the job to cleanup.
+     * @throws Exception Thrown, if an exception occurred while cleaning data stored by them.
+     */
+    void cleanupJobData(JobID jobID) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/AbstractNonHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/AbstractNonHaServices.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.highavailability.nonha;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -110,6 +111,9 @@ public abstract class AbstractNonHaServices implements HighAvailabilityServices 
         // this stores no data, so this method is the same as 'close()'
         close();
     }
+
+    @Override
+    public void cleanupJobData(JobID jobID) throws Exception {}
 
     // ----------------------------------------------------------------------
     // Helper methods

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -131,6 +131,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     private CompletableFuture<BlobKey> storedHABlobFuture;
     private CompletableFuture<JobID> deleteAllHABlobsFuture;
     private CompletableFuture<JobID> cleanupJobFuture;
+    private CompletableFuture<JobID> cleanupJobHADataFuture;
     private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
 
     @BeforeClass
@@ -153,6 +154,8 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         clearedJobLatch = new OneShotLatch();
         runningJobsRegistry = new SingleRunningJobsRegistry(jobId, clearedJobLatch);
         highAvailabilityServices.setRunningJobsRegistry(runningJobsRegistry);
+        cleanupJobHADataFuture = new CompletableFuture<>();
+        highAvailabilityServices.setCleanupJobDataFuture(cleanupJobHADataFuture);
 
         storedHABlobFuture = new CompletableFuture<>();
         deleteAllHABlobsFuture = new CompletableFuture<>();
@@ -455,6 +458,31 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         }
 
         assertThatHABlobsHaveBeenRemoved();
+    }
+
+    @Test
+    public void testHaDataCleanupWhenJobFinished() throws Exception {
+        TestingJobManagerRunnerFactory jobManagerRunnerFactory = startDispatcherAndSubmitJob();
+        TestingJobManagerRunner jobManagerRunner =
+                jobManagerRunnerFactory.takeCreatedJobManagerRunner();
+        finishJob(jobManagerRunner);
+        JobID jobID = cleanupJobHADataFuture.get(2000, TimeUnit.MILLISECONDS);
+        assertThat(jobID, is(this.jobId));
+    }
+
+    @Test
+    public void testHaDataCleanupWhenJobNotFinished() throws Exception {
+        TestingJobManagerRunnerFactory jobManagerRunnerFactory = startDispatcherAndSubmitJob();
+        TestingJobManagerRunner jobManagerRunner =
+                jobManagerRunnerFactory.takeCreatedJobManagerRunner();
+        jobManagerRunner.completeResultFutureExceptionally(new JobNotFinishedException(jobId));
+        try {
+            cleanupJobHADataFuture.get(10L, TimeUnit.MILLISECONDS);
+            fail("We should not delete the HA data for job.");
+        } catch (TimeoutException ignored) {
+            // expected
+        }
+        assertThat(cleanupJobHADataFuture.isDone(), is(false));
     }
 
     private void finishJob(TestingJobManagerRunner takeCreatedJobManagerRunner) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -37,9 +37,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -63,7 +66,8 @@ public class AbstractHaServicesTest extends TestLogger {
                         Executors.directExecutor(),
                         testingBlobStoreService,
                         closeOperations,
-                        () -> closeOperations.offer(CloseOperations.HA_CLEANUP));
+                        () -> closeOperations.offer(CloseOperations.HA_CLEANUP),
+                        ignored -> {});
 
         haServices.closeAndCleanupAllData();
 
@@ -94,7 +98,8 @@ public class AbstractHaServicesTest extends TestLogger {
                         closeOperations,
                         () -> {
                             throw new FlinkException("test exception");
-                        });
+                        },
+                        ignored -> {});
 
         try {
             haServices.closeAndCleanupAllData();
@@ -104,6 +109,29 @@ public class AbstractHaServicesTest extends TestLogger {
         }
 
         assertThat(closeOperations, contains(CloseOperations.HA_CLOSE, CloseOperations.BLOB_CLOSE));
+    }
+
+    @Test
+    public void testCleanupJobData() throws Exception {
+        final Queue<CloseOperations> closeOperations = new ArrayDeque<>(3);
+        final TestingBlobStoreService testingBlobStoreService =
+                new TestingBlobStoreService(closeOperations);
+
+        JobID jobID = new JobID();
+        CompletableFuture<JobID> jobCleanupFuture = new CompletableFuture<>();
+
+        final TestingHaServices haServices =
+                new TestingHaServices(
+                        new Configuration(),
+                        Executors.directExecutor(),
+                        testingBlobStoreService,
+                        closeOperations,
+                        () -> {},
+                        jobCleanupFuture::complete);
+
+        haServices.cleanupJobData(jobID);
+        JobID jobIDCleaned = jobCleanupFuture.get();
+        assertThat(jobIDCleaned, is(jobID));
     }
 
     private enum CloseOperations {
@@ -156,16 +184,19 @@ public class AbstractHaServicesTest extends TestLogger {
 
         private final Queue<? super CloseOperations> closeOperations;
         private final RunnableWithException internalCleanupRunnable;
+        private final Consumer<JobID> internalJobCleanupConsumer;
 
         private TestingHaServices(
                 Configuration config,
                 Executor ioExecutor,
                 BlobStoreService blobStoreService,
                 Queue<? super CloseOperations> closeOperations,
-                RunnableWithException internalCleanupRunnable) {
+                RunnableWithException internalCleanupRunnable,
+                Consumer<JobID> internalJobCleanupConsumer) {
             super(config, ioExecutor, blobStoreService);
             this.closeOperations = closeOperations;
             this.internalCleanupRunnable = internalCleanupRunnable;
+            this.internalJobCleanupConsumer = internalJobCleanupConsumer;
         }
 
         @Override
@@ -201,6 +232,11 @@ public class AbstractHaServicesTest extends TestLogger {
         @Override
         protected void internalCleanup() throws Exception {
             internalCleanupRunnable.run();
+        }
+
+        @Override
+        protected void internalCleanupJobData(JobID jobID) throws Exception {
+            internalJobCleanupConsumer.accept(jobID);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -71,6 +72,8 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
     private CompletableFuture<Void> closeFuture = new CompletableFuture<>();
 
     private CompletableFuture<Void> closeAndCleanupAllDataFuture = new CompletableFuture<>();
+
+    private volatile CompletableFuture<JobID> jobCleanupFuture;
 
     // ------------------------------------------------------------------------
     //  Setters for mock / testing implementations
@@ -143,6 +146,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
     public void setCloseAndCleanupAllDataFuture(
             CompletableFuture<Void> closeAndCleanupAllDataFuture) {
         this.closeAndCleanupAllDataFuture = closeAndCleanupAllDataFuture;
+    }
+
+    public void setCleanupJobDataFuture(CompletableFuture<JobID> jobCleanupFuture) {
+        this.jobCleanupFuture = jobCleanupFuture;
     }
 
     // ------------------------------------------------------------------------
@@ -276,5 +283,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
     @Override
     public void closeAndCleanupAllData() throws Exception {
         closeAndCleanupAllDataFuture.complete(null);
+    }
+
+    @Override
+    public void cleanupJobData(JobID jobID) {
+        Optional.ofNullable(jobCleanupFuture).ifPresent(f -> f.complete(jobID));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
@@ -136,6 +136,11 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
         // nothing to do
     }
 
+    @Override
+    public void cleanupJobData(JobID jobID) throws Exception {
+        // nothing to do
+    }
+
     public void grantLeadership(JobID jobId, int index, UUID leaderId) {
         ManualLeaderService manualLeaderService = jobManagerLeaderServices.get(jobId);
 


### PR DESCRIPTION
Backport of #15561 to `release-1.12`.