### PR TITLE
[FLINK-12295][table] Fix comments in MinAggFunction and MaxAggFunction

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MaxAggFunction.java
@@ -72,9 +72,12 @@ public abstract class MaxAggFunction extends DeclarativeAggregateFunction {
 
     @Override
     public Expression[] retractExpressions() {
-        // TODO FLINK-12295, ignore exception now
-        //		throw new TableException("This function does not support retraction, Please choose
-        // MaxWithRetractAggFunction.");
+        // See optimization in FlinkRelMdModifiedMonotonicity.
+        // This function can ignore retraction message:
+        // SQL: SELECT MAX(cnt), SUM(cnt) FROM (SELECT count(a) as cnt FROM T GROUP BY b)
+        // The cnt is modified increasing, so the MAX(cnt) can ignore retraction message. But this
+        // doesn't mean that the node won't receive the retraction message, because there are other
+        // aggregate operators that need retraction message, such as SUM(cnt).
         return new Expression[0];
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/MinAggFunction.java
@@ -72,9 +72,7 @@ public abstract class MinAggFunction extends DeclarativeAggregateFunction {
 
     @Override
     public Expression[] retractExpressions() {
-        // TODO FLINK-12295, ignore exception now
-        //		throw new TableException("This function does not support retraction, Please choose
-        // MinWithRetractAggFunction.");
+        // See MaxAggFunction.retractExpressions
         return new Expression[0];
     }
 


### PR DESCRIPTION

## What is the purpose of the change

Fix comments in `MaxAggFunction.retractExpressions`, return `Expression[0]` is right.

```
See optimization in FlinkRelMdModifiedMonotonicity.
MaxAggFunction can ignore retraction message:
SQL: SELECT MAX(cnt), SUM(cnt) FROM (SELECT count(a) as cnt FROM T GROUP BY b)
The cnt is modified increasing, so the MAX(cnt) can ignore retraction message. But this
doesn't mean that the node won't receive the retraction message, because there are other
aggregate operators that need retraction message, such as SUM(cnt).
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no