### PR TITLE
[FLINK-22683][runtime] Fix the null or incorrect value of total Flink…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
@@ -38,12 +38,11 @@ import static org.apache.flink.configuration.TaskManagerOptions.MANAGED_MEMORY_S
 import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_MAX;
 import static org.apache.flink.configuration.TaskManagerOptions.TASK_HEAP_MEMORY;
 import static org.apache.flink.configuration.TaskManagerOptions.TASK_OFF_HEAP_MEMORY;
-import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_FLINK_MEMORY;
-import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_PROCESS_MEMORY;
+import static org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils.calculateTotalFlinkMemoryFromComponents;
+import static org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils.calculateTotalProcessMemoryFromComponents;
 
 /** TaskExecutorConfiguration collects the configuration of a TaskExecutor instance. */
 public class TaskExecutorMemoryConfiguration implements Serializable {
-
     public static final String FIELD_NAME_FRAMEWORK_HEAP = "frameworkHeap";
     public static final String FIELD_NAME_TASK_HEAP = "taskHeap";
 
@@ -116,8 +115,8 @@ public class TaskExecutorMemoryConfiguration implements Serializable {
                 getConfigurationValue(config, MANAGED_MEMORY_SIZE),
                 getConfigurationValue(config, JVM_METASPACE),
                 getConfigurationValue(config, JVM_OVERHEAD_MAX),
-                getConfigurationValue(config, TOTAL_FLINK_MEMORY),
-                getConfigurationValue(config, TOTAL_PROCESS_MEMORY));
+                calculateTotalFlinkMemoryFromComponents(config),
+                calculateTotalProcessMemoryFromComponents(config));
     }
 
     @JsonCreator

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -81,6 +81,8 @@ public class ActiveResourceManagerTest extends TestLogger {
     private static final long TESTING_START_WORKER_TIMEOUT_MS = 50;
 
     private static final WorkerResourceSpec WORKER_RESOURCE_SPEC = WorkerResourceSpec.ZERO;
+    private static final TaskExecutorMemoryConfiguration TESTING_CONFIG =
+            new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 21L, 36L);
 
     /** Tests worker successfully requested, started and registered. */
     @Test
@@ -941,7 +943,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             1234,
                             23456,
                             new HardwareDescription(1, 2L, 3L, 4L),
-                            TaskExecutorMemoryConfiguration.create(flinkConfig),
+                            TESTING_CONFIG,
                             ResourceProfile.ZERO,
                             ResourceProfile.ZERO);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfigurationTest.java
@@ -37,8 +37,6 @@ import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_M
 import static org.apache.flink.configuration.TaskManagerOptions.NETWORK_MEMORY_MIN;
 import static org.apache.flink.configuration.TaskManagerOptions.TASK_HEAP_MEMORY;
 import static org.apache.flink.configuration.TaskManagerOptions.TASK_OFF_HEAP_MEMORY;
-import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_FLINK_MEMORY;
-import static org.apache.flink.configuration.TaskManagerOptions.TOTAL_PROCESS_MEMORY;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -46,49 +44,26 @@ import static org.junit.Assert.assertThat;
 public class TaskExecutorMemoryConfigurationTest extends TestLogger {
 
     @Test
-    public void testInitializationWithAllValuesBeingSet() {
+    public void testInitialization() {
         Configuration config = new Configuration();
 
         config.set(FRAMEWORK_HEAP_MEMORY, new MemorySize(1));
         config.set(TASK_HEAP_MEMORY, new MemorySize(2));
         config.set(FRAMEWORK_OFF_HEAP_MEMORY, new MemorySize(3));
         config.set(TASK_OFF_HEAP_MEMORY, new MemorySize(4));
-        config.set(NETWORK_MEMORY_MIN, new MemorySize(5));
+        config.set(NETWORK_MEMORY_MIN, new MemorySize(6));
         config.set(NETWORK_MEMORY_MAX, new MemorySize(6));
         config.set(NETWORK_MEMORY_FRACTION, 0.1f);
         config.set(MANAGED_MEMORY_SIZE, new MemorySize(7));
         config.set(MANAGED_MEMORY_FRACTION, 0.2f);
         config.set(JVM_METASPACE, new MemorySize(8));
-        config.set(JVM_OVERHEAD_MIN, new MemorySize(9));
+        config.set(JVM_OVERHEAD_MIN, new MemorySize(10));
         config.set(JVM_OVERHEAD_MAX, new MemorySize(10));
         config.set(JVM_OVERHEAD_FRACTION, 0.3f);
-        config.set(TOTAL_FLINK_MEMORY, new MemorySize(11));
-        config.set(TOTAL_PROCESS_MEMORY, new MemorySize(12));
 
         TaskExecutorMemoryConfiguration actual = TaskExecutorMemoryConfiguration.create(config);
         TaskExecutorMemoryConfiguration expected =
-                new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 6L, 7L, 8L, 10L, 11L, 12L);
-
-        assertThat(actual, is(expected));
-    }
-
-    @Test
-    public void testInitializationWithMissingValues() {
-        Configuration config = new Configuration();
-
-        TaskExecutorMemoryConfiguration actual = TaskExecutorMemoryConfiguration.create(config);
-        TaskExecutorMemoryConfiguration expected =
-                new TaskExecutorMemoryConfiguration(
-                        FRAMEWORK_HEAP_MEMORY.defaultValue().getBytes(),
-                        null,
-                        FRAMEWORK_OFF_HEAP_MEMORY.defaultValue().getBytes(),
-                        TASK_OFF_HEAP_MEMORY.defaultValue().getBytes(),
-                        NETWORK_MEMORY_MAX.defaultValue().getBytes(),
-                        null,
-                        JVM_METASPACE.defaultValue().getBytes(),
-                        JVM_OVERHEAD_MAX.defaultValue().getBytes(),
-                        null,
-                        null);
+                new TaskExecutorMemoryConfiguration(1L, 2L, 3L, 4L, 6L, 7L, 8L, 10L, 23L, 41L);
 
         assertThat(actual, is(expected));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
@@ -126,6 +126,68 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
         assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MAX), is(networkMemorySize));
     }
 
+    @Test
+    public void testCalculateTotalFlinkMemoryWithAllFactorsBeingSet() {
+        Configuration config = new Configuration();
+
+        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, new MemorySize(1));
+        config.set(TaskManagerOptions.TASK_HEAP_MEMORY, new MemorySize(2));
+        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, new MemorySize(3));
+        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, new MemorySize(4));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, new MemorySize(6));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, new MemorySize(6));
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, new MemorySize(7));
+
+        assertThat(
+                TaskExecutorResourceUtils.calculateTotalFlinkMemoryFromComponents(config), is(23L));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCalculateTotalFlinkMemoryWithMissingFactors() {
+        Configuration config = new Configuration();
+
+        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, new MemorySize(1));
+        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, new MemorySize(3));
+        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, new MemorySize(4));
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, new MemorySize(7));
+
+        TaskExecutorResourceUtils.calculateTotalFlinkMemoryFromComponents(config);
+    }
+
+    @Test
+    public void testCalculateTotalProcessMemoryWithAllFactorsBeingSet() {
+        Configuration config = new Configuration();
+
+        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, new MemorySize(1));
+        config.set(TaskManagerOptions.TASK_HEAP_MEMORY, new MemorySize(2));
+        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, new MemorySize(3));
+        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, new MemorySize(4));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, new MemorySize(6));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, new MemorySize(6));
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, new MemorySize(7));
+        config.set(TaskManagerOptions.JVM_METASPACE, new MemorySize(8));
+        config.set(TaskManagerOptions.JVM_OVERHEAD_MAX, new MemorySize(10));
+        config.set(TaskManagerOptions.JVM_OVERHEAD_MIN, new MemorySize(10));
+
+        assertThat(
+                TaskExecutorResourceUtils.calculateTotalProcessMemoryFromComponents(config),
+                is(41L));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCalculateTotalProcessMemoryWithMissingFactors() {
+        Configuration config = new Configuration();
+
+        config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, new MemorySize(1));
+        config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, new MemorySize(3));
+        config.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, new MemorySize(4));
+        config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, new MemorySize(6));
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, new MemorySize(7));
+        config.set(TaskManagerOptions.JVM_METASPACE, new MemorySize(8));
+
+        TaskExecutorResourceUtils.calculateTotalProcessMemoryFromComponents(config);
+    }
+
     private static Configuration createValidConfig() {
         Configuration configuration = new Configuration();
         configuration.set(TaskManagerOptions.CPU_CORES, CPU_CORES);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.zookeeper.ZooKeeperResource;
@@ -335,6 +336,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
                 Configuration cfg = parameterTool.getConfiguration();
                 final PluginManager pluginManager =
                         PluginUtils.createPluginManagerFromRootFolder(cfg);
+                TaskExecutorResourceUtils.adjustForLocalExecution(cfg);
 
                 TaskManagerRunner.runTaskManager(cfg, pluginManager);
             } catch (Throwable t) {

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.DispatcherProcess;
@@ -268,6 +269,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
         config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
+        TaskExecutorResourceUtils.adjustForLocalExecution(config);
 
         final RpcService rpcService =
                 AkkaRpcServiceUtils.remoteServiceBuilder(config, "localhost", 0).createAndStart();


### PR DESCRIPTION
…/process memory in creating TaskExecutorMemoryConfiguration

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
