### PR TITLE
[FLINK-22813][connector-hive] Clean up flink-connector-hive's pom.xml

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -129,19 +129,13 @@ under the License.
 
 	<dependencies>
 
-		<!-- core dependencies -->
+		<!-- Table ecosystem -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>
@@ -165,6 +159,14 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- Connectors -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-bulk_${scala.binary.version}</artifactId>
@@ -177,7 +179,7 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- format dependencies -->
+		<!-- Formats -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -209,16 +211,7 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<!--We downgrade the version of avro for tests. We do that because we test Hive's built-in
-			formats, which do not work with newer avro versions. We do not downgrade the version
-			permanently, because it should be safe to use hive as a catalog with newer avro
-			versions. -->
-		<dependency>
-			<groupId>org.apache.avro</groupId>
-			<artifactId>avro</artifactId>
-			<version>${hive.avro.version}</version>
-			<scope>test</scope>
-		</dependency>
+		<!-- File systems -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -226,7 +219,8 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- Hadoop dependency -->
+		<!-- Hadoop -->
+
 		<!-- Hadoop as provided dependencies, so we can depend on them without pulling in Hadoop -->
 
 		<!--
@@ -245,7 +239,9 @@ under the License.
 			<artifactId>hadoop-mapreduce-client-core</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		<!-- Hive dependencies -->
+
+		<!-- Hive -->
+
 		<!-- Note: Hive published jars do not have proper dependencies declared.
 		We need to push for HIVE-16391 (https://issues.apache.org/jira/browse/HIVE-16391) to resolve this problem. -->
 
@@ -515,7 +511,7 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<!-- test dependencies -->
+		<!-- Tests -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -535,13 +531,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
@@ -549,7 +538,6 @@ under the License.
 		</dependency>
 
 		<!--flink-java and flink-clients test dependencies used for HiveInputFormatTest-->
-
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
@@ -564,27 +552,27 @@ under the License.
 		</dependency>
 
 		<dependency>
-            <groupId>com.klarna</groupId>
-            <artifactId>hiverunner</artifactId>
-            <version>${hiverunner.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hive</groupId>
-                    <artifactId>hive-serde</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hive</groupId>
-                    <artifactId>hive-jdbc</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hive</groupId>
-                    <artifactId>hive-service</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hive</groupId>
-                    <artifactId>hive-contrib</artifactId>
-                </exclusion>
+			<groupId>com.klarna</groupId>
+			<artifactId>hiverunner</artifactId>
+			<version>${hiverunner.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hive</groupId>
+					<artifactId>hive-serde</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hive</groupId>
+					<artifactId>hive-jdbc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hive</groupId>
+					<artifactId>hive-service</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hive</groupId>
+					<artifactId>hive-contrib</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>org.apache.hive</groupId>
 					<artifactId>hive-exec</artifactId>
@@ -658,8 +646,8 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
-            </exclusions>
-        </dependency>
+			</exclusions>
+		</dependency>
 
 		<!--  We have 0.9.10 in dependency management but hiverunner requires 0.9.8, so need to explicitly specify it here -->
 		<dependency>
@@ -676,10 +664,10 @@ under the License.
 		</dependency>
 
 		<dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-service</artifactId>
-            <version>${hive.version}</version>
-            <scope>test</scope>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-service</artifactId>
+			<version>${hive.version}</version>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.hive</groupId>
@@ -762,10 +750,10 @@ under the License.
 		</dependency>
 
 		<dependency>
-            <groupId>org.apache.hive.hcatalog</groupId>
-            <artifactId>hive-hcatalog-core</artifactId>
-            <version>${hive.version}</version>
-            <scope>test</scope>
+			<groupId>org.apache.hive.hcatalog</groupId>
+			<artifactId>hive-hcatalog-core</artifactId>
+			<version>${hive.version}</version>
+			<scope>test</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.hive</groupId>
@@ -811,8 +799,8 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
-            </exclusions>
-        </dependency>
+			</exclusions>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hive.hcatalog</groupId>
@@ -852,11 +840,11 @@ under the License.
 		</dependency>
 
 		<dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
 			<scope>test</scope>
-        </dependency>
+		</dependency>
 
 		<!-- The derby we use suffers some security vulnerabilities. Explicitly set it to test scope here. -->
 		<dependency>
@@ -866,7 +854,17 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-    </dependencies>
+		<!--We downgrade the version of avro for tests. We do that because we test Hive's built-in
+			formats, which do not work with newer avro versions. We do not downgrade the version
+			permanently, because it should be safe to use hive as a catalog with newer avro
+			versions. -->
+		<dependency>
+			<groupId>org.apache.avro</groupId>
+			<artifactId>avro</artifactId>
+			<version>${hive.avro.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<plugins>
@@ -1109,7 +1107,7 @@ under the License.
 			<properties>
 				<hive.version>3.1.1</hive.version>
 				<derby.version>10.14.1.0</derby.version>
-                <!-- need a hadoop version that fixes HADOOP-14683 -->
+				<!-- need a hadoop version that fixes HADOOP-14683 -->
 				<hivemetastore.hadoop.version>2.8.2</hivemetastore.hadoop.version>
 			</properties>
 


### PR DESCRIPTION
## What is the purpose of the change

This removes the unused `flink-table-planner` dependency and cleanups the `pom.xml` in general.

## Brief change log

- remove `flink-table-planner`
- reorder and proper categorize dependencies
- fix whitespace issues

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
