### PR TITLE
[FLINK-22765][runtime][tests] Improve logging for debugging rare test failure

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestProcessBuilder.java
@@ -23,6 +23,9 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.CommonTestUtils.PipeForwarder;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -35,6 +38,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Utility class wrapping {@link ProcessBuilder} and pre-configuring it with common options. */
 public class TestProcessBuilder {
+    private static final Logger LOG = LoggerFactory.getLogger(TestProcessBuilder.class);
+
     private final String javaCommand = checkNotNull(getJavaCommandPath());
 
     private final ArrayList<String> jvmArgs = new ArrayList<>();
@@ -72,6 +77,7 @@ public class TestProcessBuilder {
 
         StringWriter processOutput = new StringWriter();
         StringWriter errorOutput = new StringWriter();
+        LOG.info("Starting process with commands {}", commands);
         final ProcessBuilder processBuilder = new ProcessBuilder(commands);
         if (withCleanEnvironment) {
             processBuilder.environment().clear();

--- a/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
@@ -55,23 +55,25 @@ public class ExceptionUtilsITCase extends TestLogger {
     @Test
     public void testIsDirectOutOfMemoryError() throws IOException, InterruptedException {
         String className = DummyDirectAllocatingProgram.class.getName();
-        String out = run(className, Collections.emptyList(), DIRECT_MEMORY_SIZE, -1);
-        assertThat(out, is(""));
+        RunResult result = run(className, Collections.emptyList(), DIRECT_MEMORY_SIZE, -1);
+        assertThat(result.getErrorOut() + result.getStandardOut(), is(""));
     }
 
     @Test
     public void testIsMetaspaceOutOfMemoryError() throws IOException, InterruptedException {
         String className = DummyClassLoadingProgram.class.getName();
         // load only one class and record required Metaspace
-        String normalOut =
+        RunResult normalOut =
                 run(className, getDummyClassLoadingProgramArgs(1), -1, INITIAL_BIG_METASPACE_SIZE);
-        long okMetaspace = Long.parseLong(normalOut);
+        long okMetaspace = Long.parseLong(normalOut.getStandardOut());
         // load more classes to cause 'OutOfMemoryError: Metaspace'
-        String oomOut = run(className, getDummyClassLoadingProgramArgs(1000), -1, okMetaspace);
-        assertThat(oomOut, is(""));
+        RunResult oomOut = run(className, getDummyClassLoadingProgramArgs(1000), -1, okMetaspace);
+        // 'OutOfMemoryError: Metaspace' errors are caught, hence no output means we produced the
+        // expected exception.
+        assertThat(oomOut.getErrorOut() + oomOut.getStandardOut(), is(""));
     }
 
-    private static String run(
+    private static RunResult run(
             String className, Iterable<String> args, long directMemorySize, long metaspaceSize)
             throws InterruptedException, IOException {
         TestProcessBuilder taskManagerProcessBuilder = new TestProcessBuilder(className);
@@ -91,8 +93,26 @@ public class ExceptionUtilsITCase extends TestLogger {
         taskManagerProcessBuilder.withCleanEnvironment();
         TestProcess p = taskManagerProcessBuilder.start();
         p.getProcess().waitFor();
-        assertThat(p.getErrorOutput().toString().trim(), is(""));
-        return p.getProcessOutput().toString().trim();
+        return new RunResult(
+                p.getErrorOutput().toString().trim(), p.getProcessOutput().toString().trim());
+    }
+
+    private static final class RunResult {
+        private final String errorOut;
+        private final String standardOut;
+
+        public RunResult(String errorOut, String standardOut) {
+            this.errorOut = errorOut;
+            this.standardOut = standardOut;
+        }
+
+        public String getErrorOut() {
+            return errorOut;
+        }
+
+        public String getStandardOut() {
+            return standardOut;
+        }
     }
 
     private static Collection<String> getDummyClassLoadingProgramArgs(int numberOfLoadedClasses) {
@@ -120,7 +140,10 @@ public class ExceptionUtilsITCase extends TestLogger {
         }
     }
 
-    /** Dummy java program to generate Metaspace OOM. */
+    /**
+     * Dummy java program to generate Metaspace OOM. The program will catch Metaspace out of memory
+     * errors and produce no output in this case.
+     */
     public static class DummyClassLoadingProgram {
         private DummyClassLoadingProgram() {}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/util/ExceptionUtilsITCase.java
@@ -56,7 +56,7 @@ public class ExceptionUtilsITCase extends TestLogger {
     public void testIsDirectOutOfMemoryError() throws IOException, InterruptedException {
         String className = DummyDirectAllocatingProgram.class.getName();
         RunResult result = run(className, Collections.emptyList(), DIRECT_MEMORY_SIZE, -1);
-        assertThat(result.getErrorOut() + result.getStandardOut(), is(""));
+        assertThat(result.getErrorOut() + "|" + result.getStandardOut(), is("|"));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ExceptionUtilsITCase extends TestLogger {
         RunResult oomOut = run(className, getDummyClassLoadingProgramArgs(1000), -1, okMetaspace);
         // 'OutOfMemoryError: Metaspace' errors are caught, hence no output means we produced the
         // expected exception.
-        assertThat(oomOut.getErrorOut() + oomOut.getStandardOut(), is(""));
+        assertThat(oomOut.getErrorOut() + "|" + oomOut.getStandardOut(), is("|"));
     }
 
     private static RunResult run(


### PR DESCRIPTION
## What is the purpose of the change

The `testIsMetaspaceOutOfMemoryError` test failed once, but didn't provide enough information to fully understand the cause. This improves the logging a bit.
