### PR TITLE
[hotfix] [docs] Fix PunctuatedAssigner Scala example 

### DIFF
--- a/docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
@@ -271,7 +271,7 @@ class BoundedOutOfOrdernessGenerator extends WatermarkGenerator[MyEvent] {
 
     var currentMaxTimestamp: Long = _
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
+    override def onEvent(event: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         currentMaxTimestamp = max(eventTimestamp, currentMaxTimestamp)
     }
 
@@ -288,7 +288,7 @@ class TimeLagWatermarkGenerator extends WatermarkGenerator[MyEvent] {
 
     val maxTimeLag = 5000L // 5 秒
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
+    override def onEvent(event: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         // 处理时间场景下不需要实现
     }
 
@@ -331,7 +331,7 @@ public class PunctuatedAssigner implements WatermarkGenerator<MyEvent> {
 ```scala
 class PunctuatedAssigner extends WatermarkGenerator[MyEvent] {
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
+    override def onEvent(event: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         if (event.hasWatermarkMarker()) {
             output.emitWatermark(new Watermark(event.getWatermarkTimestamp()))
         }

--- a/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
@@ -325,7 +325,7 @@ class BoundedOutOfOrdernessGenerator extends WatermarkGenerator[MyEvent] {
 
     var currentMaxTimestamp: Long = _
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
+    override def onEvent(event: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         currentMaxTimestamp = max(eventTimestamp, currentMaxTimestamp)
     }
 
@@ -344,7 +344,7 @@ class TimeLagWatermarkGenerator extends WatermarkGenerator[MyEvent] {
 
     val maxTimeLag = 5000L // 5 seconds
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
+    override def onEvent(event: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         // don't need to do anything because we work on processing time
     }
 
@@ -388,7 +388,7 @@ public class PunctuatedAssigner implements WatermarkGenerator<MyEvent> {
 ```scala
 class PunctuatedAssigner extends WatermarkGenerator[MyEvent] {
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
+    override def onEvent(event: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         if (event.hasWatermarkMarker()) {
             output.emitWatermark(new Watermark(event.getWatermarkTimestamp()))
         }

--- a/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
@@ -388,13 +388,13 @@ public class PunctuatedAssigner implements WatermarkGenerator<MyEvent> {
 ```scala
 class PunctuatedAssigner extends WatermarkGenerator[MyEvent] {
 
-    override def onEvent(element: MyEvent, eventTimestamp: Long): Unit = {
+    override def onEvent(element: MyEvent, eventTimestamp: Long, output: WatermarkOutput): Unit = {
         if (event.hasWatermarkMarker()) {
             output.emitWatermark(new Watermark(event.getWatermarkTimestamp()))
         }
     }
 
-    override def onPeriodicEmit(): Unit = {
+    override def onPeriodicEmit(output: WatermarkOutput): Unit = {
         // don't need to do anything because we emit in reaction to events above
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The PunctuatedAssigner example written in Scala does not correctly implement the WatermarkGenerator interface. The overridden methods were missing a `WatermarkOutput` parameter. The examples have been fixed by adding a `WatermarkOutput` in the method definition.

Also, the Scala examples reference the `MyEvent` object as `element`.This is incorrect as the code would later reference the object as `event`. `element` has been renamed to `event` to fix the code examples and to be consistent with the Java examples.

The English and Chinese docs have been adjusted. While adjusting the Chinese documentation, I noticed that some of the code examples have diverged from the English documentation. I've also included those minor fixes in this PR as well. 