### PR TITLE
[FLINK-22808][state/changelog] Log metadata

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
@@ -19,6 +19,7 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 
@@ -43,8 +44,9 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
             TypeSerializer<Ns> namespaceSerializer,
             TypeSerializer<Value> valueSerializer,
             InternalKeyContext<Key> keyContext,
-            StateChangelogWriter<?> stateChangelogWriter) {
-        super(stateChangelogWriter, keyContext);
+            StateChangelogWriter<?> stateChangelogWriter,
+            RegisteredStateMetaInfoBase metaInfo) {
+        super(stateChangelogWriter, keyContext, metaInfo);
         this.keySerializer = checkNotNull(keySerializer);
         this.valueSerializer = checkNotNull(valueSerializer);
         this.namespaceSerializer = checkNotNull(namespaceSerializer);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
@@ -19,6 +19,7 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 
@@ -33,8 +34,9 @@ class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger
     PriorityQueueStateChangeLoggerImpl(
             TypeSerializer<T> serializer,
             InternalKeyContext<K> keyContext,
-            StateChangelogWriter<?> stateChangelogWriter) {
-        super(stateChangelogWriter, keyContext);
+            StateChangelogWriter<?> stateChangelogWriter,
+            RegisteredPriorityQueueStateBackendMetaInfo<T> meta) {
+        super(stateChangelogWriter, keyContext, meta);
         this.serializer = checkNotNull(serializer);
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.apache.flink.api.common.state.StateDescriptor.Type.VALUE;
+import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.MERGE_NS;
+
+/** {@link KvStateChangeLoggerImpl} test. */
+public class KvStateChangeLoggerImplTest extends StateChangeLoggerTestBase<String> {
+
+    @Override
+    protected StateChangeLogger<String, String> getLogger(
+            TestingStateChangelogWriter writer, InternalKeyContextImpl<String> keyContext) {
+        StringSerializer keySerializer = new StringSerializer();
+        StringSerializer nsSerializer = new StringSerializer();
+        StringSerializer valueSerializer = new StringSerializer();
+        RegisteredKeyValueStateBackendMetaInfo<String, String> metaInfo =
+                new RegisteredKeyValueStateBackendMetaInfo<>(
+                        VALUE, "test", nsSerializer, valueSerializer);
+        return new KvStateChangeLoggerImpl<>(
+                keySerializer, nsSerializer, valueSerializer, keyContext, writer, metaInfo);
+    }
+
+    @Override
+    protected String getNamespace(String element) {
+        return element;
+    }
+
+    @Override
+    protected Optional<Tuple2<Integer, StateChangeOperation>> log(
+            StateChangeOperation op,
+            String element,
+            StateChangeLogger<String, String> logger,
+            InternalKeyContextImpl<String> keyContext)
+            throws IOException {
+        if (op == MERGE_NS) {
+            keyContext.setCurrentKey(element);
+            ((KvStateChangeLogger<String, String>) logger)
+                    .namespacesMerged(element, Collections.emptyList());
+            return Optional.of(Tuple2.of(keyContext.getCurrentKeyGroupIndex(), op));
+        } else {
+            return super.log(op, element, logger, keyContext);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImplTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.REMOVE_FIRST_ELEMENT;
+
+/** {@link PriorityQueueStateChangeLoggerImpl} test. */
+public class PriorityQueueStateChangeLoggerImplTest extends StateChangeLoggerTestBase<Void> {
+
+    @Override
+    protected StateChangeLogger<String, Void> getLogger(
+            TestingStateChangelogWriter writer, InternalKeyContextImpl<String> keyContext) {
+        StringSerializer valueSerializer = new StringSerializer();
+        RegisteredPriorityQueueStateBackendMetaInfo<String> metaInfo =
+                new RegisteredPriorityQueueStateBackendMetaInfo<>("test", valueSerializer);
+        return new PriorityQueueStateChangeLoggerImpl<>(
+                valueSerializer, keyContext, writer, metaInfo);
+    }
+
+    @Override
+    protected Optional<Tuple2<Integer, StateChangeOperation>> log(
+            StateChangeOperation op,
+            String element,
+            StateChangeLogger<String, Void> logger,
+            InternalKeyContextImpl<String> keyContext)
+            throws IOException {
+        if (op == REMOVE_FIRST_ELEMENT) {
+            keyContext.setCurrentKey(element);
+            ((PriorityQueueStateChangeLogger<String>) logger).stateElementPolled();
+            return Optional.of(Tuple2.of(keyContext.getCurrentKeyGroupIndex(), op));
+        } else {
+            return super.log(op, element, logger, keyContext);
+        }
+    }
+
+    @Override
+    protected Void getNamespace(String element) {
+        return null;
+    }
+}

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.changelog;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
+import org.apache.flink.runtime.state.heap.InternalKeyContextImpl;
+import org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.state.changelog.AbstractStateChangeLogger.COMMON_KEY_GROUP;
+import static org.apache.flink.state.changelog.AbstractStateChangeLogger.StateChangeOperation.METADATA;
+import static org.junit.Assert.assertEquals;
+
+abstract class StateChangeLoggerTestBase<Namespace> {
+    /** A basic test for appending the metadata on first state access. */
+    @Test
+    public void testMetadataOperationLogged() throws IOException {
+        TestingStateChangelogWriter writer = new TestingStateChangelogWriter();
+        InternalKeyContextImpl<String> keyContext =
+                new InternalKeyContextImpl<>(KeyGroupRange.of(1, 1000), 1000);
+        StateChangeLogger<String, Namespace> logger = getLogger(writer, keyContext);
+
+        List<Tuple2<Integer, StateChangeOperation>> expectedAppends = new ArrayList<>();
+        expectedAppends.add(Tuple2.of(COMMON_KEY_GROUP, METADATA));
+
+        // log every applicable operations, several times each
+        int numOpTypes = StateChangeOperation.values().length;
+        for (int i = 0; i < numOpTypes * 7; i++) {
+            String element = Integer.toString(i);
+            StateChangeOperation operation = StateChangeOperation.byCode((byte) (i % numOpTypes));
+            log(operation, element, logger, keyContext).ifPresent(expectedAppends::add);
+        }
+        assertEquals(expectedAppends, writer.appends);
+    }
+
+    protected abstract StateChangeLogger<String, Namespace> getLogger(
+            TestingStateChangelogWriter writer, InternalKeyContextImpl<String> keyContext);
+
+    protected Optional<Tuple2<Integer, StateChangeOperation>> log(
+            StateChangeOperation op,
+            String element,
+            StateChangeLogger<String, Namespace> logger,
+            InternalKeyContextImpl<String> keyContext)
+            throws IOException {
+        keyContext.setCurrentKey(element);
+        Namespace namespace = getNamespace(element);
+        switch (op) {
+            case ADD:
+                logger.valueAdded(element, namespace);
+                break;
+            case ADD_ELEMENT:
+                logger.valueElementAdded(w -> {}, namespace);
+                break;
+            case REMOVE_ELEMENT:
+                logger.valueElementRemoved(w -> {}, namespace);
+                break;
+            case CLEAR:
+                logger.valueCleared(namespace);
+                break;
+            case SET:
+                logger.valueUpdated(element, namespace);
+                break;
+            case SET_INTERNAL:
+                logger.valueUpdatedInternal(element, namespace);
+                break;
+            case ADD_OR_UPDATE_ELEMENT:
+                logger.valueElementAddedOrUpdated(w -> {}, namespace);
+                break;
+            default:
+                return Optional.empty();
+        }
+        return Optional.of(Tuple2.of(keyContext.getCurrentKeyGroupIndex(), op));
+    }
+
+    protected abstract Namespace getNamespace(String element);
+
+    @SuppressWarnings("rawtypes")
+    protected static class TestingStateChangelogWriter implements StateChangelogWriter {
+        private final List<Tuple2<Integer, StateChangeOperation>> appends = new ArrayList<>();
+
+        @Override
+        public void append(int keyGroup, byte[] value) {
+            appends.add(Tuple2.of(keyGroup, StateChangeOperation.byCode(value[0])));
+        }
+
+        @Override
+        public SequenceNumber lastAppendedSequenceNumber() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<?> persist(SequenceNumber from) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void truncate(SequenceNumber to) {}
+
+        @Override
+        public void confirm(SequenceNumber from, SequenceNumber to) {}
+
+        @Override
+        public void reset(SequenceNumber from, SequenceNumber to) {}
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Write metadata before state changes (#15200) so that they can be applied on recovery (#15420).

See also [detailed design doc](https://docs.google.com/document/d/10c6hZsOVxzUjeCLPSDpKGyZOYHi73yd92lCqRs1CyUE/edit?usp=sharing).

## Verifying this change

- Added `PriorityQueueStateChangeLoggerImplTest` and `KvStateChangeLoggerImplTest`
- (better coverage will be possible in #15420 with recovery implemented)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
