### PR TITLE
[FLINK-22769][flink-yarn]yarnship symlinks support

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -49,13 +49,13 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -331,6 +331,22 @@ public class FileUtilsTest extends TestLogger {
         FileUtils.listFilesInDirectory(file.toPath(), FileUtils::isJarFile);
     }
 
+    @Test
+    public void testFollowSymbolicDirectoryLink() throws IOException {
+        final File directory = tmp.newFolder("a");
+        final File file = new File(directory, "a.jar");
+        assertTrue(file.createNewFile());
+
+        final File otherDirectory = tmp.newFolder();
+        java.nio.file.Path linkPath = Paths.get(otherDirectory.getPath(), "a.lnk");
+        Files.createSymbolicLink(linkPath, directory.toPath());
+
+        Collection<java.nio.file.Path> paths =
+                FileUtils.listFilesInDirectory(linkPath, FileUtils::isJarFile);
+
+        assertThat(paths, containsInAnyOrder(linkPath.resolve(file.getName())));
+    }
+
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
@@ -43,10 +44,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -255,22 +252,17 @@ class YarnApplicationFileUploader implements AutoCloseable {
             } else {
                 final File file = new File(shipFile.toUri().getPath());
                 if (file.isDirectory()) {
-                    final java.nio.file.Path shipPath = file.toPath();
+                    final java.nio.file.Path shipPath = file.toPath().toRealPath();
                     final java.nio.file.Path parentPath = shipPath.getParent();
-                    Files.walkFileTree(
-                            shipPath,
-                            new SimpleFileVisitor<java.nio.file.Path>() {
-                                @Override
-                                public FileVisitResult visitFile(
-                                        java.nio.file.Path file, BasicFileAttributes attrs) {
-                                    localPaths.add(new Path(file.toUri()));
-                                    relativePaths.add(
-                                            new Path(
-                                                    localResourcesDirectory,
-                                                    parentPath.relativize(file).toString()));
-                                    return FileVisitResult.CONTINUE;
-                                }
-                            });
+                    Collection<java.nio.file.Path> paths =
+                            FileUtils.listFilesInDirectory(shipPath, path -> true);
+                    for (java.nio.file.Path javaPath : paths) {
+                        localPaths.add(new Path(javaPath.toUri()));
+                        relativePaths.add(
+                                new Path(
+                                        localResourcesDirectory,
+                                        parentPath.relativize(javaPath).toString()));
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*make sure -yarnship(-yt) works on symbolic directory, and avoiding exception.*

Here is code:
https://github.com/apache/flink/blob/80ad5b3b511a68cce19a53291000c9936e10db17/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java#L260-L274

if `file.isDirectory()` and file is a symbolic path, it will be added to `localPaths` as a file.

Then causing exception below:
```
Caused by: java.lang.IllegalArgumentException: File to copy cannot be a directory: file:/path/to/sql/connectors/ at
org.apache.flink.util.Preconditions.checkArgument(Preconditions.java:138) at
org.apache.flink.yarn.YarnApplicationFileUploader.uploadLocalFileToRemote(YarnApplicationFileUploader.java:197) at
org.apache.flink.yarn.YarnApplicationFileUploader.registerSingleLocalResource(YarnApplicationFileUploader.java:179) at
org.apache.flink.yarn.YarnApplicationFileUploader.registerMultipleLocalResources(YarnApplicationFileUploader.java:289) at
org.apache.flink.yarn.YarnClusterDescriptor.startAppMaster(YarnClusterDescriptor.java:870)
```


## Brief change log

*-yarnship(-yt) now supports symbolic path*
  - *otherwise, it will failed to transfer anything, job submission failed*


## Verifying this change

This change is covered by unit test:
```
org.apache.flink.yarn.YarnFileStageTest#testCopySymbolicPathFromLocal
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
