### PR TITLE
[FLINK-22712][python] Support accessing Row fields by attribute name in PyFlink Row-based Operation

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -29,6 +29,8 @@ cdef enum InternalRowKind:
 cdef class InternalRow:
     cdef readonly list values
     cdef readonly InternalRowKind row_kind
+    cdef list field_names
+    cpdef object to_row(self)
     cdef bint is_retract_msg(self)
     cdef bint is_accumulate_msg(self)
 

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -37,7 +37,21 @@ ROW_KIND_BIT_SIZE = 2
 cdef class InternalRow:
     def __cinit__(self, list values, InternalRowKind row_kind):
         self.values = values
-        self.row_kind = row_kind
+        self.field_names = []
+
+    cpdef object to_row(self):
+        row = Row()
+        row._values = self.values
+        row.set_field_names(self.field_names)
+        row.set_row_kind(RowKind(self.row_kind))
+        return row
+
+    @staticmethod
+    def from_row(row: Row) -> InternalRow:
+        cdef InternalRow internal_row
+        internal_row = InternalRow(row._values, row.get_row_kind().value)
+        internal_row.field_names = row._fields
+        return internal_row
 
     cdef bint is_retract_msg(self):
         return self.row_kind == InternalRowKind.UPDATE_BEFORE or \

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -37,6 +37,7 @@ ROW_KIND_BIT_SIZE = 2
 cdef class InternalRow:
     def __cinit__(self, list values, InternalRowKind row_kind):
         self.values = values
+        self.row_kind = row_kind
         self.field_names = []
 
     cpdef object to_row(self):

--- a/flink-python/pyflink/fn_execution/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/operation_utils.py
@@ -84,15 +84,9 @@ def normalize_pandas_result(it):
     return arrays
 
 
-def wrap_inputs_as_row(*args):
-    from pyflink.common.types import Row
+def wrap_input_series_as_datframe(*args):
     import pandas as pd
-    if type(args[0]) == pd.Series:
-        return pd.concat(args, axis=1)
-    elif len(args) == 1 and isinstance(args[0], (pd.DataFrame, Row, Tuple)):
-        return args[0]
-    else:
-        return Row(*args)
+    return pd.concat(args, axis=1)
 
 
 def check_pandas_udf_result(f, *input_args):
@@ -171,8 +165,16 @@ def extract_user_defined_function(user_defined_function_proto, pandas_udaf=False
     variable_dict.update(input_variable_dict)
     user_defined_funcs.extend(input_funcs)
     if user_defined_function_proto.takes_row_as_input:
-        variable_dict['wrap_inputs_as_row'] = wrap_inputs_as_row
-        func_str = "%s(wrap_inputs_as_row(%s))" % (func_name, func_args)
+        if input_variable_dict:
+            func_str = "%s(%s)" % (func_name, func_args)
+        elif user_defined_function_proto.is_pandas_udf or pandas_udaf:
+            # for pandas udf/udaf, the input data structure is a List of Pandas.Series
+            # we need to merge these Pandas.Series into a Pandas.DataFrame
+            variable_dict['wrap_input_series_as_datframe'] = wrap_input_series_as_datframe
+            func_str = "%s(wrap_input_series_as_datframe(%s))" % (func_name, func_args)
+        else:
+            # directly use `value` as input argument
+            func_str = "%s(value)" % func_name
     else:
         func_str = "%s(%s)" % (func_name, func_args)
     return func_str, variable_dict, user_defined_funcs
@@ -249,9 +251,8 @@ def extract_user_defined_aggregate_function(
             distinct_index = current_index
     else:
         distinct_index = -1
-    if user_defined_function_proto.takes_row_as_input:
-        local_variable_dict['wrap_inputs_as_row'] = wrap_inputs_as_row
-        func_str = "lambda value : [wrap_inputs_as_row(%s)]" % ",".join(args_str)
+    if user_defined_function_proto.takes_row_as_input and not local_variable_dict:
+        func_str = "lambda value : [value]"
     else:
         func_str = "lambda value : (%s,)" % ",".join(args_str)
     return user_defined_agg, \

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -383,7 +383,7 @@ class AbstractStreamGroupAggregateOperation(StatefulTableOperation):
         # all the fields are nullable except the "element_type"
         if input_data[0] == NORMAL_RECORD:
             if has_cython:
-                row = InternalRow(input_data[1]._values, input_data[1].get_row_kind().value)
+                row = InternalRow.from_row(input_data[1])
             else:
                 row = input_data[1]
             self.group_agg_function.process_element(row)
@@ -519,7 +519,7 @@ class StreamGroupWindowAggregateOperation(AbstractStreamGroupAggregateOperation)
         if input_data[0] == NORMAL_RECORD:
             self.group_agg_function.process_watermark(input_data[3])
             if has_cython:
-                input_row = InternalRow(input_data[1]._values, input_data[1].get_row_kind().value)
+                input_row = InternalRow.from_row(input_data[1])
             else:
                 input_row = input_data[1]
             result_datas = self.group_agg_function.process_element(input_row)

--- a/flink-python/pyflink/fn_execution/table/aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/table/aggregate_fast.pxd
@@ -31,8 +31,8 @@ cdef class RowKeySelector:
 
 cdef class AggsHandleFunctionBase:
     cdef void open(self, object state_data_view_store)
-    cdef void accumulate(self, list input_data)
-    cdef void retract(self, list input_data)
+    cdef void accumulate(self, InternalRow input_data)
+    cdef void retract(self, InternalRow input_data)
     cdef void merge(self, list accumulators)
     cdef void set_accumulators(self, list accumulators)
     cdef list get_accumulators(self)

--- a/flink-python/pyflink/fn_execution/table/aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/table/aggregate_fast.pyx
@@ -253,7 +253,7 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
                 else:
                     raise Exception(
                         "The args are not in the distinct data view, this should not happen.")
-            # Transfer InternalRow to Row in row-based operations
+            # Convert InternalRow to Row
             if len(args) == 1 and isinstance(args[0], InternalRow):
                 internal_row = <InternalRow> args[0]
                 args[0] = internal_row.to_row()
@@ -293,7 +293,7 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
             distinct_index = self._distinct_indexes[i]
             if distinct_index >= 0 and args in self._distinct_data_views[distinct_index]:
                 continue
-            # Transfer InternalRow to Row in row-based operations
+            # Convert InternalRow to Row
             if len(args) == 1 and isinstance(args[0], InternalRow):
                 internal_row = <InternalRow> args[0]
                 args[0] = internal_row.to_row()

--- a/flink-python/pyflink/fn_execution/table/aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/table/aggregate_fast.pyx
@@ -77,19 +77,19 @@ cdef class AggsHandleFunctionBase:
         """
         pass
 
-    cdef void accumulate(self, list input_data):
+    cdef void accumulate(self, InternalRow input_data):
         """
         Accumulates the input values to the accumulators.
 
-        :param input_data: Input values bundled in a List.
+        :param input_data: Input values bundled in a InternalRow.
         """
         pass
 
-    cdef void retract(self, list input_data):
+    cdef void retract(self, InternalRow input_data):
         """
         Retracts the input values from the accumulators.
 
-        :param input_data: Input values bundled in a List.
+        :param input_data: Input values bundled in a InternalRow.
         """
         pass
 
@@ -211,13 +211,14 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
                 PickleCoder(),
                 PickleCoder())
 
-    cdef void accumulate(self, list input_data):
+    cdef void accumulate(self, InternalRow input_data):
         cdef size_t i, j, filter_length
         cdef int distinct_index, filter_arg
         cdef int*filter_args
         cdef bint filtered
         cdef DistinctViewDescriptor distinct_view_descriptor
         cdef object distinct_data_view
+        cdef InternalRow internal_row
         for i in range(self._udf_num):
             if i in self._distinct_data_views:
                 distinct_view_descriptor = self._distinct_view_descriptors[i]
@@ -252,14 +253,19 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
                 else:
                     raise Exception(
                         "The args are not in the distinct data view, this should not happen.")
+            # Transfer InternalRow to Row in row-based operations
+            if len(args) == 1 and isinstance(args[0], InternalRow):
+                internal_row = <InternalRow> args[0]
+                args[0] = internal_row.to_row()
             self._udfs[i].accumulate(self._accumulators[i], *args)
 
-    cdef void retract(self, list input_data):
+    cdef void retract(self, InternalRow input_data):
         cdef size_t i, j, filter_length
         cdef int distinct_index, filter_arg
         cdef bint filtered
         cdef DistinctViewDescriptor distinct_view_descriptor
         cdef object distinct_data_view
+        cdef InternalRow internal_row
         for i in range(self._udf_num):
             if i in self._distinct_data_views:
                 distinct_view_descriptor = self._distinct_view_descriptors[i]
@@ -287,6 +293,10 @@ cdef class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
             distinct_index = self._distinct_indexes[i]
             if distinct_index >= 0 and args in self._distinct_data_views[distinct_index]:
                 continue
+            # Transfer InternalRow to Row in row-based operations
+            if len(args) == 1 and isinstance(args[0], InternalRow):
+                internal_row = <InternalRow> args[0]
+                args[0] = internal_row.to_row()
             self._udfs[i].retract(self._accumulators[i], *args)
 
     cdef void merge(self, list accumulators):
@@ -525,10 +535,10 @@ cdef class GroupAggFunction(GroupAggFunctionBase):
                 # update aggregate result and set to the newRow
                 if input_data.is_accumulate_msg():
                     # accumulate input
-                    aggs_handle.accumulate(input_data.values)
+                    aggs_handle.accumulate(input_data)
                 else:
                     # retract input
-                    aggs_handle.retract(input_data.values)
+                    aggs_handle.retract(input_data)
 
             # get current aggregate result
             new_agg_value = aggs_handle.get_value()
@@ -632,10 +642,10 @@ cdef class GroupTableAggFunction(GroupAggFunctionBase):
                 # update aggregate result and set to the newRow
                 if input_data.is_accumulate_msg():
                     # accumulate input
-                    aggs_handle.accumulate(input_data.values)
+                    aggs_handle.accumulate(input_data)
                 else:
                     # retract input
-                    aggs_handle.retract(input_data.values)
+                    aggs_handle.retract(input_data)
 
             # get accumulator
             accumulators = aggs_handle.get_accumulators()

--- a/flink-python/pyflink/fn_execution/table/aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/aggregate_slow.py
@@ -73,20 +73,20 @@ class AggsHandleFunctionBase(ABC):
         pass
 
     @abstractmethod
-    def accumulate(self, input_data: List):
+    def accumulate(self, input_data: Row):
         """
         Accumulates the input values to the accumulators.
 
-        :param input_data: Input values bundled in a List.
+        :param input_data: Input values bundled in a Row.
         """
         pass
 
     @abstractmethod
-    def retract(self, input_data: List):
+    def retract(self, input_data: Row):
         """
         Retracts the input values from the accumulators.
 
-        :param input_data: Input values bundled in a List.
+        :param input_data: Input values bundled in a Row.
         """
 
     @abstractmethod
@@ -224,7 +224,7 @@ class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
                 PickleCoder(),
                 PickleCoder())
 
-    def accumulate(self, input_data: List):
+    def accumulate(self, input_data: Row):
         for i in range(len(self._udfs)):
             if i in self._distinct_data_views:
                 if len(self._distinct_view_descriptors[i].get_filter_args()) == 0:
@@ -255,7 +255,7 @@ class SimpleAggsHandleFunctionBase(AggsHandleFunctionBase):
                         "The args are not in the distinct data view, this should not happen.")
             self._udfs[i].accumulate(self._accumulators[i], *args)
 
-    def retract(self, input_data: List):
+    def retract(self, input_data: Row):
         for i in range(len(self._udfs)):
             if i in self._distinct_data_views:
                 if len(self._distinct_view_descriptors[i].get_filter_args()) == 0:
@@ -496,10 +496,10 @@ class GroupAggFunction(GroupAggFunctionBase):
                 # update aggregate result and set to the newRow
                 if input_row._is_accumulate_msg():
                     # accumulate input
-                    self.aggs_handle.accumulate(input_row._values)
+                    self.aggs_handle.accumulate(input_row)
                 else:
                     # retract input
-                    self.aggs_handle.retract(input_row._values)
+                    self.aggs_handle.retract(input_row)
 
             # get current aggregate result
             new_agg_value = self.aggs_handle.get_value()  # type: List
@@ -591,10 +591,10 @@ class GroupTableAggFunction(GroupAggFunctionBase):
                 # update aggregate result and set to the newRow
                 if input_row._is_accumulate_msg():
                     # accumulate input
-                    self.aggs_handle.accumulate(input_row._values)
+                    self.aggs_handle.accumulate(input_row)
                 else:
                     # retract input
-                    self.aggs_handle.retract(input_row._values)
+                    self.aggs_handle.retract(input_row)
 
             # get accumulator
             accumulators = self.aggs_handle.get_accumulators()

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pxd
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_fast.pxd
@@ -21,8 +21,8 @@ from pyflink.fn_execution.coder_impl_fast cimport InternalRow
 
 cdef class NamespaceAggsHandleFunctionBase:
     cdef void open(self, object state_data_view_store)
-    cdef void accumulate(self, list input_data)
-    cdef void retract(self, list input_data)
+    cdef void accumulate(self, InternalRow input_data)
+    cdef void retract(self, InternalRow input_data)
     cpdef void merge(self, object namespace, list accumulators)
     cpdef void set_accumulators(self, object namespace, list accumulators)
     cdef list get_accumulators(self)

--- a/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/window_aggregate_slow.py
@@ -58,20 +58,20 @@ class NamespaceAggsHandleFunctionBase(Generic[N], ABC):
         pass
 
     @abstractmethod
-    def accumulate(self, input_data: List):
+    def accumulate(self, input_data: Row):
         """
         Accumulates the input values to the accumulators.
 
-        :param input_data: Input values bundled in a List.
+        :param input_data: Input values bundled in a Row.
         """
         pass
 
     @abstractmethod
-    def retract(self, input_data: List):
+    def retract(self, input_data: Row):
         """
         Retracts the input values from the accumulators.
 
-        :param input_data: Input values bundled in a List.
+        :param input_data: Input values bundled in a Row.
         """
 
     @abstractmethod
@@ -187,7 +187,7 @@ class SimpleNamespaceAggsHandleFunction(NamespaceAggsHandleFunction[N]):
                 PickleCoder(),
                 PickleCoder())
 
-    def accumulate(self, input_data: List):
+    def accumulate(self, input_data: Row):
         for i in range(len(self._udfs)):
             if i in self._distinct_data_views:
                 if len(self._distinct_view_descriptors[i].get_filter_args()) == 0:
@@ -218,7 +218,7 @@ class SimpleNamespaceAggsHandleFunction(NamespaceAggsHandleFunction[N]):
                         "The args are not in the distinct data view, this should not happen.")
             self._udfs[i].accumulate(self._accumulators[i], *args)
 
-    def retract(self, input_data: List):
+    def retract(self, input_data: Row):
         for i in range(len(self._udfs)):
             if i in self._distinct_data_views:
                 if len(self._distinct_view_descriptors[i].get_filter_args()) == 0:
@@ -359,9 +359,9 @@ class GroupWindowAggFunctionBase(Generic[K, W]):
             self._window_aggregator.set_accumulators(window, acc)
 
             if input_row._is_accumulate_msg():
-                self._window_aggregator.accumulate(input_value)
+                self._window_aggregator.accumulate(input_row)
             else:
-                self._window_aggregator.retract(input_value)
+                self._window_aggregator.retract(input_row)
             acc = self._window_aggregator.get_accumulators()
             self._window_state.update(acc)
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/RowDataPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/RowDataPythonScalarFunctionOperator.java
@@ -58,7 +58,7 @@ public class RowDataPythonScalarFunctionOperator
                 outputType,
                 udfInputOffsets,
                 forwardedFields,
-                FlinkFnApi.CoderParam.DataType.FLATTEN_ROW,
+                toCoderParam(scalarFunctions),
                 FlinkFnApi.CoderParam.DataType.FLATTEN_ROW);
     }
 
@@ -89,5 +89,15 @@ public class RowDataPythonScalarFunctionOperator
         bais.setBuffer(rawUdfResult, 0, length);
         RowData udfResult = udfOutputTypeSerializer.deserialize(baisWrapper);
         rowDataWrapper.collect(reuseJoinedRow.replace(input, udfResult));
+    }
+
+    private static FlinkFnApi.CoderParam.DataType toCoderParam(
+            PythonFunctionInfo[] pythonFunctionInfos) {
+        for (PythonFunctionInfo pythonFunctionInfo : pythonFunctionInfos) {
+            if (pythonFunctionInfo.getPythonFunction().takesRowAsInput()) {
+                return FlinkFnApi.CoderParam.DataType.ROW;
+            }
+        }
+        return FlinkFnApi.CoderParam.DataType.FLATTEN_ROW;
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/AbstractPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/AbstractPythonTableFunctionOperator.java
@@ -64,7 +64,7 @@ public abstract class AbstractPythonTableFunctionOperator<IN, OUT, UDTFIN>
                 inputType,
                 outputType,
                 udtfInputOffsets,
-                FlinkFnApi.CoderParam.DataType.FLATTEN_ROW,
+                toCoderParam(tableFunction),
                 FlinkFnApi.CoderParam.DataType.FLATTEN_ROW,
                 FlinkFnApi.CoderParam.OutputMode.MULTIPLE_WITH_END);
         this.tableFunction = Preconditions.checkNotNull(tableFunction);
@@ -102,6 +102,15 @@ public abstract class AbstractPythonTableFunctionOperator<IN, OUT, UDTFIN>
         builder.addUdfs(PythonOperatorUtils.getUserDefinedFunctionProto(tableFunction));
         builder.setMetricEnabled(getPythonConfig().isMetricEnabled());
         return builder.build();
+    }
+
+    private static FlinkFnApi.CoderParam.DataType toCoderParam(
+            PythonFunctionInfo pythonFunctionInfo) {
+        if (pythonFunctionInfo.getPythonFunction().takesRowAsInput()) {
+            return FlinkFnApi.CoderParam.DataType.ROW;
+        } else {
+            return FlinkFnApi.CoderParam.DataType.FLATTEN_ROW;
+        }
     }
 
     /** The received udtf execution result is a finish message when it is a byte with value 0x00. */

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.xml
@@ -41,9 +41,10 @@ LogicalProject(_c0=[org$apache$flink$table$planner$runtime$utils$JavaUserDefined
 	<Resource name="optimized rel plan">
 	  <![CDATA[
 FlinkLogicalCalc(select=[f0.f0 AS _c0, f0.f1 AS _c1])
-+- FlinkLogicalCalc(select=[pandas_func(f0) AS f0])
-   +- FlinkLogicalCalc(select=[general_func(a, b, c) AS f0])
-      +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, source, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- FlinkLogicalCalc(select=[pandas_func(f0, f1) AS f0])
+   +- FlinkLogicalCalc(select=[f0.f0 AS f0, f0.f1 AS f1])
+      +- FlinkLogicalCalc(select=[general_func(a, b, c) AS f0])
+         +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, source, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
 	</Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.scala
@@ -60,7 +60,7 @@ class PythonMapMergeRuleTest extends TableTestBase {
     val sourceTable = util.addTableSource[(Int, Int, Int)]("source", 'a, 'b, 'c)
     val func = new RowPythonScalarFunction("pyFunc2")
     val result = sourceTable.map(func(withColumns('*)))
-      .map(func(withColumns('*))).as("a", "b")
+      .map(func(withColumns('*)))
       .map(func(withColumns('*)))
     util.verifyRelPlan(result)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.scala
@@ -60,7 +60,7 @@ class PythonMapMergeRuleTest extends TableTestBase {
     val sourceTable = util.addTableSource[(Int, Int, Int)]("source", 'a, 'b, 'c)
     val func = new RowPythonScalarFunction("pyFunc2")
     val result = sourceTable.map(func(withColumns('*)))
-      .map(func(withColumns('*)))
+      .map(func(withColumns('*))).as("a", "b")
       .map(func(withColumns('*)))
     util.verifyRelPlan(result)
   }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support accessing Row fields by attribute name in PyFlink Row-based Operation*


## Brief change log

  - *Support accessing Row fields by attribute name in PyFlink Row-based Operation*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_map`/`test_flat_map`/`test_aggregate`/`test_flat_aggregate`*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
