### PR TITLE
[FLINK-15390][Connectors/ORC]List/Map/Struct types support for vectorized orc reader

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -19,16 +19,22 @@
 package org.apache.flink.orc.vector;
 
 import org.apache.flink.orc.TimestampUtil;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -68,6 +74,12 @@ public abstract class AbstractOrcColumnVector
             return new OrcDecimalColumnVector((DecimalColumnVector) vector);
         } else if (TimestampUtil.isHiveTimestampColumnVector(vector)) {
             return new OrcTimestampColumnVector(vector);
+        } else if (vector instanceof ListColumnVector) {
+            return new OrcArrayColumnVector((ListColumnVector) vector, (ArrayType) logicalType);
+        } else if (vector instanceof StructColumnVector) {
+            return new OrcRowColumnVector((StructColumnVector) vector, (RowType) logicalType);
+        } else if (vector instanceof MapColumnVector) {
+            return new OrcMapColumnVector((MapColumnVector) vector, (MapType) logicalType);
         } else {
             throw new UnsupportedOperationException(
                     "Unsupport vector: " + vector.getClass().getName());

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcArrayColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcArrayColumnVector.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.vector;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.ColumnarArrayData;
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.types.logical.ArrayType;
+
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+
+/** This column vector is used to adapt hive's ListColumnVector to Flink's ArrayColumnVector. */
+public class OrcArrayColumnVector extends AbstractOrcColumnVector
+        implements org.apache.flink.table.data.vector.ArrayColumnVector {
+
+    private ListColumnVector hiveVector;
+    private ArrayType type;
+    private ColumnVector flinkVector;
+
+    public OrcArrayColumnVector(ListColumnVector hiveVector, ArrayType type) {
+        super(hiveVector);
+        this.hiveVector = hiveVector;
+        this.type = type;
+        this.flinkVector = createFlinkVector(hiveVector.child, type.getElementType());
+    }
+
+    @Override
+    public ArrayData getArray(int i) {
+        long offset = hiveVector.offsets[i];
+        long length = hiveVector.lengths[i];
+        return new ColumnarArrayData(flinkVector, (int) offset, (int) length);
+    }
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcMapColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcMapColumnVector.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.vector;
+
+import org.apache.flink.table.data.ColumnarMapData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.types.logical.MapType;
+
+import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+
+/** This column vector is used to adapt hive's MapColumnVector to Flink's MapColumnVector. */
+public class OrcMapColumnVector extends AbstractOrcColumnVector
+        implements org.apache.flink.table.data.vector.MapColumnVector {
+
+    private MapColumnVector hiveVector;
+    private MapType type;
+    private ColumnVector keyFlinkVector;
+    private ColumnVector valueFlinkVector;
+
+    public OrcMapColumnVector(MapColumnVector hiveVector, MapType type) {
+        super(hiveVector);
+        this.hiveVector = hiveVector;
+        this.type = type;
+        this.keyFlinkVector = createFlinkVector(hiveVector.keys, type.getKeyType());
+        this.valueFlinkVector = createFlinkVector(hiveVector.values, type.getValueType());
+    }
+
+    @Override
+    public MapData getMap(int i) {
+        long offset = hiveVector.offsets[i];
+        long length = hiveVector.lengths[i];
+        return new ColumnarMapData(keyFlinkVector, valueFlinkVector, (int) offset, (int) length);
+    }
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcRowColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/OrcRowColumnVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.vector;
+
+import org.apache.flink.table.data.ColumnarRowData;
+import org.apache.flink.table.data.vector.ColumnVector;
+import org.apache.flink.table.data.vector.VectorizedColumnBatch;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+
+/** This column vector is used to adapt hive's StructColumnVector to Flink's RowColumnVector. */
+public class OrcRowColumnVector extends AbstractOrcColumnVector
+        implements org.apache.flink.table.data.vector.RowColumnVector {
+
+    private StructColumnVector hiveVector;
+    private RowType type;
+    private VectorizedColumnBatch vectorizedColumnBatch;
+
+    public OrcRowColumnVector(StructColumnVector hiveVector, RowType type) {
+        super(hiveVector);
+        this.hiveVector = hiveVector;
+        this.type = type;
+        int len = hiveVector.fields.length;
+        ColumnVector[] flinkVectors = new ColumnVector[len];
+        for (int i = 0; i < len; i++) {
+            flinkVectors[i] = createFlinkVector(hiveVector.fields[i], type.getTypeAt(i));
+        }
+        this.vectorizedColumnBatch = new VectorizedColumnBatch(flinkVectors);
+    }
+
+    @Override
+    public ColumnarRowData getRow(int i) {
+        return new ColumnarRowData(this.vectorizedColumnBatch, i);
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/ColumnarArrayData.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/ColumnarArrayData.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.data.vector.DoubleColumnVector;
 import org.apache.flink.table.data.vector.FloatColumnVector;
 import org.apache.flink.table.data.vector.IntColumnVector;
 import org.apache.flink.table.data.vector.LongColumnVector;
+import org.apache.flink.table.data.vector.MapColumnVector;
+import org.apache.flink.table.data.vector.RowColumnVector;
 import org.apache.flink.table.data.vector.ShortColumnVector;
 import org.apache.flink.table.data.vector.TimestampColumnVector;
 
@@ -134,12 +136,12 @@ public final class ColumnarArrayData implements ArrayData, TypedSetters {
 
     @Override
     public MapData getMap(int pos) {
-        throw new UnsupportedOperationException("Map is not supported.");
+        return ((MapColumnVector) data).getMap(offset + pos);
     }
 
     @Override
     public RowData getRow(int pos, int numFields) {
-        throw new UnsupportedOperationException("Row is not supported.");
+        return ((RowColumnVector) data).getRow(offset + pos);
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/ColumnarMapData.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/ColumnarMapData.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data;
+
+import org.apache.flink.table.data.vector.ColumnVector;
+
+/** Columnar map to support access to vector column data. */
+public final class ColumnarMapData implements MapData {
+
+    private final ColumnVector keyColumnVector;
+    private final ColumnVector valueColumnVector;
+    private final int offset;
+    private final int numElements;
+
+    public ColumnarMapData(
+            ColumnVector keyColumnVector,
+            ColumnVector valueColumnVector,
+            int offset,
+            int numElements) {
+        this.keyColumnVector = keyColumnVector;
+        this.valueColumnVector = valueColumnVector;
+        this.offset = offset;
+        this.numElements = numElements;
+    }
+
+    @Override
+    public int size() {
+        return numElements;
+    }
+
+    @Override
+    public ArrayData keyArray() {
+        return new ColumnarArrayData(keyColumnVector, offset, numElements);
+    }
+
+    @Override
+    public ArrayData valueArray() {
+        return new ColumnarArrayData(valueColumnVector, offset, numElements);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        throw new UnsupportedOperationException(
+                "ColumnarMapData do not support equals, please compare fields one by one!");
+    }
+
+    @Override
+    public int hashCode() {
+        throw new UnsupportedOperationException(
+                "ColumnarMapData do not support hashCode, please hash fields one by one!");
+    }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/ColumnarRowData.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/ColumnarRowData.java
@@ -153,7 +153,7 @@ public final class ColumnarRowData implements RowData, TypedSetters {
 
     @Override
     public MapData getMap(int pos) {
-        throw new UnsupportedOperationException("Map is not supported.");
+        return vectorizedColumnBatch.getMap(rowId, pos);
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/vector/MapColumnVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/vector/MapColumnVector.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data.vector;
+
+import org.apache.flink.table.data.MapData;
+
+/** Map column vector. */
+public interface MapColumnVector extends ColumnVector {
+    MapData getMap(int i);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/vector/VectorizedColumnBatch.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.data.vector;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.vector.BytesColumnVector.Bytes;
@@ -125,5 +126,9 @@ public class VectorizedColumnBatch implements Serializable {
 
     public RowData getRow(int rowId, int colId) {
         return ((RowColumnVector) columns[colId]).getRow(rowId);
+    }
+
+    public MapData getMap(int rowId, int colId) {
+        return ((MapColumnVector) columns[colId]).getMap(rowId);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change  
*This pull request  support vectorized orc reader with nested types (List/Map/Struct).*


## Brief change log

  - *Add OrcArrayColumnVector,OrcMapColumnVector,OrcRowColumnVector to support vectorized orc reader with nested types *
  - *Add ColumnarMapData to support map type data*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

  - *Add test (OrcColumnarRowSplitReaderTest.testReadFileInSplitsWithNestedType) that validate OrcColumnarRowSplitReader support  List/Map/Struct types*
  - *Add integration tests (OrcFileSystemITCase.testNestedTypes) that validate orc connector support List/Map/Struct types in SQL*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)no
  - The serializers: (yes / no / don't know)no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)no
  - The S3 file system connector: (yes / no / don't know)no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)