### PR TITLE
[FLINK-22760][Hive] Fix issue of HiveParser::setCurrentTimestamp fails with hive-3.1.2

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -72,6 +72,7 @@ import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -357,8 +358,13 @@ public class HiveParser extends ParserImpl {
         if (setCurrentTSMethod != null) {
             try {
                 setCurrentTSMethod.invoke(sessionState);
-                sessionState.hiveParserCurrentTS =
-                        (Timestamp) getCurrentTSMethod.invoke(sessionState);
+                Object currentTs = getCurrentTSMethod.invoke(sessionState);
+                if (currentTs instanceof Instant) {
+                    sessionState.hiveParserCurrentTS = Timestamp.from((Instant) currentTs);
+                } else {
+                    sessionState.hiveParserCurrentTS =
+                            (Timestamp) getCurrentTSMethod.invoke(sessionState);
+                }
             } catch (IllegalAccessException | InvocationTargetException e) {
                 throw new FlinkHiveException("Failed to set current timestamp for session", e);
             }


### PR DESCRIPTION
…estamp fails with hive-3.1.2

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request fixes the issue of HiveParser::setCurrentTimestamp fails with hive-3.1.2*


## Brief change log

  - *Convert Instant return by SessionState#getQueryCurrentTimestamp in hive-3.1.2 to TimeStamp*


## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.connectors.hive.HiveDialectQueryITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:   no 
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  no
