### PR TITLE
[FLINK-22747] Upgrade to commons-io 2.8.0

### DIFF
--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - joda-time:joda-time:2.5
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - commons-codec:commons-codec:1.13

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.typesafe.akka:akka-stream_2.11:2.5.21
 - commons-cli:commons-cli:1.3.1
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 - org.apache.commons:commons-compress:1.20
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - commons-lang:commons-lang:2.6
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 - commons-logging:commons-logging:1.1.3
 - commons-beanutils:commons-beanutils:1.9.4
 - com.google.guava:guava:11.0.2

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.13
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - com.amazonaws:aws-java-sdk-core:1.11.788

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-linq4j:1.26.0
 - org.apache.calcite.avatica:avatica-core:1.17.0
 - commons-codec:commons-codec:1.13
-- commons-io:commons-io:2.7
+- commons-io:commons-io:2.8.0
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details

--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@ under the License.
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.7</version>
+				<version>2.8.0</version>
 			</dependency>
 
 			<!-- commons collections needs to be pinned to this critical security fix version -->


### PR DESCRIPTION
## What is the purpose of the change

Upgrade to commons-io 2.8.0 due to known vulnerabilities.

## Brief change log

Dependency and NOTICE files updated.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
