### PR TITLE
[FLINK-21142][connector-hive] Hide Guava from Hadoop and security tools

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
@@ -59,6 +59,11 @@ under the License.
 					<groupId>org.pentaho</groupId>
 					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
 				</exclusion>
+				<!-- Rely on the Guava version of Hadoop. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -159,6 +164,13 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<relocations>
+								<!-- Guava dependencies that still end up in the shaded JAR are relocated to avoid clashes. -->
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.com.google</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
@@ -59,6 +59,11 @@ under the License.
 					<groupId>org.pentaho</groupId>
 					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
 				</exclusion>
+				<!-- Rely on the Guava version of Hadoop. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -122,6 +127,11 @@ under the License.
 								<relocation>
 									<pattern>org.apache.parquet</pattern>
 									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+								</relocation>
+								<!-- Guava dependencies that still end up in the shaded JAR are relocated to avoid clashes. -->
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.com.google</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
@@ -126,7 +126,7 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>org.apache.parquet</pattern>
-									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+									<shadedPattern>org.apache.flink.hive.shaded.parquet</shadedPattern>
 								</relocation>
 								<!-- Guava dependencies that still end up in the shaded JAR are relocated to avoid clashes. -->
 								<relocation>

--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -97,7 +97,7 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>org.apache.parquet</pattern>
-									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+									<shadedPattern>org.apache.flink.hive.shaded.parquet</shadedPattern>
 								</relocation>
 								<!-- Guava dependencies that still end up in the shaded JAR are relocated to avoid clashes. -->
 								<relocation>

--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -59,6 +59,11 @@ under the License.
 					<groupId>org.pentaho</groupId>
 					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
 				</exclusion>
+				<!-- Rely on the Guava version of Hadoop. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -93,6 +98,11 @@ under the License.
 								<relocation>
 									<pattern>org.apache.parquet</pattern>
 									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+								</relocation>
+								<!-- Guava dependencies that still end up in the shaded JAR are relocated to avoid clashes. -->
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.com.google</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
@@ -55,6 +55,11 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<!-- Rely on the Guava version of Hadoop. -->
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -155,6 +160,11 @@ under the License.
 								<relocation>
 									<pattern>org.apache.parquet</pattern>
 									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+								</relocation>
+								<!-- Guava dependencies that still end up in the shaded JAR are relocated to avoid clashes. -->
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.hive.shaded.com.google</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>


### PR DESCRIPTION
## What is the purpose of the change

Some security tools complain that the Guava version in Hive has known vulnerabilities. Also, as seen in the JIRA issue, users are complaining about the Guava version clashing with Hadoop 3.3. There a couple of guides that simply suggest to replace the Guava version:

https://kontext.tech/column/hadoop/561/apache-hive-312-installation-on-linux-guide

http://www.mtitek.com/tutorials/bigdata/hive/install.php

Of course this is not officially supported. But by excluding Guava in our SQL connector JARs we make both security scanning tools and partially users happy. Apparently, Guava classes are still present in the JAR after exclusion (some issue on the Hive side?) therefore we additionally relocate them and have a high chance that Hive fully works after this change.

The issue should be solved after Hive 4.0.0.

## Brief change log

Rely on the Hadoop's Guava + relocate non-excluded Guava classes.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
