### PR TITLE
[FLINK-22725] Resolved SlotManagers should unregister metrics at the …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -256,6 +256,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		stopHeartbeatServices();
 
+		resourceManagerMetricGroup.close();
+
 		try {
 			slotManager.close();
 		} catch (Exception e) {
@@ -273,8 +275,6 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		} catch (Exception e) {
 			exception = ExceptionUtils.firstOrSuppressed(e, exception);
 		}
-
-		resourceManagerMetricGroup.close();
 
 		clearStateInternal();
 
@@ -977,7 +977,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 	protected void startServicesOnLeadership() {
 		startHeartbeatServices();
-
+		registerSlotAndTaskExecutorMetrics();
 		slotManager.start(getFencingToken(), getMainThreadExecutor(), new ResourceActionsImpl());
 	}
 
@@ -993,6 +993,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				clearStateInternal();
 
 				setFencingToken(null);
+
 
 				slotManager.suspend();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -277,17 +277,17 @@ public class SlotManagerImpl implements SlotManager {
 			slotRequestTimeoutCheck = null;
 		}
 
-		for (PendingSlotRequest pendingSlotRequest : pendingSlotRequests.values()) {
-			cancelPendingSlotRequest(pendingSlotRequest);
-		}
-
-		pendingSlotRequests.clear();
-
 		ArrayList<InstanceID> registeredTaskManagers = new ArrayList<>(taskManagerRegistrations.keySet());
 
 		for (InstanceID registeredTaskManager : registeredTaskManagers) {
 			unregisterTaskManager(registeredTaskManager, new SlotManagerException("The slot manager is being suspended."));
 		}
+
+		for (PendingSlotRequest pendingSlotRequest : pendingSlotRequests.values()) {
+			cancelPendingSlotRequest(pendingSlotRequest);
+		}
+
+		pendingSlotRequests.clear();
 
 		resourceManagerId = null;
 		resourceActions = null;
@@ -592,11 +592,11 @@ public class SlotManagerImpl implements SlotManager {
 	 * @param taskManagerConnection to communicate with the remote task manager
 	 */
 	private void registerSlot(
-			SlotID slotId,
-			AllocationID allocationId,
-			JobID jobId,
-			ResourceProfile resourceProfile,
-			TaskExecutorConnection taskManagerConnection) {
+		SlotID slotId,
+		AllocationID allocationId,
+		JobID jobId,
+		ResourceProfile resourceProfile,
+		TaskExecutorConnection taskManagerConnection) {
 
 		if (slots.containsKey(slotId)) {
 			// remove the old slot first
@@ -684,10 +684,10 @@ public class SlotManagerImpl implements SlotManager {
 	}
 
 	private void updateSlotState(
-			TaskManagerSlot slot,
-			TaskManagerRegistration taskManagerRegistration,
-			@Nullable AllocationID allocationId,
-			@Nullable JobID jobId) {
+		TaskManagerSlot slot,
+		TaskManagerRegistration taskManagerRegistration,
+		@Nullable AllocationID allocationId,
+		@Nullable JobID jobId) {
 		if (null != allocationId) {
 			switch (slot.getState()) {
 				case PENDING:
@@ -1223,11 +1223,11 @@ public class SlotManagerImpl implements SlotManager {
 	@VisibleForTesting
 	public void unregisterTaskManagersAndReleaseResources() {
 		Iterator<Map.Entry<InstanceID, TaskManagerRegistration>> taskManagerRegistrationIterator =
-				taskManagerRegistrations.entrySet().iterator();
+			taskManagerRegistrations.entrySet().iterator();
 
 		while (taskManagerRegistrationIterator.hasNext()) {
 			TaskManagerRegistration taskManagerRegistration =
-					taskManagerRegistrationIterator.next().getValue();
+				taskManagerRegistrationIterator.next().getValue();
 
 			taskManagerRegistrationIterator.remove();
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form 
  - [FLINK-22725](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-22725?filter=allissues)

  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - SlotManagerImplTest#testTaskManagerRegistration
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request causes the slotManager to unregister the indicator at the beginning of suspend()

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*
```
AkkaRpcActorTest#testOnStartIsCalledWhenRpcEndpointStarts
```
and
```
MetricRegistryImplTest#testMetricQueryServiceSetup
```

By observing the [FLINK-22646](https://issues.apache.org/jira/browse/FLINK-22646) associated with this issue  I believe that the timing of registering and canceling indicators should be earlier than resourceMangaer calling slotManager's start() and close() methods, so I made such a modification.

Adjust the position of resourceManager registration and cancellation indicators