### PR TITLE
[FLINK-22319][table][sql-client] Support RESET table option for ALTER TABLE statement

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -33,6 +33,7 @@
     "org.apache.flink.sql.parser.ddl.SqlAlterTableDropConstraint"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableOptions"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableRename"
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableReset"
     "org.apache.flink.sql.parser.ddl.SqlCreateCatalog"
     "org.apache.flink.sql.parser.ddl.SqlCreateDatabase"
     "org.apache.flink.sql.parser.ddl.SqlCreateFunction"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -463,6 +463,7 @@ SqlAlterTable SqlAlterTable() :
     SqlIdentifier tableIdentifier;
     SqlIdentifier newTableIdentifier = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
+    SqlNodeList propertyKeyList = SqlNodeList.EMPTY;
     SqlIdentifier constraintName;
     SqlTableConstraint constraint;
 }
@@ -477,6 +478,15 @@ SqlAlterTable SqlAlterTable() :
                         startPos.plus(getPos()),
                         tableIdentifier,
                         newTableIdentifier);
+        }
+    |
+        <RESET>
+        propertyKeyList = TablePropertyKeys()
+        {
+            return new SqlAlterTableReset(
+                        startPos.plus(getPos()),
+                        tableIdentifier,
+                        propertyKeyList);
         }
     |
         <SET>
@@ -503,6 +513,31 @@ SqlAlterTable SqlAlterTable() :
                 startPos.plus(getPos()));
         }
     )
+}
+
+/** Parse a table option key list. */
+SqlNodeList TablePropertyKeys():
+{
+    SqlNode key;
+    final List<SqlNode> proKeyList = new ArrayList<SqlNode>();
+    final Span span;
+}
+{
+    <LPAREN> { span = span(); }
+    [
+        key = StringLiteral()
+        {
+            proKeyList.add(key);
+        }
+        (
+            <COMMA> key = StringLiteral()
+            {
+                proKeyList.add(key);
+            }
+        )*
+    ]
+    <RPAREN>
+    {  return new SqlNodeList(proKeyList, span.end(this)); }
 }
 
 void TableColumn(TableCreationContext context) :

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableReset.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableReset.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.NlsString;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/** ALTER TABLE [[catalogName.] dataBasesName].tableName RESET ( 'key1' [, 'key2']*). */
+public class SqlAlterTableReset extends SqlAlterTable {
+    private final SqlNodeList propertyKeyList;
+
+    public SqlAlterTableReset(
+            SqlParserPos pos, SqlIdentifier tableName, SqlNodeList propertyKeyList) {
+        super(pos, tableName, null);
+        this.propertyKeyList =
+                requireNonNull(propertyKeyList, "propertyKeyList should not be null");
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(tableIdentifier, propertyKeyList);
+    }
+
+    public SqlNodeList getPropertyKeyList() {
+        return propertyKeyList;
+    }
+
+    public Set<String> getResetKeys() {
+        return propertyKeyList.getList().stream()
+                .map(key -> ((NlsString) SqlLiteral.value(key)).getValue())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        super.unparse(writer, leftPrec, rightPrec);
+        writer.keyword("RESET");
+        SqlWriter.Frame withFrame = writer.startList("(", ")");
+        for (SqlNode property : propertyKeyList) {
+            printIndent(writer);
+            property.unparse(writer, leftPrec, rightPrec);
+        }
+        writer.newlineAndIndent();
+        writer.endList(withFrame);
+    }
+
+    protected void printIndent(SqlWriter writer) {
+        writer.sep(",", false);
+        writer.newlineAndIndent();
+        writer.print("  ");
+    }
+
+    public String[] fullTableName() {
+        return tableIdentifier.names.toArray(new String[0]);
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -236,6 +236,16 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
+    public void testAlterTableReset() {
+        sql("alter table t1 reset ('key1')").ok("ALTER TABLE `T1` RESET (\n  'key1'\n)");
+
+        sql("alter table t1 reset ('key1', 'key2')")
+                .ok("ALTER TABLE `T1` RESET (\n  'key1',\n  'key2'\n)");
+
+        sql("alter table t1 reset()").ok("ALTER TABLE `T1` RESET (\n)");
+    }
+
+    @Test
     public void testCreateTable() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1128,18 +1128,7 @@ public class SqlToOperationConverterTest {
 
     @Test
     public void testAlterTable() throws Exception {
-        Catalog catalog = new GenericInMemoryCatalog("default", "default");
-        catalogManager.registerCatalog("cat1", catalog);
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
-        CatalogTable catalogTable =
-                CatalogTable.of(
-                        Schema.newBuilder().column("a", DataTypes.STRING()).build(),
-                        "tb1",
-                        Collections.emptyList(),
-                        Collections.emptyMap());
-        catalogManager.setCurrentCatalog("cat1");
-        catalogManager.setCurrentDatabase("db1");
-        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+        prepareTable(false);
         final String[] renameTableSqls =
                 new String[] {
                     "alter table cat1.db1.tb1 rename to tb2",
@@ -1162,35 +1151,25 @@ public class SqlToOperationConverterTest {
                 parse(
                         "alter table cat1.db1.tb1 set ('k1' = 'v1', 'K2' = 'V2')",
                         SqlDialect.DEFAULT);
-        assert operation instanceof AlterTableOptionsOperation;
-        final AlterTableOptionsOperation alterTableOptionsOperation =
-                (AlterTableOptionsOperation) operation;
-        assertEquals(expectedIdentifier, alterTableOptionsOperation.getTableIdentifier());
-        assertEquals(2, alterTableOptionsOperation.getCatalogTable().getOptions().size());
-        Map<String, String> options = new HashMap<>();
-        options.put("k1", "v1");
-        options.put("K2", "V2");
-        assertEquals(options, alterTableOptionsOperation.getCatalogTable().getOptions());
+        Map<String, String> expectedOptions = new HashMap<>();
+        expectedOptions.put("k", "v");
+        expectedOptions.put("k1", "v1");
+        expectedOptions.put("K2", "V2");
+
+        assertAlterTableOptions(operation, expectedIdentifier, expectedOptions);
+
+        // test alter table reset
+        operation = parse("alter table cat1.db1.tb1 reset ('k')", SqlDialect.DEFAULT);
+        assertAlterTableOptions(operation, expectedIdentifier, Collections.emptyMap());
+
+        thrown.expect(ValidationException.class);
+        thrown.expectMessage("ALTER TABLE RESET does not support empty key");
+        parse("alter table cat1.db1.tb1 reset ()", SqlDialect.DEFAULT);
     }
 
     @Test
     public void testAlterTableAddPkConstraint() throws Exception {
-        Catalog catalog = new GenericInMemoryCatalog("default", "default");
-        catalogManager.registerCatalog("cat1", catalog);
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
-        CatalogTable catalogTable =
-                CatalogTable.of(
-                        Schema.newBuilder()
-                                .column("a", DataTypes.STRING().notNull())
-                                .column("b", DataTypes.BIGINT().notNull())
-                                .column("c", DataTypes.BIGINT())
-                                .build(),
-                        "tb1",
-                        Collections.emptyList(),
-                        Collections.emptyMap());
-        catalogManager.setCurrentCatalog("cat1");
-        catalogManager.setCurrentDatabase("db1");
-        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+        prepareTable(false);
         // Test alter add table constraint.
         Operation operation =
                 parse(
@@ -1212,22 +1191,7 @@ public class SqlToOperationConverterTest {
 
     @Test
     public void testAlterTableAddPkConstraintEnforced() throws Exception {
-        Catalog catalog = new GenericInMemoryCatalog("default", "default");
-        catalogManager.registerCatalog("cat1", catalog);
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
-        CatalogTable catalogTable =
-                CatalogTable.of(
-                        Schema.newBuilder()
-                                .column("a", DataTypes.STRING().notNull())
-                                .column("b", DataTypes.BIGINT().notNull())
-                                .column("c", DataTypes.BIGINT())
-                                .build(),
-                        "tb1",
-                        Collections.emptyList(),
-                        Collections.emptyMap());
-        catalogManager.setCurrentCatalog("cat1");
-        catalogManager.setCurrentDatabase("db1");
-        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+        prepareTable(false);
         // Test alter table add enforced
         thrown.expect(ValidationException.class);
         thrown.expectMessage(
@@ -1240,21 +1204,7 @@ public class SqlToOperationConverterTest {
 
     @Test
     public void testAlterTableAddUniqueConstraint() throws Exception {
-        Catalog catalog = new GenericInMemoryCatalog("default", "default");
-        catalogManager.registerCatalog("cat1", catalog);
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
-        CatalogTable catalogTable =
-                CatalogTable.of(
-                        Schema.newBuilder()
-                                .column("a", DataTypes.STRING().notNull())
-                                .column("b", DataTypes.BIGINT().notNull())
-                                .build(),
-                        "tb1",
-                        Collections.emptyList(),
-                        Collections.emptyMap());
-        catalogManager.setCurrentCatalog("cat1");
-        catalogManager.setCurrentDatabase("db1");
-        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+        prepareTable(false);
         // Test alter add table constraint.
         thrown.expect(UnsupportedOperationException.class);
         thrown.expectMessage("UNIQUE constraint is not supported yet");
@@ -1263,22 +1213,7 @@ public class SqlToOperationConverterTest {
 
     @Test
     public void testAlterTableAddUniqueConstraintEnforced() throws Exception {
-        Catalog catalog = new GenericInMemoryCatalog("default", "default");
-        catalogManager.registerCatalog("cat1", catalog);
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
-        CatalogTable catalogTable =
-                CatalogTable.of(
-                        Schema.newBuilder()
-                                .column("a", DataTypes.STRING().notNull())
-                                .column("b", DataTypes.BIGINT().notNull())
-                                .column("c", DataTypes.BIGINT())
-                                .build(),
-                        "tb1",
-                        Collections.emptyList(),
-                        Collections.emptyMap());
-        catalogManager.setCurrentCatalog("cat1");
-        catalogManager.setCurrentDatabase("db1");
-        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+        prepareTable(false);
         // Test alter table add enforced
         thrown.expect(UnsupportedOperationException.class);
         thrown.expectMessage("UNIQUE constraint is not supported yet");
@@ -1287,23 +1222,7 @@ public class SqlToOperationConverterTest {
 
     @Test
     public void testAlterTableDropConstraint() throws Exception {
-        Catalog catalog = new GenericInMemoryCatalog("default", "default");
-        catalogManager.registerCatalog("cat1", catalog);
-        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
-        CatalogTable catalogTable =
-                CatalogTable.of(
-                        Schema.newBuilder()
-                                .column("a", DataTypes.STRING().notNull())
-                                .column("b", DataTypes.BIGINT().notNull())
-                                .column("c", DataTypes.BIGINT())
-                                .primaryKeyNamed("ct1", "a", "b")
-                                .build(),
-                        "tb1",
-                        Collections.emptyList(),
-                        Collections.emptyMap());
-        catalogManager.setCurrentCatalog("cat1");
-        catalogManager.setCurrentDatabase("db1");
-        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
+        prepareTable(true);
         // Test alter table add enforced
         Operation operation = parse("alter table tb1 drop constraint ct1", SqlDialect.DEFAULT);
         assert operation instanceof AlterTableDropConstraintOperation;
@@ -1454,6 +1373,20 @@ public class SqlToOperationConverterTest {
         assertEquals(expectedSummary, showFunctionsOperation.asSummaryString());
     }
 
+    private void assertAlterTableOptions(
+            Operation operation,
+            ObjectIdentifier expectedIdentifier,
+            Map<String, String> expectedOptions) {
+        assert operation instanceof AlterTableOptionsOperation;
+        final AlterTableOptionsOperation alterTableOptionsOperation =
+                (AlterTableOptionsOperation) operation;
+        assertEquals(expectedIdentifier, alterTableOptionsOperation.getTableIdentifier());
+        assertEquals(
+                expectedOptions.size(),
+                alterTableOptionsOperation.getCatalogTable().getOptions().size());
+        assertEquals(expectedOptions, alterTableOptionsOperation.getCatalogTable().getOptions());
+    }
+
     private Operation parse(String sql, FlinkPlannerImpl planner, CalciteParser parser) {
         SqlNode node = parser.parse(sql);
         return SqlToOperationConverter.convert(planner, catalogManager, node).get();
@@ -1464,6 +1397,28 @@ public class SqlToOperationConverterTest {
         final CalciteParser parser = getParserBySqlDialect(sqlDialect);
         SqlNode node = parser.parse(sql);
         return SqlToOperationConverter.convert(planner, catalogManager, node).get();
+    }
+
+    private void prepareTable(boolean hasConstraint) throws Exception {
+        Catalog catalog = new GenericInMemoryCatalog("default", "default");
+        catalogManager.registerCatalog("cat1", catalog);
+        catalog.createDatabase("db1", new CatalogDatabaseImpl(new HashMap<>(), null), true);
+        Schema.Builder builder =
+                Schema.newBuilder()
+                        .column("a", DataTypes.STRING().notNull())
+                        .column("b", DataTypes.BIGINT().notNull())
+                        .column("c", DataTypes.BIGINT());
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        hasConstraint
+                                ? builder.primaryKeyNamed("ct1", "a", "b").build()
+                                : builder.build(),
+                        "tb1",
+                        Collections.emptyList(),
+                        Collections.singletonMap("k", "v"));
+        catalogManager.setCurrentCatalog("cat1");
+        catalogManager.setCurrentDatabase("db1");
+        catalog.createTable(new ObjectPath("db1", "tb1"), catalogTable, true);
     }
 
     private FlinkPlannerImpl getPlannerBySqlDialect(SqlDialect sqlDialect) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -18,10 +18,10 @@
 
 package org.apache.flink.table.planner.catalog
 
+import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, TableConfigOptions}
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
-import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, TableException, ValidationException}
-import org.apache.flink.table.catalog.{CatalogDatabaseImpl, CatalogFunctionImpl, GenericInMemoryCatalog, ObjectPath}
+import org.apache.flink.table.catalog._
 import org.apache.flink.table.planner.expressions.utils.Func0
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0
@@ -92,6 +92,12 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
       i => row.setField(i, args(i))
     }
     row
+  }
+
+  def getTableOptions(tableName: String): java.util.Map[String, String] = {
+    tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
+      .getTable(new ObjectPath(tableEnv.getCurrentDatabase, tableName))
+      .getOptions
   }
 
   //~ Tests ------------------------------------------------------------------
@@ -957,17 +963,24 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |)
       """.stripMargin
     tableEnv.executeSql(ddl1)
+
+    // alter table rename
     tableEnv.executeSql("alter table t1 rename to t2")
     assert(tableEnv.listTables().sameElements(Array[String]("t2")))
+
+    // alter table options
     tableEnv.executeSql("alter table t2 set ('k1' = 'a', 'k2' = 'b')")
     val expectedOptions = new util.HashMap[String, String]()
     expectedOptions.put("connector", "COLLECTION")
     expectedOptions.put("k1", "a")
     expectedOptions.put("k2", "b")
-    val options = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
-      .getTable(new ObjectPath(tableEnv.getCurrentDatabase, "t2"))
-      .getOptions
-    assertEquals(expectedOptions, options)
+    assertEquals(expectedOptions, getTableOptions("t2"))
+
+    tableEnv.executeSql("alter table t2 reset ('k1')")
+    expectedOptions.remove("k1")
+    assertEquals(expectedOptions, getTableOptions("t2"))
+
+    // alter table add constraint
     val currentCatalog = tableEnv.getCurrentCatalog
     val currentDB = tableEnv.getCurrentDatabase
     tableEnv.executeSql("alter table t2 add constraint ct1 primary key(a) not enforced")
@@ -977,6 +990,8 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
     assert(tableSchema1.getPrimaryKey.isPresent)
     assertEquals("CONSTRAINT ct1 PRIMARY KEY (a)",
       tableSchema1.getPrimaryKey.get().asSummaryString())
+
+    // alter table drop constraint
     tableEnv.executeSql("alter table t2 drop constraint ct1")
     val tableSchema2 = tableEnv.getCatalog(currentCatalog).get()
       .getTable(ObjectPath.fromString(s"${currentDB}.t2"))


### PR DESCRIPTION
## What is the purpose of the change

This pull request supports `ALTER TABLE t RESET('key', ...)` syntax.


## Brief change log

- Extend `Parser.tdd` and `parserImpls.ftl` templates to support syntax. Add `SqlAlterTableReset` to represent the SqlNode after parsing.
- Extend `SqlToOperationConverter` to convert `SqlAlterTableReset` to `AlterTableOptionsOperation` by first cloning the table options of the current resolved catalog table, and then removing the keys present in `SqlAlterTableReset`.
- Add a util method `OperationConverterUtils#extractTableOptionKeys`  to extract table option keys from `SqlAlterTableReset`.

## Verifying this change

This change added tests and can be verified as follows:

- Added tests in `FlinkSqlParserImplTest` to verify parsing syntax correctly.
- Added cases in `SqlToOperatorConverterTest#testAlterTable` to verify operation transforming behaves correctly. 
- Added cases in `CatalogTableITCase` to verify the altered table options are as expected.
- Added tests in `TableEnvironmentTest`. `testAlterTableResetInvalidOptionKey` is to verify the RESET statement can fix the invalid table options. `testAlterTableResetOptionalOptionKey` is to verify the RESET statement can reset the table option key to its default value. `testAlterTableResetRequiredOptionKey` is to verify the throwed exception when reseting a required key. 
- Added cases in the `table.q` to verify SqlCli behaves correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
    - Docs will be updated after FLINK-22320 finishes.
