### PR TITLE
[FLINK-22700] [api] Propagate watermarks to sink API

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink/SinkWriter.java
@@ -20,6 +20,7 @@
 package org.apache.flink.api.connector.sink;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.eventtime.Watermark;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,6 +46,16 @@ public interface SinkWriter<InputT, CommT, WriterStateT> extends AutoCloseable {
      * @throws IOException if fail to add an element.
      */
     void write(InputT element, Context context) throws IOException;
+
+    /**
+     * Add a watermark to the writer.
+     *
+     * <p>This method is intended for advanced sinks that propagate watermarks.
+     *
+     * @param watermark The watermark.
+     * @throws IOException if fail to add a watermark.
+     */
+    default void writeWatermark(Watermark watermark) throws IOException {}
 
     /**
      * Prepare for a commit.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.functions.sink;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.functions.Function;
 
 import java.io.Serializable;
@@ -48,6 +49,17 @@ public interface SinkFunction<IN> extends Function, Serializable {
     default void invoke(IN value, Context context) throws Exception {
         invoke(value);
     }
+
+    /**
+     * Writes the given watermark to the sink. This function is called for every watermark.
+     *
+     * <p>This method is intended for advanced sinks that propagate watermarks.
+     *
+     * @param watermark The watermark.
+     * @throws Exception This method may throw exceptions. Throwing an exception will cause the
+     *     operation to fail and may trigger recovery.
+     */
+    default void writeWatermark(Watermark watermark) throws Exception {}
 
     /**
      * Context that {@link SinkFunction SinkFunctions } can use for getting additional data about an

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -66,6 +66,8 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         this.currentWatermark = mark.getTimestamp();
+        userFunction.writeWatermark(
+                new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 
     private class SimpleContext<IN> implements SinkFunction.Context {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/AbstractSinkWriterOperator.java
@@ -90,6 +90,8 @@ abstract class AbstractSinkWriterOperator<InputT, CommT> extends AbstractStreamO
     public void processWatermark(Watermark mark) throws Exception {
         super.processWatermark(mark);
         this.currentWatermark = mark.getTimestamp();
+        sinkWriter.writeWatermark(
+                new org.apache.flink.api.common.eventtime.Watermark(mark.getTimestamp()));
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSinkOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSinkOperatorTest.java
@@ -79,6 +79,15 @@ public class StreamSinkOperatorTest extends TestLogger {
                         new Tuple4<>(42L, 15L, 13L, "Ciao"),
                         new Tuple4<>(42L, 15L, null, "Ciao")));
 
+        assertThat(bufferingSink.watermarks.size(), is(3));
+
+        assertThat(
+                bufferingSink.watermarks,
+                contains(
+                        new org.apache.flink.api.common.eventtime.Watermark(17L),
+                        new org.apache.flink.api.common.eventtime.Watermark(42L),
+                        new org.apache.flink.api.common.eventtime.Watermark(42L)));
+
         testHarness.close();
     }
 
@@ -87,8 +96,11 @@ public class StreamSinkOperatorTest extends TestLogger {
         // watermark, processing-time, timestamp, event
         private final List<Tuple4<Long, Long, Long, T>> data;
 
+        private final List<org.apache.flink.api.common.eventtime.Watermark> watermarks;
+
         public BufferingQueryingSink() {
             data = new ArrayList<>();
+            watermarks = new ArrayList<>();
         }
 
         @Override
@@ -109,6 +121,12 @@ public class StreamSinkOperatorTest extends TestLogger {
                                 null,
                                 value));
             }
+        }
+
+        @Override
+        public void writeWatermark(org.apache.flink.api.common.eventtime.Watermark watermark)
+                throws Exception {
+            watermarks.add(watermark);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.operators.sink;
 
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.sink.Committer;
 import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
@@ -199,16 +200,24 @@ public class TestSink implements Sink<Integer, String, String, String> {
 
         protected List<String> elements;
 
+        protected List<Watermark> watermarks;
+
         protected ProcessingTimeService processingTimerService;
 
         DefaultSinkWriter() {
             this.elements = new ArrayList<>();
+            this.watermarks = new ArrayList<>();
         }
 
         @Override
         public void write(Integer element, Context context) {
             elements.add(
                     Tuple3.of(element, context.timestamp(), context.currentWatermark()).toString());
+        }
+
+        @Override
+        public void writeWatermark(Watermark watermark) throws IOException {
+            watermarks.add(watermark);
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/FileReadingWatermarkITCase.java
@@ -19,6 +19,7 @@ package org.apache.flink.test.streaming.api;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -104,9 +105,12 @@ public class FileReadingWatermarkITCase {
             }
 
             @Override
-            public void invoke(String value, SinkFunction.Context context) {
-                if (context.currentWatermark() != lastWatermark) {
-                    lastWatermark = context.currentWatermark();
+            public void invoke(String value, SinkFunction.Context context) {}
+
+            @Override
+            public void writeWatermark(Watermark watermark) throws Exception {
+                if (watermark.getTimestamp() != lastWatermark) {
+                    lastWatermark = watermark.getTimestamp();
                     numWatermarks.add(1);
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

Propagates watermarks to the `SinkFunction` and `SinkWriter` for connector-specific purposes such as external watermark storage.

## Brief change log

 - Add `writeWatermark()` method to `SinkFunction`
 - Add `writeWatermark()` method to `SinkWriter`
 - Add watermark forwarding logic to `StreamSink` and to `AbstractSinkWriterOperator`
 
## Verifying this change

This change added tests and can be verified as follows:

 - Updated test method in `StreamSinkOperatorTest`
 - Added new test method to `SinkWriterOperatorTestBase`
 - Updated `FileReadingWatermarkITCase` to count watermarks directly (wasn't possible before)
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes ([FLIP-167](https://cwiki.apache.org/confluence/display/FLINK/FLIP-167%3A+Watermarks+for+Sink+API))
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
