### PR TITLE
[FLINK-22835] Adjust ChangelogStateBackend tests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -53,7 +53,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class AbstractKeyedStateBackend<K>
         implements CheckpointableKeyedStateBackend<K>,
                 CheckpointListener,
-                TestableKeyedStateBackend {
+                TestableKeyedStateBackend<K> {
 
     /** The key serializer. */
     protected final TypeSerializer<K> keySerializer;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.ReadableConfig;
 
 /** An interface for state backends that pick up additional parameters from a configuration. */
 @Internal
-public interface ConfigurableStateBackend {
+public interface ConfigurableStateBackend extends StateBackend {
 
     /**
      * Creates a variant of the state backend that applies additional configuration parameters.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TestableKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TestableKeyedStateBackend.java
@@ -21,7 +21,15 @@ import org.apache.flink.annotation.VisibleForTesting;
 
 /** A keyed state backend interface for internal testing purpose. */
 @VisibleForTesting
-public interface TestableKeyedStateBackend {
+public interface TestableKeyedStateBackend<K> extends KeyedStateBackend<K> {
     /** Returns the total number of state entries across all keys/namespaces. */
     int numKeyValueStateEntries();
+    /**
+     * @return delegated {@link KeyedStateBackend} if this backends delegates its
+     *     responisibilities..
+     * @param recursive true if the call should be recursive
+     */
+    default KeyedStateBackend<K> getDelegatedKeyedStateBackend(boolean recursive) {
+        return this;
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/FileStateBackendTest.java
@@ -48,7 +48,7 @@ public class FileStateBackendTest extends StateBackendTestBase<FsStateBackend> {
     @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Override
-    protected FsStateBackend getStateBackend() throws Exception {
+    protected ConfigurableStateBackend getStateBackend() throws Exception {
         File checkpointPath = tempFolder.newFolder();
         return new FsStateBackend(checkpointPath.toURI(), useAsyncMode);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/HashMapStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/HashMapStateBackendTest.java
@@ -66,7 +66,7 @@ public class HashMapStateBackendTest extends StateBackendTestBase<HashMapStateBa
     public SupplierWithException<CheckpointStorage, IOException> storageSupplier;
 
     @Override
-    protected HashMapStateBackend getStateBackend() {
+    protected ConfigurableStateBackend getStateBackend() {
         return new HashMapStateBackend();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -40,7 +40,7 @@ public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBack
     @Parameterized.Parameter public boolean useAsyncmode;
 
     @Override
-    protected MemoryStateBackend getStateBackend() {
+    protected ConfigurableStateBackend getStateBackend() {
         return new MemoryStateBackend(useAsyncmode);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -139,6 +139,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -860,6 +861,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testKryoRegisteringRestoreResilienceWithDefaultSerializer() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         CheckpointableKeyedStateBackend<Integer> backend =
@@ -982,6 +984,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testKryoRegisteringRestoreResilienceWithRegisteredSerializer() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
 
@@ -3958,6 +3961,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testRestoreWithWrongKeySerializer() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
 
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
@@ -4008,6 +4012,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testValueStateRestoreWithWrongSerializers() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         CheckpointableKeyedStateBackend<Integer> backend =
@@ -4066,6 +4071,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testListStateRestoreWithWrongSerializers() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         CheckpointableKeyedStateBackend<Integer> backend =
@@ -4123,6 +4129,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testReducingStateRestoreWithWrongSerializers() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         CheckpointableKeyedStateBackend<Integer> backend =
@@ -4184,6 +4191,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
     @Test
     @SuppressWarnings("unchecked")
     public void testMapStateRestoreWithWrongSerializers() throws Exception {
+        assumeTrue(supportsMetaInfoVerification());
         CheckpointStreamFactory streamFactory = createStreamFactory();
         SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
         CheckpointableKeyedStateBackend<Integer> backend =
@@ -4599,6 +4607,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
      */
     @Test
     public void testParallelAsyncSnapshots() throws Exception {
+        assumeTrue(snapshotUsesStreamFactory());
         OneShotLatch blocker = new OneShotLatch();
         OneShotLatch waiter = new OneShotLatch();
         BlockerCheckpointStreamFactory streamFactory =
@@ -4693,6 +4702,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testAsyncSnapshot() throws Exception {
+        assumeTrue(snapshotUsesStreamFactory());
         OneShotLatch waiter = new OneShotLatch();
         BlockerCheckpointStreamFactory streamFactory =
                 new BlockerCheckpointStreamFactory(1024 * 1024);
@@ -4909,6 +4919,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     @Test
     public void testAsyncSnapshotCancellation() throws Exception {
+        assumeTrue(snapshotUsesStreamFactory());
         OneShotLatch blocker = new OneShotLatch();
         OneShotLatch waiter = new OneShotLatch();
         BlockerCheckpointStreamFactory streamFactory =
@@ -5527,5 +5538,21 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
     private MockEnvironment buildMockEnv() {
         return MockEnvironment.builder().build();
+    }
+
+    /**
+     * @return true if {@link org.apache.flink.runtime.state.Snapshotable#snapshot
+     *     backend.snapshot()} actually uses passed {@link CheckpointStreamFactory}.
+     */
+    protected boolean snapshotUsesStreamFactory() {
+        return true;
+    }
+
+    /**
+     * @return true if metadata serialization supports verification. If not, expected exceptions
+     *     will likely not be thrown.
+     */
+    protected boolean supportsMetaInfoVerification() {
+        return true;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -4502,7 +4502,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             backend.dispose();
             // Initialize again
             backend = restoreKeyedBackend(IntSerializer.INSTANCE, snapshot, env);
-            snapshot.discardState();
+            if (snapshot != null) {
+                snapshot.discardState();
+            }
 
             backend.getPartitionedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, desc);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -295,8 +295,13 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                         Collections.emptyList(),
                         new CloseableRegistry());
         try {
+            KeyedStateBackend<Integer> nested =
+                    keyedStateBackend instanceof TestableKeyedStateBackend
+                            ? ((TestableKeyedStateBackend<Integer>) keyedStateBackend)
+                                    .getDelegatedKeyedStateBackend(true)
+                            : keyedStateBackend;
             Assert.assertTrue(
-                    ((AbstractKeyedStateBackend<Integer>) keyedStateBackend)
+                    ((AbstractKeyedStateBackend<Integer>) nested)
                             .getLatencyTrackingStateConfig()
                             .isEnabled());
         } finally {

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -75,7 +75,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 class ChangelogKeyedStateBackend<K>
         implements CheckpointableKeyedStateBackend<K>,
                 CheckpointListener,
-                TestableKeyedStateBackend {
+                TestableKeyedStateBackend<K> {
 
     private static final Map<Class<? extends StateDescriptor>, StateFactory> STATE_FACTORIES =
             Stream.of(
@@ -331,6 +331,11 @@ class ChangelogKeyedStateBackend<K>
         return stateFactory.create(
                 keyedStateBackend.createInternalState(
                         namespaceSerializer, stateDesc, snapshotTransformFactory));
+    }
+
+    @Override
+    public KeyedStateBackend<K> getDelegatedKeyedStateBackend(boolean recursive) {
+        return keyedStateBackend.getDelegatedKeyedStateBackend(recursive);
     }
 
     // Factory function interface

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -25,9 +25,26 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 
+import org.junit.Ignore;
+import org.junit.Test;
+
 /** Tests for {@link ChangelogStateBackend} delegating {@link EmbeddedRocksDBStateBackend}. */
 public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
         extends EmbeddedRocksDBStateBackendTest {
+
+    @Override
+    protected boolean snapshotUsesStreamFactory() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsMetaInfoVerification() {
+        return false;
+    }
+
+    @Test
+    @Ignore("The type of handle returned from snapshot() is not incremental")
+    public void testSharedIncrementalStateDeRegistration() {}
 
     @Override
     protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateEmbeddedRocksDBStateBackendTest.java
@@ -23,10 +23,13 @@ import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendTest;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.io.IOException;
 
 /** Tests for {@link ChangelogStateBackend} delegating {@link EmbeddedRocksDBStateBackend}. */
 public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
@@ -55,10 +58,15 @@ public class ChangelogDelegateEmbeddedRocksDBStateBackendTest
             throws Exception {
 
         return ChangelogStateBackendTestUtils.createKeyedBackend(
-                new ChangelogStateBackend(getStateBackend()),
+                new ChangelogStateBackend(super.getStateBackend()),
                 keySerializer,
                 numberOfKeyGroups,
                 keyGroupRange,
                 env);
+    }
+
+    @Override
+    protected ConfigurableStateBackend getStateBackend() throws IOException {
+        return new ChangelogStateBackend(super.getStateBackend());
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -29,6 +29,16 @@ import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest {
 
     @Override
+    protected boolean snapshotUsesStreamFactory() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsMetaInfoVerification() {
+        return false;
+    }
+
+    @Override
     protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateFileStateBackendTest.java
@@ -20,10 +20,13 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.FileStateBackendTest;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 
 /** Tests for {@link ChangelogStateBackend} delegating {@link FsStateBackend}. */
 public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest {
@@ -47,10 +50,20 @@ public class ChangelogDelegateFileStateBackendTest extends FileStateBackendTest 
             throws Exception {
 
         return ChangelogStateBackendTestUtils.createKeyedBackend(
-                new ChangelogStateBackend(getStateBackend()),
+                new ChangelogStateBackend(super.getStateBackend()),
                 keySerializer,
                 numberOfKeyGroups,
                 keyGroupRange,
                 env);
+    }
+
+    @Override
+    protected ConfigurableStateBackend getStateBackend() throws Exception {
+        return new ChangelogStateBackend(super.getStateBackend());
+    }
+
+    @Override
+    protected CheckpointStorage getCheckpointStorage() {
+        return new JobManagerCheckpointStorage();
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.HashMapStateBackendTest;
 import org.apache.flink.runtime.state.KeyGroupRange;
 
@@ -46,10 +47,15 @@ public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
             throws Exception {
 
         return ChangelogStateBackendTestUtils.createKeyedBackend(
-                new ChangelogStateBackend(getStateBackend()),
+                new ChangelogStateBackend(super.getStateBackend()),
                 keySerializer,
                 numberOfKeyGroups,
                 keyGroupRange,
                 env);
+    }
+
+    @Override
+    protected ConfigurableStateBackend getStateBackend() {
+        return new ChangelogStateBackend(super.getStateBackend());
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateHashMapTest.java
@@ -28,6 +28,16 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 public class ChangelogDelegateHashMapTest extends HashMapStateBackendTest {
 
     @Override
+    protected boolean snapshotUsesStreamFactory() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsMetaInfoVerification() {
+        return false;
+    }
+
+    @Override
     protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -29,6 +29,16 @@ import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendTest {
 
     @Override
+    protected boolean snapshotUsesStreamFactory() {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsMetaInfoVerification() {
+        return false;
+    }
+
+    @Override
     protected <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogDelegateMemoryStateBackendTest.java
@@ -20,10 +20,13 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.MemoryStateBackendTest;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 
 /** Tests for {@link ChangelogStateBackend} delegating {@link MemoryStateBackend}. */
 public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendTest {
@@ -47,10 +50,20 @@ public class ChangelogDelegateMemoryStateBackendTest extends MemoryStateBackendT
             throws Exception {
 
         return ChangelogStateBackendTestUtils.createKeyedBackend(
-                new ChangelogStateBackend(getStateBackend()),
+                new ChangelogStateBackend(super.getStateBackend()),
                 keySerializer,
                 numberOfKeyGroups,
                 keyGroupRange,
                 env);
+    }
+
+    @Override
+    protected ConfigurableStateBackend getStateBackend() {
+        return new ChangelogStateBackend(super.getStateBackend());
+    }
+
+    @Override
+    protected CheckpointStorage getCheckpointStorage() {
+        return new JobManagerCheckpointStorage();
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
@@ -154,7 +155,7 @@ public class EmbeddedRocksDBStateBackendTest
     }
 
     @Override
-    protected EmbeddedRocksDBStateBackend getStateBackend() throws IOException {
+    protected ConfigurableStateBackend getStateBackend() throws IOException {
         dbPath = TEMP_FOLDER.newFolder().getAbsolutePath();
         EmbeddedRocksDBStateBackend backend =
                 new EmbeddedRocksDBStateBackend(enableIncrementalCheckpointing);


### PR DESCRIPTION
## What is the purpose of the change

Test issues were discovered during recovery implementation (#15420) and were extracted into a separate PR:
```
 - Use ChangelogStateBackend on recovery in the relevant tests
 - Discard state snapshot iff not null - changelog backend returns null if nothing was snapshotted (according to the contract)
 - Add assumptions to state backend tests - e.g. changelog backend doesn't use the provided output stream factory
 - Assert latency tracking on delegated backend - there is an explicit cast which fails for changelog backend
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
