### PR TITLE
[FLINK-21871][hive] Hive streaming source use FIFO FileSplitAssigner instead of LIFO

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FIFOSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FIFOSplitAssigner.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Optional;
+
+/** The {@code FIFOSplitAssigner} hands out splits in a FIFO order. */
+@PublicEvolving
+public class FIFOSplitAssigner implements FileSplitAssigner {
+
+    private final LinkedList<FileSourceSplit> splits;
+
+    public FIFOSplitAssigner(Collection<FileSourceSplit> splits) {
+        this.splits = new LinkedList<>(splits);
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public Optional<FileSourceSplit> getNext(@Nullable String hostname) {
+        return Optional.ofNullable(splits.poll());
+    }
+
+    @Override
+    public void addSplits(Collection<FileSourceSplit> newSplits) {
+        splits.addAll(newSplits);
+    }
+
+    @Override
+    public Collection<FileSourceSplit> remainingSplits() {
+        return splits;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/FIFOSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/assigners/FIFOSplitAssignerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Unit tests for the {@link FIFOSplitAssigner}. */
+public class FIFOSplitAssignerTest {
+    private static final Path TEST_PATH =
+            Path.fromLocalFile(new File(System.getProperty("java.io.tmpdir")));
+
+    @Test
+    public void testAssign() {
+        List<FileSourceSplit> fileSourceSplits = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            fileSourceSplits.add(createSplit(i, "host" + i));
+        }
+
+        FIFOSplitAssigner splitAssigner = new FIFOSplitAssigner(fileSourceSplits);
+        for (int i = 0; i < 2; i++) {
+            Assert.assertEquals(
+                    String.valueOf(i), splitAssigner.getNext("host" + i).get().splitId());
+        }
+
+        Assert.assertFalse(splitAssigner.getNext("host").isPresent());
+    }
+
+    // ------------------------------------------------------------------------
+    //  utilities
+    // ------------------------------------------------------------------------
+
+    private static FileSourceSplit createSplit(int id, String... hosts) {
+        return new FileSourceSplit(String.valueOf(id), TEST_PATH, 0, 1024, hosts);
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -25,8 +25,8 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.file.src.AbstractFileSource;
 import org.apache.flink.connector.file.src.ContinuousEnumerationSettings;
 import org.apache.flink.connector.file.src.PendingSplitsCheckpoint;
+import org.apache.flink.connector.file.src.assigners.FIFOSplitAssigner;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
-import org.apache.flink.connector.file.src.assigners.SimpleSplitAssigner;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connectors.hive.read.HiveBulkFormatAdapter;
@@ -204,7 +204,7 @@ public class HiveSource extends AbstractFileSource<RowData, HiveSourceSplit>
             FileSplitAssigner.Provider splitAssigner =
                     continuousSourceSettings == null || partitionKeys.isEmpty()
                             ? DEFAULT_SPLIT_ASSIGNER
-                            : SimpleSplitAssigner::new;
+                            : FIFOSplitAssigner::new;
             return new HiveSource(
                     inputPaths,
                     fileEnumerator,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Make Hive streaming source use FIFO FileSplitAssigner to hands out splits in order*


## Brief change log
  - *Add FIFOSplitAssigner which return FileSourceSplit in FIFO order*
  - *Use FIFOSplitAssigner to build HiveSource*

## Verifying this change

This change added tests and can be verified as follows:
  -  The change is covered by newly added test FIFOSplitAssignerTest and other existing tests involves with hive.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no