### PR TITLE
[FLINK-22782][docs] Remove legacy planner from Chinese docs

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_dialect.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_dialect.md
@@ -69,7 +69,7 @@ Flink SQL> set table.sql-dialect=default; -- to use default dialect
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner()...build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 // to use hive dialect
 tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
@@ -82,7 +82,7 @@ tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
 ```python
 from pyflink.table import *
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 t_env = TableEnvironment.create(settings)
 
 # to use hive dialect

--- a/docs/content.zh/docs/connectors/table/hive/overview.md
+++ b/docs/content.zh/docs/connectors/table/hive/overview.md
@@ -312,7 +312,7 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 String name            = "myhive";
@@ -330,7 +330,7 @@ tableEnv.useCatalog("myhive");
 
 ```scala
 
-val settings = EnvironmentSettings.newInstance().useBlinkPlanner().build()
+val settings = EnvironmentSettings.newInstance().build()
 val tableEnv = TableEnvironment.create(settings)
 
 val name            = "myhive"
@@ -349,7 +349,7 @@ tableEnv.useCatalog("myhive")
 from pyflink.table import *
 from pyflink.table.catalog import HiveCatalog
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 t_env = TableEnvironment.create(settings)
 
 catalog_name = "myhive"

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -394,7 +394,7 @@ tableEnv.useCatalog("mypg")
 ```python
 from pyflink.table.catalog import JdbcCatalog
 
-environment_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+environment_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 t_env = TableEnvironment.create(environment_settings)
 
 name = "mypg"

--- a/docs/content.zh/docs/dev/python/dependency_management.md
+++ b/docs/content.zh/docs/dev/python/dependency_management.md
@@ -294,7 +294,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 
 TableEnvironment tEnv = TableEnvironment.create(
-    EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build());
+    EnvironmentSettings.newInstance().inBatchMode().build());
 tEnv.getConfig().getConfiguration().set(CoreOptions.DEFAULT_PARALLELISM, 1);
 
 // register the Python UDF

--- a/docs/content.zh/docs/dev/python/python_config.md
+++ b/docs/content.zh/docs/dev/python/python_config.md
@@ -47,7 +47,7 @@ The config options could be set as following in a Table API program:
 ```python
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 t_env = TableEnvironment.create(env_settings)
 
 config = t_env.get_config().get_configuration()

--- a/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
@@ -40,7 +40,7 @@ Python Table API 程序的基本结构
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 1. 创建 TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings) 
 
 # 2. 创建 source 表
@@ -92,11 +92,11 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").wait()
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 # or create a blink batch TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(env_settings)
 ```
 
@@ -133,7 +133,7 @@ table_env = TableEnvironment.create(env_settings)
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 创建 blink 批 TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
@@ -197,7 +197,7 @@ print('Now the type of the "id" column is %s.' % type)
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 创建 blink 流 TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 table_env.execute_sql("""
@@ -277,7 +277,7 @@ new_table.to_pandas()
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 通过 batch table environment 来执行查询
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
@@ -312,7 +312,7 @@ from pyflink.table.udf import udf
 import pandas as pd
 
 # 通过 batch table environment 来执行查询
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
@@ -348,7 +348,7 @@ Flink 的 SQL 基于 [Apache Calcite](https://calcite.apache.org)，它实现了
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 通过 stream table environment 来执行查询
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 
@@ -634,7 +634,7 @@ Table API 提供了一种机制来查看 `Table` 的逻辑查询计划和优化�
 # 使用流模式 TableEnvironment
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -687,7 +687,7 @@ Stage 136 : Data Source
 # 使用流模式 TableEnvironment
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(environment_settings=env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])

--- a/docs/content.zh/docs/dev/python/table/operations/row_based_operations.md
+++ b/docs/content.zh/docs/dev/python/table/operations/row_based_operations.md
@@ -37,7 +37,7 @@ from pyflink.table import EnvironmentSettings, TableEnvironment
 from pyflink.table.expressions import col
 from pyflink.table.types import DataTypes
 
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -101,7 +101,7 @@ from pyflink.common import Row
 from pyflink.table.udf import udtf
 from pyflink.table import DataTypes, EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi,Flink'), (2, 'Hello')], ['id', 'data'])
@@ -181,7 +181,7 @@ agg = udaf(function,
 
 # aggregate with a python general aggregate function
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
 
@@ -196,7 +196,7 @@ result.to_pandas()
 # 1  2  1  1
 
 # aggregate with a python vectorized aggregate function
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(env_settings)
 
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
@@ -256,7 +256,7 @@ class Top2(TableAggregateFunction):
             [DataTypes.FIELD("a", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udtaf decorator:
 # top2 = udtaf(Top2(), result_type=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]), accumulator_type=DataTypes.ARRAY(DataTypes.BIGINT()))

--- a/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
@@ -83,7 +83,7 @@ t_env.sql_query("SELECT a FROM source_table") \
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
 def log_processing():
-    env_settings = EnvironmentSettings.new_instance().use_blink_planner().is_streaming_mode().build()
+    env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
     t_env = TableEnvironment.create(env_settings)
     # specify connector and format jars
     t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")

--- a/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
@@ -50,7 +50,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(settings)
 
 hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
@@ -80,7 +80,7 @@ public class HashCode extends ScalarFunction {
 '''
 from pyflink.table.expressions import call
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(settings)
 
 # 注册 Java 函数
@@ -148,7 +148,7 @@ class Split(TableFunction):
         for s in string.split(" "):
             yield s, len(s)
 
-env_settings = EnvironmentSettings.new_instance().use_blink_planner().is_streaming_mode().build()
+env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
@@ -186,7 +186,7 @@ public class Split extends TableFunction<Tuple2<String, Integer>> {
 '''
 from pyflink.table.expressions import call
 
-env_settings = EnvironmentSettings.new_instance().use_blink_planner().is_streaming_mode().build()
+env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
@@ -301,7 +301,7 @@ class WeightedAvg(AggregateFunction):
             DataTypes.FIELD("f1", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().use_blink_planner().is_streaming_mode().build()
+env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udaf decorator:
 # weighted_avg = udaf(WeightedAvg(), result_type=DataTypes.BIGINT(), accumulator_type=...)
@@ -476,7 +476,7 @@ class Top2(TableAggregateFunction):
             [DataTypes.FIELD("a", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udtaf decorator:
 # top2 = udtaf(Top2(), result_type=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]), accumulator_type=DataTypes.ARRAY(DataTypes.BIGINT()))

--- a/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -53,7 +53,7 @@ under the License.
 def add(i, j):
   return i + j
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(settings)
 
 # use the vectorized Python scalar function in Python Table API
@@ -87,7 +87,7 @@ and `Over Window Aggregation` 使用它:
 def mean_udaf(v):
     return v.mean()
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 table_env = TableEnvironment.create(settings)
 
 my_table = ...  # type: Table, table schema: [a: String, b: BigInt, c: BigInt]

--- a/docs/content.zh/docs/dev/python/table_api_tutorial.md
+++ b/docs/content.zh/docs/dev/python/table_api_tutorial.md
@@ -67,7 +67,7 @@ $ python -m pip install apache-flink
 编写Flink Python Table API程序的第一步是创建`TableEnvironment`。这是Python Table API作业的入口类。
 
 ```python
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 t_env = TableEnvironment.create(settings)
 ```
 
@@ -147,7 +147,7 @@ from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
 from pyflink.table.descriptors import Schema, OldCsv, FileSystem
 from pyflink.table.expressions import lit
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 t_env = TableEnvironment.create(settings)
 
 # write all the data to one file

--- a/docs/content.zh/docs/dev/table/catalogs.md
+++ b/docs/content.zh/docs/dev/table/catalogs.md
@@ -240,7 +240,7 @@ from pyflink.table import *
 from pyflink.table.catalog import HiveCatalog, CatalogDatabase, ObjectPath, CatalogBaseTable
 from pyflink.table.descriptors import Kafka
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().in_batch_mode().build()
 t_env = TableEnvironment.create(settings)
 
 # Create a HiveCatalog

--- a/docs/content.zh/docs/dev/table/common.md
+++ b/docs/content.zh/docs/dev/table/common.md
@@ -26,20 +26,9 @@ under the License.
 
 # 概念与通用 API
 
-Table API 和 SQL 集成在同一套 API 中。这套 API 的核心概念是`Table`，用作查询的输入和输出。本文介绍了 Table API 和 SQL 查询程序的通用结构、如何注册 `Table` 、如何查询 `Table` 以及如何输出 `Table` 。
-
-<a name="main-differences-between-the-two-planners"></a>
-
-两种计划器（Planner）的主要区别
------------------------------------------
-
-1. Blink 将批处理作业视作流处理的一种特例。严格来说，`Table` 和 `DataSet` 之间不支持相互转换，并且批处理作业也不会转换成 `DataSet` 程序而是转换成 `DataStream` 程序，流处理作业也一样。
-2. Blink 计划器不支持  `BatchTableSource`，而是使用有界的  `StreamTableSource` 来替代。
-3. 旧计划器和 Blink 计划器中 `FilterableTableSource` 的实现是不兼容的。旧计划器会将 `PlannerExpression` 下推至 `FilterableTableSource`，而 Blink 计划器则是将 `Expression` 下推。
-4. 基于字符串的键值配置选项仅在 Blink 计划器中使用。（详情参见 [配置]({{< ref "docs/dev/table/config" >}}) ）
-5. `PlannerConfig` 在两种计划器中的实现（`CalciteConfig`）是不同的。
-6. Blink 计划器会将多sink（multiple-sinks）优化成一张有向无环图（DAG），`TableEnvironment` 和 `StreamTableEnvironment` 都支持该特性。旧计划器总是将每个sink都优化成一个新的有向无环图，且所有图相互独立。
-7. 旧计划器目前不支持 catalog 统计数据，而 Blink 支持。
+Table API 和 SQL 集成在同一套 API 中。
+这套 API 的核心概念是`Table`，用作查询的输入和输出。
+本文介绍 Table API 和 SQL 查询程序的通用结构、如何注册 `Table` 、如何查询 `Table` 以及如何输出 `Table` 。
 
 <a name="structure-of-table-api-and-sql-programs"></a>
 
@@ -52,7 +41,7 @@ Table API 和 SQL 程序的结构
 {{< tab "Java" >}}
 ```java
 
-// create a TableEnvironment for specific planner batch or streaming
+// create a TableEnvironment for batch or streaming execution
 TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
 
 // create an input Table
@@ -74,7 +63,7 @@ tableResult...
 {{< tab "Scala" >}}
 ```scala
 
-// create a TableEnvironment for specific planner batch or streaming
+// create a TableEnvironment for batch or streaming execution
 val tableEnv = ... // see "Create a TableEnvironment" section
 
 // create an input Table
@@ -96,7 +85,7 @@ tableResult...
 {{< tab "Python" >}}
 ```python
 
-# create a TableEnvironment for specific planner batch or streaming
+# create a TableEnvironment for batch or streaming execution
 table_env = ... # see "Create a TableEnvironment" section
 
 # register an input Table
@@ -117,7 +106,7 @@ table_result...
 {{< /tab >}}
 {{< /tabs >}}
 
-**注意：** Table API 和 SQL 查询可以很容易地集成并嵌入到 DataStream 或 DataSet 程序中。 请参阅[与 DataStream 和 DataSet API 结合](#integration-with-datastream-and-dataset-api) 章节了解如何将 DataSet 和 DataStream 与表之间的相互转化。
+**注意：** Table API 和 SQL 查询可以很容易地集成并嵌入到 DataStream 程序中。 请参阅[与 DataStream API 集成]({{< ref "docs/dev/table/data_stream_api" >}}) 章节了解如何将 DataStream 与表之间的相互转化。
 
 {{< top >}}
 
@@ -133,156 +122,90 @@ table_result...
 * 加载可插拔模块
 * 执行 SQL 查询
 * 注册自定义函数 （scalar、table 或 aggregation）
-* 将 `DataStream` 或 `DataSet` 转换成 `Table`
-* 持有对  `ExecutionEnvironment` 或 `StreamExecutionEnvironment` 的引用
+* `DataStream` 和 `Table` 之间的转换(面向 `StreamTableEnvironment` )
 
-`Table` 总是与特定的 `TableEnvironment` 绑定。不能在同一条查询中使用不同 TableEnvironment 中的表，例如，对它们进行 join 或 union 操作。
-
-`TableEnvironment` 可以通过静态方法 `BatchTableEnvironment.create()` 或者 `StreamTableEnvironment.create()` 在 `StreamExecutionEnvironment` 或者 `ExecutionEnvironment` 中创建，`TableConfig` 是可选项。`TableConfig`可用于配置`TableEnvironment`或定制的查询优化和转换过程(参见 [查询优化](#query-optimization))。
-
-请确保选择与你的编程语言匹配的特定的计划器`BatchTableEnvironment`/`StreamTableEnvironment`。
-
-如果两种计划器的 jar 包都在 classpath 中（默认行为），你应该明确地设置要在当前程序中使用的计划器。
+`Table` 总是与特定的 `TableEnvironment` 绑定。
+不能在同一条查询中使用不同 TableEnvironment 中的表，例如，对它们进行 join 或 union 操作。
+`TableEnvironment` 可以通过静态方法 `TableEnvironment.create()` 创建。
 
 {{< tabs "74c10eb1-1267-4b4e-89cd-2d85f761d139" >}}
 {{< tab "Java" >}}
 ```java
-
-// **********************
-// FLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-
-EnvironmentSettings fsSettings = EnvironmentSettings.newInstance().useOldPlanner().inStreamingMode().build();
-StreamExecutionEnvironment fsEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-StreamTableEnvironment fsTableEnv = StreamTableEnvironment.create(fsEnv, fsSettings);
-// or TableEnvironment fsTableEnv = TableEnvironment.create(fsSettings);
-
-// ******************
-// FLINK BATCH QUERY
-// ******************
-import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.table.api.bridge.java.BatchTableEnvironment;
-
-ExecutionEnvironment fbEnv = ExecutionEnvironment.getExecutionEnvironment();
-BatchTableEnvironment fbTableEnv = BatchTableEnvironment.create(fbEnv);
-
-// **********************
-// BLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-
-StreamExecutionEnvironment bsEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-StreamTableEnvironment bsTableEnv = StreamTableEnvironment.create(bsEnv, bsSettings);
-// or TableEnvironment bsTableEnv = TableEnvironment.create(bsSettings);
-
-// ******************
-// BLINK BATCH QUERY
-// ******************
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 
-EnvironmentSettings bbSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-TableEnvironment bbTableEnv = TableEnvironment.create(bbSettings);
+EnvironmentSettings settings = EnvironmentSettings
+    .newInstance()
+    .inStreamingMode()
+    //.inBatchMode()
+    .build();
 
+TableEnvironment tEnv = TableEnvironment.create(setting);
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-
-// **********************
-// FLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.EnvironmentSettings
-import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
-
-val fsSettings = EnvironmentSettings.newInstance().useOldPlanner().inStreamingMode().build()
-val fsEnv = StreamExecutionEnvironment.getExecutionEnvironment
-val fsTableEnv = StreamTableEnvironment.create(fsEnv, fsSettings)
-// or val fsTableEnv = TableEnvironment.create(fsSettings)
-
-// ******************
-// FLINK BATCH QUERY
-// ******************
-import org.apache.flink.api.scala.ExecutionEnvironment
-import org.apache.flink.table.api.bridge.scala.BatchTableEnvironment
-
-val fbEnv = ExecutionEnvironment.getExecutionEnvironment
-val fbTableEnv = BatchTableEnvironment.create(fbEnv)
-
-// **********************
-// BLINK STREAMING QUERY
-// **********************
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.EnvironmentSettings
-import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
-
-val bsEnv = StreamExecutionEnvironment.getExecutionEnvironment
-val bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
-val bsTableEnv = StreamTableEnvironment.create(bsEnv, bsSettings)
-// or val bsTableEnv = TableEnvironment.create(bsSettings)
-
-// ******************
-// BLINK BATCH QUERY
-// ******************
 import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
 
-val bbSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
-val bbTableEnv = TableEnvironment.create(bbSettings)
+val settings = EnvironmentSettings
+    .newInstance()
+    .inStreamingMode()
+    //.inBatchMode()
+    .build()
 
+val tEnv = TableEnvironment.create(setting)
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
+from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# **********************
-# FLINK STREAMING QUERY
-# **********************
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import StreamTableEnvironment, EnvironmentSettings
+# create a blink streaming TableEnvironment
+env_settings = EnvironmentSettings.new_instance().build()
+table_env = TableEnvironment.create(env_settings)
 
-f_s_env = StreamExecutionEnvironment.get_execution_environment()
-f_s_settings = EnvironmentSettings.new_instance().use_old_planner().in_streaming_mode().build()
-f_s_t_env = StreamTableEnvironment.create(f_s_env, environment_settings=f_s_settings)
-
-# ******************
-# FLINK BATCH QUERY
-# ******************
-from pyflink.dataset import ExecutionEnvironment
-from pyflink.table import BatchTableEnvironment
-
-f_b_env = ExecutionEnvironment.get_execution_environment()
-f_b_t_env = BatchTableEnvironment.create(f_b_env, table_config)
-
-# **********************
-# BLINK STREAMING QUERY
-# **********************
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import StreamTableEnvironment, EnvironmentSettings
-
-b_s_env = StreamExecutionEnvironment.get_execution_environment()
-b_s_settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
-b_s_t_env = StreamTableEnvironment.create(b_s_env, environment_settings=b_s_settings)
-
-# ******************
-# BLINK BATCH QUERY
-# ******************
-from pyflink.table import EnvironmentSettings, BatchTableEnvironment
-
-b_b_settings = EnvironmentSettings.new_instance().use_blink_planner().in_batch_mode().build()
-b_b_t_env = BatchTableEnvironment.create(environment_settings=b_b_settings)
+# create a blink batch TableEnvironment
+env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+table_env = TableEnvironment.create(env_settings)
 
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
-**注意：** 如果`/lib`目录中只有一种计划器的 jar 包，则可以使用`useAnyPlanner`（python 使用 `use any_u_planner`）创建 `EnvironmentSettings`。
+或者，用户可以从现有的 `StreamExecutionEnvironment` 创建一个 `StreamTableEnvironment` 与 `DataStream` API 互操作。
+
+{{< tabs "c91b91ec-7197-4305-827d-9f91dedadce5" >}}
+{{< tab "Java" >}}
+```java
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+
+StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```scala
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.EnvironmentSettings
+import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+
+val env = StreamExecutionEnvironment.getExecutionEnvironment
+val tEnv = StreamTableEnvironment.create(env)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment
+
+s_env = StreamExecutionEnvironment.get_execution_environment()
+t_env = StreamTableEnvironment.create(s_env)
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 {{< top >}}
 
@@ -374,43 +297,9 @@ table_env.register_table("projectedTable", proj_table)
 
 另外一个方式去创建 `TABLE` 是通过 [connector]({{< ref "docs/connectors/table/overview" >}}) 声明。Connector 描述了存储表数据的外部系统。存储系统例如 Apache Kafka 或者常规的文件系统都可以通过这种方式来声明。
 
-{{< tabs "0b2e02bb-4185-4036-b948-85961ad05764" >}}
-{{< tab "Java" >}}
-```java
-tableEnvironment
-  .connect(...)
-  .withFormat(...)
-  .withSchema(...)
-  .inAppendMode()
-  .createTemporaryTable("MyTable")
-```
-{{< /tab >}}
-{{< tab "Scala" >}}
-```scala
-tableEnvironment
-  .connect(...)
-  .withFormat(...)
-  .withSchema(...)
-  .inAppendMode()
-  .createTemporaryTable("MyTable")
-```
-{{< /tab >}}
-{{< tab "Python" >}}
-```python
-table_environment \
-    .connect(...) \
-    .with_format(...) \
-    .with_schema(...) \
-    .in_append_mode() \
-    .create_temporary_table("MyTable")
-```
-{{< /tab >}}
-{{< tab "DDL" >}}
 ```sql
 tableEnvironment.executeSql("CREATE [TEMPORARY] TABLE MyTable (...) WITH (...)")
 ```
-{{< /tab >}}
-{{< /tabs >}}
 
 <a name="expanding-table-identifiers"></a>
 
@@ -717,7 +606,7 @@ Table API 和 SQL 查询的混用非常简单因为它们都返回 `Table` 对�
 
 批处理 `Table` 只能写入 `BatchTableSink`，而流处理 `Table` 需要指定写入 `AppendStreamTableSink`，`RetractStreamTableSink` 或者 `UpsertStreamTableSink`。
 
-请参考文档 [Table Sources & Sinks]({{< ref "docs/dev/table/sourcesSinks" >}}) 以获取更多关于可用 Sink 的信息以及如何自定义 `TableSink`。
+请参考文档 [Table Sources & Sinks]({{< ref "docs/dev/table/sourcesSinks" >}}) 以获取更多关于可用 Sink 的信息以及如何自定义 `DynamicTableSink`。
 
 方法 `Table.executeInsert(String tableName)` 将 `Table` 发送至已注册的 `TableSink`。该方法通过名称在 catalog 中查找 `TableSink` 并确认`Table` schema 和 `TableSink` schema 一致。
 
@@ -742,6 +631,7 @@ tableEnv.connect(new FileSystem().path("/path/to/file"))
 
 // compute a result Table using Table API operators and/or SQL queries
 Table result = ...
+
 // emit the result Table to the registered TableSink
 result.executeInsert("CsvSinkTable");
 
@@ -804,11 +694,8 @@ result.execute_insert("CsvSinkTable")
 翻译与执行查询
 -----------------------------
 
-两种计划器翻译和执行查询的方式是不同的。
-
-{{< tabs "58b3e383-ade2-482d-a86f-b4f243ffce48" >}}
-{{< tab "Blink planner" >}}
-不论输入数据源是流式的还是批式的，Table API 和 SQL 查询都会被转换成 [DataStream]({{< ref "docs/dev/datastream/overview" >}}) 程序。查询在内部表示为逻辑查询计划，并被翻译成两个阶段：
+不论输入数据源是流式的还是批式的，Table API 和 SQL 查询都会被转换成 [DataStream]({{< ref "docs/dev/datastream/overview" >}}) 程序。
+查询在内部表示为逻辑查询计划，并被翻译成两个阶段：
 
 1. 优化逻辑执行计划
 2. 翻译成 DataStream 程序
@@ -819,28 +706,7 @@ Table API 或者 SQL 查询在下列情况下会被翻译：
 * 当 `Table.executeInsert()` 被调用时。该方法是用来将一个表的内容插入到目标表中，一旦该方法被调用， TABLE API 程序立即被翻译。
 * 当 `Table.execute()` 被调用时。该方法是用来将一个表的内容收集到本地，一旦该方法被调用， TABLE API 程序立即被翻译。
 * 当 `StatementSet.execute()` 被调用时。`Table` （通过 `StatementSet.addInsert()` 输出给某个 `Sink`）和 INSERT 语句 （通过调用 `StatementSet.addInsertSql()`）会先被缓存到 `StatementSet` 中，`StatementSet.execute()` 方法被调用时，所有的 sink 会被优化成一张有向无环图。
-* 当 `Table` 被转换成 `DataStream` 时（参阅[与 DataStream 和 DataSet API 结合](#integration-with-datastream-and-dataset-api)）。转换完成后，它就成为一个普通的 DataStream 程序，并会在调用 `StreamExecutionEnvironment.execute()` 时被执行。
-
-<span class="label label-danger">注意</span> **从 1.11 版本开始，`sqlUpdate` 方法 和 `insertInto` 方法被废弃，从这两个方法构建的 Table 程序必须通过 `StreamTableEnvironment.execute()` 方法执行，而不能通过 `StreamExecutionEnvironment.execute()` 方法来执行。**
-{{< /tab >}}
-{{< tab "Old planner" >}}
-Table API 和 SQL 查询会被翻译成 [DataStream]({{< ref "docs/dev/datastream/overview" >}}) 或者 [DataSet]({{< ref "docs/dev/dataset/overview" >}}) 程序， 这取决于它们的输入数据源是流式的还是批式的。查询在内部表示为逻辑查询计划，并被翻译成两个阶段：
-
-1. 优化逻辑执行计划
-2. 翻译成 DataStream 或 DataSet 程序
-
-Table API 或者 SQL 查询在下列情况下会被翻译：
-
-* 当 `TableEnvironment.executeSql()` 被调用时。该方法是用来执行一个 SQL 语句，一旦该方法被调用， SQL 语句立即被翻译。
-* 当 `Table.executeInsert()` 被调用时。该方法是用来将一个表的内容插入到目标表中，一旦该方法被调用， TABLE API 程序立即被翻译。
-* 当 `Table.execute()` 被调用时。该方法是用来将一个表的内容收集到本地，一旦该方法被调用， TABLE API 程序立即被翻译。
-* 当 `StatementSet.execute()` 被调用时。`Table` （通过 `StatementSet.addInsert()` 输出给某个 `Sink`）和 INSERT 语句 （通过调用 `StatementSet.addInsertSql()`）会先被缓存到 `StatementSet` 中，`StatementSet.execute()` 方法被调用时，所有的 sink 会被优化成一张有向无环图。
-* 对于 Streaming 而言，当`Table` 被转换成 `DataStream` 时（参阅[与 DataStream 和 DataSet API 结合](#integration-with-datastream-and-dataset-api)）触发翻译。转换完成后，它就成为一个普通的 DataStream 程序，并会在调用 `StreamExecutionEnvironment.execute()` 时被执行。对于 Batch 而言，`Table` 被转换成 `DataSet` 时（参阅[与 DataStream 和 DataSet API 结合](#integration-with-datastream-and-dataset-api)）触发翻译。转换完成后，它就成为一个普通的 DataSet 程序，并会在调用 `ExecutionEnvironment.execute()` 时被执行。
-
-<span class="label label-danger">注意</span> **从 1.11 版本开始，`sqlUpdate` 方法 和 `insertInto` 方法被废弃。对于 Streaming 而言，如果一个 Table 程序是从这两个方法构建出来的，必须通过 `StreamTableEnvironment.execute()` 方法执行，而不能通过 `StreamExecutionEnvironment.execute()` 方法执行；对于 Batch 而言，如果一个 Table 程序是从这两个方法构建出来的，必须通过 `BatchTableEnvironment.execute()` 方法执行，而不能通过 `ExecutionEnvironment.execute()` 方法执行。**
-
-{{< /tab >}}
-{{< /tabs >}}
+* 当 `Table` 被转换成 `DataStream` 时（参阅[与 DataStream 集成](#integration-with-datastream)）。转换完成后，它就成为一个普通的 DataStream 程序，并会在调用 `StreamExecutionEnvironment.execute()` 时被执行。
 
 {{< top >}}
 
@@ -850,8 +716,6 @@ Table API 或者 SQL 查询在下列情况下会被翻译：
 查询优化
 ------------------
 
-{{< tabs "76bc65c8-6242-448a-a9d8-1b2909ad2198" >}}
-{{< tab "Blink planner" >}}
 Apache Flink 使用并扩展了 Apache Calcite 来执行复杂的查询优化。
 这包括一系列基于规则和成本的优化，例如：
 
@@ -871,13 +735,6 @@ Apache Flink 使用并扩展了 Apache Calcite 来执行复杂的查询优化。
 优化器不仅基于计划，而且还基于可从数据源获得的丰富统计信息以及每个算子（例如 io，cpu，网络和内存）的细粒度成本来做出明智的决策。
 
 高级用户可以通过 `CalciteConfig` 对象提供自定义优化，可以通过调用  `TableEnvironment＃getConfig＃setPlannerConfig` 将其提供给 TableEnvironment。
-{{< /tab >}}
-{{< tab "Old planner" >}}
-Apache Flink 利用 Apache Calcite 来优化和翻译查询。当前执行的优化包括投影和过滤器下推，子查询消除以及其他类型的查询重写。原版计划程序尚未优化 join 的顺序，而是按照查询中定义的顺序执行它们（FROM 子句中的表顺序和/或 WHERE 子句中的 join 谓词顺序）。
-
-通过提供一个 `CalciteConfig` 对象，可以调整在不同阶段应用的优化规则集合。这个对象可以通过调用构造器 `CalciteConfig.createBuilder()` 创建，并通过调用 `tableEnv.getConfig.setPlannerConfig(calciteConfig)` 提供给 TableEnvironment。
-{{< /tab >}}
-{{< /tabs >}}
 
 <a name="explaining-a-table"></a>
 
@@ -910,8 +767,8 @@ Table table2 = tEnv.fromDataStream(stream2, $("count"), $("word"));
 Table table = table1
   .where($("word").like("F%"))
   .unionAll(table2);
-System.out.println(table.explain());
 
+System.out.println(table.explain());
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -924,8 +781,8 @@ val table2 = env.fromElements((1, "hello")).toTable(tEnv, $"count", $"word")
 val table = table1
   .where($"word".like("F%"))
   .unionAll(table2)
-println(table.explain())
 
+println(table.explain())
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -986,7 +843,7 @@ Stage 2 : Data Source
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
 final Schema schema = new Schema()
@@ -1025,7 +882,7 @@ System.out.println(explanation);
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance.useBlinkPlanner.inStreamingMode.build
+val settings = EnvironmentSettings.newInstance.inStreamingMode.build
 val tEnv = TableEnvironment.create(settings)
 
 val schema = new Schema()
@@ -1064,7 +921,7 @@ println(explanation)
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance().use_blink_planner().in_streaming_mode().build()
+settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 t_env = TableEnvironment.create(environment_settings=settings)
 
 schema = Schema()
@@ -1106,7 +963,6 @@ print(explanation)
 多 sink 计划的结果是：
 <div>
 ```text
-
 == Abstract Syntax Tree ==
 LogicalLegacySink(name=[MySink1], fields=[count, word])
 +- LogicalFilter(condition=[LIKE($1, _UTF-16LE'F%')])

--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -1007,7 +1007,7 @@ public abstract class AggregateFunction<T, ACC> extends UserDefinedAggregateFunc
 
   /**
     * Merges a group of accumulator instances into one accumulator instance. This function must be
-    * implemented for datastream session window grouping aggregate and dataset grouping aggregate.
+    * implemented for datastream session window grouping aggregate and bounded grouping aggregate.
     *
     * @param accumulator  the accumulator which will keep the merged aggregate results. It should
     *                     be noted that the accumulator may contain the previous aggregated
@@ -1032,7 +1032,7 @@ public abstract class AggregateFunction<T, ACC> extends UserDefinedAggregateFunc
 
   /**
     * Resets the accumulator for this [[AggregateFunction]]. This function must be implemented for
-    * dataset grouping aggregate.
+    * bounded grouping aggregate.
     *
     * @param accumulator  the accumulator which needs to be reset
     */
@@ -1116,7 +1116,7 @@ abstract class AggregateFunction[T, ACC] extends UserDefinedAggregateFunction[T,
 
   /**
     * Merges a group of accumulator instances into one accumulator instance. This function must be
-    * implemented for datastream session window grouping aggregate and dataset grouping aggregate.
+    * implemented for datastream session window grouping aggregate and bounded grouping aggregate.
     *
     * @param accumulator  the accumulator which will keep the merged aggregate results. It should
     *                     be noted that the accumulator may contain the previous aggregated
@@ -1141,7 +1141,7 @@ abstract class AggregateFunction[T, ACC] extends UserDefinedAggregateFunction[T,
 
   /**
     * Resets the accumulator for this [[AggregateFunction]]. This function must be implemented for
-    * dataset grouping aggregate.
+    * bounded grouping aggregate.
     *
     * @param accumulator  the accumulator which needs to be reset
     */
@@ -1489,7 +1489,7 @@ public abstract class TableAggregateFunction<T, ACC> extends UserDefinedAggregat
 
   /**
     * Merges a group of accumulator instances into one accumulator instance. This function must be
-    * implemented for datastream session window grouping aggregate and dataset grouping aggregate.
+    * implemented for datastream session window grouping aggregate and bounded grouping aggregate.
     *
     * @param accumulator  the accumulator which will keep the merged aggregate results. It should
     *                     be noted that the accumulator may contain the previous aggregated
@@ -1616,7 +1616,7 @@ abstract class TableAggregateFunction[T, ACC] extends UserDefinedAggregateFuncti
 
   /**
     * Merges a group of accumulator instances into one accumulator instance. This function must be
-    * implemented for datastream session window grouping aggregate and dataset grouping aggregate.
+    * implemented for datastream session window grouping aggregate and bounded grouping aggregate.
     *
     * @param accumulator  the accumulator which will keep the merged aggregate results. It should
     *                     be noted that the accumulator may contain the previous aggregated

--- a/docs/content.zh/docs/dev/table/modules.md
+++ b/docs/content.zh/docs/dev/table/modules.md
@@ -83,7 +83,7 @@ Users can use SQL to load/unload/use/list modules in both Table API and SQL CLI.
 {{< tabs "SQL snippets" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
 TableEnvironment tableEnv = TableEnvironment.create(setting);
 
 // Show initially loaded and enabled modules
@@ -168,7 +168,7 @@ tableEnv.executeSql("SHOW FULL MODULES").print();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance().useBlinkPlanner().build()
+val settings = EnvironmentSettings.newInstance().build()
 val tableEnv = TableEnvironment.create(setting)
 
 // Show initially loaded and enabled modules
@@ -256,7 +256,7 @@ tableEnv.executeSql("SHOW FULL MODULES").print()
 from pyflink.table import *
 
 # environment configuration
-settings = EnvironmentSettings.new_instance().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().build()
 t_env = TableEnvironment.create(settings)
 
 # Show initially loaded and enabled modules
@@ -456,7 +456,7 @@ Users can use Java, Scala or Python to load/unload/use/list modules programmatic
 {{< tabs "API snippets" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().build();
+EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
 TableEnvironment tableEnv = TableEnvironment.create(setting);
 
 // Show initially loaded and enabled modules
@@ -541,7 +541,7 @@ tableEnv.listFullModules();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance().useBlinkPlanner().build()
+val settings = EnvironmentSettings.newInstance().build()
 val tableEnv = TableEnvironment.create(setting)
 
 // Show initially loaded and enabled modules
@@ -629,7 +629,7 @@ tableEnv.listFullModules()
 from pyflink.table import *
 
 # environment configuration
-settings = EnvironmentSettings.new_instance().use_blink_planner().build()
+settings = EnvironmentSettings.new_instance().build()
 t_env = TableEnvironment.create(settings)
 
 # Show initially loaded and enabled modules

--- a/docs/content.zh/docs/dev/table/overview.md
+++ b/docs/content.zh/docs/dev/table/overview.md
@@ -27,51 +27,27 @@ under the License.
 
 # Table API & SQL
 
-Apache Flink 有两种关系型 API 来做流批统一处理：Table API 和 SQL。Table API 是用于 Scala 和 Java 语言的查询API，它可以用一种非常直观的方式来组合使用选取、过滤、join 等关系型算子。Flink SQL 是基于 [Apache Calcite](https://calcite.apache.org) 来实现的标准 SQL。这两种 API 中的查询对于批（DataSet）和流（DataStream）的输入有相同的语义，也会产生同样的计算结果。
+Apache Flink 有两种关系型 API 来做流批统一处理：Table API 和 SQL。Table API 是用于 Scala 和 Java 语言的查询API，它可以用一种非常直观的方式来组合使用选取、过滤、join 等关系型算子。Flink SQL 是基于 [Apache Calcite](https://calcite.apache.org) 来实现的标准 SQL。无论输入是连续的（流式）还是有界的（批处理），在两个接口中指定的查询都具有相同的语义，并指定相同的结果。
 
-Table API 和 SQL 两种 API 是紧密集成的，以及 DataStream 和 DataSet API。你可以在这些 API 之间，以及一些基于这些 API 的库之间轻松的切换。比如，你可以先用 [CEP]({{< ref "docs/libs/cep" >}}) 从 DataStream 中做模式匹配，然后用 Table API 来分析匹配的结果；或者你可以用 SQL 来扫描、过滤、聚合一个批式的表，然后再跑一个 [Gelly 图算法]({{< ref "docs/libs/gelly/overview" >}}) 来处理已经预处理好的数据。
+Table API 和 SQL 两种 API 是紧密集成的，以及 DataStream API。你可以在这些 API 之间，以及一些基于这些 API 的库之间轻松的切换。比如，你可以先用 [CEP]({{< ref "docs/libs/cep" >}}) 从 DataStream 中做模式匹配，然后用 Table API 来分析匹配的结果；或者你可以用 SQL 来扫描、过滤、聚合一个批式的表，然后再跑一个 [Gelly 图算法]({{< ref "docs/libs/gelly/overview" >}}) 来处理已经预处理好的数据。
 
-**注意：Table API 和 SQL 现在还处于活跃开发阶段，还没有完全实现所有的特性。不是所有的 \[Table API，SQL\] 和 \[流，批\] 的组合都是支持的。**
-
-依赖图
---------------------
-
-从1.9开始，Flink 提供了两个 Table Planner 实现来执行 Table API 和 SQL 程序：Blink Planner 和 Old Planner，Old Planner 在1.9之前就已经存在了。
-Planner 的作用主要是把关系型的操作翻译成可执行的、经过优化的 Flink 任务。两种 Planner 所使用的优化规则以及运行时类都不一样。
-它们在支持的功能上也有些差异。
-
-<span class="label label-danger">注意</span> 对于生产环境，我们建议使用在1.11版本之后已经变成默认的Blink Planner。
-
-所有的 Table API 和 SQL 的代码都在 `flink-table` 或者 `flink-table-blink` Maven artifacts 下。
-
-下面是各个依赖：
-
-* `flink-table-common`: 公共模块，比如自定义函数、格式等需要依赖的。
-* `flink-table-api-java`: Table 和 SQL API，使用 Java 语言编写的，给纯 table 程序使用（还在早期开发阶段，不建议使用）
-* `flink-table-api-scala`: Table 和 SQL API，使用 Scala 语言编写的，给纯 table 程序使用（还在早期开发阶段，不建议使用）
-* `flink-table-api-java-bridge`: Table 和 SQL API 结合 DataStream/DataSet API 一起使用，给 Java 语言使用。
-* `flink-table-api-scala-bridge`: Table 和 SQL API 结合 DataStream/DataSet API 一起使用，给 Scala 语言使用。
-* `flink-table-planner`: table Planner 和运行时。这是在1.9之前 Flink 的唯一的 Planner，但是从1.11版本开始我们不推荐继续使用。
-* `flink-table-planner-blink`: 新的 Blink Planner，从1.11版本开始成为默认的 Planner。
-* `flink-table-runtime-blink`: 新的 Blink 运行时。
-* `flink-table-uber`: 把上述模块以及 Old Planner 打包到一起，可以在大部分 Table & SQL API 场景下使用。打包到一起的 jar 文件 `flink-table-*.jar` 默认会直接放到 Flink 发行版的 `/lib` 目录下。
-* `flink-table-uber-blink`: 把上述模块以及 Blink Planner 打包到一起，可以在大部分 Table & SQL API 场景下使用。打包到一起的 jar 文件 `flink-table-blink-*.jar` 默认会放到 Flink 发行版的 `/lib` 目录下。
-
-关于如何使用 Old Planner 以及 Blink Planner，可以参考[公共 API](common.html)。 
-
-### Table 程序依赖
+## Table 程序依赖
 
 取决于你使用的编程语言，选择 Java 或者 Scala API 来构建你的 Table API 和 SQL 程序：
 
+{{< tabs "94f8aceb-507f-4c8f-977e-df00fe903203" >}}
+{{< tab "Java" >}}
 ```xml
-<!-- Either... -->
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-api-java-bridge{{< scala_version >}}</artifactId>
   <version>{{< version >}}</version>
   <scope>provided</scope>
 </dependency>
-<!-- or... -->
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```xml
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-api-scala-bridge{{< scala_version >}}</artifactId>
@@ -79,29 +55,30 @@ Planner 的作用主要是把关系型的操作翻译成可执行的、经过优
   <scope>provided</scope>
 </dependency>
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+{{< stable >}}
+```bash
+$ python -m pip install apache-flink {{< version >}}
+```
+{{< /stable >}}
+{{< unstable >}}
+```bash
+$ python -m pip install apache-flink
+```
+{{< /unstable >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 除此之外，如果你想在 IDE 本地运行你的程序，你需要添加下面的模块，具体用哪个取决于你使用哪个 Planner：
 
 ```xml
-<!-- Either... (for the old planner that was available before Flink 1.9) -->
-<dependency>
-  <groupId>org.apache.flink</groupId>
-  <artifactId>flink-table-planner{{< scala_version >}}</artifactId>
-  <version>{{< version >}}</version>
-  <scope>provided</scope>
-</dependency>
-<!-- or.. (for the new Blink planner) -->
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-table-planner-blink{{< scala_version >}}</artifactId>
   <version>{{< version >}}</version>
   <scope>provided</scope>
 </dependency>
-```
-
-内部实现上，部分 table 相关的代码是用 Scala 实现的。所以，下面的依赖也需要添加到你的程序里，不管是批式还是流式的程序：
-
-```xml
 <dependency>
   <groupId>org.apache.flink</groupId>
   <artifactId>flink-streaming-scala{{< scala_version >}}</artifactId>
@@ -112,7 +89,7 @@ Planner 的作用主要是把关系型的操作翻译成可执行的、经过优
 
 ### 扩展依赖
 
-如果你想实现[自定义格式]({{< ref "docs/dev/table/sourcesSinks" >}}#define-a-tablefactory)来解析 Kafka 数据，或者[自定义函数]({{< ref "docs/dev/table/functions/systemFunctions" >}})，下面的依赖就足够了，编译出来的 jar 文件可以直接给 SQL Client 使用：
+如果你想实现[自定义格式或连接器]({{< ref "docs/dev/table/sourcesSinks" >}}) 用于（反）序列化行或一组[用户定义的函数]({{< ref "docs/dev/table/functions/udfs" >}})，下面的依赖就足够了，编译出来的 jar 文件可以直接给 SQL Client 使用：
 
 ```xml
 <dependency>
@@ -122,13 +99,6 @@ Planner 的作用主要是把关系型的操作翻译成可执行的、经过优
   <scope>provided</scope>
 </dependency>
 ```
-
-当前，本模块包含以下可以扩展的接口：
-- `SerializationSchemaFactory`
-- `DeserializationSchemaFactory`
-- `ScalarFunction`
-- `TableFunction`
-- `AggregateFunction`
 
 {{< top >}}
 

--- a/docs/content.zh/docs/dev/table/sql/explain.md
+++ b/docs/content.zh/docs/dev/table/sql/explain.md
@@ -157,8 +157,6 @@ Flink SQL> EXPLAIN PLAN FOR SELECT `count`, word FROM MyTable1 WHERE word LIKE '
 {{< /tabs >}}
 
 The `EXPLAIN` result is:
-{{< tabs "6ee087b2-3a49-4d75-a803-f436a2166c92" >}}
-{{< tab "Blink Planner" >}}
 ```text
 == Abstract Syntax Tree ==
 LogicalUnion(all=[true])
@@ -178,42 +176,6 @@ Union(all=[true], union all=[count, word])
     TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[count, word])
   TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[count, word])
 ```
-{{< /tab >}}
-{{< tab "Legacy Planner" >}}
-```text
-== Abstract Syntax Tree ==
-LogicalUnion(all=[true])
-  LogicalFilter(condition=[LIKE($1, _UTF-16LE'F%')])
-    FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[count, word])
-  FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[count, word])
-
-== Optimized Logical Plan ==
-DataStreamUnion(all=[true], union all=[count, word])
-  DataStreamCalc(select=[count, word], where=[LIKE(word, _UTF-16LE'F%')])
-    TableSourceScan(table=[[default_catalog, default_database, MyTable1]], fields=[count, word])
-  TableSourceScan(table=[[default_catalog, default_database, MyTable2]], fields=[count, word])
-
-== Physical Execution Plan ==
-Stage 1 : Data Source
-	content : collect elements with CollectionInputFormat
-
-Stage 2 : Data Source
-	content : collect elements with CollectionInputFormat
-
-	Stage 3 : Operator
-		content : from: (count, word)
-		ship_strategy : REBALANCE
-
-		Stage 4 : Operator
-			content : where: (LIKE(word, _UTF-16LE'F%')), select: (count, word)
-			ship_strategy : FORWARD
-
-			Stage 5 : Operator
-				content : from: (count, word)
-				ship_strategy : REBALANCE
-```
-{{< /tab >}}
-{{< /tabs >}}
 
 {{< top >}}
 

--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -70,9 +70,8 @@ Table counts = orders
         .groupBy($("a"))
         .select($("a"), $("b").count().as("cnt"));
 
-// conversion to DataSet
-DataSet<Row> result = tEnv.toDataSet(counts, Row.class);
-result.print();
+// print
+counts.execute().print();
 ```
 
 {{< /tab >}}
@@ -104,7 +103,7 @@ val orders = tEnv.from("Orders") // schema (a, b, c, rowtime)
 val result = orders
                .groupBy($"a")
                .select($"a", $"b".count as "cnt")
-               .toDataSet[Row] // conversion to DataSet
+               .execute()
                .print()
 ```
 
@@ -117,8 +116,8 @@ The following example shows how a Python Table API program is constructed and ho
 from pyflink.table import *
 
 # environment configuration
-t_env = BatchTableEnvironment.create(
-    environment_settings=EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+t_env = TableEnvironment.create(
+    environment_settings=EnvironmentSettings.new_instance().in_batch_mode().build())
 
 # register Orders table and Result table sink in table environment
 source_data_path = "/path/to/source/directory/"
@@ -891,8 +890,8 @@ Similar to a SQL JOIN clause. Joins two tables. Both tables must have distinct f
 {{< tabs "innerjoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.fromDataSet(ds1, "a, b, c");
-Table right = tableEnv.fromDataSet(ds2, "d, e, f");
+Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"));
+Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"));
 Table result = left.join(right)
     .where($("a").isEqual($("d")))
     .select($("a"), $("b"), $("e"));
@@ -900,8 +899,8 @@ Table result = left.join(right)
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val left = ds1.toTable(tableEnv, $"a", $"b", $"c")
-val right = ds2.toTable(tableEnv, $"d", $"e", $"f")
+val left = tableEnv.from("MyTable").select($"a", $"b", $"c")
+val right = tableEnv.from("MyTable").select($"d", $"e", $"f")
 val result = left.join(right).where($"a" === $"d").select($"a", $"b", $"e")
 ```
 {{< /tab >}}
@@ -929,8 +928,8 @@ Both tables must have distinct field names and at least one equality join predic
 {{< tabs "outerjoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.fromDataSet(ds1, "a, b, c");
-Table right = tableEnv.fromDataSet(ds2, "d, e, f");
+Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"));
+Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"));
 
 Table leftOuterResult = left.leftOuterJoin(right, $("a").isEqual($("d")))
                             .select($("a"), $("b"), $("e"));
@@ -942,8 +941,8 @@ Table fullOuterResult = left.fullOuterJoin(right, $("a").isEqual($("d")))
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val left = tableEnv.fromDataSet(ds1, $"a", $"b", $"c")
-val right = tableEnv.fromDataSet(ds2, $"d", $"e", $"f")
+val left = tableEnv.from("MyTable").select($"a", $"b", $"c")
+val right = tableEnv.from("MyTable").select($"d", $"e", $"f")
 
 val leftOuterResult = left.leftOuterJoin(right, $"a" === $"d").select($"a", $"b", $"e")
 val rightOuterResult = left.rightOuterJoin(right, $"a" === $"d").select($"a", $"b", $"e")
@@ -977,8 +976,8 @@ An interval join requires at least one equi-join predicate and a join condition 
 {{< tabs "intervaljoin" >}}
 {{< tab "Java" >}}
 ```java
-Table left = tableEnv.fromDataSet(ds1, $("a"), $("b"), $("c"), $("ltime").rowtime());
-Table right = tableEnv.fromDataSet(ds2, $("d"), $("e"), $("f"), $("rtime").rowtime()));
+Table left = tableEnv.from("MyTable).select($("a"), $("b"), $("c"), $("ltime"));
+Table right = tableEnv.from("MyTable).select($("d"), $("e"), $("f"), $("rtime"));
 
 Table result = left.join(right)
   .where(
@@ -992,8 +991,8 @@ Table result = left.join(right)
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val left = ds1.toTable(tableEnv, $"a", $"b", $"c", $"ltime".rowtime)
-val right = ds2.toTable(tableEnv, $"d", $"e", $"f", $"rtime".rowtime)
+val left = tableEnv.from("MyTable").select($"a", $"b", $"c", $"ltime")
+val right = tableEnv.from("MyTable").select($"d", $"e", $"f", $"rtime")
 
 val result = left.join(right)
   .where($"a" === $"d" && $"ltime" >= $"rtime" - 5.minutes && $"ltime" < $"rtime" + 10.minutes)
@@ -1587,7 +1586,7 @@ table = input.window([w: GroupWindow].alias("w")) \
 {{< /tab >}}
 {{< /tabs >}}
 
-The `Window` parameter defines how rows are mapped to windows. `Window` is not an interface that users can implement. Instead, the Table API provides a set of predefined `Window` classes with specific semantics, which are translated into underlying `DataStream` or `DataSet` operations. The supported window definitions are listed below.
+The `Window` parameter defines how rows are mapped to windows. `Window` is not an interface that users can implement. Instead, the Table API provides a set of predefined `Window` classes with specific semantics. The supported window definitions are listed below.
 
 #### Tumble (Tumbling Windows)
 

--- a/docs/content/docs/dev/python/python_config.md
+++ b/docs/content/docs/dev/python/python_config.md
@@ -47,7 +47,7 @@ The config options could be set as following in a Table API program:
 ```python
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build()
+env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
 t_env = TableEnvironment.create(env_settings)
 
 config = t_env.get_config().get_configuration()

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -116,7 +116,7 @@ The following example shows how a Python Table API program is constructed and ho
 from pyflink.table import *
 
 # environment configuration
-t_env = BatchTableEnvironment.create(
+t_env = TableEnvironment.create(
     environment_settings=EnvironmentSettings.new_instance().in_batch_mode().build())
 
 # register Orders table and Result table sink in table environment


### PR DESCRIPTION
## What is the purpose of the change

*This is another step in getting rid of the legacy planner. The Chinese docs are still not perfect but better than before with this PR. The Chinese docs should be done in a followup issue, I only dropped the legacy planner page there.*

## Brief change log

  - Remove reference of `useBlink/LegacyPlanner`
  - Remove `DataSet`
  - Remove legacy planner mentioning

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)