### PR TITLE
[FLINK-22849][e2e][python] Drop remaining usages of legacy planner in E2E tests and Python

### DIFF
--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -42,7 +42,6 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSin
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.OnCheckpointRollingPolicy;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -79,18 +78,6 @@ public class StreamSQLTestProgram {
 
         ParameterTool params = ParameterTool.fromArgs(args);
         String outputPath = params.getRequired("outputPath");
-        String planner = params.get("planner", "blink");
-
-        final EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance();
-        builder.inStreamingMode();
-
-        if (planner.equals("old")) {
-            builder.useOldPlanner();
-        } else if (planner.equals("blink")) {
-            builder.useBlinkPlanner();
-        }
-
-        final EnvironmentSettings settings = builder.build();
 
         final StreamExecutionEnvironment sEnv =
                 StreamExecutionEnvironment.getExecutionEnvironment();
@@ -99,7 +86,7 @@ public class StreamSQLTestProgram {
         sEnv.enableCheckpointing(4000);
         sEnv.getConfig().setAutoWatermarkInterval(1000);
 
-        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(sEnv, settings);
+        final StreamTableEnvironment tEnv = StreamTableEnvironment.create(sEnv);
 
         ((TableEnvironmentInternal) tEnv)
                 .registerTableSourceInternal("table1", new GeneratorTableSource(10, 100, 60, 0));

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -184,8 +184,7 @@ run_test "Queryable state (rocksdb) with TM restart end-to-end test" "$END_TO_EN
 
 run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
 run_test "Batch SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_sql.sh"
-run_test "Streaming SQL end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh old" "skip_check_exceptions"
-run_test "Streaming SQL end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh blink" "skip_check_exceptions"
+run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh" "skip_check_exceptions"
 
 if [[ ${PROFILE} != *"enable-adaptive-scheduler"* ]]; then # FLINK-21400
   run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_file_sink.sh local StreamingFileSink" "skip_check_exceptions"

--- a/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
@@ -19,8 +19,6 @@
 
 source "$(dirname "$0")"/common.sh
 
-PLANNER="${1:-old}"
-
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-stream-sql-test/target/StreamSQLTestProgram.jar
 
 start_cluster
@@ -28,7 +26,7 @@ $FLINK_DIR/bin/taskmanager.sh start
 $FLINK_DIR/bin/taskmanager.sh start
 $FLINK_DIR/bin/taskmanager.sh start
 
-$FLINK_DIR/bin/flink run -p 4 $TEST_PROGRAM_JAR -outputPath file://${TEST_DATA_DIR}/out/result -planner ${PLANNER}
+$FLINK_DIR/bin/flink run -p 4 $TEST_PROGRAM_JAR -outputPath file://${TEST_DATA_DIR}/out/result
 
 # collect results from files
 cat $TEST_DATA_DIR/out/result/20/.part-* $TEST_DATA_DIR/out/result/20/part-* | sort > $TEST_DATA_DIR/out/result-complete

--- a/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
+++ b/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
@@ -103,7 +103,6 @@ checkCodeDependencies "${END_TO_END_DIR}/../flink-table/flink-table-api-scala/ta
 checkCodeDependencies "${END_TO_END_DIR}/../flink-table/flink-table-api-java-bridge/target/flink-table-api-java-bridge_${FLINK_SCALA_VERSION}.jar"
 checkCodeDependencies "${END_TO_END_DIR}/../flink-table/flink-table-api-scala-bridge/target/flink-table-api-scala-bridge_${FLINK_SCALA_VERSION}.jar"
 
-checkCodeDependencies "${END_TO_END_DIR}/../flink-table/flink-table-planner/target/flink-table-planner_${FLINK_SCALA_VERSION}.jar"
 checkCodeDependencies "${END_TO_END_DIR}/../flink-table/flink-table-planner-blink/target/flink-table-planner-blink_${FLINK_SCALA_VERSION}.jar"
 checkCodeDependencies "${END_TO_END_DIR}/../flink-table/flink-table-runtime-blink/target/flink-table-runtime-blink_${FLINK_SCALA_VERSION}.jar"
 checkCodeDependencies "${FLINK_DIR}/lib/flink-table-blink_${FLINK_SCALA_VERSION}.jar"
@@ -114,7 +113,6 @@ checkAllowedPackages "${END_TO_END_DIR}/../flink-table/flink-table-api-scala/tar
 checkAllowedPackages "${END_TO_END_DIR}/../flink-table/flink-table-api-java-bridge/target/flink-table-api-java-bridge_${FLINK_SCALA_VERSION}.jar"
 checkAllowedPackages "${END_TO_END_DIR}/../flink-table/flink-table-api-scala-bridge/target/flink-table-api-scala-bridge_${FLINK_SCALA_VERSION}.jar"
 
-checkAllowedPackages "${END_TO_END_DIR}/../flink-table/flink-table-planner/target/flink-table-planner_${FLINK_SCALA_VERSION}.jar"
 checkAllowedPackages "${END_TO_END_DIR}/../flink-table/flink-table-planner-blink/target/flink-table-planner-blink_${FLINK_SCALA_VERSION}.jar"
 checkAllowedPackages "${END_TO_END_DIR}/../flink-table/flink-table-runtime-blink/target/flink-table-runtime-blink_${FLINK_SCALA_VERSION}.jar"
 checkAllowedPackages "${FLINK_DIR}/lib/flink-table-blink_${FLINK_SCALA_VERSION}.jar"

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -482,6 +482,24 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- This is only a temporary solution until FLINK-22872 is fixed. -->
+			<!-- It compiles `org.apache.flink.table.legacyutils` containing code from the old planner. -->
+			<!-- We should not start adding more Scala code. Please remove this as soon as possible. -->
+			<plugin>
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<executions>
+					<!-- Run Scala compiler in the process-test-resources phase, so that dependencies on
+						 Scala classes can be resolved later in the (Java) test-compile phase -->
+					<execution>
+						<id>scala-test-compile</id>
+						<phase>process-test-resources</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -154,7 +154,6 @@ def download_apache_avro():
 
 def construct_test_classpath():
     test_jar_patterns = [
-        "flink-table/flink-table-planner/target/flink-table-planner*-tests.jar",
         "flink-runtime/target/flink-runtime*tests.jar",
         "flink-streaming-java/target/flink-streaming-java*tests.jar",
         "flink-formats/flink-csv/target/flink-csv*.jar",
@@ -162,6 +161,7 @@ def construct_test_classpath():
         "flink-formats/flink-avro/target/avro*.jar",
         "flink-formats/flink-json/target/flink-json*.jar",
         "flink-python/target/artifacts/testDataStream.jar",
+        "flink-python/target/flink-python*-tests.jar",
     ]
     test_jars = []
     flink_source_root = _find_flink_source_root()

--- a/flink-python/pyflink/table/tests/test_correlate.py
+++ b/flink-python/pyflink/table/tests/test_correlate.py
@@ -24,7 +24,7 @@ class CorrelateTests(PyFlinkBlinkStreamTableTestCase):
     def test_join_lateral(self):
         t_env = self.t_env
         t_env.create_java_temporary_system_function("split",
-                                                    "org.apache.flink.table.utils.TableFunc1")
+                                                    "org.apache.flink.table.legacyutils.TableFunc1")
         source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
 
         result = source.join_lateral("split(words) as (word)")
@@ -37,7 +37,7 @@ class CorrelateTests(PyFlinkBlinkStreamTableTestCase):
     def test_join_lateral_with_join_predicate(self):
         t_env = self.t_env
         t_env.create_java_temporary_system_function("split",
-                                                    "org.apache.flink.table.utils.TableFunc1")
+                                                    "org.apache.flink.table.legacyutils.TableFunc1")
         source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
 
         result = source.join_lateral(expr.call('split', source.words).alias('word'),
@@ -52,7 +52,7 @@ class CorrelateTests(PyFlinkBlinkStreamTableTestCase):
     def test_left_outer_join_lateral(self):
         t_env = self.t_env
         t_env.create_java_temporary_system_function("split",
-                                                    "org.apache.flink.table.utils.TableFunc1")
+                                                    "org.apache.flink.table.legacyutils.TableFunc1")
         source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
 
         result = source.left_outer_join_lateral(expr.call('split', source.words).alias('word'))
@@ -65,7 +65,7 @@ class CorrelateTests(PyFlinkBlinkStreamTableTestCase):
     def test_left_outer_join_lateral_with_join_predicate(self):
         t_env = self.t_env
         t_env.create_java_temporary_system_function("split",
-                                                    "org.apache.flink.table.utils.TableFunc1")
+                                                    "org.apache.flink.table.legacyutils.TableFunc1")
         source = t_env.from_elements([("1", "1#3#5#7"), ("2", "2#4#6#8")], ["id", "words"])
 
         # only support "true" as the join predicate currently

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -744,18 +744,18 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
 
     def test_timestamps_from_extractor(self):
         rowtime = Rowtime().timestamps_from_extractor(
-            "org.apache.flink.table.descriptors.RowtimeTest$CustomExtractor")
+            "org.apache.flink.table.legacyutils.CustomExtractor")
 
         properties = rowtime.to_properties()
         expected = {
             'rowtime.timestamps.type': 'custom',
             'rowtime.timestamps.class':
-                'org.apache.flink.table.descriptors.RowtimeTest$CustomExtractor',
+                'org.apache.flink.table.legacyutils.CustomExtractor',
             'rowtime.timestamps.serialized':
-                'rO0ABXNyAD5vcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmRlc2NyaXB0b3JzLlJvd3RpbWVUZXN0JEN1c3R'
-                'vbUV4dHJhY3RvcoaChjMg55xwAgABTAAFZmllbGR0ABJMamF2YS9sYW5nL1N0cmluZzt4cgA-b3JnLm'
-                'FwYWNoZS5mbGluay50YWJsZS5zb3VyY2VzLnRzZXh0cmFjdG9ycy5UaW1lc3RhbXBFeHRyYWN0b3Jf1'
-                'Y6piFNsGAIAAHhwdAACdHM'}
+                'rO0ABXNyADJvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmxlZ2FjeXV0aWxzLkN1c3RvbUV4dHJhY3Rvctj'
+                'ZLTGK9XvxAgABTAAFZmllbGR0ABJMamF2YS9sYW5nL1N0cmluZzt4cgA-b3JnLmFwYWNoZS5mbGluay'
+                '50YWJsZS5zb3VyY2VzLnRzZXh0cmFjdG9ycy5UaW1lc3RhbXBFeHRyYWN0b3Jf1Y6piFNsGAIAAHhwd'
+                'AACdHM'}
         self.assertEqual(expected, properties)
 
     def test_watermarks_periodic_ascending(self):
@@ -782,19 +782,18 @@ class RowTimeDescriptorTests(PyFlinkTestCase):
 
     def test_watermarks_from_strategy(self):
         rowtime = Rowtime().watermarks_from_strategy(
-            "org.apache.flink.table.descriptors.RowtimeTest$CustomAssigner")
+            "org.apache.flink.table.legacyutils.CustomAssigner")
 
         properties = rowtime.to_properties()
         expected = {
             'rowtime.watermarks.type': 'custom',
             'rowtime.watermarks.class':
-                'org.apache.flink.table.descriptors.RowtimeTest$CustomAssigner',
+                'org.apache.flink.table.legacyutils.CustomAssigner',
             'rowtime.watermarks.serialized':
-                'rO0ABXNyAD1vcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmRlc2NyaXB0b3JzLlJvd3RpbWVUZXN0JEN1c3R'
-                'vbUFzc2lnbmVyeDcuDvfbu0kCAAB4cgBHb3JnLmFwYWNoZS5mbGluay50YWJsZS5zb3VyY2VzLndtc3'
-                'RyYXRlZ2llcy5QdW5jdHVhdGVkV2F0ZXJtYXJrQXNzaWduZXKBUc57oaWu9AIAAHhyAD1vcmcuYXBhY'
-                '2hlLmZsaW5rLnRhYmxlLnNvdXJjZXMud21zdHJhdGVnaWVzLldhdGVybWFya1N0cmF0ZWd53nt-g2OW'
-                'aT4CAAB4cA'}
+                'rO0ABXNyADFvcmcuYXBhY2hlLmZsaW5rLnRhYmxlLmxlZ2FjeXV0aWxzLkN1c3RvbUFzc2lnbmVyu_8'
+                'TLNBQBsACAAB4cgBHb3JnLmFwYWNoZS5mbGluay50YWJsZS5zb3VyY2VzLndtc3RyYXRlZ2llcy5QdW'
+                '5jdHVhdGVkV2F0ZXJtYXJrQXNzaWduZXKBUc57oaWu9AIAAHhyAD1vcmcuYXBhY2hlLmZsaW5rLnRhY'
+                'mxlLnNvdXJjZXMud21zdHJhdGVnaWVzLldhdGVybWFya1N0cmF0ZWd53nt-g2OWaT4CAAB4cA'}
         self.assertEqual(expected, properties)
 
 

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -80,10 +80,10 @@ class TableEnvironmentTest(object):
             "python_scalar_func", udf(lambda i: i, result_type=DataTypes.INT()))
 
         t_env.register_java_function("scalar_func",
-                                     "org.apache.flink.table.expressions.utils.RichFunc0")
+                                     "org.apache.flink.table.legacyutils.RichFunc0")
         t_env.register_java_function(
-            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
-        t_env.register_java_function("table_func", "org.apache.flink.table.utils.TableFunc1")
+            "agg_func", "org.apache.flink.table.legacyutils.ByteMaxAggFunction")
+        t_env.register_java_function("table_func", "org.apache.flink.table.legacyutils.TableFunc1")
 
         actual = t_env.list_user_defined_functions()
         expected = ['python_scalar_func', 'scalar_func', 'agg_func', 'table_func']
@@ -148,11 +148,11 @@ class TableEnvironmentTest(object):
         t_env = self.t_env
 
         t_env.create_java_temporary_system_function(
-            "scalar_func", "org.apache.flink.table.expressions.utils.RichFunc0")
+            "scalar_func", "org.apache.flink.table.legacyutils.RichFunc0")
         t_env.create_java_function(
-            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+            "agg_func", "org.apache.flink.table.legacyutils.ByteMaxAggFunction")
         t_env.create_java_temporary_function(
-            "table_func", "org.apache.flink.table.utils.TableFunc1")
+            "table_func", "org.apache.flink.table.legacyutils.TableFunc1")
         self.assert_equals(t_env.list_user_defined_functions(),
                            ['scalar_func', 'agg_func', 'table_func'])
 
@@ -354,13 +354,13 @@ class BlinkBatchTableEnvironmentTests(PyFlinkBlinkBatchTableTestCase):
         t_env = self.t_env
 
         t_env.register_java_function(
-            "scalar_func", "org.apache.flink.table.expressions.utils.RichFunc0")
+            "scalar_func", "org.apache.flink.table.legacyutils.RichFunc0")
 
         t_env.register_java_function(
-            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+            "agg_func", "org.apache.flink.table.legacyutils.ByteMaxAggFunction")
 
         t_env.register_java_function(
-            "table_func", "org.apache.flink.table.utils.TableFunc2")
+            "table_func", "org.apache.flink.table.legacyutils.TableFunc1")
 
         actual = t_env.list_user_defined_functions()
         expected = ['scalar_func', 'agg_func', 'table_func']
@@ -432,11 +432,11 @@ class BlinkBatchTableEnvironmentTests(PyFlinkBlinkBatchTableTestCase):
         t_env = self.t_env
 
         t_env.create_java_temporary_system_function(
-            "scalar_func", "org.apache.flink.table.expressions.utils.RichFunc0")
+            "scalar_func", "org.apache.flink.table.legacyutils.RichFunc0")
         t_env.create_java_function(
-            "agg_func", "org.apache.flink.table.functions.aggfunctions.ByteMaxAggFunction")
+            "agg_func", "org.apache.flink.table.legacyutils.ByteMaxAggFunction")
         t_env.create_java_temporary_function(
-            "table_func", "org.apache.flink.table.utils.TableFunc1")
+            "table_func", "org.apache.flink.table.legacyutils.TableFunc1")
         self.assert_equals(t_env.list_user_defined_functions(),
                            ['scalar_func', 'agg_func', 'table_func'])
 

--- a/flink-python/pyflink/testing/source_sink_utils.py
+++ b/flink-python/pyflink/testing/source_sink_utils.py
@@ -51,17 +51,16 @@ class TestTableSink(TableSink):
 
         FLINK_SOURCE_ROOT_DIR = _find_flink_source_root()
         filename_pattern = (
-            "flink-table/flink-table-planner/target/"
-            "flink-table-planner*-tests.jar")
+            "flink-python/target/flink-python*-tests.jar")
         if not glob.glob(os.path.join(FLINK_SOURCE_ROOT_DIR, filename_pattern)):
             raise unittest.SkipTest(
-                "'flink-table-planner*-tests.jar' is not available. Will skip the related tests.")
+                "'flink-python*-tests.jar' is not available. Will skip the related tests.")
 
         gateway = get_gateway()
-        java_import(gateway.jvm, "org.apache.flink.table.runtime.stream.table.TestAppendSink")
-        java_import(gateway.jvm, "org.apache.flink.table.runtime.stream.table.TestRetractSink")
-        java_import(gateway.jvm, "org.apache.flink.table.runtime.stream.table.TestUpsertSink")
-        java_import(gateway.jvm, "org.apache.flink.table.runtime.stream.table.RowCollector")
+        java_import(gateway.jvm, "org.apache.flink.table.legacyutils.TestAppendSink")
+        java_import(gateway.jvm, "org.apache.flink.table.legacyutils.TestRetractSink")
+        java_import(gateway.jvm, "org.apache.flink.table.legacyutils.TestUpsertSink")
+        java_import(gateway.jvm, "org.apache.flink.table.legacyutils.RowCollector")
 
         TestTableSink._inited = True
 

--- a/flink-python/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-python/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.legacyutils.TestCollectionTableFactory

--- a/flink-python/src/test/scala/org/apache/flink/table/legacyutils/TestCollectionTableFactory.scala
+++ b/flink-python/src/test/scala/org/apache/flink/table/legacyutils/TestCollectionTableFactory.scala
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.legacyutils
+
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.io.{CollectionInputFormat, LocalCollectionOutputFormat}
+import org.apache.flink.api.java.operators.DataSink
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink, DataStreamSource}
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
+import org.apache.flink.table.descriptors.{DescriptorProperties, Schema}
+import org.apache.flink.table.factories.{BatchTableSinkFactory, BatchTableSourceFactory, StreamTableSinkFactory, StreamTableSourceFactory}
+import org.apache.flink.table.functions.{AsyncTableFunction, TableFunction}
+import org.apache.flink.table.legacyutils.TestCollectionTableFactory.{getCollectionSink, getCollectionSource}
+import org.apache.flink.table.sinks.{AppendStreamTableSink, BatchTableSink, StreamTableSink, TableSink}
+import org.apache.flink.table.sources.{BatchTableSource, LookupableTableSource, StreamTableSource, TableSource}
+import org.apache.flink.types.Row
+
+import java.io.IOException
+import java.util
+import java.util.{Optional, ArrayList => JArrayList, LinkedList => JLinkedList, List => JList, Map => JMap}
+
+import scala.collection.JavaConversions._
+
+/**
+ * Testing utils adopted from legacy planner until the Python code is updated.
+ */
+@deprecated
+class TestCollectionTableFactory
+  extends StreamTableSourceFactory[Row]
+  with StreamTableSinkFactory[Row]
+  with BatchTableSourceFactory[Row]
+  with BatchTableSinkFactory[Row]
+{
+
+  override def createTableSource(properties: JMap[String, String]): TableSource[Row] = {
+    getCollectionSource(properties, TestCollectionTableFactory.isStreaming)
+  }
+
+  override def createTableSink(properties: JMap[String, String]): TableSink[Row] = {
+    getCollectionSink(properties)
+  }
+
+  override def createStreamTableSource(properties: JMap[String, String]): StreamTableSource[Row] = {
+    getCollectionSource(properties, isStreaming = true)
+  }
+
+  override def createStreamTableSink(properties: JMap[String, String]): StreamTableSink[Row] = {
+    getCollectionSink(properties)
+  }
+
+  override def createBatchTableSource(properties: JMap[String, String]): BatchTableSource[Row] = {
+    getCollectionSource(properties, isStreaming = false)
+  }
+
+  override def createBatchTableSink(properties: JMap[String, String]): BatchTableSink[Row] = {
+    getCollectionSink(properties)
+  }
+
+  override def requiredContext(): JMap[String, String] = {
+    val context = new util.HashMap[String, String]()
+    context.put(CONNECTOR, "COLLECTION")
+    context
+  }
+
+  override def supportedProperties(): JList[String] = {
+    val supported = new JArrayList[String]()
+    supported.add("*")
+    supported
+  }
+}
+
+@deprecated
+object TestCollectionTableFactory {
+  var isStreaming: Boolean = true
+
+  val SOURCE_DATA = new JLinkedList[Row]()
+  val DIM_DATA = new JLinkedList[Row]()
+  val RESULT = new JLinkedList[Row]()
+  private var emitIntervalMS = -1L
+
+  def initData(sourceData: JList[Row],
+      dimData: JList[Row] = List(),
+      emitInterval: Long = -1L): Unit ={
+    SOURCE_DATA.addAll(sourceData)
+    DIM_DATA.addAll(dimData)
+    emitIntervalMS = emitInterval
+  }
+
+  def reset(): Unit ={
+    RESULT.clear()
+    SOURCE_DATA.clear()
+    DIM_DATA.clear()
+    emitIntervalMS = -1L
+  }
+
+  def getCollectionSource(props: JMap[String, String],
+      isStreaming: Boolean): CollectionTableSource = {
+    val properties = new DescriptorProperties()
+    properties.putProperties(props)
+    val schema = properties.getTableSchema(Schema.SCHEMA)
+    val parallelism = properties.getOptionalInt("parallelism")
+    new CollectionTableSource(emitIntervalMS, schema, isStreaming, parallelism)
+  }
+
+  def getCollectionSink(props: JMap[String, String]): CollectionTableSink = {
+    val properties = new DescriptorProperties()
+    properties.putProperties(props)
+    val schema = properties.getTableSchema(Schema.SCHEMA)
+    new CollectionTableSink(schema.toRowType.asInstanceOf[RowTypeInfo])
+  }
+
+  /**
+    * Table source of collection.
+    */
+  class CollectionTableSource(
+      val emitIntervalMs: Long,
+      val schema: TableSchema,
+      val isStreaming: Boolean,
+      val parallelism: Optional[Integer])
+    extends BatchTableSource[Row]
+    with StreamTableSource[Row]
+    with LookupableTableSource[Row] {
+
+    private val rowType: TypeInformation[Row] = schema.toRowType
+
+    override def isBounded: Boolean = !isStreaming
+
+    def getDataSet(execEnv: ExecutionEnvironment): DataSet[Row] = {
+      val dataSet = execEnv.createInput(new TestCollectionInputFormat[Row](emitIntervalMs,
+        SOURCE_DATA,
+        rowType.createSerializer(new ExecutionConfig)),
+        rowType)
+      if (parallelism.isPresent) {
+        dataSet.setParallelism(parallelism.get())
+      }
+      dataSet
+    }
+
+    override def getDataStream(streamEnv: StreamExecutionEnvironment): DataStreamSource[Row] = {
+      val dataStream = streamEnv.createInput(new TestCollectionInputFormat[Row](emitIntervalMs,
+        SOURCE_DATA,
+        rowType.createSerializer(new ExecutionConfig)),
+        rowType)
+      if (parallelism.isPresent) {
+        dataStream.setParallelism(parallelism.get())
+      }
+      dataStream
+    }
+
+    override def getReturnType: TypeInformation[Row] = rowType
+
+    override def getTableSchema: TableSchema = {
+      schema
+    }
+
+    override def getLookupFunction(lookupKeys: Array[String]): TemporalTableFetcher = {
+      new TemporalTableFetcher(DIM_DATA, lookupKeys.map(schema.getFieldNames.indexOf(_)))
+    }
+
+    override def getAsyncLookupFunction(lookupKeys: Array[String]): AsyncTableFunction[Row] = null
+
+    override def isAsyncEnabled: Boolean = false
+  }
+
+  /**
+    * Table sink of collection.
+    */
+  class CollectionTableSink(val outputType: RowTypeInfo)
+      extends BatchTableSink[Row]
+      with AppendStreamTableSink[Row] {
+    override def consumeDataSet(dataSet: DataSet[Row]): DataSink[_] = {
+      dataSet.output(new LocalCollectionOutputFormat[Row](RESULT)).setParallelism(1)
+    }
+
+    override def getOutputType: RowTypeInfo = outputType
+
+    override def getFieldNames: Array[String] = outputType.getFieldNames
+
+    override def getFieldTypes: Array[TypeInformation[_]] = {
+      outputType.getFieldTypes
+    }
+
+    override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
+      dataStream.addSink(new UnsafeMemorySinkFunction(outputType)).setParallelism(1)
+    }
+
+    override def configure(fieldNames: Array[String],
+        fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = this
+  }
+
+  /**
+    * Sink function of unsafe memory.
+    */
+  class UnsafeMemorySinkFunction(outputType: TypeInformation[Row]) extends RichSinkFunction[Row] {
+    private var serializer: TypeSerializer[Row] = _
+
+    override def open(param: Configuration): Unit = {
+      serializer = outputType.createSerializer(new ExecutionConfig)
+    }
+
+    @throws[Exception]
+    override def invoke(row: Row): Unit = {
+      RESULT.add(serializer.copy(row))
+    }
+  }
+
+  /**
+    * Collection inputFormat for testing.
+    */
+  class TestCollectionInputFormat[T](
+      val emitIntervalMs: Long,
+      val dataSet: java.util.Collection[T],
+      val serializer: TypeSerializer[T])
+    extends CollectionInputFormat[T](dataSet, serializer) {
+    @throws[IOException]
+    override def reachedEnd: Boolean = {
+      if (emitIntervalMs > 0) {
+        try
+          Thread.sleep(emitIntervalMs)
+        catch {
+          case _: InterruptedException =>
+        }
+      }
+      super.reachedEnd
+    }
+  }
+
+  /**
+    * Dimension table source fetcher.
+    */
+  class TemporalTableFetcher(
+      val dimData: JLinkedList[Row],
+      val keys: Array[Int]) extends TableFunction[Row] {
+
+    @throws[Exception]
+    def eval(values: Any*): Unit = {
+      for (data <- dimData) {
+        var matched = true
+        var idx = 0
+        while (matched && idx < keys.length) {
+          val dimField = data.getField(keys(idx))
+          val inputField = values(idx)
+          matched = dimField.equals(inputField)
+          idx += 1
+        }
+        if (matched) {
+          // copy the row data
+          val ret = new Row(data.getArity)
+          0 until data.getArity foreach { idx =>
+            ret.setField(idx, data.getField(idx))
+          }
+          collect(ret)
+        }
+      }
+    }
+  }
+}

--- a/flink-python/src/test/scala/org/apache/flink/table/legacyutils/legacyTestingDescriptors.scala
+++ b/flink-python/src/test/scala/org/apache/flink/table/legacyutils/legacyTestingDescriptors.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.legacyutils
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.streaming.api.watermark.Watermark
+import org.apache.flink.table.api.{DataTypes, ValidationException}
+import org.apache.flink.table.expressions.{ApiExpressionUtils, Expression, FieldReferenceExpression, ResolvedFieldReference}
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions
+import org.apache.flink.table.sources.tsextractors.TimestampExtractor
+import org.apache.flink.table.sources.wmstrategies.PunctuatedWatermarkAssigner
+import org.apache.flink.table.types.utils.TypeConversions
+import org.apache.flink.types.Row
+
+/*
+ * Testing utils adopted from legacy planner until the Python code is updated.
+ */
+
+@deprecated
+class CustomAssigner extends PunctuatedWatermarkAssigner() {
+  override def getWatermark(row: Row, timestamp: Long): Watermark =
+    throw new UnsupportedOperationException()
+}
+
+@deprecated
+class CustomExtractor(val field: String) extends TimestampExtractor {
+  def this() = {
+    this("ts")
+  }
+
+  override def getArgumentFields: Array[String] = Array(field)
+
+  override def validateArgumentFields(argumentFieldTypes: Array[TypeInformation[_]]): Unit = {
+    argumentFieldTypes(0) match {
+      case Types.SQL_TIMESTAMP =>
+      case _ =>
+        throw new ValidationException(
+          s"Field 'ts' must be of type Timestamp but is of type ${argumentFieldTypes(0)}.")
+    }
+  }
+
+  override def getExpression(fieldAccesses: Array[ResolvedFieldReference]): Expression = {
+    val fieldAccess = fieldAccesses(0)
+    require(fieldAccess.resultType == Types.SQL_TIMESTAMP)
+    val fieldReferenceExpr = new FieldReferenceExpression(
+      fieldAccess.name,
+      TypeConversions.fromLegacyInfoToDataType(fieldAccess.resultType),
+      0,
+      fieldAccess.fieldIndex)
+    ApiExpressionUtils.unresolvedCall(
+      BuiltInFunctionDefinitions.CAST,
+      fieldReferenceExpr,
+      ApiExpressionUtils.typeLiteral(DataTypes.BIGINT()))
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: CustomExtractor => field == that.field
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    field.hashCode
+  }
+}

--- a/flink-python/src/test/scala/org/apache/flink/table/legacyutils/legacyTestingFunctions.scala
+++ b/flink-python/src/test/scala/org/apache/flink/table/legacyutils/legacyTestingFunctions.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.legacyutils
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.TupleTypeInfo
+import org.apache.flink.table.functions.{AggregateFunction, FunctionContext, ScalarFunction, TableFunction}
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+
+import java.lang.{Iterable => JIterable}
+import org.junit.Assert
+
+/*
+ * Testing utils adopted from legacy planner until the Python code is updated.
+ */
+
+@deprecated
+class RichFunc0 extends ScalarFunction {
+  var openCalled = false
+  var closeCalled = false
+
+  override def open(context: FunctionContext): Unit = {
+    super.open(context)
+    if (openCalled) {
+      Assert.fail("Open called more than once.")
+    } else {
+      openCalled = true
+    }
+    if (closeCalled) {
+      Assert.fail("Close called before open.")
+    }
+  }
+
+  def eval(index: Int): Int = {
+    if (!openCalled) {
+      Assert.fail("Open was not called before eval.")
+    }
+    if (closeCalled) {
+      Assert.fail("Close called before eval.")
+    }
+
+    index + 1
+  }
+
+  override def close(): Unit = {
+    super.close()
+    if (closeCalled) {
+      Assert.fail("Close called more than once.")
+    } else {
+      closeCalled = true
+    }
+    if (!openCalled) {
+      Assert.fail("Open was not called before close.")
+    }
+  }
+}
+
+@deprecated
+class MaxAccumulator[T] extends JTuple2[T, Boolean]
+
+@deprecated
+abstract class MaxAggFunction[T](implicit ord: Ordering[T])
+  extends AggregateFunction[T, MaxAccumulator[T]] {
+
+  override def createAccumulator(): MaxAccumulator[T] = {
+    val acc = new MaxAccumulator[T]
+    acc.f0 = getInitValue
+    acc.f1 = false
+    acc
+  }
+
+  def accumulate(acc: MaxAccumulator[T], value: Any): Unit = {
+    if (value != null) {
+      val v = value.asInstanceOf[T]
+      if (!acc.f1 || ord.compare(acc.f0, v) < 0) {
+        acc.f0 = v
+        acc.f1 = true
+      }
+    }
+  }
+
+  override def getValue(acc: MaxAccumulator[T]): T = {
+    if (acc.f1) {
+      acc.f0
+    } else {
+      null.asInstanceOf[T]
+    }
+  }
+
+  def merge(acc: MaxAccumulator[T], its: JIterable[MaxAccumulator[T]]): Unit = {
+    val iter = its.iterator()
+    while (iter.hasNext) {
+      val a = iter.next()
+      if (a.f1) {
+        accumulate(acc, a.f0)
+      }
+    }
+  }
+
+  def resetAccumulator(acc: MaxAccumulator[T]): Unit = {
+    acc.f0 = getInitValue
+    acc.f1 = false
+  }
+
+  override def getAccumulatorType: TypeInformation[MaxAccumulator[T]] = {
+    new TupleTypeInfo(
+      classOf[MaxAccumulator[T]],
+      getValueTypeInfo,
+      BasicTypeInfo.BOOLEAN_TYPE_INFO)
+  }
+
+  def getInitValue: T
+
+  def getValueTypeInfo: TypeInformation[_]
+}
+
+@deprecated
+class ByteMaxAggFunction extends MaxAggFunction[Byte] {
+  override def getInitValue: Byte = 0.toByte
+  override def getValueTypeInfo = BasicTypeInfo.BYTE_TYPE_INFO
+}
+
+@deprecated
+class TableFunc1 extends TableFunction[String] {
+  def eval(str: String): Unit = {
+    if (str.contains("#")){
+      str.split("#").foreach(collect)
+    }
+  }
+
+  def eval(str: String, prefix: String): Unit = {
+    if (str.contains("#")) {
+      str.split("#").foreach(s => collect(prefix + s))
+    }
+  }
+}

--- a/flink-python/src/test/scala/org/apache/flink/table/legacyutils/legacyTestingSinks.scala
+++ b/flink-python/src/test/scala/org/apache/flink/table/legacyutils/legacyTestingSinks.scala
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.legacyutils
+
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
+import org.apache.flink.table.sinks.{AppendStreamTableSink, RetractStreamTableSink, TableSink, UpsertStreamTableSink}
+import org.apache.flink.types.Row
+
+import java.lang.{Boolean => JBool}
+
+import scala.collection.mutable
+
+/*
+ * Testing utils adopted from legacy planner until the Python code is updated.
+ */
+
+@deprecated
+private[flink] class TestAppendSink extends AppendStreamTableSink[Row] {
+
+  var fNames: Array[String] = _
+  var fTypes: Array[TypeInformation[_]] = _
+
+  override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
+    dataStream.map(
+      new MapFunction[Row, JTuple2[JBool, Row]] {
+        override def map(value: Row): JTuple2[JBool, Row] = new JTuple2(true, value)
+      })
+      .addSink(new RowSink)
+  }
+
+  override def getOutputType: TypeInformation[Row] = new RowTypeInfo(fTypes, fNames)
+
+  override def getFieldNames: Array[String] = fNames
+
+  override def getFieldTypes: Array[TypeInformation[_]] = fTypes
+
+  override def configure(
+    fieldNames: Array[String],
+    fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = {
+    val copy = new TestAppendSink
+    copy.fNames = fieldNames
+    copy.fTypes = fieldTypes
+    copy
+  }
+}
+
+@deprecated
+private[flink] class TestRetractSink extends RetractStreamTableSink[Row] {
+
+  var fNames: Array[String] = _
+  var fTypes: Array[TypeInformation[_]] = _
+
+  override def consumeDataStream(s: DataStream[JTuple2[JBool, Row]]): DataStreamSink[_] = {
+    s.addSink(new RowSink)
+  }
+
+  override def getRecordType: TypeInformation[Row] = new RowTypeInfo(fTypes, fNames)
+
+  override def getFieldNames: Array[String] = fNames
+
+  override def getFieldTypes: Array[TypeInformation[_]] = fTypes
+
+  override def configure(
+      fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]]): TableSink[JTuple2[JBool, Row]] = {
+    val copy = new TestRetractSink
+    copy.fNames = fieldNames
+    copy.fTypes = fieldTypes
+    copy
+  }
+}
+
+@deprecated
+private[flink] class TestUpsertSink(
+    expectedKeys: Array[String],
+    expectedIsAppendOnly: Boolean)
+  extends UpsertStreamTableSink[Row] {
+
+  var fNames: Array[String] = _
+  var fTypes: Array[TypeInformation[_]] = _
+
+  override def setKeyFields(keys: Array[String]): Unit =
+    if (keys != null) {
+      if (!expectedKeys.sorted.mkString(",").equals(keys.sorted.mkString(","))) {
+        throw new AssertionError("Provided key fields do not match expected keys")
+      }
+    } else {
+      if (expectedKeys != null) {
+        throw new AssertionError("Provided key fields should not be null.")
+      }
+    }
+
+  override def setIsAppendOnly(isAppendOnly: JBool): Unit =
+    if (expectedIsAppendOnly != isAppendOnly) {
+      throw new AssertionError("Provided isAppendOnly does not match expected isAppendOnly")
+    }
+
+  override def getRecordType: TypeInformation[Row] = new RowTypeInfo(fTypes, fNames)
+
+  override def consumeDataStream(s: DataStream[JTuple2[JBool, Row]]): DataStreamSink[_] = {
+    s.addSink(new RowSink)
+  }
+
+  override def getFieldNames: Array[String] = fNames
+
+  override def getFieldTypes: Array[TypeInformation[_]] = fTypes
+
+  override def configure(
+      fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]]): TableSink[JTuple2[JBool, Row]] = {
+    val copy = new TestUpsertSink(expectedKeys, expectedIsAppendOnly)
+    copy.fNames = fieldNames
+    copy.fTypes = fieldTypes
+    copy
+  }
+}
+
+@deprecated
+class RowSink extends SinkFunction[JTuple2[JBool, Row]] {
+  override def invoke(value: JTuple2[JBool, Row]): Unit = RowCollector.addValue(value)
+}
+
+@deprecated
+object RowCollector {
+  private val sink: mutable.ArrayBuffer[JTuple2[JBool, Row]] =
+    new mutable.ArrayBuffer[JTuple2[JBool, Row]]()
+
+  def addValue(value: JTuple2[JBool, Row]): Unit = {
+
+    // make a copy
+    val copy = new JTuple2[JBool, Row](value.f0, Row.copy(value.f1))
+    sink.synchronized {
+      sink += copy
+    }
+  }
+
+  def getAndClearValues: List[JTuple2[JBool, Row]] = {
+    val out = sink.toList
+    sink.clear()
+    out
+  }
+
+  /** Converts a list of retraction messages into a list of final results. */
+  def retractResults(results: List[JTuple2[JBool, Row]]): List[String] = {
+
+    val retracted = results
+      .foldLeft(Map[String, Int]()){ (m: Map[String, Int], v: JTuple2[JBool, Row]) =>
+        val cnt = m.getOrElse(v.f1.toString, 0)
+        if (v.f0) {
+          m + (v.f1.toString -> (cnt + 1))
+        } else {
+          m + (v.f1.toString -> (cnt - 1))
+        }
+      }.filter{ case (_, c: Int) => c != 0 }
+
+    if (retracted.exists{ case (_, c: Int) => c < 0}) {
+      throw new AssertionError("Received retracted rows which have not been accumulated.")
+    }
+
+    retracted.flatMap { case (r: String, c: Int) => (0 until c).map(_ => r) }.toList
+  }
+
+  /** Converts a list of upsert messages into a list of final results. */
+  def upsertResults(results: List[JTuple2[JBool, Row]], keys: Array[Int]): List[String] = {
+
+    def getKeys(r: Row): Row = Row.project(r, keys)
+
+    val upserted = results.foldLeft(Map[Row, String]()){ (o: Map[Row, String], r) =>
+      val key = getKeys(r.f1)
+      if (r.f0) {
+        o + (key -> r.f1.toString)
+      } else {
+        o - key
+      }
+    }
+
+    upserted.values.toList
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This removes remaining references to the legacy planner outside of the `flink-table` module. The Python API still has test dependencies to legacy planner classes. Those classes are temporarily moved to the `flink-python` module because they are used by a large amount of tests.

## Brief change log

- Remove remaining end-to-end tests that reference the old planner
- Use the dedicated `flink-python` test jar instead of the legacy planner once

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
