### PR TITLE
[FLINK-22894][table-runtime-blink] Fix rankEnd validation of WindowRank to support top1

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -126,7 +126,7 @@ public class WindowRankOperatorBuilder {
                 String.format("Illegal rank start %s, it should be positive!", rankStart));
         checkArgument(
                 rankEnd >= 1,
-                String.format("Illegal rank end %s, it should be bigger than 1!", rankEnd));
+                String.format("Illegal rank end %s, it should be at least 1!", rankEnd));
         checkArgument(
                 rankEnd >= rankStart,
                 String.format(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -125,7 +125,7 @@ public class WindowRankOperatorBuilder {
                 rankStart > 0,
                 String.format("Illegal rank start %s, it should be positive!", rankStart));
         checkArgument(
-                rankEnd > 1,
+                rankEnd >= 1,
                 String.format("Illegal rank end %s, it should be bigger than 1!", rankEnd));
         checkArgument(
                 rankEnd >= rankStart,


### PR DESCRIPTION
## What is the purpose of the change

The pull request aims to a minor fix on rankEnd validation of WindowRank to support top1 


## Brief change log

  - A minor update in `WindowRankOperatorBuilder` to support top1 

## Verifying this change

  - Add ITCase in WindowRankITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
