### PR TITLE
[FLINK-22774][sql-connector-kinesis] Update Kinesis SQL connector's Guava to 27.0-jre

### DIFF
--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -35,6 +35,17 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- Bumped for security purposes to a common version in the Hadoop ecosystem -->
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>27.0-jre</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-codec:commons-codec:1.13
 - org.apache.commons:commons-lang3:3.3.2
-- com.google.guava:guava:18.0
+- com.google.guava:guava:27.0-jre
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1


### PR DESCRIPTION
## What is the purpose of the change

Avoids security tools to complain about an outdated Guava version.

## Brief change log

Bump guava of Kinesis to `27.0-jre`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
