### PR TITLE
[FLINK-22721][ha] Add default implementation for HighAvailabilityServices.cleanupJobData

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -244,5 +244,5 @@ public interface HighAvailabilityServices extends ClientHighAvailabilityServices
      * @param jobID The identifier of the job to cleanup.
      * @throws Exception Thrown, if an exception occurred while cleaning data stored by them.
      */
-    void cleanupJobData(JobID jobID) throws Exception;
+    default void cleanupJobData(JobID jobID) throws Exception {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/AbstractNonHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/AbstractNonHaServices.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.highavailability.nonha;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
@@ -111,9 +110,6 @@ public abstract class AbstractNonHaServices implements HighAvailabilityServices 
         // this stores no data, so this method is the same as 'close()'
         close();
     }
-
-    @Override
-    public void cleanupJobData(JobID jobID) throws Exception {}
 
     // ----------------------------------------------------------------------
     // Helper methods

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
@@ -136,11 +136,6 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
         // nothing to do
     }
 
-    @Override
-    public void cleanupJobData(JobID jobID) throws Exception {
-        // nothing to do
-    }
-
     public void grantLeadership(JobID jobId, int index, UUID leaderId) {
         ManualLeaderService manualLeaderService = jobManagerLeaderServices.get(jobId);
 


### PR DESCRIPTION
In order to not break the HighAvailabilityServices interface, this commit adds a default
implementation for the HighAavilabilityServices.cleanupJobData method which does nothing.
Users of this interface are recommended to override this method and add a specific
implementation in order to clean up job specific HA services after a job completion.
