### PR TITLE
[FLINK-22284] Log the remote address when channel is closed in NettyPartitionRequestClient

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -127,19 +127,12 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                     public void operationComplete(ChannelFuture future) throws Exception {
                         if (!future.isSuccess()) {
                             clientHandler.removeInputChannel(inputChannel);
-                            SocketAddress remoteAddr = future.channel().remoteAddress();
-                            String address =
-                                    remoteAddr == null
-                                            ? String.format(
-                                                    "%s (#%d)",
-                                                    connectionId.getAddress(),
-                                                    connectionId.getConnectionIndex())
-                                            : remoteAddr.toString();
                             inputChannel.onError(
                                     new LocalTransportException(
                                             String.format(
-                                                    "Sending the partition request to '%s' failed.",
-                                                    address),
+                                                    "Sending the partition request to '%s (#%d)' failed.",
+                                                    connectionId.getAddress(),
+                                                    connectionId.getConnectionIndex()),
                                             future.channel().localAddress(),
                                             future.cause()));
                         }
@@ -187,19 +180,12 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
                                 if (!future.isSuccess()) {
-                                    SocketAddress remoteAddr = future.channel().remoteAddress();
-                                    String address =
-                                            remoteAddr == null
-                                                    ? String.format(
-                                                            "%s (#%d)",
-                                                            connectionId.getAddress(),
-                                                            connectionId.getConnectionIndex())
-                                                    : remoteAddr.toString();
                                     inputChannel.onError(
                                             new LocalTransportException(
                                                     String.format(
-                                                            "Sending the task event to '%s' failed.",
-                                                            address),
+                                                            "Sending the task event to '%s (#%d)' failed.",
+                                                            connectionId.getAddress(),
+                                                            connectionId.getConnectionIndex()),
                                                     future.channel().localAddress(),
                                                     future.cause()));
                                 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -128,11 +128,18 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                         if (!future.isSuccess()) {
                             clientHandler.removeInputChannel(inputChannel);
                             SocketAddress remoteAddr = future.channel().remoteAddress();
+                            String address =
+                                    remoteAddr == null
+                                            ? String.format(
+                                                    "%s (#%d)",
+                                                    connectionId.getAddress(),
+                                                    connectionId.getConnectionIndex())
+                                            : remoteAddr.toString();
                             inputChannel.onError(
                                     new LocalTransportException(
                                             String.format(
                                                     "Sending the partition request to '%s' failed.",
-                                                    remoteAddr),
+                                                    address),
                                             future.channel().localAddress(),
                                             future.cause()));
                         }
@@ -181,11 +188,18 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                             public void operationComplete(ChannelFuture future) throws Exception {
                                 if (!future.isSuccess()) {
                                     SocketAddress remoteAddr = future.channel().remoteAddress();
+                                    String address =
+                                            remoteAddr == null
+                                                    ? String.format(
+                                                            "%s (#%d)",
+                                                            connectionId.getAddress(),
+                                                            connectionId.getConnectionIndex())
+                                                    : remoteAddr.toString();
                                     inputChannel.onError(
                                             new LocalTransportException(
                                                     String.format(
                                                             "Sending the task event to '%s' failed.",
-                                                            remoteAddr),
+                                                            address),
                                                     future.channel().localAddress(),
                                                     future.cause()));
                                 }


### PR DESCRIPTION
## What is the purpose of the change

*For `NettyPartitionRequestClient#requestSubpartition`, when a channel is closed, the channel will throw a LocalTransportException with the error message "Sending the partition request to 'null' failed.". The message is confusing since we wouldn't know where the remote client connected to this channel locates, and we couldn't track down to that TaskExecutor and find out what happened.*

*In this situation, we need to log the address stored in `ConnectionID` instead of the null value in `ChannelFuture`. Users can located the destination TaskManager based on this remote address.*

## Brief change log

  - *Log the remote address stored in `ConnectionID` instead of null value in `ChannelFuture` when channel is closed in NettyPartitionRequestClient*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
