### PR TITLE
[FLINK-22639][runtime] ClassLoaderUtil cannot print classpath of Flin…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoaders.java
@@ -188,6 +188,11 @@ public class FlinkUserCodeClassLoaders {
             return ensureInner().getResources(name);
         }
 
+        @Override
+        public URL[] getURLs() {
+            return ensureInner().getURLs();
+        }
+
         static {
             ClassLoader.registerAsParallelCapable();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.runtime.rpc.messages.RemoteRpcInvocation;
+import org.apache.flink.runtime.util.ClassLoaderUtil;
 import org.apache.flink.testutils.ClassLoaderUtils;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -38,9 +39,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 
 /** Tests for classloading and class loader utilities. */
 public class FlinkUserCodeClassLoadersTest extends TestLogger {
@@ -206,6 +209,40 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
         assertEquals(clazz1, clazz4);
 
         childClassLoader.close();
+    }
+
+    @Test
+    public void testGetClassLoaderInfo() throws Exception {
+        final ClassLoader parentClassLoader = getClass().getClassLoader();
+
+        final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
+
+        final URLClassLoader childClassLoader =
+                createChildFirstClassLoader(childCodePath, parentClassLoader);
+
+        String formattedURL = ClassLoaderUtil.formatURL(childCodePath);
+
+        assertEquals(
+                ClassLoaderUtil.getUserCodeClassLoaderInfo(childClassLoader),
+                "URL ClassLoader:" + formattedURL);
+
+        childClassLoader.close();
+    }
+
+    @Test
+    public void testGetClassLoaderInfoWithClassLoaderClosed() throws Exception {
+        final ClassLoader parentClassLoader = getClass().getClassLoader();
+
+        final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
+
+        final URLClassLoader childClassLoader =
+                createChildFirstClassLoader(childCodePath, parentClassLoader);
+
+        childClassLoader.close();
+
+        assertThat(
+                ClassLoaderUtil.getUserCodeClassLoaderInfo(childClassLoader),
+                startsWith("Cannot access classloader info due to an exception."));
     }
 
     private static URLClassLoader createParentFirstClassLoader(


### PR DESCRIPTION
## What is the purpose of the change

Fixed missing classloader URL when using ClassLoaderUtil.getUserCodeClassLoaderInfo to retrieve the info of SafetyNetWrapperClassLoader.

## Brief change log

  - Added overridden getURLs method in SafetyNetWrapperClassLoader
  - Added corresponding unit tests
  - Refactored getUserCodeClassLoaderInfo in ClassLoaderUtil, by extracting the URL formatting logic to an independent method.

## Verifying this change

This change is already covered by existing tests, such as:

 - FlinkUserCodeClassLoadersTest.testGetClassLoaderInfo
 - FlinkUserCodeClassLoadersTest.testGetClassLoaderInfoWithClassLoaderClosed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
