### PR TITLE
[FLINK-23298][datagen] Normalize parameter names in RandomGeneratorVisitor and SequenceGeneratorVisitor

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/RandomGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/RandomGeneratorVisitor.java
@@ -86,7 +86,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(CharType booleanType) {
+    public DataGeneratorContainer visit(CharType charType) {
         ConfigOption<Integer> lenOption =
                 key(FIELDS + "." + name + "." + LENGTH)
                         .intType()
@@ -96,7 +96,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(VarCharType booleanType) {
+    public DataGeneratorContainer visit(VarCharType varCharType) {
         ConfigOption<Integer> lenOption =
                 key(FIELDS + "." + name + "." + LENGTH)
                         .intType()
@@ -106,7 +106,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(TinyIntType booleanType) {
+    public DataGeneratorContainer visit(TinyIntType tinyIntType) {
         ConfigOption<Integer> min = minKey.intType().defaultValue((int) Byte.MIN_VALUE);
         ConfigOption<Integer> max = maxKey.intType().defaultValue((int) Byte.MAX_VALUE);
         return DataGeneratorContainer.of(
@@ -117,7 +117,7 @@ public class RandomGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(SmallIntType booleanType) {
+    public DataGeneratorContainer visit(SmallIntType smallIntType) {
         ConfigOption<Integer> min = minKey.intType().defaultValue((int) Short.MIN_VALUE);
         ConfigOption<Integer> max = maxKey.intType().defaultValue((int) Short.MAX_VALUE);
         return DataGeneratorContainer.of(

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/SequenceGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/datagen/SequenceGeneratorVisitor.java
@@ -98,7 +98,7 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(CharType booleanType) {
+    public DataGeneratorContainer visit(CharType charType) {
         return DataGeneratorContainer.of(
                 getSequenceStringGenerator(config.get(longStart), config.get(longEnd)),
                 longStart,
@@ -106,7 +106,7 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(VarCharType booleanType) {
+    public DataGeneratorContainer visit(VarCharType varCharType) {
         return DataGeneratorContainer.of(
                 getSequenceStringGenerator(config.get(longStart), config.get(longEnd)),
                 longStart,
@@ -114,7 +114,7 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(TinyIntType booleanType) {
+    public DataGeneratorContainer visit(TinyIntType tinyIntType) {
         return DataGeneratorContainer.of(
                 SequenceGenerator.byteGenerator(
                         config.get(intStart).byteValue(), config.get(intEnd).byteValue()),
@@ -123,7 +123,7 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
     }
 
     @Override
-    public DataGeneratorContainer visit(SmallIntType booleanType) {
+    public DataGeneratorContainer visit(SmallIntType smallIntType) {
         return DataGeneratorContainer.of(
                 SequenceGenerator.shortGenerator(
                         config.get(intStart).shortValue(), config.get(intEnd).shortValue()),


### PR DESCRIPTION
## What is the purpose of the change
This PR normalized parameter names in  RandomGeneratorVisitor and SequenceGeneratorVisitor.
related methods:
![7A6816E108816370DB96ABD3DDDE72D9](https://user-images.githubusercontent.com/5745228/118935994-b47c6080-b97e-11eb-86ef-43c191f602fd.jpg)



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
