### PR TITLE
[FLINK-22832][sql-client] Drop usages of legacy planner in SQL Client

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -339,7 +339,6 @@ CREATE FUNCTION foo.bar.AggregateUDF AS myUDF;
 
 -- Properties that change the fundamental execution behavior of a table program.
 
-SET 'table.planner' = 'blink'; -- planner: either 'blink' (default) or 'old'
 SET 'execution.runtime-mode' = 'streaming'; -- execution mode either 'batch' or 'streaming'
 SET 'sql-client.execution.result-mode' = 'table'; -- available values: 'table', 'changelog' and 'tableau'
 SET 'sql-client.execution.max-table-result.rows' = '10000'; -- optional: maximum number of maintained rows
@@ -362,7 +361,7 @@ This configuration:
 - defines a table `MyTableSource` that can read data from a CSV file,
 - defines a view `MyCustomView` that declares a virtual table using a SQL query,
 - defines a user-defined function `myUDF` that can be instantiated using the class name,
-- uses the blink planner in streaming mode for running statements and a parallelism of 1,
+- uses streaming mode for running statements and a parallelism of 1,
 - runs exploratory queries in the `table` result mode,
 - and makes some planner adjustments around join reordering and spilling via configuration options.
 
@@ -688,8 +687,6 @@ To distinguish the deprecated key, the sql client use the '[DEPRECATED]' as the 
 Flink SQL>SET;
 execution.runtime-mode=batch
 sql-client.execution.result-mode=table
-table.planner=blink
-[DEPRECATED] execution.planner=blink
 [DEPRECATED] execution.result-mode=table
 [DEPRECATED] execution.type=batch
 ```

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -345,7 +345,6 @@ CREATE FUNCTION foo.bar.AggregateUDF AS myUDF;
 
 -- Properties that change the fundamental execution behavior of a table program.
 
-SET 'table.planner' = 'blink'; -- planner: either 'blink' (default) or 'old'
 SET 'execution.runtime-mode' = 'streaming'; -- execution mode either 'batch' or 'streaming'
 SET 'sql-client.execution.result-mode' = 'table'; -- available values: 'table', 'changelog' and 'tableau'
 SET 'sql-client.execution.max-table-result.rows' = '10000'; -- optional: maximum number of maintained rows
@@ -368,7 +367,7 @@ This configuration:
 - defines a table `MyTableSource` that can read data from a CSV file,
 - defines a view `MyCustomView` that declares a virtual table using a SQL query,
 - defines a user-defined function `myUDF` that can be instantiated using the class name,
-- uses the blink planner in streaming mode for running statements and a parallelism of 1,
+- uses streaming mode for running statements and a parallelism of 1,
 - runs exploratory queries in the `table` result mode,
 - and makes some planner adjustments around join reordering and spilling via configuration options.
 
@@ -694,8 +693,6 @@ To distinguish the deprecated key, the sql client use the '[DEPRECATED]' as the 
 Flink SQL>SET;
 execution.runtime-mode=batch
 sql-client.execution.result-mode=table
-table.planner=blink
-[DEPRECATED] execution.planner=blink
 [DEPRECATED] execution.result-mode=table
 [DEPRECATED] execution.type=batch
 ```

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -216,8 +216,7 @@ fi
 run_test "State TTL Heap backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh hashmap" "skip_check_exceptions"
 run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scripts/test_stream_state_ttl.sh rocks" "skip_check_exceptions"
 
-run_test "SQL Client end-to-end test (Old planner) Elasticsearch (v7.5.1)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh old"
-run_test "SQL Client end-to-end test (Blink planner) Elasticsearch (v7.5.1)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh blink"
+run_test "SQL Client end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_client.sh"
 
 run_test "TPC-H end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpch.sh"
 run_test "TPC-DS end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpcds.sh"

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -19,8 +19,6 @@
 
 set -Eeuo pipefail
 
-PLANNER="${1:-old}"
-
 KAFKA_VERSION="2.2.2"
 CONFLUENT_VERSION="5.0.0"
 CONFLUENT_MAJOR_VERSION="5.0"
@@ -213,9 +211,6 @@ functions:
   - name: RegReplace
     from: class
     class: org.apache.flink.table.toolbox.StringRegexReplaceFunction
-
-execution:
-  planner: "$PLANNER"
 EOF
 
 # submit SQL statements

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -80,12 +80,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/entries/ExecutionEntry.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -53,8 +54,6 @@ public class ExecutionEntry extends ConfigEntry {
             new ExecutionEntry(new DescriptorProperties(true));
 
     public static final String EXECUTION_PLANNER = "planner";
-
-    public static final String EXECUTION_PLANNER_VALUE_OLD = "old";
 
     public static final String EXECUTION_PLANNER_VALUE_BLINK = "blink";
 
@@ -117,9 +116,7 @@ public class ExecutionEntry extends ConfigEntry {
     @Override
     protected void validate(DescriptorProperties properties) {
         properties.validateEnumValues(
-                EXECUTION_PLANNER,
-                true,
-                Arrays.asList(EXECUTION_PLANNER_VALUE_OLD, EXECUTION_PLANNER_VALUE_BLINK));
+                EXECUTION_PLANNER, true, Collections.singletonList(EXECUTION_PLANNER_VALUE_BLINK));
         properties.validateEnumValues(
                 EXECUTION_TYPE,
                 true,
@@ -164,35 +161,6 @@ public class ExecutionEntry extends ConfigEntry {
                 .getOptionalString(EXECUTION_TYPE)
                 .map((v) -> v.equals(EXECUTION_TYPE_VALUE_BATCH))
                 .orElse(false);
-    }
-
-    public boolean isStreamingPlanner() {
-        final String planner =
-                properties
-                        .getOptionalString(EXECUTION_PLANNER)
-                        .orElse(EXECUTION_PLANNER_VALUE_BLINK);
-
-        // Blink planner is a streaming planner
-        if (planner.equals(EXECUTION_PLANNER_VALUE_BLINK)) {
-            return true;
-        }
-        // Old planner can be a streaming or batch planner
-        else if (planner.equals(EXECUTION_PLANNER_VALUE_OLD)) {
-            return inStreamingMode();
-        }
-
-        return false;
-    }
-
-    public boolean isBlinkPlanner() {
-        final String planner =
-                properties
-                        .getOptionalString(EXECUTION_PLANNER)
-                        .orElse(EXECUTION_PLANNER_VALUE_BLINK);
-        if (planner.equals(EXECUTION_PLANNER_VALUE_OLD)) {
-            return false;
-        }
-        return true;
     }
 
     public Optional<Integer> getParallelism() {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/config/YamlConfigUtilsTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/config/YamlConfigUtilsTest.java
@@ -120,13 +120,13 @@ public class YamlConfigUtilsTest {
                         "sql-client.execution.max-table-result.rows=100",
                         "sql-client.execution.result-mode=table",
                         "table.exec.state.ttl=1000",
-                        "table.planner=old",
+                        "table.planner=blink",
                         "[DEPRECATED] execution.max-parallelism=16",
                         "[DEPRECATED] execution.max-table-result-rows=100",
                         "[DEPRECATED] execution.min-idle-state-retention=1000",
                         "[DEPRECATED] execution.parallelism=1",
                         "[DEPRECATED] execution.periodic-watermarks-interval=99",
-                        "[DEPRECATED] execution.planner=old",
+                        "[DEPRECATED] execution.planner=blink",
                         "[DEPRECATED] execution.restart-strategy.delay=1000",
                         "[DEPRECATED] execution.restart-strategy.failure-rate-interval=99000",
                         "[DEPRECATED] execution.restart-strategy.max-failures-per-interval=10",
@@ -138,7 +138,7 @@ public class YamlConfigUtilsTest {
 
     private Environment getEnvironment() throws Exception {
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", "old");
+        replaceVars.put("$VAR_PLANNER", "blink");
         replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
         replaceVars.put("$VAR_RESULT_MODE", "table");
         replaceVars.put("$VAR_UPDATE_MODE", "");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/context/ExecutionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/context/ExecutionContextTest.java
@@ -298,8 +298,7 @@ public class ExecutionContextTest {
     @Test
     public void testTemporalTables() throws Exception {
         final ExecutionContext context = createStreamingExecutionContext();
-        final StreamTableEnvironment tableEnv =
-                (StreamTableEnvironment) context.getTableEnvironment();
+        final StreamTableEnvironment tableEnv = context.getTableEnvironment();
 
         assertArrayEquals(
                 new String[] {
@@ -391,7 +390,6 @@ public class ExecutionContextTest {
 
     private Map<String, String> createDefaultReplaceVars() {
         Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", "old");
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "changelog");
         replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
@@ -402,7 +400,6 @@ public class ExecutionContextTest {
 
     static Map<String, String> createModuleReplaceVars() {
         Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", "blink");
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "changelog");
         replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
@@ -421,7 +418,6 @@ public class ExecutionContextTest {
 
     private ExecutionContext createCatalogExecutionContext() throws Exception {
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", "old");
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "changelog");
         replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/context/SessionContextTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/context/SessionContextTest.java
@@ -38,12 +38,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
 import static org.apache.flink.configuration.PipelineOptions.JARS;
 import static org.apache.flink.configuration.PipelineOptions.MAX_PARALLELISM;
 import static org.apache.flink.configuration.PipelineOptions.NAME;
 import static org.apache.flink.configuration.PipelineOptions.OBJECT_REUSE;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
-import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_PLANNER;
 import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_SQL_DIALECT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -163,12 +163,12 @@ public class SessionContextTest {
     @Test
     public void testSetWithConfigOptionAndResetWithYamlKey() {
         // runtime config option and has deprecated key
-        sessionContext.set(TABLE_PLANNER.key(), "blink");
-        assertEquals("blink", getConfiguration().get(TABLE_PLANNER).name().toLowerCase());
+        sessionContext.set(RUNTIME_MODE.key(), "BATCH");
+        assertEquals("BATCH", getConfiguration().get(RUNTIME_MODE).name());
 
-        sessionContext.reset(TABLE_PLANNER.key());
-        assertEquals("old", getConfiguration().get(TABLE_PLANNER).name().toLowerCase());
-        assertEquals("old", getConfigurationMap().get("execution.planner").toLowerCase());
+        sessionContext.reset(RUNTIME_MODE.key());
+        assertEquals("STREAMING", getConfiguration().get(RUNTIME_MODE).name());
+        assertEquals("STREAMING", getConfigurationMap().get("execution.type").toUpperCase());
     }
 
     @Test
@@ -222,7 +222,6 @@ public class SessionContextTest {
 
     private SessionContext createSessionContext() throws Exception {
         Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", "old");
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "changelog");
         replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentTest.java
@@ -51,7 +51,6 @@ public class EnvironmentTest {
     @Test
     public void testMerging() throws Exception {
         final Map<String, String> replaceVars1 = new HashMap<>();
-        replaceVars1.put("$VAR_PLANNER", "old");
         replaceVars1.put("$VAR_EXECUTION_TYPE", "batch");
         replaceVars1.put("$VAR_RESULT_MODE", "table");
         replaceVars1.put("$VAR_UPDATE_MODE", "");

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -113,8 +113,6 @@ public class LocalExecutorITCase extends TestLogger {
         return config;
     }
 
-    private static final String PLANNER = "blink";
-
     @Rule public ExpectedException exception = ExpectedException.none();
 
     @Test
@@ -149,7 +147,6 @@ public class LocalExecutorITCase extends TestLogger {
         final URL url = getClass().getClassLoader().getResource("test-data.csv");
         Objects.requireNonNull(url);
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "changelog");
@@ -194,7 +191,6 @@ public class LocalExecutorITCase extends TestLogger {
         final URL url = getClass().getClassLoader().getResource("test-data.csv");
         Objects.requireNonNull(url);
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "changelog");
@@ -242,7 +238,6 @@ public class LocalExecutorITCase extends TestLogger {
         Objects.requireNonNull(url);
 
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -269,7 +264,6 @@ public class LocalExecutorITCase extends TestLogger {
         Objects.requireNonNull(url);
 
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -306,7 +300,6 @@ public class LocalExecutorITCase extends TestLogger {
         Objects.requireNonNull(url);
 
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -327,7 +320,6 @@ public class LocalExecutorITCase extends TestLogger {
         final URL url = getClass().getClassLoader().getResource("test-data.csv");
         Objects.requireNonNull(url);
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
         replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -368,7 +360,6 @@ public class LocalExecutorITCase extends TestLogger {
         final URL url = getClass().getClassLoader().getResource("test-data.csv");
         Objects.requireNonNull(url);
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
         replaceVars.put("$VAR_RESULT_MODE", "table");
@@ -416,7 +407,6 @@ public class LocalExecutorITCase extends TestLogger {
         final URL url = getClass().getClassLoader().getResource("test-data.csv");
         Objects.requireNonNull(url);
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
         replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
         replaceVars.put("$VAR_SOURCE_SINK_PATH", csvOutputPath);
@@ -555,7 +545,6 @@ public class LocalExecutorITCase extends TestLogger {
 
     private Environment createDefaultEnvironment() throws Exception {
         final Map<String, String> replaceVars = new HashMap<>();
-        replaceVars.put("$VAR_PLANNER", PLANNER);
         replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
         replaceVars.put("$VAR_UPDATE_MODE", "");
         replaceVars.put("$VAR_MAX_ROWS", "100");

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
@@ -122,7 +122,6 @@ functions:
         value: 5
 
 execution:
-  planner: "$VAR_PLANNER"
   type: "$VAR_EXECUTION_TYPE"
   time-characteristic: event-time
   periodic-watermarks-interval: 99

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-configuration.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-configuration.yaml
@@ -22,7 +22,6 @@
 #==============================================================================
 
 execution:
-  planner: blink
   type: batch
   result-mode: table
 

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -135,7 +135,7 @@ catalogs:
     test-table: test-table
 
 execution:
-  planner: "$VAR_PLANNER"
+  planner: blink
   type: "$VAR_EXECUTION_TYPE"
   time-characteristic: event-time
   periodic-watermarks-interval: 99

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-dialect.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-dialect.yaml
@@ -22,7 +22,6 @@
 #==============================================================================
 
 execution:
-  planner: blink
   type: batch
   result-mode: table
 

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-execution.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-execution.yaml
@@ -24,7 +24,6 @@
 # this file has variables that can be filled with content by replacing $VAR_XXX
 
 execution:
-  planner: "$VAR_PLANNER"
   type: "$VAR_EXECUTION_TYPE"
   time-characteristic: event-time
   periodic-watermarks-interval: 99

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-modules.yaml
@@ -24,7 +24,6 @@
 # this file has variables that can be filled with content by replacing $VAR_XXX
 
 execution:
-  planner: "$VAR_PLANNER"
   type: "$VAR_EXECUTION_TYPE"
   time-characteristic: event-time
   periodic-watermarks-interval: 99

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-python-functions.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-python-functions.yaml
@@ -22,7 +22,6 @@
 #==============================================================================
 
 execution:
-  planner: blink
   type: batch
   result-mode: table
 


### PR DESCRIPTION
## What is the purpose of the change

This removes support of the legacy planner in SQL Client. It also removes the concept of having different planners. A user will get a helpful exception if `table.planner=old` is used. `table.planner=blink` is still supported.


## Brief change log

- remove all code locations to legacy planner
- remove BatchTableEnvironment

## Verifying this change

This change is already covered by existing tests. Also the change has been manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
