### PR TITLE
[FLINK-22833][metrics] Set checkpointStartDelay in checkpoint metrics for SourceTasks

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -78,28 +78,6 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
             ResultPartitionID partitionId,
             ResultPartitionManager partitionManager,
             TaskEventPublisher taskEventPublisher,
-            Counter numBytesIn,
-            Counter numBuffersIn) {
-
-        this(
-                inputGate,
-                channelIndex,
-                partitionId,
-                partitionManager,
-                taskEventPublisher,
-                0,
-                0,
-                numBytesIn,
-                numBuffersIn,
-                ChannelStateWriter.NO_OP);
-    }
-
-    public LocalInputChannel(
-            SingleInputGate inputGate,
-            int channelIndex,
-            ResultPartitionID partitionId,
-            ResultPartitionManager partitionManager,
-            TaskEventPublisher taskEventPublisher,
             int initialBackoff,
             int maxBackoff,
             Counter numBytesIn,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -69,10 +69,6 @@ public class TestTaskStateManager implements TaskStateManager {
                 localRecoveryConfig);
     }
 
-    public TestTaskStateManager(JobID jobId, ExecutionAttemptID executionAttemptID) {
-        this(jobId, executionAttemptID, null, TestLocalRecoveryConfig.disabled());
-    }
-
     public TestTaskStateManager(
             JobID jobId,
             ExecutionAttemptID executionAttemptID,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -952,7 +952,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                                             System.currentTimeMillis()
                                                     - checkpointMetaData.getTimestamp());
                     try {
-                        result.complete(triggerCheckpoint(checkpointMetaData, checkpointOptions));
+                        result.complete(
+                                triggerCheckpointAsyncInMailbox(
+                                        checkpointMetaData, checkpointOptions));
                     } catch (Exception ex) {
                         // Report the failure both via the Future result but also to the mailbox
                         result.completeExceptionally(ex);
@@ -965,7 +967,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         return result;
     }
 
-    private boolean triggerCheckpoint(
+    private boolean triggerCheckpointAsyncInMailbox(
             CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions)
             throws Exception {
         FlinkSecurityManager.monitorUserSystemExitForCurrentThread();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -945,12 +945,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
         CompletableFuture<Boolean> result = new CompletableFuture<>();
         mainMailboxExecutor.execute(
                 () -> {
-                    latestAsyncCheckpointStartDelayNanos =
-                            1_000_000
-                                    * Math.max(
-                                            0,
-                                            System.currentTimeMillis()
-                                                    - checkpointMetaData.getTimestamp());
                     try {
                         result.complete(
                                 triggerCheckpointAsyncInMailbox(
@@ -972,11 +966,18 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
             throws Exception {
         FlinkSecurityManager.monitorUserSystemExitForCurrentThread();
         try {
+            latestAsyncCheckpointStartDelayNanos =
+                    1_000_000
+                            * Math.max(
+                                    0,
+                                    System.currentTimeMillis() - checkpointMetaData.getTimestamp());
+
             // No alignment if we inject a checkpoint
             CheckpointMetricsBuilder checkpointMetrics =
                     new CheckpointMetricsBuilder()
                             .setAlignmentDurationNanos(0L)
-                            .setBytesProcessedDuringAlignment(0L);
+                            .setBytesProcessedDuringAlignment(0L)
+                            .setCheckpointStartDelayNanos(latestAsyncCheckpointStartDelayNanos);
 
             subtaskCheckpointCoordinator.initInputsCheckpoint(
                     checkpointMetaData.getCheckpointId(), checkpointOptions);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -32,16 +32,12 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.MetricNames;
-import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.operators.SourceOperator;
@@ -56,23 +52,18 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO;
 import static org.apache.flink.streaming.util.TestHarnessUtil.assertOutputEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -80,48 +71,17 @@ import static org.junit.Assert.assertTrue;
  * Tests for verifying that the {@link SourceOperator} as a task input can be integrated well with
  * {@link org.apache.flink.streaming.runtime.io.StreamOneInputProcessor}.
  */
-public class SourceOperatorStreamTaskTest {
+public class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
     private static final OperatorID OPERATOR_ID = new OperatorID();
     private static final int NUM_RECORDS = 10;
 
     @Test
     public void testMetrics() throws Exception {
-        long sleepTime = 42;
-
-        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                        SourceOperatorStreamTask::new, INT_TYPE_INFO);
-
-        final Map<String, Metric> metrics = new ConcurrentHashMap<>();
-        final TaskMetricGroup taskMetricGroup =
-                new StreamTaskTestHarness.TestTaskMetricGroup(metrics);
-
-        try (StreamTaskMailboxTestHarness<Integer> harness =
-                builder.setupOutputForSingletonOperatorChain(
-                                new SourceOperatorFactory<>(
-                                        new MockSource(Boundedness.BOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
-                        .setTaskMetricGroup(taskMetricGroup)
-                        .build()) {
-
-            Future<Boolean> triggerFuture =
-                    harness.streamTask.triggerCheckpointAsync(
-                            new CheckpointMetaData(1L, System.currentTimeMillis()),
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
-
-            assertFalse(triggerFuture.isDone());
-            Thread.sleep(sleepTime);
-            while (!triggerFuture.isDone()) {
-                harness.streamTask.runMailboxStep();
-            }
-            Gauge<Long> checkpointStartDelayGauge =
-                    (Gauge<Long>) metrics.get(MetricNames.CHECKPOINT_START_DELAY_TIME);
-            assertThat(
-                    checkpointStartDelayGauge.getValue(),
-                    greaterThanOrEqualTo(sleepTime * 1_000_000));
-            Gauge<Double> busyTimeGauge = (Gauge<Double>) metrics.get(MetricNames.TASK_BUSY_TIME);
-            assertThat(busyTimeGauge.getValue(), lessThanOrEqualTo(1_000_000d));
-        }
+        testMetrics(
+                SourceOperatorStreamTask::new,
+                new SourceOperatorFactory<>(
+                        new MockSource(Boundedness.BOUNDED, 1), WatermarkStrategy.noWatermarks()),
+                lessThanOrEqualTo(1_000_000d));
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -27,14 +27,10 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.MetricNames;
-import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
@@ -43,6 +39,7 @@ import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
@@ -60,11 +57,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -75,21 +70,21 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT_SUSPEND;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
  * These tests verify that the RichFunction methods are called (in correct order). And that
  * checkpointing/element emission don't occur concurrently.
  */
-public class SourceStreamTaskTest {
+public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
 
     @Test
     public void testInputEndedBeforeStopWithSavepointConfirmed() throws Exception {
@@ -101,7 +96,7 @@ public class SourceStreamTaskTest {
                 new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO)
                         .setupOperatorChain(
                                 new OperatorID(),
-                                new StreamSource<String, CancelTestSource>(source))
+                                new StreamSource<String, CancelTestSource<String>>(source))
                         .chain(
                                 new OperatorID(),
                                 chainTail,
@@ -147,42 +142,16 @@ public class SourceStreamTaskTest {
         Assert.assertEquals(10, resultElements.size());
     }
 
-    @Test(timeout = 60_000)
+    @Test
     public void testMetrics() throws Exception {
-        long sleepTime = 42;
-        StreamTaskMailboxTestHarnessBuilder<String> builder =
-                new StreamTaskMailboxTestHarnessBuilder<>(SourceStreamTask::new, STRING_TYPE_INFO);
-
-        final Map<String, Metric> metrics = new ConcurrentHashMap<>();
-        final TaskMetricGroup taskMetricGroup =
-                new StreamTaskTestHarness.TestTaskMetricGroup(metrics);
-
-        StreamTaskMailboxTestHarness<String> harness =
-                builder.setupOutputForSingletonOperatorChain(
-                                new StreamSource<>(
-                                        new CancelTestSource(
-                                                STRING_TYPE_INFO.createSerializer(
-                                                        new ExecutionConfig()),
-                                                "Hello")))
-                        .setTaskMetricGroup(taskMetricGroup)
-                        .build();
-
-        Future<Boolean> triggerFuture =
-                harness.streamTask.triggerCheckpointAsync(
-                        new CheckpointMetaData(1L, System.currentTimeMillis()),
-                        CheckpointOptions.forCheckpointWithDefaultLocation());
-
-        assertFalse(triggerFuture.isDone());
-        Thread.sleep(sleepTime);
-        while (!triggerFuture.isDone()) {
-            harness.streamTask.runMailboxStep();
-        }
-        Gauge<Long> checkpointStartDelayGauge =
-                (Gauge<Long>) metrics.get(MetricNames.CHECKPOINT_START_DELAY_TIME);
-        assertThat(
-                checkpointStartDelayGauge.getValue(), greaterThanOrEqualTo(sleepTime * 1_000_000));
-        Gauge<Double> busyTimeGauge = (Gauge<Double>) metrics.get(MetricNames.TASK_BUSY_TIME);
-        assertTrue(Double.isNaN(busyTimeGauge.getValue()));
+        testMetrics(
+                SourceStreamTask::new,
+                SimpleOperatorFactory.of(
+                        new StreamSource<Integer, SourceFunction<Integer>>(
+                                new CancelTestSource(
+                                        INT_TYPE_INFO.createSerializer(new ExecutionConfig()),
+                                        42))),
+                is(Double.NaN));
     }
 
     /**
@@ -792,20 +761,19 @@ public class SourceStreamTaskTest {
         public void cancel() {}
     }
 
-    private static class CancelTestSource extends FromElementsFunction<String> {
+    private static class CancelTestSource<T> extends FromElementsFunction<T> {
         private static final long serialVersionUID = 8713065281092996067L;
 
         private static MultiShotLatch dataProcessing = new MultiShotLatch();
 
         private static MultiShotLatch cancellationWaiting = new MultiShotLatch();
 
-        public CancelTestSource(TypeSerializer<String> serializer, String... elements)
-                throws IOException {
+        public CancelTestSource(TypeSerializer<T> serializer, T... elements) throws IOException {
             super(serializer, elements);
         }
 
         @Override
-        public void run(SourceContext<String> ctx) throws Exception {
+        public void run(SourceContext<T> ctx) throws Exception {
             super.run(ctx);
 
             dataProcessing.trigger();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -25,8 +26,11 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.util.function.FunctionWithException;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.hamcrest.Matcher;
 
@@ -66,6 +70,9 @@ public class SourceStreamTaskTestBase {
                             new CheckpointMetaData(1L, System.currentTimeMillis()),
                             CheckpointOptions.forCheckpointWithDefaultLocation());
 
+            OneShotLatch checkpointAcknowledgeLatch = new OneShotLatch();
+            harness.getCheckpointResponder().setAcknowledgeLatch(checkpointAcknowledgeLatch);
+
             assertFalse(triggerFuture.isDone());
             Thread.sleep(sleepTime);
             while (!triggerFuture.isDone()) {
@@ -78,6 +85,14 @@ public class SourceStreamTaskTestBase {
                     greaterThanOrEqualTo(sleepTime * 1_000_000));
             Gauge<Double> busyTimeGauge = (Gauge<Double>) metrics.get(MetricNames.TASK_BUSY_TIME);
             assertThat(busyTimeGauge.getValue(), busyTimeMatcher);
+
+            checkpointAcknowledgeLatch.await();
+            TestCheckpointResponder.AcknowledgeReport acknowledgeReport =
+                    Iterables.getOnlyElement(
+                            harness.getCheckpointResponder().getAcknowledgeReports());
+            assertThat(
+                    acknowledgeReport.getCheckpointMetrics().getCheckpointStartDelayNanos(),
+                    greaterThanOrEqualTo(sleepTime * 1_000_000));
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTestBase.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.hamcrest.Matcher;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/** Common base class for testing source tasks. */
+public class SourceStreamTaskTestBase {
+    public void testMetrics(
+            FunctionWithException<Environment, ? extends StreamTask<Integer, ?>, Exception>
+                    taskFactory,
+            StreamOperatorFactory<?> operatorFactory,
+            Matcher<Double> busyTimeMatcher)
+            throws Exception {
+        long sleepTime = 42;
+
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(taskFactory, INT_TYPE_INFO);
+
+        final Map<String, Metric> metrics = new ConcurrentHashMap<>();
+        final TaskMetricGroup taskMetricGroup =
+                new StreamTaskTestHarness.TestTaskMetricGroup(metrics);
+
+        try (StreamTaskMailboxTestHarness<Integer> harness =
+                builder.setupOutputForSingletonOperatorChain(operatorFactory)
+                        .setTaskMetricGroup(taskMetricGroup)
+                        .build()) {
+
+            Future<Boolean> triggerFuture =
+                    harness.streamTask.triggerCheckpointAsync(
+                            new CheckpointMetaData(1L, System.currentTimeMillis()),
+                            CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            assertFalse(triggerFuture.isDone());
+            Thread.sleep(sleepTime);
+            while (!triggerFuture.isDone()) {
+                harness.streamTask.runMailboxStep();
+            }
+            Gauge<Long> checkpointStartDelayGauge =
+                    (Gauge<Long>) metrics.get(MetricNames.CHECKPOINT_START_DELAY_TIME);
+            assertThat(
+                    checkpointStartDelayGauge.getValue(),
+                    greaterThanOrEqualTo(sleepTime * 1_000_000));
+            Gauge<Double> busyTimeGauge = (Gauge<Double>) metrics.get(MetricNames.TASK_BUSY_TIME);
+            assertThat(busyTimeGauge.getValue(), busyTimeMatcher);
+        }
+    }
+}


### PR DESCRIPTION
This PR is fixing a bug of `checkpointStartDelay` being not set in `CheckpointMetrics` of `SourceStreamTask` and `SourceOperatorStreamTask`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
