### PR TITLE
[FLINK-22776][connector-jdbc] Delete casting to byte[] in AbstractJdbcRowConverter class

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/AbstractJdbcRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/AbstractJdbcRowConverter.java
@@ -177,7 +177,7 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
                 return val -> StringData.fromString((String) val);
             case BINARY:
             case VARBINARY:
-                return val -> (byte[]) val;
+                return val -> val;
             case ARRAY:
             case ROW:
             case MAP:


### PR DESCRIPTION
## What is the purpose of the change

Casting to 'byte[]' is redundant.

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

## Brief change log

Delete casting to byte[] in createInternalConverter method of AbstractJdbcRowConverter class

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
