### PR TITLE
[FLINK-22759][docs] Correct the applicability of some RocksDB related options as per operator

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -54,7 +54,7 @@
             <td><h5>state.backend.rocksdb.files.open</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '-1'.</td>
+            <td>The maximum number of open files (per stateful operator) that can be used by the DB, '-1' means no limit. RocksDB has default configuration as '-1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.log.level</h5></td>
@@ -66,7 +66,7 @@
             <td><h5>state.backend.rocksdb.thread.num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The maximum number of concurrent background flush and compaction jobs (per TaskManager). RocksDB has default configuration as '1'.</td>
+            <td>The maximum number of concurrent background flush and compaction jobs (per stateful operator). RocksDB has default configuration as '1'.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.write-batch-size</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -61,7 +61,7 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "The maximum number of concurrent background flush and compaction jobs (per TaskManager). "
+                            "The maximum number of concurrent background flush and compaction jobs (per stateful operator). "
                                     + "RocksDB has default configuration as '1'.");
 
     public static final ConfigOption<Integer> MAX_OPEN_FILES =
@@ -69,7 +69,7 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "The maximum number of open files (per TaskManager) that can be used by the DB, '-1' means no limit. "
+                            "The maximum number of open files (per stateful operator) that can be used by the DB, '-1' means no limit. "
                                     + "RocksDB has default configuration as '-1'.");
 
     public static final ConfigOption<InfoLogLevel> LOG_LEVEL =


### PR DESCRIPTION
## What is the purpose of the change

Correct the applicability of some RocksDB related options as per operator


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
