### PR TITLE
[FLINK-22796] Update mem_setup_tm documentation

### DIFF
--- a/docs/content.zh/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content.zh/docs/deployment/memory/mem_setup_tm.md
@@ -102,14 +102,15 @@ Flink 会根据默认值或其他配置参数自动调整剩余内存部分的�
 对于包含不同种类的托管内存消费者的作业，可以进一步控制托管内存如何在消费者之间分配。
 通过 [`taskmanager.memory.managed.consumer-weights`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-consumer-weights) 可以为每一种类型的消费者指定一个权重，Flink 会按照权重的比例进行内存分配。
 目前支持的消费者类型包括：
-* `DATAPROC`：用于流处理中的 RocksDB State Backend 和批处理中的内置算法。
+* `OPERATOR`: 用于流处理中和批处理中的内置算法。
+* `STATE_BACKEND`: 用于流处理中的 RocksDB State Backend。
 * `PYTHON`：用户 Python 进程。
 
-例如，一个流处理作业同时使用到了 RocksDB State Backend 和 Python UDF，消费者权重设置为 `DATAPROC:70,PYTHON:30`，那么 Flink 会将 `70%` 的托管内存用于 RocksDB State Backend，`30%` 留给 Python 进程。
+例如，一个流处理作业同时使用到了 RocksDB State Backend 和 Python UDF，消费者权重设置为 `STATE_BACKEND:70,PYTHON:30`，那么 Flink 会将 `70%` 的托管内存用于 RocksDB State Backend，`30%` 留给 Python 进程。
 
 <span class="label label-info">提示</span>
 只有作业中包含某种类型的消费者时，Flink 才会为该类型分配托管内存。
-例如，一个流处理作业使用 Heap State Backend 和 Python UDF，消费者权重设置为 `DATAPROC:70,PYTHON:30`，那么 Flink 会将全部托管内存用于 Python 进程，因为 Heap State Backend 不使用托管内存。
+例如，一个流处理作业使用 Heap State Backend 和 Python UDF，消费者权重设置为 `STATE_BACKEND:70,PYTHON:30`，那么 Flink 会将全部托管内存用于 Python 进程，因为 Heap State Backend 不使用托管内存。
 
 <span class="label label-info">提示</span>
 对于未出现在消费者权重中的类型，Flink 将不会为其分配托管内存。

--- a/docs/content.zh/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content.zh/docs/deployment/memory/mem_setup_tm.md
@@ -83,7 +83,7 @@ Flink 会根据默认值或其他配置参数自动调整剩余内存部分的�
 *托管内存*是由 Flink 负责分配和管理的本地（堆外）内存。
 以下场景需要使用*托管内存*：
 * 流处理作业中用于 [RocksDB State Backend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend)。
-* [批处理作业]({{< ref "docs/dev/dataset/overview" >}})中用于排序、哈希表及缓存中间结果。
+* 流处理和批处理作业中用于排序、哈希表及缓存中间结果。
 * 流处理和批处理作业中用于[在 Python 进程中执行用户自定义函数]({{< ref "docs/dev/python/table/udfs/python_udfs" >}})。
 
 可以通过以下两种范式指定*托管内存*的大小：
@@ -102,7 +102,7 @@ Flink 会根据默认值或其他配置参数自动调整剩余内存部分的�
 对于包含不同种类的托管内存消费者的作业，可以进一步控制托管内存如何在消费者之间分配。
 通过 [`taskmanager.memory.managed.consumer-weights`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-consumer-weights) 可以为每一种类型的消费者指定一个权重，Flink 会按照权重的比例进行内存分配。
 目前支持的消费者类型包括：
-* `OPERATOR`: 用于流处理中和批处理中的内置算法。
+* `OPERATOR`: 用于内置算法。
 * `STATE_BACKEND`: 用于流处理中的 RocksDB State Backend。
 * `PYTHON`：用户 Python 进程。
 

--- a/docs/content/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content/docs/deployment/memory/mem_setup_tm.md
@@ -81,7 +81,7 @@ It will be added to the JVM Heap size and will be dedicated to Flink’s operato
 
 *Managed memory* is managed by Flink and is allocated as native memory (off-heap). The following workloads use *managed memory*:
 * Streaming jobs can use it for [RocksDB state backend]({{< ref "docs/ops/state/state_backends" >}}#the-rocksdbstatebackend).
-* [Batch jobs]({{< ref "docs/dev/dataset/overview" >}}) can use it for sorting, hash tables, caching of intermediate results.
+* Both streaming and batch jobs can use it for sorting, hash tables, caching of intermediate results.
 * Both streaming and batch jobs can use it for executing [User Defined Functions in Python processes]({{< ref "docs/dev/python/table/udfs/python_udfs" >}}).
 
 The size of *managed memory* can be
@@ -98,7 +98,7 @@ See also [how to configure memory for state backends]({{< ref "docs/deployment/m
 If your job contains multiple types of managed memory consumers, you can also control how managed memory should be shared across these types.
 The configuration option [`taskmanager.memory.managed.consumer-weights`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-consumer-weights) allows you to set a weight for each type, to which Flink will reserve managed memory proportionally.
 Valid consumer types are:
-* `OPERATOR`: for built-in algorithms in streaming or batch.
+* `OPERATOR`: for built-in algorithms.
 * `STATE_BACKEND`: for RocksDB state backend in streaming
 * `PYTHON`: for Python processes.
 

--- a/docs/content/docs/deployment/memory/mem_setup_tm.md
+++ b/docs/content/docs/deployment/memory/mem_setup_tm.md
@@ -98,13 +98,14 @@ See also [how to configure memory for state backends]({{< ref "docs/deployment/m
 If your job contains multiple types of managed memory consumers, you can also control how managed memory should be shared across these types.
 The configuration option [`taskmanager.memory.managed.consumer-weights`]({{< ref "docs/deployment/config" >}}#taskmanager-memory-managed-consumer-weights) allows you to set a weight for each type, to which Flink will reserve managed memory proportionally.
 Valid consumer types are:
-* `DATAPROC`: for RocksDB state backend in streaming and built-in algorithms in batch.
+* `OPERATOR`: for built-in algorithms in streaming or batch.
+* `STATE_BACKEND`: for RocksDB state backend in streaming
 * `PYTHON`: for Python processes.
 
-E.g. if a streaming job uses both RocksDB state backend and Python UDFs, and the consumer weights are configured as `DATAPROC:70,PYTHON:30`, Flink will reserve `70%` of the total managed memory for RocksDB state backend and `30%` for Python processes.
+E.g. if a streaming job uses both RocksDB state backend and Python UDFs, and the consumer weights are configured as `STATE_BACKEND:70,PYTHON:30`, Flink will reserve `70%` of the total managed memory for RocksDB state backend and `30%` for Python processes.
 
 For each type, Flink reserves managed memory only if the job contains managed memory consumers of that type.
-E.g, if a streaming job uses the heap state backend and Python UDFs, and the consumer weights are configured as `DATAPROC:70,PYTHON:30`, Flink will use all of its managed memory for Python processes, because the heap state backend does not use managed memory.
+E.g, if a streaming job uses the heap state backend and Python UDFs, and the consumer weights are configured as `STATE_BACKEND:70,PYTHON:30`, Flink will use all of its managed memory for Python processes, because the heap state backend does not use managed memory.
 
 {{< hint warning >}}
 Flink will not reserve managed memory for consumer types that are not included in the consumer weights.


### PR DESCRIPTION
## What is the purpose of the change

improve `mem_setup_tm` document - update supported consumer types for `taskmanager.memory.managed.consumer-weights`.

## Brief change log

- update docs

## Verifying this change

this is documentation improvement.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
