### PR TITLE
[FLINK-22863][runtime] Fix ArrayIndexOutOfBoundsException when building rescale edges in EdgeManagerBuildUtil

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
@@ -131,9 +131,8 @@ public class EdgeManagerBuildUtil {
                 ConsumedPartitionGroup consumerPartitionGroup =
                         ConsumedPartitionGroup.fromSinglePartition(partition.getPartitionId());
 
-                float factor = ((float) targetCount) / sourceCount;
-                int start = (int) (Math.ceil(partitionNum * factor));
-                int end = (int) (Math.ceil((partitionNum + 1) * factor));
+                int start = (partitionNum * targetCount + sourceCount - 1) / sourceCount;
+                int end = ((partitionNum + 1) * targetCount + sourceCount - 1) / sourceCount;
 
                 List<ExecutionVertexID> consumers = new ArrayList<>(end - start);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -145,6 +145,7 @@ public class PointwisePatternTest {
         testLowToHigh(19, 21);
         testLowToHigh(15, 20);
         testLowToHigh(11, 31);
+        testLowToHigh(11, 29);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*For EdgeManagerBuildUtil introduced in FLINK-21326, we find that during the construction of rescale edges, it may throw ArrayIndexOutOfBoundsException. This is mainly caused by the precision of `double` in Java. This change aims to fix this issue.*


## Brief change log

  - *Fix the logic of building rescale edges in `EdgeManagerBuildUtil#connectPointwise`*

## Verifying this change

 - *Add a test in `PointwisePatternTest#testLowHighIrregular`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
