### PR TITLE
[FLINK-22851][security] Add basic authentication support to job dashboard and REST

### DIFF
--- a/docs/layouts/shortcodes/generated/expert_rest_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rest_section.html
@@ -98,5 +98,23 @@
             <td>Integer</td>
             <td>Thread priority of the REST server's executor for processing asynchronous requests. Lowering the thread priority will give Flink's main components more CPU time whereas increasing will allocate more time for the REST server's processing.</td>
         </tr>
+        <tr>
+            <td><h5>security.basic.auth.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enables HTTP basic authentication.</td>
+        </tr>
+        <tr>
+            <td><h5>security.basic.auth.password.file</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication password file.</td>
+        </tr>
+        <tr>
+            <td><h5>security.basic.auth.client.credentials</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication client credentials user:password.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/expert_rest_section.html
+++ b/docs/layouts/shortcodes/generated/expert_rest_section.html
@@ -99,6 +99,12 @@
             <td>Thread priority of the REST server's executor for processing asynchronous requests. Lowering the thread priority will give Flink's main components more CPU time whereas increasing will allocate more time for the REST server's processing.</td>
         </tr>
         <tr>
+            <td><h5>security.basic.auth.client.credentials</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication client credentials user:pwd.</td>
+        </tr>
+        <tr>
             <td><h5>security.basic.auth.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -109,12 +115,6 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Basic authentication password file.</td>
-        </tr>
-        <tr>
-            <td><h5>security.basic.auth.client.credentials</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Basic authentication client credentials user:password.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/history_server_configuration.html
+++ b/docs/layouts/shortcodes/generated/history_server_configuration.html
@@ -33,6 +33,12 @@
             <td>The maximum number of jobs to retain in each archive directory defined by `historyserver.archive.fs.dir`. If set to `-1`(default), there is no limit to the number of archives. If set to `0` or less than `-1` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
         </tr>
         <tr>
+            <td><h5>historyserver.security.basic.auth.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable basic authentication to the HistoryServer web frontend.</td>
+        </tr>
+        <tr>
             <td><h5>historyserver.web.address</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
@@ -55,12 +61,6 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the global SSL flag security.ssl.enabled is set to true.</td>
-        </tr>
-        <tr>
-            <td><h5>historyserver.security.basic.auth.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Enable basic authentication to the HistoryServer web frontend.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.tmpdir</h5></td>

--- a/docs/layouts/shortcodes/generated/history_server_configuration.html
+++ b/docs/layouts/shortcodes/generated/history_server_configuration.html
@@ -57,6 +57,12 @@
             <td>Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the global SSL flag security.ssl.enabled is set to true.</td>
         </tr>
         <tr>
+            <td><h5>historyserver.security.basic.auth.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable basic authentication to the HistoryServer web frontend.</td>
+        </tr>
+        <tr>
             <td><h5>historyserver.web.tmpdir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -101,10 +101,10 @@
       "type" : "object",
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:DashboardConfiguration:Features",
       "properties" : {
-        "web-submit" : {
+        "web-cancel" : {
           "type" : "boolean"
         },
-        "web-cancel" : {
+        "web-submit" : {
           "type" : "boolean"
         }
       }

--- a/docs/layouts/shortcodes/generated/security_configuration.html
+++ b/docs/layouts/shortcodes/generated/security_configuration.html
@@ -9,6 +9,24 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>security.basic.auth.client.credentials</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication client credentials user:pwd.</td>
+        </tr>
+        <tr>
+            <td><h5>security.basic.auth.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enables HTTP basic authentication.</td>
+        </tr>
+        <tr>
+            <td><h5>security.basic.auth.password.file</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication password file.</td>
+        </tr>
+        <tr>
             <td><h5>security.context.factory.classes</h5></td>
             <td style="word-wrap: break-word;">"org.apache.flink.runtime.security.contexts.HadoopSecurityContextFactory";<wbr>"org.apache.flink.runtime.security.contexts.NoOpSecurityContextFactory"</td>
             <td>List&lt;String&gt;</td>
@@ -211,24 +229,6 @@
             <td style="word-wrap: break-word;">"zookeeper"</td>
             <td>String</td>
             <td></td>
-        </tr>
-        <tr>
-            <td><h5>security.basic.auth.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Enables HTTP basic authentication.</td>
-        </tr>
-        <tr>
-            <td><h5>security.basic.auth.password.file</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Basic authentication password file.</td>
-        </tr>
-        <tr>
-            <td><h5>security.basic.auth.client.credentials</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Basic authentication client credentials user:password.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/security_configuration.html
+++ b/docs/layouts/shortcodes/generated/security_configuration.html
@@ -212,5 +212,23 @@
             <td>String</td>
             <td></td>
         </tr>
+        <tr>
+            <td><h5>security.basic.auth.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enables HTTP basic authentication.</td>
+        </tr>
+        <tr>
+            <td><h5>security.basic.auth.password.file</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication password file.</td>
+        </tr>
+        <tr>
+            <td><h5>security.basic.auth.client.credentials</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Basic authentication client credentials user:password.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -95,6 +95,13 @@ public class HistoryServerOptions {
                             "Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the"
                                     + " global SSL flag security.ssl.enabled is set to true.");
 
+    /** Enables/Disables basic authentication support for the HistoryServer web-frontend. */
+    public static final ConfigOption<Boolean> HISTORY_SERVER_WEB_BASIC_AUTH_ENABLED =
+            key("historyserver.security.basic.auth.enabled")
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enable basic authentication to the HistoryServer web frontend.");
+
     public static final ConfigOption<Integer> HISTORY_SERVER_RETAINED_JOBS =
             key("historyserver.archive.retained-jobs")
                     .intType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -510,4 +510,27 @@ public class SecurityOptions {
                                     + "channel. If the `close_notify` was not flushed in the given timeout the channel will be closed "
                                     + "forcibly. (-1 = use system default)")
                     .withDeprecatedKeys("security.ssl.close-notify-flush-timeout");
+
+    // ------------------- basic authentication parameters --------------------
+
+    /** Basic authentication enabled. */
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<Boolean> BASIC_AUTH_ENABLED =
+            key("security.basic.auth.enabled")
+                    .defaultValue(false)
+                    .withDescription("Enables HTTP basic authentication.");
+
+    /** Basic authentication password file. */
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<String> BASIC_AUTH_PWD_FILE =
+            key("security.basic.auth.password.file")
+                    .noDefaultValue()
+                    .withDescription("Basic authentication password file.");
+
+    /** Basic authentication client credentials user:pwd. */
+    @Documentation.Section(Documentation.Sections.EXPERT_REST)
+    public static final ConfigOption<String> BASIC_AUTH_CLIENT_CREDENTIALS =
+            key("security.basic.auth.client.credentials")
+                    .noDefaultValue()
+                    .withDescription("Basic authentication client credentials user:pwd.");
 }

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -76,6 +76,11 @@ under the License.
 			<artifactId>flink-shaded-jackson</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+
 		<!-- ===================================================
 								Testing
 			=================================================== -->

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.webmonitor.utils;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.io.network.netty.ServerBasicAuthHandlerFactory;
 import org.apache.flink.runtime.rest.handler.router.Router;
@@ -36,7 +35,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInitializer;
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCodec;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/LeaderRetrievalHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/LeaderRetrievalHandlerTest.java
@@ -70,7 +70,8 @@ public class LeaderRetrievalHandlerTest extends TestLogger {
 
         router.addGet(restPath, testingHandler);
         WebFrontendBootstrap bootstrap =
-                new WebFrontendBootstrap(router, log, null, null, "localhost", 0, configuration);
+                new WebFrontendBootstrap(
+                        router, log, null, null, null, "localhost", 0, configuration);
 
         try (HttpTestClient httpClient =
                 new HttpTestClient("localhost", bootstrap.getServerPort())) {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerBasicAuthTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerBasicAuthTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.history;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HistoryServerOptions;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.rest.RestBasicAuthITCase;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Base64;
+
+/** Test for the HistoryServer Basic authentication integration. */
+public class HistoryServerBasicAuthTest extends TestLogger {
+
+    private static final String PASSWORD_FILE =
+            RestBasicAuthITCase.class.getResource("/.htpasswd").getFile();
+
+    private static final String USER_CREDENTIALS = "testusr:testpwd";
+
+    @Rule public final TemporaryFolder haBaseFolder = new TemporaryFolder();
+
+    private File jmDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        jmDirectory = haBaseFolder.newFolder("jm");
+    }
+
+    @Test
+    public void testAuthGoodCredentials() throws Exception {
+        Configuration serverConfig = getServerConfig();
+        HistoryServer hs = new HistoryServer(serverConfig);
+
+        try {
+            hs.start();
+            String baseUrl = "http://localhost:" + hs.getWebPort();
+            String authHeader =
+                    "Basic " + new String(Base64.getEncoder().encode(USER_CREDENTIALS.getBytes()));
+            Assert.assertEquals(200, getHTTPResponseCode(baseUrl, authHeader));
+        } finally {
+            hs.stop();
+        }
+    }
+
+    @Test
+    public void testAuthBadCredentials() throws Exception {
+        Configuration serverConfig = getServerConfig();
+        HistoryServer hs = new HistoryServer(serverConfig);
+
+        try {
+            hs.start();
+            String baseUrl = "http://localhost:" + hs.getWebPort();
+            Assert.assertEquals(401, getHTTPResponseCode(baseUrl, null));
+        } finally {
+            hs.stop();
+        }
+    }
+
+    private Configuration getServerConfig() {
+        Configuration config = new Configuration();
+        config.setString(
+                HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS, jmDirectory.toURI().toString());
+        config.set(HistoryServerOptions.HISTORY_SERVER_WEB_BASIC_AUTH_ENABLED, true);
+        config.set(SecurityOptions.BASIC_AUTH_PWD_FILE, PASSWORD_FILE);
+        config.set(SecurityOptions.BASIC_AUTH_ENABLED, true);
+        config.set(SecurityOptions.BASIC_AUTH_CLIENT_CREDENTIALS, USER_CREDENTIALS);
+        return config;
+    }
+
+    private int getHTTPResponseCode(String url, String authHeader) throws Exception {
+        URL u = new URL(url);
+        HttpURLConnection connection = (HttpURLConnection) u.openConnection();
+        connection.setConnectTimeout(10000);
+        if (authHeader != null) {
+            connection.setRequestProperty("Authorization", authHeader);
+        }
+        connection.connect();
+        return connection.getResponseCode();
+    }
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
@@ -51,6 +51,7 @@ public class HistoryServerStaticFileServerHandlerTest extends TestLogger {
                         LoggerFactory.getLogger(HistoryServerStaticFileServerHandlerTest.class),
                         tmp.newFolder("uploadDir"),
                         null,
+                        null,
                         "localhost",
                         0,
                         new Configuration());

--- a/flink-runtime-web/src/test/resources/.htpasswd
+++ b/flink-runtime-web/src/test/resources/.htpasswd
@@ -1,0 +1,2 @@
+testusr:$apr1$w7MhlTpg$r1Lx2b8S21.Y97ohCvNTj/
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/ServerBasicAuthHandlerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/ServerBasicAuthHandlerFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.runtime.rest.handler.ServerBasicHttpAuthenticator;
+import org.apache.flink.util.ConfigurationException;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class ServerBasicAuthHandlerFactory {
+
+    private final ImmutableMap<String, String> credentials;
+
+    public ServerBasicAuthHandlerFactory(String pwdFile) throws ConfigurationException {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        try (Stream<String> stream = Files.lines(Paths.get(pwdFile))) {
+            stream.forEach(
+                    line -> {
+                        if (!line.isEmpty()) {
+                            String[] split = line.split(":", 2);
+                            builder.put(split[0], split[1]);
+                        }
+                    });
+        } catch (IOException ioe) {
+            throw new ConfigurationException(ioe);
+        }
+        this.credentials = builder.build();
+    }
+
+    public ServerBasicHttpAuthenticator getAuthHandler(Map<String, String> responseHeaders) {
+        return new ServerBasicHttpAuthenticator(credentials, responseHeaders);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/ClientBasicHttpAuthenticator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/ClientBasicHttpAuthenticator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelDuplexHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
+
+import java.util.Base64;
+
+/**
+ * Netty handler for basic authentication on the Client side. Based on
+ * https://github.com/vzhn/netty-http-authenticator/blob/master/src/main/java/me/vzhilin/auth/netty/BasicNettyHttpAuthenticator.java
+ * (MIT License).
+ */
+@ChannelHandler.Sharable
+public final class ClientBasicHttpAuthenticator extends ChannelDuplexHandler {
+    private final String basicAuthHeader;
+
+    public ClientBasicHttpAuthenticator(String credentials) {
+        this.basicAuthHeader =
+                "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes());
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+            throws Exception {
+        if (msg instanceof HttpRequest) {
+            ((HttpRequest) msg).headers().set(HttpHeaderNames.AUTHORIZATION, basicAuthHeader);
+        }
+        super.write(ctx, msg, promise);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/ServerBasicHttpAuthenticator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/ServerBasicHttpAuthenticator.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
+import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.apache.commons.codec.digest.Md5Crypt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/** Netty handler for basic authentication on the Server side. */
+@ChannelHandler.Sharable
+public class ServerBasicHttpAuthenticator extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerBasicHttpAuthenticator.class);
+
+    private final Map<String, String> responseHeaders;
+
+    private final ImmutableMap<String, String> credentials;
+
+    public ServerBasicHttpAuthenticator(
+            ImmutableMap<String, String> credentials, final Map<String, String> responseHeaders) {
+        this.responseHeaders = new HashMap<>(requireNonNull(responseHeaders));
+        this.responseHeaders.put("WWW-Authenticate", "Basic realm=\"flink\"");
+        this.credentials = credentials;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (msg instanceof HttpRequest) {
+            HttpHeaders headers = ((HttpRequest) msg).headers();
+            /*
+             * look for auth token
+             */
+            String auth = headers.get("Authorization");
+            if (auth == null) {
+                HandlerUtils.sendErrorResponse(
+                        ctx,
+                        false,
+                        new ErrorResponseBody("Missing Authorization header"),
+                        HttpResponseStatus.UNAUTHORIZED,
+                        responseHeaders);
+                return;
+            }
+            int sp = auth.indexOf(' ');
+            if (sp == -1 || !auth.substring(0, sp).equals("Basic")) {
+                HandlerUtils.sendErrorResponse(
+                        ctx,
+                        false,
+                        new ErrorResponseBody("Unknown Authorization method"),
+                        HttpResponseStatus.UNAUTHORIZED,
+                        responseHeaders);
+                return;
+            }
+            byte[] b = Base64.getDecoder().decode(auth.substring(sp + 1));
+            String userpass = new String(b);
+            int colon = userpass.indexOf(':');
+            if (colon < 0) {
+                HandlerUtils.sendErrorResponse(
+                        ctx,
+                        false,
+                        new ErrorResponseBody("No password found in basic authentication header"),
+                        HttpResponseStatus.UNAUTHORIZED,
+                        responseHeaders);
+                return;
+            }
+            String uname = userpass.substring(0, colon);
+            String pass = userpass.substring(colon + 1);
+
+            if (checkCredentials(uname, pass)) {
+                ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+            } else {
+                HandlerUtils.sendErrorResponse(
+                        ctx,
+                        false,
+                        new ErrorResponseBody("Invalid credentials"),
+                        HttpResponseStatus.UNAUTHORIZED,
+                        responseHeaders);
+            }
+        } else {
+            // Only HttpRequests are authenticated
+            ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+        }
+    }
+
+    /**
+     * Checks credentials against the stored hashes using salted MD5 hashing as described in
+     * http://httpd.apache.org/docs/2.2/misc/password_encryptions.html. This is the default format
+     * produced by the htpasswd command.
+     *
+     * @param username Username provided in the http request
+     * @param password Password provided in the http request
+     * @return True if username & password match the stored credentials
+     */
+    private boolean checkCredentials(String username, String password) {
+        String storedPwdHash = credentials.get(username);
+        if (storedPwdHash == null) {
+            return false;
+        }
+
+        String computedPwdHash =
+                Md5Crypt.apr1Crypt(password.getBytes(), storedPwdHash.substring(6, 14));
+        return storedPwdHash.equals(computedPwdHash);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestBasicAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestBasicAuthITCase.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.rest.util.TestRestServerEndpoint;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** This test validates basic auth for rest endpoints. */
+public class RestBasicAuthITCase extends TestLogger {
+
+    private static final String PASSWORD_FILE =
+            RestBasicAuthITCase.class.getResource("/.htpasswd").getFile();
+
+    private static RestServerEndpoint serverEndpoint;
+    private static RestServerEndpointITCase.TestVersionHandler testVersionHandler;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        RestServerEndpointConfiguration restServerConfig =
+                RestServerEndpointConfiguration.fromConfiguration(getConfig());
+
+        RestfulGateway restfulGateway = new TestingRestfulGateway.Builder().build();
+        testVersionHandler =
+                new RestServerEndpointITCase.TestVersionHandler(
+                        () -> CompletableFuture.completedFuture(restfulGateway),
+                        RpcUtils.INF_TIMEOUT);
+
+        serverEndpoint =
+                new TestRestServerEndpoint(
+                        restServerConfig,
+                        Arrays.asList(
+                                Tuple2.of(
+                                        testVersionHandler.getMessageHeaders(),
+                                        testVersionHandler)));
+        serverEndpoint.start();
+    }
+
+    @Test
+    public void testAuthGoodCredentials() throws Exception {
+        RestClient restClientWithGoodCredentials =
+                new RestClient(
+                        RestClientConfiguration.fromConfiguration(getConfig()),
+                        TestingUtils.defaultExecutor());
+        restClientWithGoodCredentials
+                .sendRequest(
+                        serverEndpoint.getServerAddress().getHostString(),
+                        serverEndpoint.getServerAddress().getPort(),
+                        testVersionHandler.getMessageHeaders())
+                .get();
+    }
+
+    @Test
+    public void testAuthBadCredentials() throws Exception {
+        Configuration badCredsConf = getConfig();
+        badCredsConf.set(SecurityOptions.BASIC_AUTH_CLIENT_CREDENTIALS, "wrong:pwd");
+        RestClient restClientWithBadCredentials =
+                new RestClient(
+                        RestClientConfiguration.fromConfiguration(badCredsConf),
+                        TestingUtils.defaultExecutor());
+
+        try {
+            restClientWithBadCredentials
+                    .sendRequest(
+                            serverEndpoint.getServerAddress().getHostString(),
+                            serverEndpoint.getServerAddress().getPort(),
+                            testVersionHandler.getMessageHeaders())
+                    .get();
+            fail();
+        } catch (ExecutionException ee) {
+            assertTrue(ee.getCause().getMessage().contains("Invalid credentials"));
+        }
+    }
+
+    private static Configuration getConfig() {
+        final Configuration conf = new Configuration();
+        conf.setString(RestOptions.BIND_PORT, "0");
+        conf.setString(RestOptions.ADDRESS, "localhost");
+        conf.set(SecurityOptions.BASIC_AUTH_ENABLED, true);
+        conf.set(SecurityOptions.BASIC_AUTH_PWD_FILE, PASSWORD_FILE);
+        conf.set(SecurityOptions.BASIC_AUTH_CLIENT_CREDENTIALS, "testusr:testpwd");
+        return conf;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/TestRestServerEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/TestRestServerEndpoint.java
@@ -76,7 +76,7 @@ public class TestRestServerEndpoint extends RestServerEndpoint {
 
     private final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers;
 
-    private TestRestServerEndpoint(
+    public TestRestServerEndpoint(
             final RestServerEndpointConfiguration configuration,
             final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers)
             throws IOException {

--- a/flink-runtime/src/test/resources/.htpasswd
+++ b/flink-runtime/src/test/resources/.htpasswd
@@ -1,0 +1,2 @@
+testusr:$apr1$w7MhlTpg$r1Lx2b8S21.Y97ohCvNTj/
+


### PR DESCRIPTION
## What is the purpose of the change

The Flink Dashboard and HistoryServer lacks any kind of authentication but enterprise users are expecting that.
In this PR I'm adding basic authentication. Please see [FLIP](https://docs.google.com/document/d/1NMPeJ9H0G49TGy3AzTVVJVKmYC0okwOtqLTSPnGqzHw/edit?usp=sharing) for further details.

## Brief change log

  - Added the necessary configurations (please see docs)
  - Added basic authentication to History Server
  - Added basic authentication to REST Client
  - Added basic authentication to REST Server
  - Added `commons-codec` dependency to `flink-runtime-web` because of MD5 usage
  - Made `TestRestServerEndpoint` public
  - Added various documentations

## Verifying this change

The following automated tests has been added:
  - `RestBasicAuthITCase`
  - `HistoryServerBasicAuthTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs + JavaDocs
