### PR TITLE
[BP-1.12][FLINK-22434] Store suspended execution graphs on termination to keep them accessible

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -70,6 +70,8 @@ import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultResponseBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
@@ -128,6 +130,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -599,6 +602,18 @@ public class RestClusterClientTest extends TestLogger {
                         new RestHandlerException(
                                 "should trigger retry", HttpResponseStatus.SERVICE_UNAVAILABLE),
                         JobExecutionResultResponseBody.inProgress(),
+                        // On an UNKNOWN JobResult it should be retried
+                        JobExecutionResultResponseBody.created(
+                                new JobResult.Builder()
+                                        .applicationStatus(ApplicationStatus.UNKNOWN)
+                                        .jobId(jobId)
+                                        .netRuntime(Long.MAX_VALUE)
+                                        .accumulatorResults(
+                                                Collections.singletonMap(
+                                                        "testName",
+                                                        new SerializedValue<>(
+                                                                OptionalFailure.of(1.0))))
+                                        .build()),
                         JobExecutionResultResponseBody.created(
                                 new JobResult.Builder()
                                         .applicationStatus(ApplicationStatus.SUCCEEDED)
@@ -818,6 +833,47 @@ public class RestClusterClientTest extends TestLogger {
         }
     }
 
+    /**
+     * The SUSPENDED job status should never be returned by the client thus client retries until it
+     * either receives a different job status or the cluster is not reachable.
+     */
+    @Test
+    public void testNotShowSuspendedJobStatus() throws Exception {
+        final List<JobDetailsInfo> jobDetails = new ArrayList<>();
+        jobDetails.add(buildJobDetail(JobStatus.SUSPENDED));
+        jobDetails.add(buildJobDetail(JobStatus.RUNNING));
+        final TestJobStatusHandler jobStatusHandler =
+                new TestJobStatusHandler(jobDetails.iterator());
+
+        try (TestRestServerEndpoint restServerEndpoint =
+                createRestServerEndpoint(jobStatusHandler)) {
+            final RestClusterClient<?> restClusterClient =
+                    createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
+            try {
+                final CompletableFuture<JobStatus> future = restClusterClient.getJobStatus(jobId);
+                assertEquals(JobStatus.RUNNING, future.get());
+            } finally {
+                restClusterClient.close();
+            }
+        }
+    }
+
+    private JobDetailsInfo buildJobDetail(JobStatus jobStatus) {
+        return new JobDetailsInfo(
+                jobId,
+                "testJob",
+                true,
+                jobStatus,
+                1L,
+                2L,
+                1L,
+                1984L,
+                new HashMap<>(),
+                new ArrayList<>(),
+                new HashMap<>(),
+                "{\"id\":\"1234\"}");
+    }
+
     private class TestClientCoordinationHandler
             extends TestHandler<
                     ClientCoordinationRequestBody,
@@ -953,6 +1009,29 @@ public class RestClusterClientTest extends TestLogger {
                             new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0);
             return CompletableFuture.completedFuture(
                     new MultipleJobsDetails(Arrays.asList(running, finished)));
+        }
+    }
+
+    private class TestJobStatusHandler
+            extends TestHandler<EmptyRequestBody, JobDetailsInfo, JobMessageParameters> {
+
+        private final Iterator<JobDetailsInfo> jobDetailsInfo;
+
+        private TestJobStatusHandler(@Nonnull Iterator<JobDetailsInfo> jobDetailsInfo) {
+            super(JobDetailsHeaders.getInstance());
+            checkState(jobDetailsInfo.hasNext(), "Job details are empty");
+            this.jobDetailsInfo = checkNotNull(jobDetailsInfo);
+        }
+
+        @Override
+        protected CompletableFuture<JobDetailsInfo> handleRequest(
+                @Nonnull HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
+                @Nonnull DispatcherGateway gateway)
+                throws RestHandlerException {
+            if (!jobDetailsInfo.hasNext()) {
+                throw new IllegalStateException("More job details were requested than configured");
+            }
+            return CompletableFuture.completedFuture(jobDetailsInfo.next());
         }
     }
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -495,7 +495,7 @@ function wait_job_terminal_state {
   echo "Waiting for job ($job) to reach terminal state $expected_terminal_state ..."
 
   while : ; do
-    local N=$(grep -o "Job $job reached globally terminal state .*" $FLINK_DIR/log/*$log_file_name*.log | tail -1 || true)
+    local N=$(grep -o "Job $job reached terminal state .*" $FLINK_DIR/log/*$log_file_name*.log | tail -1 || true)
     if [[ -z $N ]]; then
       sleep 1
     else

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_application.sh
@@ -59,4 +59,4 @@ wait_rest_endpoint_up_k8s $jm_pod_name
 # The Flink cluster will be destroyed immediately once the job finished or failed. So we check jobmanager logs
 # instead of checking the result
 kubectl logs -f $jm_pod_name >$LOCAL_LOGS_PATH/jobmanager.log
-grep -E "Job [A-Za-z0-9]+ reached globally terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log
+grep -E "Job [A-Za-z0-9]+ reached terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_pyflink_application.sh
@@ -99,4 +99,4 @@ wait_rest_endpoint_up_k8s $jm_pod_name
 # The Flink cluster will be destroyed immediately once the job finished or failed. So we check jobmanager logs
 # instead of checking the result
 kubectl logs -f $jm_pod_name >$LOCAL_LOGS_PATH/jobmanager.log
-grep -E "Job [A-Za-z0-9]+ reached globally terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log
+grep -E "Job [A-Za-z0-9]+ reached terminal state FINISHED" $LOCAL_LOGS_PATH/jobmanager.log

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -118,10 +118,10 @@ public class MiniDispatcher extends Dispatcher {
     }
 
     @Override
-    protected CleanupJobState jobReachedGloballyTerminalState(
+    protected CleanupJobState jobReachedTerminalState(
             ArchivedExecutionGraph archivedExecutionGraph) {
         final CleanupJobState cleanupHAState =
-                super.jobReachedGloballyTerminalState(archivedExecutionGraph);
+                super.jobReachedTerminalState(archivedExecutionGraph);
 
         if (jobCancelled || executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
             // shut down if job is cancelled or we don't have to wait for the execution result
@@ -136,13 +136,5 @@ public class MiniDispatcher extends Dispatcher {
         }
 
         return cleanupHAState;
-    }
-
-    @Override
-    protected void jobNotFinished(JobID jobId) {
-        super.jobNotFinished(jobId);
-        // shut down since we have done our job
-        log.info("Shutting down cluster because job not finished");
-        shutDownFuture.complete(ApplicationStatus.UNKNOWN);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -219,8 +220,13 @@ public class JobManagerRunnerImpl
 
                             classLoaderLease.release();
 
-                            resultFuture.completeExceptionally(
-                                    new JobNotFinishedException(jobGraph.getJobID()));
+                            resultFuture.complete(
+                                    ArchivedExecutionGraph.createFromInitializingJob(
+                                            jobGraph.getJobID(),
+                                            jobGraph.getName(),
+                                            JobStatus.SUSPENDED,
+                                            null,
+                                            0L));
 
                             if (throwable != null) {
                                 terminationFuture.completeExceptionally(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -220,12 +220,12 @@ public class JobResult implements Serializable {
         final JobStatus jobStatus = accessExecutionGraph.getState();
 
         checkArgument(
-                jobStatus.isGloballyTerminalState(),
+                jobStatus.isTerminalState(),
                 "The job "
                         + accessExecutionGraph.getJobName()
                         + '('
                         + jobId
-                        + ") is not in a globally "
+                        + ") is not in a "
                         + "terminal state. It is in state "
                         + jobStatus
                         + '.');

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherJobTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherJobTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /** Test for the {@link DispatcherJob} class. */
@@ -209,8 +210,7 @@ public class DispatcherJobTest extends TestLogger {
 
         // ensure the result future is complete (how it completes is up to the JobManager)
         CompletableFuture<DispatcherJobResult> resultFuture = dispatcherJob.getResultFuture();
-        CommonTestUtils.assertThrows(
-                "has not been finished", ExecutionException.class, resultFuture::get);
+        assertSuspendedExecutionGraph(resultFuture);
     }
 
     @Test
@@ -245,8 +245,13 @@ public class DispatcherJobTest extends TestLogger {
 
         // result future should complete exceptionally.
         CompletableFuture<DispatcherJobResult> resultFuture = dispatcherJob.getResultFuture();
-        CommonTestUtils.assertThrows(
-                "has not been finished", ExecutionException.class, resultFuture::get);
+        assertSuspendedExecutionGraph(resultFuture);
+    }
+
+    private void assertSuspendedExecutionGraph(CompletableFuture<DispatcherJobResult> resultFuture)
+            throws ExecutionException, InterruptedException {
+        assertEquals(
+                resultFuture.get().getArchivedExecutionGraph().getState(), JobStatus.SUSPENDED);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingDispatcher.java
@@ -65,7 +65,7 @@ class TestingDispatcher extends Dispatcher {
     }
 
     void completeJobExecution(ArchivedExecutionGraph archivedExecutionGraph) {
-        runAsync(() -> jobReachedGloballyTerminalState(archivedExecutionGraph));
+        runAsync(() -> jobReachedTerminalState(archivedExecutionGraph));
     }
 
     CompletableFuture<Void> getJobTerminationFuture(@Nonnull JobID jobId, @Nonnull Time timeout) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImplTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -169,17 +170,16 @@ public class JobManagerRunnerImplTest extends TestLogger {
 
             jobManagerRunner.closeAsync();
 
-            try {
-                resultFuture.get();
-                fail("Should have failed.");
-            } catch (ExecutionException ee) {
-                assertThat(
-                        ExceptionUtils.stripExecutionException(ee),
-                        instanceOf(JobNotFinishedException.class));
-            }
+            assertJobNotFinished(resultFuture);
         } finally {
             jobManagerRunner.close();
         }
+    }
+
+    private void assertJobNotFinished(CompletableFuture<ArchivedExecutionGraph> resultFuture)
+            throws ExecutionException, InterruptedException {
+        final ArchivedExecutionGraph graph = resultFuture.get();
+        assertEquals(graph.getState(), JobStatus.SUSPENDED);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.util.Preconditions;
@@ -51,9 +52,11 @@ public class TestingJobManagerRunner implements JobManagerRunner {
         this.resultFuture = resultFuture;
         this.terminationFuture = new CompletableFuture<>();
 
+        final ArchivedExecutionGraph suspendedExecutionGraph =
+                ArchivedExecutionGraph.createFromInitializingJob(
+                        jobId, "TestJob", JobStatus.SUSPENDED, null, 0L);
         terminationFuture.whenComplete(
-                (ignored, ignoredThrowable) ->
-                        resultFuture.completeExceptionally(new JobNotFinishedException(jobId)));
+                (ignored, ignoredThrowable) -> resultFuture.complete(suspendedExecutionGraph));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderChangeClusterComponentsTest.java
@@ -21,12 +21,12 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServicesWithLeadershipControl;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.utils.JobResultUtils;
 import org.apache.flink.runtime.minicluster.TestingMiniCluster;
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.minicluster.TestingMiniClusterConfiguration;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -44,12 +43,11 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /** Tests which verify the cluster behaviour in case of leader changes. */
 public class LeaderChangeClusterComponentsTest extends TestLogger {
@@ -108,14 +106,8 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
         highAvailabilityServices.revokeDispatcherLeadership().get();
 
-        try {
-            jobResultFuture.get();
-            fail("Expected JobNotFinishedException");
-        } catch (ExecutionException ee) {
-            assertThat(
-                    ExceptionUtils.findThrowable(ee, JobNotFinishedException.class).isPresent(),
-                    is(true));
-        }
+        JobResult jobResult = jobResultFuture.get();
+        assertEquals(jobResult.getApplicationStatus(), ApplicationStatus.UNKNOWN);
 
         highAvailabilityServices.grantDispatcherLeadership();
 
@@ -128,7 +120,7 @@ public class LeaderChangeClusterComponentsTest extends TestLogger {
 
         final CompletableFuture<JobResult> jobResultFuture2 = miniCluster.requestJobResult(jobId);
 
-        JobResult jobResult = jobResultFuture2.get();
+        jobResult = jobResultFuture2.get();
 
         JobResultUtils.assertSuccess(jobResult);
     }


### PR DESCRIPTION
Backport of #15799 
@tillrohrmann Can you have another look at 5638689? I resolved a lot of conflicts for this commit