### PR TITLE
[FLINK-22688][runtime] Eases assertion on ExceptionHistoryEntry

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -215,9 +215,6 @@ public class JobExceptionsHandler
         Preconditions.checkArgument(
                 exceptionHistoryEntry.getFailingTaskName() != null,
                 "The taskName must not be null for a non-global failure.");
-        Preconditions.checkArgument(
-                exceptionHistoryEntry.getTaskManagerLocation() != null,
-                "The location must not be null for a non-global failure.");
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
@@ -48,10 +48,13 @@ public class ExceptionHistoryEntry extends ErrorInfo {
      * @param failedExecution the failed {@code Execution}.
      * @param taskName the name of the task.
      * @return The {@code ExceptionHistoryEntry}.
+     * @throws NullPointerException if {@code null} is passed as one of the parameters.
      * @throws IllegalArgumentException if the passed {@code Execution} does not provide a {@link
      *     Execution#getFailureInfo() failureInfo}.
      */
     public static ExceptionHistoryEntry create(AccessExecution failedExecution, String taskName) {
+        Preconditions.checkNotNull(failedExecution, "No Execution is specified.");
+        Preconditions.checkNotNull(taskName, "No task name is specified.");
         Preconditions.checkArgument(
                 failedExecution.getFailureInfo().isPresent(),
                 "The selected Execution " + failedExecution.getAttemptId() + " didn't fail.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -164,6 +164,33 @@ public class JobExceptionsHandlerTest extends TestLogger {
     }
 
     @Test
+    public void testWithLocalExceptionHistoryEntryNotHavingATaskManagerInformationAvailable()
+            throws HandlerRequestException {
+        final RootExceptionHistoryEntry failure =
+                new RootExceptionHistoryEntry(
+                        new RuntimeException("exception #1"),
+                        System.currentTimeMillis(),
+                        "task name",
+                        null,
+                        Collections.emptySet());
+
+        final ExecutionGraphInfo executionGraphInfo = createExecutionGraphInfo(failure);
+        final HandlerRequest<EmptyRequestBody, JobExceptionsMessageParameters> request =
+                createRequest(executionGraphInfo.getJobId(), 10);
+        final JobExceptionsInfoWithHistory response =
+                testInstance.handleRequest(request, executionGraphInfo);
+
+        assertThat(
+                response.getExceptionHistory().getEntries(),
+                contains(
+                        historyContainsJobExceptionInfo(
+                                failure.getException(),
+                                failure.getTimestamp(),
+                                failure.getFailingTaskName(),
+                                JobExceptionsHandler.toString(failure.getTaskManagerLocation()))));
+    }
+
+    @Test
     public void testWithExceptionHistoryWithTruncationThroughParameter()
             throws HandlerRequestException {
         final RootExceptionHistoryEntry rootCause =


### PR DESCRIPTION




Additionally, I added a few Preconditions to the ExceptionHistoryEntry creation
to make the code more robust.

## What is the purpose of the change

An `ExceptionHistoryEntry` referring to a local task failure can also have the
TaskManagerLocation not being set (e.g. in cases where the task is not deployed,
yet). The previous implementation failed in the REST endpoint in that case.

## Brief change log

The Precondition checking the availability of the `TaskManagerLocation` was removed. The `ExceptionHistoryEntry.isGlobal` which is called before only checks the availability of the task name.

Additionally, I added some Preconditions to make the code more robust and added tests for these.

## Verifying this change

* A test was added to `JobExceptionsHandlerTest` to verify the issue 
* Additional tests were added to `ExceptionHistoryEntryTest` to test the Preconditions added to make `ExceptionHistoryEntry` more robust.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
