### PR TITLE
[FLINK-13538][formats] Figure out wrong field name when serializer/deserializer throw exceptions while doing serializing/deserializing for json and csv format. 

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroToRowDataConverters.java
@@ -79,6 +79,8 @@ public class AvroToRowDataConverters {
             IndexedRecord record = (IndexedRecord) avroObject;
             GenericRowData row = new GenericRowData(arity);
             for (int i = 0; i < arity; ++i) {
+                // avro always deserialize successfully even though the type isn't matched
+                // so no need to throw exception about which field can't be deserialized
                 row.setField(i, fieldConverters[i].convert(record.get(i)));
             }
             return row;

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RowDataToAvroConverters.java
@@ -242,10 +242,17 @@ public class RowDataToAvroConverters {
                 final GenericRecord record = new GenericData.Record(schema);
                 for (int i = 0; i < length; ++i) {
                     final Schema.Field schemaField = fields.get(i);
-                    Object avroObject =
-                            fieldConverters[i].convert(
-                                    schemaField.schema(), fieldGetters[i].getFieldOrNull(row));
-                    record.put(i, avroObject);
+                    try {
+                        Object avroObject =
+                                fieldConverters[i].convert(
+                                        schemaField.schema(), fieldGetters[i].getFieldOrNull(row));
+                        record.put(i, avroObject);
+                    } catch (Throwable t) {
+                        throw new RuntimeException(
+                                String.format(
+                                        "Fail to serialize at field: %s.", schemaField.name()),
+                                t);
+                    }
                 }
                 return record;
             }

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -159,10 +159,7 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
                 return null;
             }
             throw new IOException(
-                    String.format(
-                            "Failed to deserialize CSV row '%s' %s.",
-                            new String(message), t.getMessage()),
-                    t);
+                    String.format("Failed to deserialize CSV row '%s'.", new String(message)), t);
         }
     }
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -159,7 +159,10 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
                 return null;
             }
             throw new IOException(
-                    "Failed to deserialize CSV row '" + new String(message) + "'.", t);
+                    String.format(
+                            "Failed to deserialize CSV row '%s' %s.",
+                            new String(message), t.getMessage()),
+                    t);
         }
     }
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataSerializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataSerializationSchema.java
@@ -137,8 +137,7 @@ public final class CsvRowDataSerializationSchema implements SerializationSchema<
             runtimeConverter.convert(csvMapper, root, row);
             return objectWriter.writeValueAsBytes(root);
         } catch (Throwable t) {
-            throw new RuntimeException(
-                    String.format("Could not serialize row '%s' %s.", row, t.getMessage()), t);
+            throw new RuntimeException(String.format("Could not serialize row '%s'.", row), t);
         }
     }
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataSerializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataSerializationSchema.java
@@ -137,7 +137,8 @@ public final class CsvRowDataSerializationSchema implements SerializationSchema<
             runtimeConverter.convert(csvMapper, root, row);
             return objectWriter.writeValueAsBytes(root);
         } catch (Throwable t) {
-            throw new RuntimeException("Could not serialize row '" + row + "'.", t);
+            throw new RuntimeException(
+                    String.format("Could not serialize row '%s' %s.", row, t.getMessage()), t);
         }
     }
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvToRowDataConverters.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvToRowDataConverters.java
@@ -96,10 +96,14 @@ public class CsvToRowDataConverters implements Serializable {
                 } else {
                     field = jsonNode.get(i);
                 }
-                if (field == null) {
-                    row.setField(i, null);
-                } else {
-                    row.setField(i, fieldConverters[i].convert(field));
+                try {
+                    if (field == null) {
+                        row.setField(i, null);
+                    } else {
+                        row.setField(i, fieldConverters[i].convert(field));
+                    }
+                } catch (Throwable t) {
+                    throw new RuntimeException("at field: " + fieldNames[i], t);
                 }
             }
             return row;

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvToRowDataConverters.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvToRowDataConverters.java
@@ -103,7 +103,8 @@ public class CsvToRowDataConverters implements Serializable {
                         row.setField(i, fieldConverters[i].convert(field));
                     }
                 } catch (Throwable t) {
-                    throw new RuntimeException("at field: " + fieldNames[i], t);
+                    throw new RuntimeException(
+                            String.format("Fail to deserialize at field: %s.", fieldNames[i]), t);
                 }
             }
             return row;

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowDataToCsvConverters.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowDataToCsvConverters.java
@@ -84,8 +84,13 @@ public class RowDataToCsvConverters implements Serializable {
             // top level reuses the object node container
             final ObjectNode objectNode = (ObjectNode) container;
             for (int i = 0; i < rowArity; i++) {
-                objectNode.set(
-                        fieldNames[i], fieldConverters[i].convert(csvMapper, container, row, i));
+                try {
+                    objectNode.set(
+                            fieldNames[i],
+                            fieldConverters[i].convert(csvMapper, container, row, i));
+                } catch (Throwable t) {
+                    throw new RuntimeException("at field: " + fieldNames[i], t);
+                }
             }
             return objectNode;
         };

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowDataToCsvConverters.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowDataToCsvConverters.java
@@ -89,7 +89,8 @@ public class RowDataToCsvConverters implements Serializable {
                             fieldNames[i],
                             fieldConverters[i].convert(csvMapper, container, row, i));
                 } catch (Throwable t) {
-                    throw new RuntimeException("at field: " + fieldNames[i], t);
+                    throw new RuntimeException(
+                            String.format("Fail to serialize at field: %s.", fieldNames[i]), t);
                 }
             }
             return objectNode;

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -349,7 +349,7 @@ public class CsvRowDataSerDeSchemaTest {
     }
 
     @Test
-    public void testSerializationWithTypeMisMatch() {
+    public void testSerializationWithTypesMismatch() {
         DataType dataType = ROW(FIELD("f0", STRING()), FIELD("f1", INT()), FIELD("f2", INT()));
         RowType rowType = (RowType) dataType.getLogicalType();
         CsvRowDataSerializationSchema.Builder serSchemaBuilder =
@@ -365,7 +365,7 @@ public class CsvRowDataSerDeSchemaTest {
     }
 
     @Test
-    public void testDeserializationWithTypeMisMatch() {
+    public void testDeserializationWithTypesMismatch() {
         DataType dataType = ROW(FIELD("f0", STRING()), FIELD("f1", INT()), FIELD("f2", INT()));
         RowType rowType = (RowType) dataType.getLogicalType();
         CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.csv;
 
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
+import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
@@ -60,6 +61,7 @@ import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.data.StringData.fromString;
 import static org.apache.flink.table.data.TimestampData.fromInstant;
 import static org.apache.flink.table.data.TimestampData.fromLocalDateTime;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -355,12 +357,12 @@ public class CsvRowDataSerDeSchemaTest {
         CsvRowDataSerializationSchema.Builder serSchemaBuilder =
                 new CsvRowDataSerializationSchema.Builder(rowType);
         RowData rowData = rowData("Test", 1, "Test");
-        String errorMessage = String.format("Could not serialize row '%s' at field: f2.", rowData);
+        String errorMessage = "Fail to serialize at field: f2.";
         try {
             serialize(serSchemaBuilder, rowData);
             fail("expecting exception message:" + errorMessage);
         } catch (Throwable t) {
-            assertEquals(errorMessage, t.getMessage());
+            assertThat(t, FlinkMatchers.containsMessage(errorMessage));
         }
     }
 
@@ -371,13 +373,12 @@ public class CsvRowDataSerDeSchemaTest {
         CsvRowDataDeserializationSchema.Builder deserSchemaBuilder =
                 new CsvRowDataDeserializationSchema.Builder(rowType, InternalTypeInfo.of(rowType));
         String data = "Test,1,Test";
-        String errorMessage =
-                String.format("Failed to deserialize CSV row '%s' at field: f2.", data);
+        String errorMessage = "Fail to deserialize at field: f2.";
         try {
             deserialize(deserSchemaBuilder, data);
             fail("expecting exception message:" + errorMessage);
         } catch (Throwable t) {
-            assertEquals(errorMessage, t.getMessage());
+            assertThat(t, FlinkMatchers.containsMessage(errorMessage));
         }
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -109,7 +109,10 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
                 return null;
             }
             throw new IOException(
-                    format("Failed to deserialize JSON '%s'.", new String(message)), t);
+                    format(
+                            "Failed to deserialize JSON '%s' %s.",
+                            new String(message), t.getMessage()),
+                    t);
         }
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -109,10 +109,7 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
                 return null;
             }
             throw new IOException(
-                    format(
-                            "Failed to deserialize JSON '%s' %s.",
-                            new String(message), t.getMessage()),
-                    t);
+                    format("Failed to deserialize JSON '%s'.", new String(message)), t);
         }
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
@@ -96,7 +96,8 @@ public class JsonRowDataSerializationSchema implements SerializationSchema<RowDa
             runtimeConverter.convert(mapper, node, row);
             return mapper.writeValueAsBytes(node);
         } catch (Throwable t) {
-            throw new RuntimeException("Could not serialize row '" + row + "'. ", t);
+            throw new RuntimeException(
+                    String.format("Could not serialize row '%s' %s.", row, t.getMessage()), t);
         }
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataSerializationSchema.java
@@ -96,8 +96,7 @@ public class JsonRowDataSerializationSchema implements SerializationSchema<RowDa
             runtimeConverter.convert(mapper, node, row);
             return mapper.writeValueAsBytes(node);
         } catch (Throwable t) {
-            throw new RuntimeException(
-                    String.format("Could not serialize row '%s' %s.", row, t.getMessage()), t);
+            throw new RuntimeException(String.format("Could not serialize row '%s'.", row), t);
         }
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -347,8 +347,12 @@ public class JsonToRowDataConverters implements Serializable {
             for (int i = 0; i < arity; i++) {
                 String fieldName = fieldNames[i];
                 JsonNode field = node.get(fieldName);
-                Object convertedField = convertField(fieldConverters[i], fieldName, field);
-                row.setField(i, convertedField);
+                try {
+                    Object convertedField = convertField(fieldConverters[i], fieldName, field);
+                    row.setField(i, convertedField);
+                } catch (Throwable t) {
+                    throw new JsonParseException("at field: " + fieldName, t);
+                }
             }
             return row;
         };

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonToRowDataConverters.java
@@ -351,7 +351,8 @@ public class JsonToRowDataConverters implements Serializable {
                     Object convertedField = convertField(fieldConverters[i], fieldName, field);
                     row.setField(i, convertedField);
                 } catch (Throwable t) {
-                    throw new JsonParseException("at field: " + fieldName, t);
+                    throw new JsonParseException(
+                            String.format("Fail to deserialize at field: %s.", fieldName), t);
                 }
             }
             return row;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -330,8 +330,14 @@ public class RowDataToJsonConverters implements Serializable {
             RowData row = (RowData) value;
             for (int i = 0; i < fieldCount; i++) {
                 String fieldName = fieldNames[i];
-                Object field = fieldGetters[i].getFieldOrNull(row);
-                node.set(fieldName, fieldConverters[i].convert(mapper, node.get(fieldName), field));
+                try {
+                    Object field = fieldGetters[i].getFieldOrNull(row);
+                    node.set(
+                            fieldName,
+                            fieldConverters[i].convert(mapper, node.get(fieldName), field));
+                } catch (Throwable t) {
+                    throw new RuntimeException("at field: " + fieldName, t);
+                }
             }
             return node;
         };

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/RowDataToJsonConverters.java
@@ -336,7 +336,8 @@ public class RowDataToJsonConverters implements Serializable {
                             fieldName,
                             fieldConverters[i].convert(mapper, node.get(fieldName), field));
                 } catch (Throwable t) {
-                    throw new RuntimeException("at field: " + fieldName, t);
+                    throw new RuntimeException(
+                            String.format("Fail to serialize at field: %s.", fieldName), t);
                 }
             }
             return node;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*To figure out wrong field name when serializer/deserializer  throw exceptions while doing serializing/deserializing for json/ csv/avro format.*
NOTE: In avro format, only figure out wrong field name when doing serializing for avro will always deserialize succefully even though the type mismatch.


## Brief change log

  - Throw exception with error message about which field can't  be serialized/deserialized in JsonRowDataSerializationSchema/JsonRowDataDeerializationSchema and CsvRowDataSerializationSchema/CsvRowDataDeserializationSchema


## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests testSerializationWithTypesMismatch() and testDeserializationWithTypesMismatch() in CsvRowDataSerDeSchemaTest*
  - *Modified tests testJsonParse() in JsonRowDataSerDeSchemaTest and added test testSerializationWithTypesMismatch() in JsonRowDataSerDeSchemaTest*
  - *Added test testSerializationWithTypesMismatch() in AvroRowDataDeSerializationSchemaTest *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
