### PR TITLE
[FLINK-20140][docs] Add documentation of TableResult.collect for Python Table API.

### DIFF
--- a/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
@@ -511,6 +511,37 @@ table.to_pandas()
 
 <span class="label label-info">Note</span> flink planner 不支持 "to_pandas"，并且，并不是所有的数据类型都可以转换为 pandas DataFrames。
 
+### 将结果作为可关闭的行迭代器
+
+你可以使用TableResult.collect 将结果作为可关闭的行迭代器
+
+注意：为了获取本地结果，你可以调用collect()和print()。但是,他们可以不能在同一个TableResult实例上同时调用。
+
+以下代码展示了如何使用 `TableResult.collect()` 方法：
+
+```python
+
+# 准备 source 表
+t_env = self.t_env
+source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+
+# 得到TableResult
+res = t_env.execute_sql("select a + 1, b, c from %s" % source)
+
+# 遍历 结果
+with res.collect() as results:
+   for result in results:
+       print(result)
+
+```
+
+结果为：
+
+```text
+<Row(2, 'Hi', 'Hello')>
+<Row(3, 'Hello', 'Hello')>
+```
+
 ### 将结果写入到一张 Sink 表中
 
 你可以调用 "execute_insert" 方法来将 `Table` 对象中的数据写入到一张 sink 表中：

--- a/docs/content/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content/docs/dev/python/table/intro_to_table_api.md
@@ -510,6 +510,36 @@ The result is:
 
 <span class="label label-info">Note</span> "to_pandas" is not supported by the flink planner, and not all data types can be emitted to pandas DataFrames.
 
+### Get the result contents as a closeable row iterator
+
+You can call the "TableResult.collect"  method to emit the data as a closeable row iterator
+
+note：In order to fetch result to local, you can call either collect() and print(). But, they can not be called both on the same TableResult instance
+
+The following code shows how to use the  `TableResult.collect()` method：
+
+```python
+
+# prepare source tables 
+source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+
+# Get TableResult
+res = t_env.execute_sql("select a + 1, b, c from %s" % source)
+
+# Traversal result
+with res.collect() as results:
+   for result in results:
+       print(result)
+
+```
+
+The result is：
+
+```text
+<Row(2, 'Hi', 'Hello')>
+<Row(3, 'Hello', 'Hello')>
+```
+
 ### Emit Results to One Sink Table
 
 You can call the "execute_insert" method to emit the data in a `Table` object to a sink table:


### PR DESCRIPTION
> ## What is the purpose of the change
> Add documentation of TableResult.collect for Python Table API
> 
> ## Brief change log
> Add documentation of TableResult.collect for Python Table API
> 
> ## Verifying this change
> _(Please pick either of the following options)_
> 
> This change is a trivial rework / code cleanup without any test coverage.
> 
> _(or)_
> 
> This change is already covered by existing tests, such as _(please describe tests)_.
> 
> _(or)_
> 
> This change added tests and can be verified as follows:
> 
> _(example:)_
> 
> * _Added integration tests for end-to-end deployment with large payloads (100MB)_
> * _Extended integration test for recovery after master (JobManager) failure_
> * _Added test that validates that TaskInfo is transferred only once across recoveries_
> * _Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly._
> 
> ## Does this pull request potentially affect one of the following parts:
> * Dependencies (does it add or upgrade a dependency): no
> * The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
> * The serializers:  no
> * The runtime per-record code paths (performance sensitive): no
> * Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no
> * The S3 file system connector: no
> 
> ## Documentation
> * Does this pull request introduce a new feature? no
> * If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)