### PR TITLE
[hotfix][docs] Fix typos in BatchTask, MutableRecordReader and Priori…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/MutableRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/MutableRecordReader.java
@@ -36,7 +36,7 @@ public class MutableRecordReader<T extends IOReadableWritable> extends AbstractR
      * can spill partial records to disk, if they grow large.
      *
      * @param inputGate The input gate to read from.
-     * @param tmpDirectories The temp directories. USed for spilling if the reader concurrently
+     * @param tmpDirectories The temp directories. Used for spilling if the reader concurrently
      *     reconstructs multiple large records.
      */
     public MutableRecordReader(InputGate inputGate, String[] tmpDirectories) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -70,7 +70,7 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
                 priorPriority.addFirst(deque.poll());
             }
             deque.addFirst(element);
-            // readd them before the newly added element
+            // read them before the newly added element
             for (final T priorityEvent : priorPriority) {
                 deque.addFirst(priorityEvent);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -825,7 +825,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable
         this.inputIsAsyncMaterialized = new boolean[numInputs];
         this.materializationMemory = new int[numInputs];
 
-        // set up the local strategies first, such that the can work before any temp barrier is
+        // set up the local strategies first, such that they can work before any temp barrier is
         // created
         for (int i = 0; i < numInputs; i++) {
             initInputLocalStrategy(i);


### PR DESCRIPTION
…tizedDeque


## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

Fix typos in BatchTask::initLocalStrategies(), MutableRecordReader and PrioritizedDeque::addPriorityElement().


## Brief change log

Fix typos in BatchTask::initLocalStrategies(), MutableRecordReader and PrioritizedDeque::addPriorityElement().
Details can be found in the commit.


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(yes)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
