### PR TITLE
[FLINK-22666][table] Make structured type's fields more lenient for Scala

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
@@ -187,7 +187,7 @@ public final class ExtractionUtils {
             }
         }
         throw extractionError(
-                "Could not to find a field named '%s' in class '%s' for structured type.",
+                "Could not find a field named '%s' in class '%s' for structured type.",
                 fieldName, clazz.getName());
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastAvoidanceTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastAvoidanceTest.java
@@ -230,7 +230,7 @@ public class LogicalTypeCastAvoidanceTest {
                         true
                     },
 
-                    // row and structure type
+                    // row and structured type
                     {
                         RowType.of(new IntType(), new VarCharType()),
                         createUserType("User2", new IntType(), new VarCharType()),
@@ -251,6 +251,46 @@ public class LogicalTypeCastAvoidanceTest {
                         RowType.of(new BigIntType(), new VarCharType()),
                         false
                     },
+
+                    // test slightly different children of anonymous structured types
+                    {
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredType.StructuredAttribute(
+                                                        "f1", new TimestampType()),
+                                                new StructuredType.StructuredAttribute(
+                                                        "diff", new TinyIntType(false))))
+                                .build(),
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredType.StructuredAttribute(
+                                                        "f1", new TimestampType()),
+                                                new StructuredType.StructuredAttribute(
+                                                        "diff", new TinyIntType(true))))
+                                .build(),
+                        true
+                    },
+                    {
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredType.StructuredAttribute(
+                                                        "f1", new TimestampType()),
+                                                new StructuredType.StructuredAttribute(
+                                                        "diff", new TinyIntType(true))))
+                                .build(),
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredType.StructuredAttribute(
+                                                        "f1", new TimestampType()),
+                                                new StructuredType.StructuredAttribute(
+                                                        "diff", new TinyIntType(false))))
+                                .build(),
+                        false
+                    }
                 });
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeCastsTest.java
@@ -218,6 +218,42 @@ public class LogicalTypeCastsTest {
                         false,
                         true
                     },
+
+                    // test slightly different children of anonymous structured types
+                    {
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute(
+                                                        "diff", new TinyIntType(false))))
+                                .build(),
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute(
+                                                        "diff", new TinyIntType(true))))
+                                .build(),
+                        true,
+                        true
+                    },
+                    {
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute("diff", new IntType())))
+                                .build(),
+                        StructuredType.newBuilder(Void.class)
+                                .attributes(
+                                        Arrays.asList(
+                                                new StructuredAttribute("f1", new TimestampType()),
+                                                new StructuredAttribute("diff", new TinyIntType())))
+                                .build(),
+                        false,
+                        true
+                    }
                 });
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DataStreamScalaITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DataStreamScalaITCase.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.streaming.api.scala.{CloseableIterator, DataStream, StreamExecutionEnvironment}
+import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+import org.apache.flink.test.util.AbstractTestBase
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.{DataTypes, Table, TableResult}
+import org.apache.flink.table.catalog.{Column, ResolvedSchema}
+import org.apache.flink.table.planner.runtime.stream.sql.DataStreamScalaITCase.{ComplexCaseClass, ImmutableCaseClass}
+import org.apache.flink.types.Row
+import org.apache.flink.util.CollectionUtil
+
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.junit.Assert.{assertEquals, assertThat}
+import org.junit.{Before, Test}
+
+import java.util
+import scala.collection.JavaConverters._
+
+/** Tests for connecting to the Scala [[DataStream]] API. */
+class DataStreamScalaITCase extends AbstractTestBase {
+
+  private var env: StreamExecutionEnvironment = _
+
+  private var tableEnv: StreamTableEnvironment = _
+
+  @Before
+  def before(): Unit = {
+    env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(4)
+    tableEnv = StreamTableEnvironment.create(env)
+  }
+
+  @Test
+  def testFromAndToDataStreamWithCaseClass(): Unit = {
+    val caseClasses = Array(
+      ComplexCaseClass(42, "hello", ImmutableCaseClass(42.0, b = true)),
+      ComplexCaseClass(42, null, ImmutableCaseClass(42.0, b = false)))
+
+    val dataStream = env.fromElements(caseClasses: _*)
+
+    val table = tableEnv.fromDataStream(dataStream)
+
+    testSchema(
+      table,
+      Column.physical("c", DataTypes.INT().notNull().bridgedTo(classOf[Int])),
+      Column.physical("a", DataTypes.STRING()),
+      Column.physical(
+        "p",
+        DataTypes.STRUCTURED(
+          classOf[ImmutableCaseClass],
+          DataTypes.FIELD(
+            "d",
+            DataTypes.DOUBLE().notNull()), // serializer doesn't support null
+          DataTypes.FIELD(
+            "b",
+            DataTypes.BOOLEAN().notNull().bridgedTo(classOf[Boolean]))).notNull()))
+
+    testResult(
+      table.execute(),
+      Row.of(Int.box(42), "hello", ImmutableCaseClass(42.0, b = true)),
+      Row.of(Int.box(42), null, ImmutableCaseClass(42.0, b = false)))
+
+    val resultStream = tableEnv.toDataStream(table, classOf[ComplexCaseClass])
+
+    testResult(resultStream, caseClasses: _*)
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Helper methods
+  // --------------------------------------------------------------------------------------------
+
+  private def testSchema(table: Table, expectedColumns: Column*): Unit = {
+    assertEquals(ResolvedSchema.of(expectedColumns: _*), table.getResolvedSchema)
+  }
+
+  private def testResult(result: TableResult, expectedRows: Row*): Unit = {
+    val actualRows: util.List[Row] = CollectionUtil.iteratorToList(result.collect)
+    assertThat(actualRows, containsInAnyOrder(expectedRows: _*))
+  }
+
+  private def testResult[T](dataStream: DataStream[T], expectedResult: T*): Unit = {
+    var iterator: CloseableIterator[T] = null
+    try {
+      iterator = dataStream.executeAndCollect()
+      val list: util.List[T] = iterator.toList.asJava
+      assertThat(list, containsInAnyOrder(expectedResult: _*))
+    } finally {
+      if (iterator != null) {
+        iterator.close()
+      }
+    }
+  }
+}
+
+object DataStreamScalaITCase {
+
+  case class ComplexCaseClass(var c: Int, var a: String, var p: ImmutableCaseClass)
+
+  case class ImmutableCaseClass(d: java.lang.Double, b: Boolean)
+}


### PR DESCRIPTION
## What is the purpose of the change

This make the logic for structured type fields more lenient. It fixes issues with Scala case classes.

## Brief change log

Compare children individually for anonymous structured types.

## Verifying this change

This change added tests and can be verified as follows: `DataStreamScalaITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
