### PR TITLE
[hotfix][hive] Remove duplicated interface implementations

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -21,7 +21,6 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.file.src.AbstractFileSource;
 import org.apache.flink.connector.file.src.ContinuousEnumerationSettings;
 import org.apache.flink.connector.file.src.PendingSplitsCheckpoint;
@@ -55,8 +54,7 @@ import static org.apache.flink.connector.file.src.FileSource.DEFAULT_SPLIT_ASSIG
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A unified data source that reads a hive table. */
-public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit>
-        implements ResultTypeQueryable<RowData> {
+public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit> {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION


## What is the purpose of the change

* Remove deduplicated interface implementations


## Brief change log

* Remove deduplicated interface implementation `ResultTypeQueryable<T>` of `HiveSource` because the parent `AbstractFileSource` has been implemented it.


## Verifying this change

- This change is a trivial code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
