### PR TITLE
[FLINK-20655][e2e] Add E2E test for new KafkaSource based on FLIP-27

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/CustomWatermarkStrategy.java
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/src/main/java/org/apache/flink/streaming/kafka/test/base/CustomWatermarkStrategy.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.kafka.test.base;
+
+import org.apache.flink.api.common.eventtime.AscendingTimestampsWatermarks;
+import org.apache.flink.api.common.eventtime.BoundedOutOfOrdernessWatermarks;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+
+/**
+ * A custom {@link WatermarkStrategy}, that simply assumes that the input stream records are
+ * strictly ascending.
+ *
+ * <p>Flink also ships some built-in convenience watermark strategies, such as the {@link
+ * BoundedOutOfOrdernessWatermarks} and {@link AscendingTimestampsWatermarks}
+ */
+public class CustomWatermarkStrategy implements WatermarkStrategy<KafkaEvent> {
+
+    private static final long serialVersionUID = -6473078087120012424L;
+
+    private long currentTimestamp = Long.MIN_VALUE;
+
+    @Override
+    public TimestampAssigner<KafkaEvent> createTimestampAssigner(
+            TimestampAssignerSupplier.Context context) {
+        return (event, recordTimestamp) -> {
+            // the inputs are assumed to be of format (message,timestamp)
+            currentTimestamp = event.getTimestamp();
+            return event.getTimestamp();
+        };
+    }
+
+    @Override
+    public WatermarkGenerator<KafkaEvent> createWatermarkGenerator(
+            WatermarkGeneratorSupplier.Context context) {
+        return new WatermarkGenerator<KafkaEvent>() {
+            @Override
+            public void onEvent(KafkaEvent event, long eventTimestamp, WatermarkOutput output) {
+                output.emitWatermark(
+                        new Watermark(
+                                currentTimestamp == Long.MIN_VALUE
+                                        ? Long.MIN_VALUE
+                                        : currentTimestamp - 1));
+            }
+
+            @Override
+            public void onPeriodicEmit(WatermarkOutput output) {}
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds E2E test case for the new KafkaSource based on FLIP-27.


## Brief change log
- Add command line argument in KafkaExample to choose which Kafka source to use (legacy SourceFunction API or new Source API)
- Add parameter in StreamingKafkaITCase to run E2E test with new KafkaSource.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
