### PR TITLE
 [FLINK-22686][checkpointing] Incompatible subtask mappings while resuming from unaligned checkpoints

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptor.java
@@ -20,76 +20,41 @@ package org.apache.flink.runtime.checkpoint;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Captures ambiguous mappings of old channels to new channels.
+ * Captures ambiguous mappings of old channels to new channels for a particular gate or partition.
  *
- * <p>For inputs, this mapping implies the following:
- * <li>
- *
- *     <ul>
- *       {@link #oldSubtaskIndexes} is set when there is a rescale on this task potentially leading
- *       to different key groups. Upstream task has a corresponding {@link
- *       #rescaledChannelsMappings} where it sends data over virtual channel while specifying the
- *       channel index in the VirtualChannelSelector. This subtask then demultiplexes over the
- *       virtual subtask index.
- * </ul>
- *
- * <ul>
- *   {@link #rescaledChannelsMappings} is set when there is a downscale of the upstream task.
- *   Upstream task has a corresponding {@link #oldSubtaskIndexes} where it sends data over virtual
- *   channel while specifying the subtask index in the VirtualChannelSelector. This subtask then
- *   demultiplexes over channel indexes.
- * </ul>
- *
- * <p>For outputs, it's vice-versa. The information must be kept in sync but they are used in
- * opposite ways for multiplexing/demultiplexing.
- *
- * <p>Note that in the common rescaling case both information is set and need to be simultaneously
- * used. If the input subtask subsumes the state of 3 old subtasks and a channel corresponds to 2
- * old channels, then there are 6 virtual channels to be demultiplexed.
+ * @see InflightDataGateOrPartitionRescalingDescriptor
  */
 public class InflightDataRescalingDescriptor implements Serializable {
+
     public static final InflightDataRescalingDescriptor NO_RESCALE = new NoRescalingDescriptor();
 
     private static final long serialVersionUID = -3396674344669796295L;
 
     /** Set when several operator instances are merged into one. */
-    private final int[] oldSubtaskIndexes;
-
-    /**
-     * Set when channels are merged because the connected operator has been rescaled for each
-     * gate/partition.
-     */
-    private final RescaleMappings[] rescaledChannelsMappings;
-
-    /** All channels where upstream duplicates data (only valid for downstream mappings). */
-    private final Set<Integer> ambiguousSubtaskIndexes;
+    private final InflightDataGateOrPartitionRescalingDescriptor[] gateOrPartitionDescriptors;
 
     public InflightDataRescalingDescriptor(
-            int[] oldSubtaskIndexes,
-            RescaleMappings[] rescaledChannelsMappings,
-            Set<Integer> ambiguousSubtaskIndexes) {
-        this.oldSubtaskIndexes = checkNotNull(oldSubtaskIndexes);
-        this.rescaledChannelsMappings = checkNotNull(rescaledChannelsMappings);
-        this.ambiguousSubtaskIndexes = checkNotNull(ambiguousSubtaskIndexes);
+            InflightDataGateOrPartitionRescalingDescriptor[] gateOrPartitionDescriptors) {
+        this.gateOrPartitionDescriptors = checkNotNull(gateOrPartitionDescriptors);
     }
 
-    public int[] getOldSubtaskIndexes() {
-        return oldSubtaskIndexes;
+    public int[] getOldSubtaskIndexes(int gateOrPartitionIndex) {
+        return gateOrPartitionDescriptors[gateOrPartitionIndex].oldSubtaskIndexes;
     }
 
     public RescaleMappings getChannelMapping(int gateOrPartitionIndex) {
-        return rescaledChannelsMappings[gateOrPartitionIndex];
+        return gateOrPartitionDescriptors[gateOrPartitionIndex].rescaledChannelsMappings;
     }
 
-    public boolean isAmbiguous(int oldSubtaskIndex) {
-        return ambiguousSubtaskIndexes.contains(oldSubtaskIndex);
+    public boolean isAmbiguous(int gateOrPartitionIndex, int oldSubtaskIndex) {
+        return gateOrPartitionDescriptors[gateOrPartitionIndex].ambiguousSubtaskIndexes.contains(
+                oldSubtaskIndex);
     }
 
     @Override
@@ -101,36 +66,136 @@ public class InflightDataRescalingDescriptor implements Serializable {
             return false;
         }
         InflightDataRescalingDescriptor that = (InflightDataRescalingDescriptor) o;
-        return Arrays.equals(oldSubtaskIndexes, that.oldSubtaskIndexes)
-                && Arrays.equals(rescaledChannelsMappings, that.rescaledChannelsMappings)
-                && Objects.equals(ambiguousSubtaskIndexes, that.ambiguousSubtaskIndexes);
+        return Arrays.equals(gateOrPartitionDescriptors, that.gateOrPartitionDescriptors);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(ambiguousSubtaskIndexes);
-        result = 31 * result + Arrays.hashCode(oldSubtaskIndexes);
-        result = 31 * result + Arrays.hashCode(rescaledChannelsMappings);
-        return result;
+        return Arrays.hashCode(gateOrPartitionDescriptors);
     }
 
     @Override
     public String toString() {
         return "InflightDataRescalingDescriptor{"
-                + "oldSubtaskIndexes="
-                + Arrays.toString(oldSubtaskIndexes)
-                + ", rescaledChannelsMappings="
-                + Arrays.toString(rescaledChannelsMappings)
-                + ", ambiguousSubtaskIndexes="
-                + ambiguousSubtaskIndexes
+                + "gateOrPartitionDescriptors="
+                + Arrays.toString(gateOrPartitionDescriptors)
                 + '}';
     }
 
+    /**
+     * Captures ambiguous mappings of old channels to new channels.
+     *
+     * <p>For inputs, this mapping implies the following:
+     * <li>
+     *
+     *     <ul>
+     *       {@link #oldSubtaskIndexes} is set when there is a rescale on this task potentially
+     *       leading to different key groups. Upstream task has a corresponding {@link
+     *       #rescaledChannelsMappings} where it sends data over virtual channel while specifying
+     *       the channel index in the VirtualChannelSelector. This subtask then demultiplexes over
+     *       the virtual subtask index.
+     * </ul>
+     *
+     * <ul>
+     *   {@link #rescaledChannelsMappings} is set when there is a downscale of the upstream task.
+     *   Upstream task has a corresponding {@link #oldSubtaskIndexes} where it sends data over
+     *   virtual channel while specifying the subtask index in the VirtualChannelSelector. This
+     *   subtask then demultiplexes over channel indexes.
+     * </ul>
+     *
+     * <p>For outputs, it's vice-versa. The information must be kept in sync but they are used in
+     * opposite ways for multiplexing/demultiplexing.
+     *
+     * <p>Note that in the common rescaling case both information is set and need to be
+     * simultaneously used. If the input subtask subsumes the state of 3 old subtasks and a channel
+     * corresponds to 2 old channels, then there are 6 virtual channels to be demultiplexed.
+     */
+    public static class InflightDataGateOrPartitionRescalingDescriptor implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        /** Set when several operator instances are merged into one. */
+        private final int[] oldSubtaskIndexes;
+
+        /**
+         * Set when channels are merged because the connected operator has been rescaled for each
+         * gate/partition.
+         */
+        private final RescaleMappings rescaledChannelsMappings;
+
+        /** All channels where upstream duplicates data (only valid for downstream mappings). */
+        private final Set<Integer> ambiguousSubtaskIndexes;
+
+        private final Rescaling rescaling;
+
+        enum Rescaling {
+            IDENTITY,
+            RESCALING
+        }
+
+        public InflightDataGateOrPartitionRescalingDescriptor(
+                int[] oldSubtaskIndexes,
+                RescaleMappings rescaledChannelsMappings,
+                Set<Integer> ambiguousSubtaskIndexes,
+                Rescaling rescaling) {
+            this.oldSubtaskIndexes = oldSubtaskIndexes;
+            this.rescaledChannelsMappings = rescaledChannelsMappings;
+            this.ambiguousSubtaskIndexes = ambiguousSubtaskIndexes;
+            this.rescaling = rescaling;
+        }
+
+        public boolean isIdentity() {
+            return rescaling == Rescaling.IDENTITY;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            InflightDataGateOrPartitionRescalingDescriptor that =
+                    (InflightDataGateOrPartitionRescalingDescriptor) o;
+            return Arrays.equals(oldSubtaskIndexes, that.oldSubtaskIndexes)
+                    && Objects.equals(rescaledChannelsMappings, that.rescaledChannelsMappings)
+                    && Objects.equals(ambiguousSubtaskIndexes, that.ambiguousSubtaskIndexes)
+                    && rescaling == that.rescaling;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(rescaledChannelsMappings, ambiguousSubtaskIndexes, rescaling);
+            result = 31 * result + Arrays.hashCode(oldSubtaskIndexes);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "InflightDataGateOrPartitionRescalingDescriptor{"
+                    + "oldSubtaskIndexes="
+                    + Arrays.toString(oldSubtaskIndexes)
+                    + ", rescaledChannelsMappings="
+                    + rescaledChannelsMappings
+                    + ", ambiguousSubtaskIndexes="
+                    + ambiguousSubtaskIndexes
+                    + ", rescaling="
+                    + rescaling
+                    + '}';
+        }
+    }
+
     private static class NoRescalingDescriptor extends InflightDataRescalingDescriptor {
-        private static final long serialVersionUID = -5544173933105855751L;
+        private static final long serialVersionUID = 1L;
 
         public NoRescalingDescriptor() {
-            super(new int[0], new RescaleMappings[0], Collections.emptySet());
+            super(new InflightDataGateOrPartitionRescalingDescriptor[0]);
+        }
+
+        @Override
+        public int[] getOldSubtaskIndexes(int gateOrPartitionIndex) {
+            return new int[0];
         }
 
         @Override
@@ -138,13 +203,13 @@ public class InflightDataRescalingDescriptor implements Serializable {
             return RescaleMappings.SYMMETRIC_IDENTITY;
         }
 
-        private Object readResolve() throws ObjectStreamException {
-            return NO_RESCALE;
+        @Override
+        public boolean isAmbiguous(int gateOrPartitionIndex, int oldSubtaskIndex) {
+            return false;
         }
 
-        @Override
-        public String toString() {
-            return "NoRescalingDescriptor";
+        private Object readResolve() throws ObjectStreamException {
+            return NO_RESCALE;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -361,7 +361,8 @@ public class StateAssignmentOperation {
                                     ResultSubpartitionInfo::getPartitionIdx,
                                     partitionIndex);
             final MappingBasedRepartitioner<ResultSubpartitionStateHandle> repartitioner =
-                    new MappingBasedRepartitioner<>(assignment.getOutputMapping(partitionIndex));
+                    new MappingBasedRepartitioner<>(
+                            assignment.getOutputMapping(partitionIndex).getRescaleMappings());
             final Map<OperatorInstanceID, List<ResultSubpartitionStateHandle>> repartitioned =
                     applyRepartitioner(
                             assignment.outputOperatorID,
@@ -406,7 +407,8 @@ public class StateAssignmentOperation {
         // subtask 0 recovers data from old subtask 0 + 1 and subtask 1 recovers data from old
         // subtask 0 + 2
         for (int gateIndex = 0; gateIndex < inputs.size(); gateIndex++) {
-            final RescaleMappings mapping = stateAssignment.getInputMapping(gateIndex);
+            final RescaleMappings mapping =
+                    stateAssignment.getInputMapping(gateIndex).getRescaleMappings();
 
             final List<List<InputChannelStateHandle>> gateState =
                     inputs.size() == 1

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
@@ -174,13 +174,7 @@ class TaskStateAssignment {
                                     int assignmentIndex =
                                             getAssignmentIndex(
                                                     assignment.getDownstreamAssignments(), this);
-                                    SubtasksRescaleMapping mapping =
-                                            assignment.outputSubtaskMappings.get(assignmentIndex);
-                                    if (recompute && mapping == null) {
-                                        return assignment.getOutputMapping(assignmentIndex);
-                                    } else {
-                                        return mapping;
-                                    }
+                                    return assignment.getOutputMapping(assignmentIndex, recompute);
                                 },
                                 inputSubtaskMappings,
                                 this::getInputMapping))
@@ -193,13 +187,7 @@ class TaskStateAssignment {
                                     int assignmentIndex =
                                             getAssignmentIndex(
                                                     assignment.getUpstreamAssignments(), this);
-                                    SubtasksRescaleMapping mapping =
-                                            assignment.inputSubtaskMappings.get(assignmentIndex);
-                                    if (recompute && mapping == null) {
-                                        return assignment.getInputMapping(assignmentIndex);
-                                    } else {
-                                        return mapping;
-                                    }
+                                    return assignment.getInputMapping(assignmentIndex, recompute);
                                 },
                                 outputSubtaskMappings,
                                 this::getOutputMapping))
@@ -336,6 +324,24 @@ class TaskStateAssignment {
             Map<OperatorInstanceID, List<T>> subManagedOperatorState) {
         List<T> value = subManagedOperatorState.get(instanceID);
         return value != null ? new StateObjectCollection<>(value) : StateObjectCollection.empty();
+    }
+
+    private SubtasksRescaleMapping getOutputMapping(int assignmentIndex, boolean recompute) {
+        SubtasksRescaleMapping mapping = outputSubtaskMappings.get(assignmentIndex);
+        if (recompute && mapping == null) {
+            return getOutputMapping(assignmentIndex);
+        } else {
+            return mapping;
+        }
+    }
+
+    private SubtasksRescaleMapping getInputMapping(int assignmentIndex, boolean recompute) {
+        SubtasksRescaleMapping mapping = inputSubtaskMappings.get(assignmentIndex);
+        if (recompute && mapping == null) {
+            return getInputMapping(assignmentIndex);
+        } else {
+            return mapping;
+        }
     }
 
     public SubtasksRescaleMapping getOutputMapping(int partitionIndex) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateAssignment.java
@@ -18,6 +18,8 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor.Rescaling;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper;
@@ -33,6 +35,7 @@ import org.apache.flink.runtime.state.StateObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
@@ -40,10 +43,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.function.BooleanSupplier;
 import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static java.util.Collections.emptySet;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -73,14 +76,9 @@ class TaskStateAssignment {
     final Map<OperatorInstanceID, List<InputChannelStateHandle>> inputChannelStates;
     final Map<OperatorInstanceID, List<ResultSubpartitionStateHandle>> resultSubpartitionStates;
     /** The subtask mapping when the output operator was rescaled. */
-    @Nullable private RescaleMappings outputSubtaskMappings;
+    private final Map<Integer, SubtasksRescaleMapping> outputSubtaskMappings = new HashMap<>();
     /** The subtask mapping when the input operator was rescaled. */
-    @Nullable private RescaleMappings inputSubtaskMappings;
-    /**
-     * If channel data cannot be safely divided into subtasks (several new subtask indexes are
-     * associated with the same old subtask index). Mostly used for range partitioners.
-     */
-    boolean mayHaveAmbiguousSubtasks;
+    private final Map<Integer, SubtasksRescaleMapping> inputSubtaskMappings = new HashMap<>();
 
     @Nullable private TaskStateAssignment[] downstreamAssignments;
     @Nullable private TaskStateAssignment[] upstreamAssignments;
@@ -134,6 +132,11 @@ class TaskStateAssignment {
         return downstreamAssignments;
     }
 
+    private static int getAssignmentIndex(
+            TaskStateAssignment[] assignments, TaskStateAssignment assignment) {
+        return Arrays.asList(assignments).indexOf(assignment);
+    }
+
     public TaskStateAssignment[] getUpstreamAssignments() {
         if (upstreamAssignments == null) {
             upstreamAssignments =
@@ -166,30 +169,45 @@ class TaskStateAssignment {
                                 instanceID,
                                 inputOperatorID,
                                 getUpstreamAssignments(),
-                                assignment -> assignment.outputSubtaskMappings,
+                                assignment ->
+                                        assignment.outputSubtaskMappings.get(
+                                                getAssignmentIndex(
+                                                        assignment.getDownstreamAssignments(),
+                                                        this)),
                                 assignment ->
                                         assignment.getOutputMapping(
-                                                Arrays.asList(assignment.getDownstreamAssignments())
-                                                        .indexOf(this)),
+                                                getAssignmentIndex(
+                                                        assignment.getDownstreamAssignments(),
+                                                        this)),
                                 inputSubtaskMappings,
-                                () -> getInputMapping(0),
-                                inputState,
-                                () -> mayHaveAmbiguousSubtasks))
+                                this::getInputMapping))
                 .setOutputRescalingDescriptor(
                         createRescalingDescriptor(
                                 instanceID,
                                 outputOperatorID,
                                 getDownstreamAssignments(),
-                                assignment -> assignment.inputSubtaskMappings,
+                                assignment ->
+                                        assignment.inputSubtaskMappings.get(
+                                                getAssignmentIndex(
+                                                        assignment.getUpstreamAssignments(), this)),
                                 assignment ->
                                         assignment.getInputMapping(
-                                                Arrays.asList(assignment.getUpstreamAssignments())
-                                                        .indexOf(this)),
+                                                getAssignmentIndex(
+                                                        assignment.getUpstreamAssignments(), this)),
                                 outputSubtaskMappings,
-                                () -> getOutputMapping(0),
-                                outputState,
-                                () -> false))
+                                this::getOutputMapping))
                 .build();
+    }
+
+    private InflightDataGateOrPartitionRescalingDescriptor log(
+            InflightDataGateOrPartitionRescalingDescriptor descriptor, int subtask, int partition) {
+        LOG.debug(
+                "created {} for task={} subtask={} partition={}",
+                descriptor,
+                executionJobVertex.getName(),
+                subtask,
+                partition);
+        return descriptor;
     }
 
     private InflightDataRescalingDescriptor log(
@@ -206,60 +224,105 @@ class TaskStateAssignment {
             OperatorInstanceID instanceID,
             OperatorID expectedOperatorID,
             TaskStateAssignment[] connectedAssignments,
-            Function<TaskStateAssignment, RescaleMappings> mappingRetriever,
-            Function<TaskStateAssignment, RescaleMappings> mappingCalculator,
-            @Nullable RescaleMappings subtaskMappings,
-            Supplier<RescaleMappings> subtaskMappingCalculator,
-            StateObjectCollection<?> state,
-            BooleanSupplier mayHaveAmbiguousSubtasks) {
+            Function<TaskStateAssignment, SubtasksRescaleMapping> mappingRetriever,
+            Function<TaskStateAssignment, SubtasksRescaleMapping> mappingCalculator,
+            Map<Integer, SubtasksRescaleMapping> subtaskGateOrPartitionMappings,
+            Function<Integer, SubtasksRescaleMapping> subtaskMappingCalculator) {
         if (!expectedOperatorID.equals(instanceID.getOperatorId())) {
             return InflightDataRescalingDescriptor.NO_RESCALE;
         }
 
-        RescaleMappings[] rescaledChannelsMappings =
+        SubtasksRescaleMapping[] rescaledChannelsMappings =
                 Arrays.stream(connectedAssignments)
                         .map(mappingRetriever)
-                        .toArray(RescaleMappings[]::new);
+                        .toArray(SubtasksRescaleMapping[]::new);
 
         // no state on input and output, especially for any aligned checkpoint
-        if (subtaskMappings == null
+        if (subtaskGateOrPartitionMappings.isEmpty()
                 && Arrays.stream(rescaledChannelsMappings).allMatch(Objects::isNull)) {
             return InflightDataRescalingDescriptor.NO_RESCALE;
         }
 
-        // no state for this assignment, but state on connected assignment
-        if (subtaskMappings == null) {
-            // calculate subtask mapping now
-            subtaskMappings = subtaskMappingCalculator.get();
-        }
-        int[] oldSubtaskInstances = subtaskMappings.getMappedIndexes(instanceID.getSubtaskId());
-        // No old task is mapped, so no data at all.
-        if (oldSubtaskInstances.length == 0) {
-            checkState(state.isEmpty(), "Unmapped new subtask should not have any state assigned");
-            return log(InflightDataRescalingDescriptor.NO_RESCALE, instanceID.getSubtaskId());
-        }
+        InflightDataGateOrPartitionRescalingDescriptor[] gateOrPartitionDescriptors =
+                createGateOrPartitionRescalingDescriptors(
+                        instanceID,
+                        connectedAssignments,
+                        mappingCalculator,
+                        subtaskGateOrPartitionMappings,
+                        subtaskMappingCalculator,
+                        rescaledChannelsMappings);
 
-        for (int partition = 0; partition < rescaledChannelsMappings.length; partition++) {
-            if (rescaledChannelsMappings[partition] == null) {
-                rescaledChannelsMappings[partition] =
-                        mappingCalculator.apply(connectedAssignments[partition]);
-            }
-        }
-
-        // no scaling or simple scale-up without the need of virtual channels.
-        if (subtaskMappings.isIdentity()
-                && Arrays.stream(rescaledChannelsMappings).allMatch(RescaleMappings::isIdentity)) {
+        if (Arrays.stream(gateOrPartitionDescriptors)
+                .allMatch(InflightDataGateOrPartitionRescalingDescriptor::isIdentity)) {
             return log(InflightDataRescalingDescriptor.NO_RESCALE, instanceID.getSubtaskId());
+        } else {
+            return log(
+                    new InflightDataRescalingDescriptor(gateOrPartitionDescriptors),
+                    instanceID.getSubtaskId());
         }
+    }
+
+    private InflightDataGateOrPartitionRescalingDescriptor[]
+            createGateOrPartitionRescalingDescriptors(
+                    OperatorInstanceID instanceID,
+                    TaskStateAssignment[] connectedAssignments,
+                    Function<TaskStateAssignment, SubtasksRescaleMapping> mappingCalculator,
+                    Map<Integer, SubtasksRescaleMapping> subtaskGateOrPartitionMappings,
+                    Function<Integer, SubtasksRescaleMapping> subtaskMappingCalculator,
+                    SubtasksRescaleMapping[] rescaledChannelsMappings) {
+        return IntStream.range(0, rescaledChannelsMappings.length)
+                .mapToObj(
+                        partition -> {
+                            TaskStateAssignment connectedAssignment =
+                                    connectedAssignments[partition];
+                            SubtasksRescaleMapping rescaleMapping =
+                                    Optional.ofNullable(rescaledChannelsMappings[partition])
+                                            .orElseGet(
+                                                    () ->
+                                                            mappingCalculator.apply(
+                                                                    connectedAssignment));
+                            SubtasksRescaleMapping subtaskMapping =
+                                    Optional.ofNullable(
+                                                    subtaskGateOrPartitionMappings.get(partition))
+                                            .orElseGet(
+                                                    () ->
+                                                            subtaskMappingCalculator.apply(
+                                                                    partition));
+                            return getInflightDataGateOrPartitionRescalingDescriptor(
+                                    instanceID, partition, rescaleMapping, subtaskMapping);
+                        })
+                .toArray(InflightDataGateOrPartitionRescalingDescriptor[]::new);
+    }
+
+    private InflightDataGateOrPartitionRescalingDescriptor
+            getInflightDataGateOrPartitionRescalingDescriptor(
+                    OperatorInstanceID instanceID,
+                    int partition,
+                    SubtasksRescaleMapping rescaleMapping,
+                    SubtasksRescaleMapping subtaskMapping) {
+
+        int[] oldSubtaskInstances =
+                subtaskMapping.rescaleMappings.getMappedIndexes(instanceID.getSubtaskId());
+
+        // no scaling or simple scale-up without the need of virtual
+        // channels.
+        boolean isIdentity =
+                (subtaskMapping.rescaleMappings.isIdentity()
+                                && rescaleMapping.getRescaleMappings().isIdentity())
+                        || oldSubtaskInstances.length == 0;
 
         final Set<Integer> ambiguousSubtasks =
-                mayHaveAmbiguousSubtasks.getAsBoolean()
-                        ? subtaskMappings.getAmbiguousTargets()
+                subtaskMapping.mayHaveAmbiguousSubtasks
+                        ? subtaskMapping.rescaleMappings.getAmbiguousTargets()
                         : emptySet();
         return log(
-                new InflightDataRescalingDescriptor(
-                        oldSubtaskInstances, rescaledChannelsMappings, ambiguousSubtasks),
-                instanceID.getSubtaskId());
+                new InflightDataGateOrPartitionRescalingDescriptor(
+                        oldSubtaskInstances,
+                        rescaleMapping.getRescaleMappings(),
+                        ambiguousSubtasks,
+                        isIdentity ? Rescaling.IDENTITY : Rescaling.RESCALING),
+                instanceID.getSubtaskId(),
+                partition);
     }
 
     private <T extends StateObject> StateObjectCollection<T> getState(
@@ -269,7 +332,7 @@ class TaskStateAssignment {
         return value != null ? new StateObjectCollection<>(value) : StateObjectCollection.empty();
     }
 
-    public RescaleMappings getOutputMapping(int partitionIndex) {
+    public SubtasksRescaleMapping getOutputMapping(int partitionIndex) {
         final TaskStateAssignment downstreamAssignment = getDownstreamAssignments()[partitionIndex];
         final IntermediateResult output = executionJobVertex.getProducedDataSets()[partitionIndex];
         final int gateIndex = downstreamAssignment.executionJobVertex.getInputs().indexOf(output);
@@ -286,11 +349,13 @@ class TaskStateAssignment {
         final RescaleMappings mapping =
                 mapper.getNewToOldSubtasksMapping(
                         oldState.get(outputOperatorID).getParallelism(), newParallelism);
-        outputSubtaskMappings = checkSubtaskMapping(outputSubtaskMappings, mapping);
-        return outputSubtaskMappings;
+        return outputSubtaskMappings.compute(
+                partitionIndex,
+                (idx, oldMapping) ->
+                        checkSubtaskMapping(oldMapping, mapping, mapper.isAmbiguous()));
     }
 
-    public RescaleMappings getInputMapping(int gateIndex) {
+    public SubtasksRescaleMapping getInputMapping(int gateIndex) {
         final SubtaskStateMapper mapper =
                 checkNotNull(
                         executionJobVertex
@@ -303,9 +368,10 @@ class TaskStateAssignment {
                 mapper.getNewToOldSubtasksMapping(
                         oldState.get(inputOperatorID).getParallelism(), newParallelism);
 
-        inputSubtaskMappings = checkSubtaskMapping(inputSubtaskMappings, mapping);
-        mayHaveAmbiguousSubtasks |= mapper.isAmbiguous();
-        return inputSubtaskMappings;
+        return inputSubtaskMappings.compute(
+                gateIndex,
+                (idx, oldMapping) ->
+                        checkSubtaskMapping(oldMapping, mapping, mapper.isAmbiguous()));
     }
 
     @Override
@@ -313,12 +379,14 @@ class TaskStateAssignment {
         return "TaskStateAssignment for " + executionJobVertex.getName();
     }
 
-    private static RescaleMappings checkSubtaskMapping(
-            @Nullable RescaleMappings oldMapping, RescaleMappings mapping) {
+    private static @Nonnull SubtasksRescaleMapping checkSubtaskMapping(
+            @Nullable SubtasksRescaleMapping oldMapping,
+            RescaleMappings mapping,
+            boolean mayHaveAmbiguousSubtasks) {
         if (oldMapping == null) {
-            return mapping;
+            return new SubtasksRescaleMapping(mapping, mayHaveAmbiguousSubtasks);
         }
-        if (!oldMapping.equals(mapping)) {
+        if (!oldMapping.rescaleMappings.equals(mapping)) {
             throw new IllegalStateException(
                     "Incompatible subtask mappings: are multiple operators "
                             + "ingesting/producing intermediate results with varying degrees of parallelism?"
@@ -328,6 +396,30 @@ class TaskStateAssignment {
                             + mapping
                             + ".");
         }
-        return oldMapping;
+        return new SubtasksRescaleMapping(
+                mapping, oldMapping.mayHaveAmbiguousSubtasks || mayHaveAmbiguousSubtasks);
+    }
+
+    static class SubtasksRescaleMapping {
+        private final RescaleMappings rescaleMappings;
+        /**
+         * If channel data cannot be safely divided into subtasks (several new subtask indexes are
+         * associated with the same old subtask index). Mostly used for range partitioners.
+         */
+        private final boolean mayHaveAmbiguousSubtasks;
+
+        private SubtasksRescaleMapping(
+                RescaleMappings rescaleMappings, boolean mayHaveAmbiguousSubtasks) {
+            this.rescaleMappings = rescaleMappings;
+            this.mayHaveAmbiguousSubtasks = mayHaveAmbiguousSubtasks;
+        }
+
+        public RescaleMappings getRescaleMappings() {
+            return rescaleMappings;
+        }
+
+        public boolean isMayHaveAmbiguousSubtasks() {
+            return mayHaveAmbiguousSubtasks;
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
@@ -54,18 +54,6 @@ public enum SubtaskStateMapper {
         }
     },
 
-    /**
-     * Discards extra state. Useful if all subtasks already contain the same information
-     * (broadcast).
-     */
-    DISCARD_EXTRA_STATE {
-        @Override
-        public int[] getOldSubtasks(
-                int newSubtaskIndex, int oldNumberOfSubtasks, int newNumberOfSubtasks) {
-            return newSubtaskIndex >= oldNumberOfSubtasks ? EMPTY : new int[] {newSubtaskIndex};
-        }
-    },
-
     /** Restores extra subtasks to the first subtask. */
     FIRST {
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptorUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/InflightDataRescalingDescriptorUtil.java
@@ -17,6 +17,9 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor.Rescaling;
+
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
 import java.util.Arrays;
@@ -44,5 +47,19 @@ public class InflightDataRescalingDescriptorUtil {
 
     public static <T> Set<T> set(T... elements) {
         return Sets.newHashSet(elements);
+    }
+
+    public static InflightDataRescalingDescriptor rescalingDescriptor(
+            int[] oldIndices, RescaleMappings[] mappings, Set<Integer> ambiguousSubtasks) {
+        return new InflightDataRescalingDescriptor(
+                Arrays.stream(mappings)
+                        .map(
+                                mapping ->
+                                        new InflightDataGateOrPartitionRescalingDescriptor(
+                                                oldIndices,
+                                                mapping,
+                                                ambiguousSubtasks,
+                                                Rescaling.RESCALING))
+                        .toArray(InflightDataGateOrPartitionRescalingDescriptor[]::new));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskStateTest.java
@@ -86,12 +86,12 @@ public class OperatorSubtaskStateTest {
                                 StateObjectCollection.singleton(
                                         createNewResultSubpartitionStateHandle(3, random)))
                         .setInputRescalingDescriptor(
-                                new InflightDataRescalingDescriptor(
+                                InflightDataRescalingDescriptorUtil.rescalingDescriptor(
                                         new int[1],
                                         new RescaleMappings[0],
                                         Collections.singleton(1)))
                         .setOutputRescalingDescriptor(
-                                new InflightDataRescalingDescriptor(
+                                InflightDataRescalingDescriptorUtil.rescalingDescriptor(
                                         new int[1],
                                         new RescaleMappings[0],
                                         Collections.singleton(2)))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
@@ -53,20 +54,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.InflightDataGateOrPartitionRescalingDescriptor.Rescaling.RESCALING;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.array;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.mappings;
+import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.rescalingDescriptor;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.set;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.to;
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewKeyedStateHandle;
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewOperatorStateHandle;
 import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper.ARBITRARY;
 import static org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper.RANGE;
 import static org.apache.flink.runtime.io.network.api.writer.SubtaskStateMapper.ROUND_ROBIN;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -435,6 +442,52 @@ public class StateAssignmentOperationTest extends TestLogger {
     }
 
     @Test
+    public void testChannelStateAssignmentDownscalingTwoDifferentGates()
+            throws JobException, JobExecutionException {
+        JobVertex upstream1 = createJobVertex(new OperatorID(), 2);
+        JobVertex upstream2 = createJobVertex(new OperatorID(), 2);
+        JobVertex downstream = createJobVertex(new OperatorID(), 2);
+        List<OperatorID> operatorIds =
+                Stream.of(upstream1, upstream2, downstream)
+                        .map(v -> v.getOperatorIDs().get(0).getGeneratedOperatorID())
+                        .collect(Collectors.toList());
+        Map<OperatorID, OperatorState> states = buildOperatorStates(operatorIds, 3);
+
+        connectVertices(upstream1, downstream, ARBITRARY, RANGE);
+        connectVertices(upstream2, downstream, ROUND_ROBIN, ROUND_ROBIN);
+
+        Map<OperatorID, ExecutionJobVertex> vertices =
+                toExecutionVertices(upstream1, upstream2, downstream);
+
+        new StateAssignmentOperation(0, new HashSet<>(vertices.values()), states, false)
+                .assignStates();
+
+        assertEquals(
+                new InflightDataRescalingDescriptor(
+                        array(
+                                gate(to(0, 1), mappings(to(0, 2), to(1)), set(1), RESCALING),
+                                gate(to(0, 2), mappings(to(0, 2), to(1)), emptySet(), RESCALING))),
+                getAssignedState(vertices.get(operatorIds.get(2)), operatorIds.get(2), 0)
+                        .getInputRescalingDescriptor());
+        assertEquals(
+                new InflightDataRescalingDescriptor(
+                        array(
+                                gate(to(0, 1), mappings(to(0, 2), to(1)), set(1), RESCALING),
+                                gate(to(0, 2), mappings(to(0, 2), to(1)), emptySet(), RESCALING))),
+                getAssignedState(vertices.get(operatorIds.get(2)), operatorIds.get(2), 0)
+                        .getInputRescalingDescriptor());
+    }
+
+    private InflightDataGateOrPartitionRescalingDescriptor gate(
+            int[] oldIndices,
+            RescaleMappings rescaleMapping,
+            Set<Integer> ambiguousSubtaskIndexes,
+            InflightDataGateOrPartitionRescalingDescriptor.Rescaling rescalingMode) {
+        return new InflightDataGateOrPartitionRescalingDescriptor(
+                oldIndices, rescaleMapping, ambiguousSubtaskIndexes, rescalingMode);
+    }
+
+    @Test
     public void testChannelStateAssignmentDownscaling() throws JobException, JobExecutionException {
         List<OperatorID> operatorIds = buildOperatorIds(2);
         Map<OperatorID, OperatorState> states = buildOperatorStates(operatorIds, 3);
@@ -482,24 +535,20 @@ public class StateAssignmentOperationTest extends TestLogger {
         }
 
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(0, 2), array(mappings(to(0, 1), to(1, 2))), set()),
+                rescalingDescriptor(to(0, 2), array(mappings(to(0, 1), to(1, 2))), set()),
                 getAssignedState(vertices.get(operatorIds.get(0)), operatorIds.get(0), 0)
                         .getOutputRescalingDescriptor());
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(1), array(mappings(to(0, 1), to(1, 2))), set()),
+                rescalingDescriptor(to(1), array(mappings(to(0, 1), to(1, 2))), set()),
                 getAssignedState(vertices.get(operatorIds.get(0)), operatorIds.get(0), 1)
                         .getOutputRescalingDescriptor());
 
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(0, 1), array(mappings(to(0, 2), to(1))), set(1)),
+                rescalingDescriptor(to(0, 1), array(mappings(to(0, 2), to(1))), set(1)),
                 getAssignedState(vertices.get(operatorIds.get(1)), operatorIds.get(1), 0)
                         .getInputRescalingDescriptor());
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(1, 2), array(mappings(to(0, 2), to(1))), set(1)),
+                rescalingDescriptor(to(1, 2), array(mappings(to(0, 2), to(1))), set(1)),
                 getAssignedState(vertices.get(operatorIds.get(1)), operatorIds.get(1), 1)
                         .getInputRescalingDescriptor());
     }
@@ -606,13 +655,11 @@ public class StateAssignmentOperationTest extends TestLogger {
         }
 
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(0), array(mappings(to(0), to(0, 1), to(1))), set()),
+                rescalingDescriptor(to(0), array(mappings(to(0), to(0, 1), to(1))), set()),
                 getAssignedState(vertices.get(operatorIds.get(0)), operatorIds.get(0), 0)
                         .getOutputRescalingDescriptor());
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(1), array(mappings(to(0), to(0, 1), to(1))), set()),
+                rescalingDescriptor(to(1), array(mappings(to(0), to(0, 1), to(1))), set()),
                 getAssignedState(vertices.get(operatorIds.get(0)), operatorIds.get(0), 1)
                         .getOutputRescalingDescriptor());
         // unmapped subtask index, so nothing to do
@@ -622,18 +669,15 @@ public class StateAssignmentOperationTest extends TestLogger {
                         .getOutputRescalingDescriptor());
 
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(0), array(mappings(to(0), to(1), to())), set(0, 1)),
+                rescalingDescriptor(to(0), array(mappings(to(0), to(1), to())), set(0, 1)),
                 getAssignedState(vertices.get(operatorIds.get(1)), operatorIds.get(1), 0)
                         .getInputRescalingDescriptor());
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(0, 1), array(mappings(to(0), to(1), to())), set(0, 1)),
+                rescalingDescriptor(to(0, 1), array(mappings(to(0), to(1), to())), set(0, 1)),
                 getAssignedState(vertices.get(operatorIds.get(1)), operatorIds.get(1), 1)
                         .getInputRescalingDescriptor());
         assertEquals(
-                new InflightDataRescalingDescriptor(
-                        to(1), array(mappings(to(0), to(1), to())), set(0, 1)),
+                rescalingDescriptor(to(1), array(mappings(to(0), to(1), to())), set(0, 1)),
                 getAssignedState(vertices.get(operatorIds.get(1)), operatorIds.get(1), 2)
                         .getInputRescalingDescriptor());
     }
@@ -766,23 +810,21 @@ public class StateAssignmentOperationTest extends TestLogger {
             throws JobException, JobExecutionException {
         final JobVertex[] jobVertices =
                 operatorIds.stream()
-                        .map(
-                                id -> {
-                                    final JobVertex jobVertex =
-                                            createJobVertex(id, id, parallelism);
-                                    return jobVertex;
-                                })
+                        .map(id -> createJobVertex(id, id, parallelism))
                         .toArray(JobVertex[]::new);
         for (int index = 1; index < jobVertices.length; index++) {
-            final JobEdge jobEdge =
-                    jobVertices[index].connectNewDataSetAsInput(
-                            jobVertices[index - 1],
-                            DistributionPattern.ALL_TO_ALL,
-                            ResultPartitionType.PIPELINED);
-            jobEdge.setDownstreamSubtaskStateMapper(downstreamRescaler);
-            jobEdge.setUpstreamSubtaskStateMapper(upstreamRescaler);
+            connectVertices(
+                    jobVertices[index - 1],
+                    jobVertices[index],
+                    upstreamRescaler,
+                    downstreamRescaler);
         }
 
+        return toExecutionVertices(jobVertices);
+    }
+
+    private Map<OperatorID, ExecutionJobVertex> toExecutionVertices(JobVertex... jobVertices)
+            throws JobException, JobExecutionException {
         JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(jobVertices);
         ExecutionGraph eg =
                 TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
@@ -800,6 +842,18 @@ public class StateAssignmentOperationTest extends TestLogger {
                                 }));
     }
 
+    private void connectVertices(
+            JobVertex upstream,
+            JobVertex downstream,
+            SubtaskStateMapper upstreamRescaler,
+            SubtaskStateMapper downstreamRescaler) {
+        final JobEdge jobEdge =
+                downstream.connectNewDataSetAsInput(
+                        upstream, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+        jobEdge.setDownstreamSubtaskStateMapper(downstreamRescaler);
+        jobEdge.setUpstreamSubtaskStateMapper(upstreamRescaler);
+    }
+
     private ExecutionJobVertex buildExecutionJobVertex(
             OperatorID operatorID, OperatorID userDefinedOperatorId, int parallelism) {
         try {
@@ -808,6 +862,10 @@ public class StateAssignmentOperationTest extends TestLogger {
         } catch (Exception e) {
             throw new AssertionError("Cannot create ExecutionJobVertex", e);
         }
+    }
+
+    private JobVertex createJobVertex(OperatorID operatorID, int parallelism) {
+        return createJobVertex(operatorID, operatorID, parallelism);
     }
 
     private JobVertex createJobVertex(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapperTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapperTest.java
@@ -17,13 +17,9 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
-import org.apache.flink.runtime.checkpoint.RescaleMappings;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
-
-import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.mappings;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.to;
@@ -32,28 +28,6 @@ import static org.junit.Assert.assertEquals;
 /** Tests to(@link SubtaskStateMapper). */
 public class SubtaskStateMapperTest {
     @Rule public ErrorCollector collector = new ErrorCollector();
-
-    @Test
-    public void testDiscardTaskMappingOnScaleDown() {
-        assertEquals(
-                RescaleMappings.of(Stream.of(to(0), to(1)), 3),
-                SubtaskStateMapper.DISCARD_EXTRA_STATE.getNewToOldSubtasksMapping(3, 2));
-    }
-
-    @Test
-    public void testDiscardTaskMappingOnNoScale() {
-        // this may be a bit surprising, but the optimization should be done on call-site
-        assertEquals(
-                mappings(to(0), to(1), to(2)),
-                SubtaskStateMapper.DISCARD_EXTRA_STATE.getNewToOldSubtasksMapping(3, 3));
-    }
-
-    @Test
-    public void testDiscardTaskMappingOnScaleUp() {
-        assertEquals(
-                mappings(to(0), to(1), to(2), to()),
-                SubtaskStateMapper.DISCARD_EXTRA_STATE.getNewToOldSubtasksMapping(3, 4));
-    }
 
     @Test
     public void testFirstTaskMappingOnScaleDown() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializer.java
@@ -197,7 +197,8 @@ class DemultiplexingRecordDeserializer<T>
             Function<Integer, RecordDeserializer<DeserializationDelegate<StreamElement>>>
                     deserializerFactory,
             Function<InputChannelInfo, Predicate<StreamRecord<T>>> recordFilterFactory) {
-        int[] oldSubtaskIndexes = rescalingDescriptor.getOldSubtaskIndexes();
+        int[] oldSubtaskIndexes =
+                rescalingDescriptor.getOldSubtaskIndexes(channelInfo.getGateIdx());
         if (oldSubtaskIndexes.length == 0) {
             return UNMAPPED;
         }
@@ -219,7 +220,7 @@ class DemultiplexingRecordDeserializer<T>
                         descriptor,
                         new VirtualChannel<>(
                                 deserializerFactory.apply(totalChannels),
-                                rescalingDescriptor.isAmbiguous(subtask)
+                                rescalingDescriptor.isAmbiguous(channelInfo.getGateIdx(), subtask)
                                         ? recordFilterFactory.apply(channelInfo)
                                         : RecordFilter.all()));
             }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
@@ -43,12 +43,12 @@ public class BroadcastPartitioner<T> extends StreamPartitioner<T> {
 
     @Override
     public SubtaskStateMapper getUpstreamSubtaskStateMapper() {
-        return SubtaskStateMapper.DISCARD_EXTRA_STATE;
+        return SubtaskStateMapper.UNSUPPORTED;
     }
 
     @Override
     public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
-        return SubtaskStateMapper.ROUND_ROBIN;
+        return SubtaskStateMapper.UNSUPPORTED;
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -81,11 +81,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -406,7 +407,9 @@ public class StreamGraphGeneratorTest extends TestLogger {
 
     private static StreamEdge edge(
             StreamGraph streamGraph, DataStream<Long> op1, DataStream<Long> op2) {
-        return streamGraph.getStreamEdges(op1.getId(), op2.getId()).get(0);
+        List<StreamEdge> streamEdges = streamGraph.getStreamEdges(op1.getId(), op2.getId());
+        assertThat(streamEdges, iterableWithSize(1));
+        return streamEdges.get(0);
     }
 
     private static Matcher<StreamEdge> supportsUnalignedCheckpoints(boolean enabled) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -68,6 +69,7 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
@@ -82,7 +84,6 @@ import java.util.Map;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -352,25 +353,72 @@ public class StreamGraphGeneratorTest extends TestLogger {
         assertEquals(7, streamGraph.getStreamNodes().size());
 
         // forward
-        assertFalse(supportsUnalignedCheckpoints(streamGraph, source1, map1));
+        assertThat(edge(streamGraph, source1, map1), supportsUnalignedCheckpoints(false));
         // shuffle
-        assertTrue(supportsUnalignedCheckpoints(streamGraph, source2, map2));
+        assertThat(edge(streamGraph, source2, map2), supportsUnalignedCheckpoints(true));
         // broadcast, but other channel is forwarded
-        assertFalse(supportsUnalignedCheckpoints(streamGraph, map1, joined));
+        assertThat(edge(streamGraph, map1, joined), supportsUnalignedCheckpoints(false));
         // forward
-        assertFalse(supportsUnalignedCheckpoints(streamGraph, map2, joined));
+        assertThat(edge(streamGraph, map2, joined), supportsUnalignedCheckpoints(false));
         // shuffle
-        assertTrue(supportsUnalignedCheckpoints(streamGraph, joined, map3));
+        assertThat(edge(streamGraph, joined, map3), supportsUnalignedCheckpoints(true));
         // rescale
-        assertFalse(supportsUnalignedCheckpoints(streamGraph, map3, map4));
+        assertThat(edge(streamGraph, map3, map4), supportsUnalignedCheckpoints(false));
     }
 
-    private boolean supportsUnalignedCheckpoints(
+    @Test
+    public void testUnalignedCheckpointDisabledOnBroadcast() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(42);
+
+        DataStream<Long> source1 = env.fromSequence(1L, 10L);
+        DataStream<Long> map1 = source1.broadcast().map(l -> l);
+        DataStream<Long> source2 = env.fromSequence(2L, 11L);
+        DataStream<Long> keyed = source2.keyBy(r -> 0L);
+
+        final MapStateDescriptor<Long, Long> descriptor =
+                new MapStateDescriptor<>(
+                        "broadcast", BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO);
+        final BroadcastStream<Long> broadcast = map1.broadcast(descriptor);
+        final SingleOutputStreamOperator<Long> joined =
+                keyed.connect(broadcast)
+                        .process(
+                                new KeyedBroadcastProcessFunction<Long, Long, Long, Long>() {
+                                    @Override
+                                    public void processElement(
+                                            Long value, ReadOnlyContext ctx, Collector<Long> out) {}
+
+                                    @Override
+                                    public void processBroadcastElement(
+                                            Long value, Context ctx, Collector<Long> out) {}
+                                });
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        assertEquals(4, streamGraph.getStreamNodes().size());
+
+        // single broadcast
+        assertThat(edge(streamGraph, source1, map1), supportsUnalignedCheckpoints(false));
+        // keyed, connected with broadcast
+        assertThat(edge(streamGraph, source2, joined), supportsUnalignedCheckpoints(false));
+        // broadcast, connected with keyed
+        assertThat(edge(streamGraph, map1, joined), supportsUnalignedCheckpoints(false));
+    }
+
+    private static StreamEdge edge(
             StreamGraph streamGraph, DataStream<Long> op1, DataStream<Long> op2) {
-        return streamGraph
-                .getStreamEdges(op1.getId(), op2.getId())
-                .get(0)
-                .supportsUnalignedCheckpoints();
+        return streamGraph.getStreamEdges(op1.getId(), op2.getId()).get(0);
+    }
+
+    private static Matcher<StreamEdge> supportsUnalignedCheckpoints(boolean enabled) {
+        return new FeatureMatcher<StreamEdge, Boolean>(
+                equalTo(enabled),
+                "supports unaligned checkpoint",
+                "supports unaligned checkpoint") {
+            @Override
+            protected Boolean featureValueOf(StreamEdge actual) {
+                return actual.supportsUnalignedCheckpoints();
+            }
+        };
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializerTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.streaming.runtime.io.recovery;
 
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
-import org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -59,6 +58,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptySet;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.array;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.mappings;
+import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.rescalingDescriptor;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.set;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.to;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createBufferBuilder;
@@ -92,7 +92,7 @@ public class DemultiplexingRecordDeserializerTest {
         DemultiplexingRecordDeserializer<Long> deserializer =
                 DemultiplexingRecordDeserializer.create(
                         new InputChannelInfo(2, 0),
-                        new InflightDataRescalingDescriptor(
+                        rescalingDescriptor(
                                 to(0, 1),
                                 array(mappings(), mappings(), mappings(to(2, 3), to(4, 5))),
                                 emptySet()),
@@ -133,7 +133,7 @@ public class DemultiplexingRecordDeserializerTest {
         DemultiplexingRecordDeserializer<Long> deserializer =
                 DemultiplexingRecordDeserializer.create(
                         new InputChannelInfo(1, 0),
-                        new InflightDataRescalingDescriptor(
+                        rescalingDescriptor(
                                 to(41, 42),
                                 array(mappings(), mappings(to(2, 3), to(4, 5))),
                                 set(42)),
@@ -177,7 +177,7 @@ public class DemultiplexingRecordDeserializerTest {
         DemultiplexingRecordDeserializer<Long> deserializer =
                 DemultiplexingRecordDeserializer.create(
                         new InputChannelInfo(0, 0),
-                        new InflightDataRescalingDescriptor(
+                        rescalingDescriptor(
                                 to(0, 1), array(mappings(to(0, 1), to(4, 5))), emptySet()),
                         unused ->
                                 new SpillingAdaptiveSpanningRecordDeserializer<>(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -50,7 +50,6 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -65,20 +64,17 @@ import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.LogLevelRule;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 import org.apache.flink.shaded.netty4.io.netty.util.internal.PlatformDependent;
 
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ErrorCollector;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
 import javax.annotation.Nullable;
 
@@ -126,10 +122,6 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
     @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
     @Rule public ErrorCollector collector = new ErrorCollector();
-
-    @ClassRule
-    public static final LogLevelRule NETWORK_LOGGER =
-            new LogLevelRule().set(NetworkActionsLogger.class, Level.TRACE);
 
     @Nullable
     protected File execute(UnalignedSettings settings) throws Exception {

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 #logger.networkactionslogger.name = org.apache.flink.runtime.io.network.logger.NetworkActionsLogger

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = INFO
+rootLogger.level = OFF
 rootLogger.appenderRef.test.ref = TestLogger
 
 #logger.networkactionslogger.name = org.apache.flink.runtime.io.network.logger.NetworkActionsLogger


### PR DESCRIPTION
## What is the purpose of the change

The aim is to fix how UC work with BROADCAST partitioning.

## Brief changelog

* Disable UC for BROADCAST partitioning
* Allow different task mapping on different input gates
* Disable NETWORK_LOGGER for UC tests (cc @curcur )
* Remove SubtaskStateMapper.DISCARD_EXTRA_STATE

For more info, check the commit messages.


## Verifying this change

Added tests in 
* UnalignedCheckpointRescaleITCase
* StateAssignmentOperationTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) - we should extend the limitations of UC separately.
