### PR TITLE
[FLINK-22831][scala-shell] Update Scala shell to use Blink planner

### DIFF
--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -87,7 +87,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkILoop.scala
@@ -21,7 +21,7 @@ package org.apache.flink.api.scala
 import org.apache.flink.api.java.{JarHelper, ScalaShellEnvironment, ScalaShellStreamEnvironment}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.EnvironmentSettings
+import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
 import org.apache.flink.table.api.bridge.scala.{BatchTableEnvironment, StreamTableEnvironment}
 import org.apache.flink.util.AbstractID
 
@@ -84,16 +84,11 @@ class FlinkILoop(
   // local environment
   val (
     scalaBenv: ExecutionEnvironment,
-    scalaSenv: StreamExecutionEnvironment,
-    scalaBTEnv: BatchTableEnvironment,
-    scalaSTEnv: StreamTableEnvironment
+    scalaSenv: StreamExecutionEnvironment
     ) = {
     val scalaBenv = new ExecutionEnvironment(remoteBenv)
     val scalaSenv = new StreamExecutionEnvironment(remoteSenv)
-    val scalaBTEnv = BatchTableEnvironment.create(scalaBenv)
-    val scalaSTEnv = StreamTableEnvironment.create(
-      scalaSenv, EnvironmentSettings.newInstance().useOldPlanner().build())
-    (scalaBenv,scalaSenv,scalaBTEnv,scalaSTEnv)
+    (scalaBenv, scalaSenv)
   }
 
   /**
@@ -142,6 +137,8 @@ class FlinkILoop(
     "org.apache.flink.streaming.api.windowing.time._",
     "org.apache.flink.table.api._",
     "org.apache.flink.table.api.bridge.scala._",
+    "org.apache.flink.table.connector.ChangelogMode",
+    "org.apache.flink.table.functions._",
     "org.apache.flink.types.Row"
   )
 
@@ -152,11 +149,9 @@ class FlinkILoop(
       // import dependencies
       intp.interpret("import " + packageImports.mkString(", "))
 
-      // set execution environment
+      // set execution environments
       intp.bind("benv", this.scalaBenv)
       intp.bind("senv", this.scalaSenv)
-      intp.bind("btenv", this.scalaBTEnv)
-      intp.bind("stenv", this.scalaSTEnv)
     }
   }
 
@@ -248,30 +243,33 @@ class FlinkILoop(
 
               F L I N K - S C A L A - S H E L L
 
-NOTE: Use the prebound Execution Environments and Table Environment to implement batch or streaming programs.
+NOTE: Use the prepared environments to implement batch or streaming programs.
 
-  Batch - Use the 'benv' and 'btenv' variable
+  Bounded and Unbounded Streaming - Use the 'senv' variable for DataStream API or Table/SQL API
+
+    * val dataStream = senv.fromElements(1, 2, 3, 4)
+    *
+    * dataStream
+    *      .countWindowAll(2)
+    *      .sum(0)
+    *      .executeAndCollect()
+    *      .foreach(println)
+    *
+    * val tenv = StreamTableEnvironment.create(senv)
+    *
+    * val table = tenv.fromValues(row("Alice", 1), row("Bob", 2)).as("name", "score")
+    *
+    * table
+    *     .groupBy($"name")
+    *     .select($"name", $"score".sum)
+    *     .execute()
+    *     .print()
+
+  Batch (Legacy) - Use the 'benv' variable for DataSet API
 
     * val dataSet = benv.readTextFile("/path/to/data")
     * dataSet.writeAsText("/path/to/output")
     * benv.execute("My batch program")
-    *
-    * val batchTable = btenv.fromDataSet(dataSet)
-    * btenv.registerTable("tableName", batchTable)
-    * val result = btenv.sqlQuery("SELECT * FROM tableName").collect
-    HINT: You can use print() on a DataSet to print the contents or collect()
-    a sql query result back to the shell.
-
-  Streaming - Use the 'senv' and 'stenv' variable
-
-    * val dataStream = senv.fromElements(1, 2, 3, 4)
-    * dataStream.countWindowAll(2).sum(0).print()
-    *
-    * val streamTable = stenv.fromDataStream(dataStream, 'num)
-    * val resultTable = streamTable.select('num).where('num % 2 === 1 )
-    * resultTable.toAppendStream[Row].print()
-    * senv.execute("My streaming program")
-    HINT: You can only print a DataStream to the shell in local mode.
       """
     // scalastyle:on
     )


### PR DESCRIPTION
## What is the purpose of the change

Updates the Scala shell to use the Blink planner and newer APIs.

## Brief change log

- Update dependencies
- Add more recent examples
- Use a reasonable set of imports

## Verifying this change

This change is already covered by existing tests.

Also manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
