### PR TITLE
[FLINK-22815][checkpointing][bp-1.11] Disable unaligned checkpoints for broadcast partitioning

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -48,7 +48,7 @@ public final class SnapshotUtils {
             throws Exception {
 
         CheckpointOptions options =
-                new CheckpointOptions(
+                CheckpointOptions.forConfig(
                         CheckpointType.SAVEPOINT,
                         AbstractFsCheckpointStorage.encodePathAsReference(savepointPath),
                         isExactlyOnceMode,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -816,7 +816,7 @@ public class CheckpointCoordinator {
             Execution[] executions) {
 
         final CheckpointOptions checkpointOptions =
-                new CheckpointOptions(
+                CheckpointOptions.forConfig(
                         props.getCheckpointType(),
                         checkpointStorageLocation.getLocationReference(),
                         isExactlyOnceMode,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
@@ -66,6 +66,12 @@ public class CheckpointBarrier extends RuntimeEvent {
         return checkpointOptions;
     }
 
+    public CheckpointBarrier withOptions(CheckpointOptions checkpointOptions) {
+        return this.checkpointOptions == checkpointOptions
+                ? this
+                : new CheckpointBarrier(id, timestamp, checkpointOptions);
+    }
+
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -241,8 +241,7 @@ public class EventSerializer {
             buf.putInt(locationBytes.length);
             buf.put(locationBytes);
         }
-        buf.put((byte) (checkpointOptions.isExactlyOnceMode() ? 1 : 0));
-        buf.put((byte) (checkpointOptions.isUnalignedCheckpoint() ? 1 : 0));
+        buf.put((byte) checkpointOptions.getAlignment().ordinal());
 
         buf.flip();
         return buf;
@@ -277,14 +276,11 @@ public class EventSerializer {
             buffer.get(bytes);
             locationRef = new CheckpointStorageLocationReference(bytes);
         }
-        final boolean isExactlyOnceMode = buffer.get() == 1;
-        final boolean isUnalignedCheckpoint = buffer.get() == 1;
+        final CheckpointOptions.AlignmentType alignmentType =
+                CheckpointOptions.AlignmentType.values()[buffer.get()];
 
         return new CheckpointBarrier(
-                id,
-                timestamp,
-                new CheckpointOptions(
-                        checkpointType, locationRef, isExactlyOnceMode, isUnalignedCheckpoint));
+                id, timestamp, new CheckpointOptions(checkpointType, locationRef, alignmentType));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
@@ -348,11 +347,8 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertEquals(0, availablityListener.getNumPriorityEvents());
 
         CheckpointOptions options =
-                new CheckpointOptions(
-                        CheckpointType.CHECKPOINT,
-                        new CheckpointStorageLocationReference(new byte[] {0, 1, 2}),
-                        true,
-                        true);
+                CheckpointOptions.unaligned(
+                        new CheckpointStorageLocationReference(new byte[] {0, 1, 2}));
         BufferConsumer barrierBuffer =
                 EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options));
         subpartition.add(barrierBuffer, true);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -67,6 +67,8 @@ public class StreamEdge implements Serializable {
 
     private long bufferTimeout;
 
+    private boolean supportsUnalignedCheckpoints = true;
+
     public StreamEdge(
             StreamNode sourceVertex,
             StreamNode targetVertex,
@@ -177,6 +179,14 @@ public class StreamEdge implements Serializable {
 
     public long getBufferTimeout() {
         return bufferTimeout;
+    }
+
+    public void setSupportsUnalignedCheckpoints(boolean supportsUnalignedCheckpoints) {
+        this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
+    }
+
+    public boolean supportsUnalignedCheckpoints() {
+        return supportsUnalignedCheckpoints;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -217,6 +217,14 @@ public class StreamGraphGenerator {
             transform(transformation);
         }
 
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            if (node.getInEdges().stream().anyMatch(edge -> edge.getPartitioner().isBroadcast())) {
+                for (StreamEdge edge : node.getInEdges()) {
+                    edge.setSupportsUnalignedCheckpoints(false);
+                }
+            }
+        }
+
         final StreamGraph builtStreamGraph = streamGraph;
 
         alreadyTransformed.clear();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -544,7 +544,12 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
                     upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader());
         }
 
-        return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag, this);
+        return new RecordWriterOutput<>(
+                recordWriter,
+                outSerializer,
+                sideOutputTag,
+                this,
+                edge.supportsUnalignedCheckpoints());
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.connector.source.ExternallyInducedSourceReader;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -116,7 +118,9 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 
     private void triggerCheckpointForExternallyInducedSource(long checkpointId) {
         final CheckpointOptions checkpointOptions =
-                CheckpointOptions.forCheckpointWithDefaultLocation(
+                CheckpointOptions.forConfig(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault(),
                         configuration.isExactlyOnceCheckpointMode(),
                         configuration.isUnalignedCheckpointsEnabled());
         final long timestamp = System.currentTimeMillis();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -21,9 +21,11 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -100,7 +102,9 @@ public class SourceStreamTask<
                             // TODO -   message from the master, and the source's trigger
                             // notification
                             final CheckpointOptions checkpointOptions =
-                                    CheckpointOptions.forCheckpointWithDefaultLocation(
+                                    CheckpointOptions.forConfig(
+                                            CheckpointType.CHECKPOINT,
+                                            CheckpointStorageLocationReference.getDefault(),
                                             configuration.isExactlyOnceCheckpointMode(),
                                             configuration.isUnalignedCheckpointsEnabled());
                             final long timestamp = System.currentTimeMillis();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -272,6 +272,13 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             return;
         }
 
+        // if checkpoint has been previously unaligned, but was forced to be aligned,
+        // revert it here so that it can jump over output data
+        if (options.getAlignment() == CheckpointOptions.AlignmentType.FORCED_ALIGNED) {
+            options = options.withUnalignedSupported();
+            initCheckpoint(metadata.getCheckpointId(), options);
+        }
+
         // Step (1): Prepare the checkpoint, allow operators to do some pre-barrier work.
         //           The pre-barrier work should be nothing or minimal in the common case.
         operatorChain.prepareSnapshotPreBarrier(metadata.getCheckpointId());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandlerTest.java
@@ -341,7 +341,7 @@ public class AlternatingCheckpointBarrierHandlerTest {
                 new CheckpointBarrier(
                         barrierId,
                         barrierTimestamp,
-                        new CheckpointOptions(
+                        CheckpointOptions.forConfig(
                                 checkpointType,
                                 CheckpointStorageLocationReference.getDefault(),
                                 true,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the behaviors of the {@link InputProcessorUtil}. */
@@ -88,10 +89,7 @@ public class InputProcessorUtilTest {
                         channelId < inputGate.getNumberOfInputChannels();
                         channelId++) {
                     bufferReceivedListener.notifyBarrierReceived(
-                            new CheckpointBarrier(
-                                    1,
-                                    42,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation(true, true)),
+                            new CheckpointBarrier(1, 42, CheckpointOptions.unaligned(getDefault())),
                             new InputChannelInfo(inputGate.getGateIndex(), channelId));
                 }
             }


### PR DESCRIPTION
This is a backport of parts of  #16019 and #15294

Broadcast partitioning can not work with unaligned checkpointing. There are no guarantees that records are consumed at the same rate in all channels. This can result in some tasks applying state changes corresponding to a certain broadcasted event while others don't. 

In turn upon restore, it may lead to an inconsistent state. This is especially harmful to the most common pattern for using a broadcast pattern where only a single operator checkpoints its state and that state is copied over to all other operators on restore.