### PR TITLE
[FLINK-22655]When using -i <init.sql> option to initialize SQL Client session It should be possible to annotate the script with --

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -176,14 +176,14 @@ public class SqlClientTest {
     public void testInitFile() throws Exception {
         List<String> statements =
                 Arrays.asList(
-                        "-- Define Table \n"
+                        "-- define table \n"
                                 + "CREATE TABLE source ("
                                 + "id INT,"
                                 + "val STRING"
                                 + ") WITH ("
                                 + "  'connector' = 'values'"
                                 + "); \n",
-                        " -- Define Table \nSET key = value; -- define set \n");
+                        " -- define config \nSET key = value;\n");
         String initFile = createSqlFile(statements, "init-sql.sql");
 
         String[] args = new String[] {"-i", initFile};

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/SqlClientTest.java
@@ -176,13 +176,14 @@ public class SqlClientTest {
     public void testInitFile() throws Exception {
         List<String> statements =
                 Arrays.asList(
-                        "CREATE TABLE source ("
+                        "-- Define Table \n"
+                                + "CREATE TABLE source ("
                                 + "id INT,"
                                 + "val STRING"
                                 + ") WITH ("
                                 + "  'connector' = 'values'"
-                                + ");\n",
-                        "SET key = value;\n");
+                                + "); \n",
+                        " -- Define Table \nSET key = value; -- define set \n");
         String initFile = createSqlFile(statements, "init-sql.sql");
 
         String[] args = new String[] {"-i", initFile};

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -252,9 +252,7 @@ public class CliClientTest extends TestLogger {
                                 + ") WITH (\n"
                                 + "  'connector' = 'values'\n"
                                 + ");\n",
-                        "INSERT INTO \n"
-                                + "--COMMENT ; \n"
-                                + "MyOtherTable VALUES (1, 101), (2, 102);",
+                        "INSERT INTO \n" + "MyOtherTable VALUES (1, 101), (2, 102);",
                         "DESC MyOtherTable;",
                         "SHOW TABLES;",
                         "QUIT;\n");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliStatementSplitterTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliStatementSplitterTest.java
@@ -55,18 +55,32 @@ public class CliStatementSplitterTest {
     public void testSplitContent() {
         List<String> lines =
                 Arrays.asList(
-                        "CREATE TABLE MyTable (\n"
+                        "-- Define Table; \n"
+                                + "CREATE TABLE MyTable (\n"
                                 + "  id INT,\n"
                                 + "  name STRING,\n"
                                 + ") WITH (\n"
                                 + "  'connector' = 'values',\n"
-                                + "  'test-property' = 'test.value'\n);",
-                        "SET a = b;",
+                                + "  'test-property' = 'test.value'\n);"
+                                + "-- Define Table;",
+                        "SET a = b;-- define set",
                         "\n" + "SELECT func(id) from MyTable\n;");
         List<String> actual = CliStatementSplitter.splitContent(String.join("\n", lines));
 
+        List<String> expected =
+                Arrays.asList(
+                        "\nCREATE TABLE MyTable (\n"
+                                + "  id INT,\n"
+                                + "  name STRING,\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'test-property' = 'test.value'\n);"
+                                + "-- Define Table;",
+                        "SET a = b;-- define set",
+                        "\n" + "SELECT func(id) from MyTable\n;");
+
         for (int i = 0; i < lines.size(); i++) {
-            assertEquals(lines.get(i), actual.get(i));
+            assertEquals(expected.get(i), actual.get(i));
         }
     }
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliStatementSplitterTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliStatementSplitterTest.java
@@ -63,7 +63,7 @@ public class CliStatementSplitterTest {
                                 + "  'connector' = 'values',\n"
                                 + "  'test-property' = 'test.value'\n);"
                                 + "-- Define Table;",
-                        "SET a = b;-- define set",
+                        "SET a = b;",
                         "\n" + "SELECT func(id) from MyTable\n;");
         List<String> actual = CliStatementSplitter.splitContent(String.join("\n", lines));
 
@@ -76,7 +76,7 @@ public class CliStatementSplitterTest {
                                 + "  'connector' = 'values',\n"
                                 + "  'test-property' = 'test.value'\n);"
                                 + "-- Define Table;",
-                        "SET a = b;-- define set",
+                        "SET a = b;",
                         "\n" + "SELECT func(id) from MyTable\n;");
 
         for (int i = 0; i < lines.size(); i++) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
@@ -35,7 +35,7 @@ public class SetOperationParseStrategy extends AbstractRegexParseStrategy {
     protected SetOperationParseStrategy() {
         super(
                 Pattern.compile(
-                        "SET(\\s+(?<key>\\S+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>\\S+).*))?",
+                        "SET(\\s+(?<key>\\S+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>\\S+)))?",
                         DEFAULT_PATTERN_FLAGS));
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
@@ -35,7 +35,7 @@ public class SetOperationParseStrategy extends AbstractRegexParseStrategy {
     protected SetOperationParseStrategy() {
         super(
                 Pattern.compile(
-                        "SET(\\s+(?<key>\\S+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>\\S+)))?.*",
+                        "SET(\\s+(?<key>\\S+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>\\S+).*))?",
                         DEFAULT_PATTERN_FLAGS));
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/parse/SetOperationParseStrategy.java
@@ -35,7 +35,7 @@ public class SetOperationParseStrategy extends AbstractRegexParseStrategy {
     protected SetOperationParseStrategy() {
         super(
                 Pattern.compile(
-                        "SET(\\s+(?<key>\\S+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>\\S+)))?",
+                        "SET(\\s+(?<key>\\S+)\\s*=\\s*('(?<quotedVal>[^']*)'|(?<val>\\S+)))?.*",
                         DEFAULT_PATTERN_FLAGS));
     }
 


### PR DESCRIPTION


## What is the purpose of the change

*this change is in order to use comments in the initialization script with '--' in the SQL Client*


## Brief change log

*add cleanLine in CliStatementSplitter#splitContent*


## Verifying this change


This change added tests and can be verified as follows:

*Modify the original test file CliStatementSplitterTest.java and CliClientTest.java*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
