### PR TITLE
[FLINK-22815][checkpointing][bp-1.12] Disable unaligned checkpoints for broadcast partitioning

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/SnapshotUtils.java
@@ -48,7 +48,7 @@ public final class SnapshotUtils {
             throws Exception {
 
         CheckpointOptions options =
-                new CheckpointOptions(
+                CheckpointOptions.forConfig(
                         CheckpointType.SAVEPOINT,
                         AbstractFsCheckpointStorageAccess.encodePathAsReference(savepointPath),
                         isExactlyOnceMode,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
@@ -66,6 +66,12 @@ public class CheckpointBarrier extends RuntimeEvent {
         return checkpointOptions;
     }
 
+    public CheckpointBarrier withOptions(CheckpointOptions checkpointOptions) {
+        return this.checkpointOptions == checkpointOptions
+                ? this
+                : new CheckpointBarrier(id, timestamp, checkpointOptions);
+    }
+
     // ------------------------------------------------------------------------
     // Serialization
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -222,8 +222,7 @@ public class EventSerializer {
             buf.putInt(locationBytes.length);
             buf.put(locationBytes);
         }
-        buf.put((byte) (checkpointOptions.isExactlyOnceMode() ? 1 : 0));
-        buf.put((byte) (checkpointOptions.isUnalignedCheckpoint() ? 1 : 0));
+        buf.put((byte) checkpointOptions.getAlignment().ordinal());
         buf.putLong(checkpointOptions.getAlignmentTimeout());
 
         buf.flip();
@@ -259,19 +258,15 @@ public class EventSerializer {
             buffer.get(bytes);
             locationRef = new CheckpointStorageLocationReference(bytes);
         }
-        final boolean isExactlyOnceMode = buffer.get() == 1;
-        final boolean isUnalignedCheckpoint = buffer.get() == 1;
+        final CheckpointOptions.AlignmentType alignmentType =
+                CheckpointOptions.AlignmentType.values()[buffer.get()];
         final long alignmentTimeout = buffer.getLong();
 
         return new CheckpointBarrier(
                 id,
                 timestamp,
                 new CheckpointOptions(
-                        checkpointType,
-                        locationRef,
-                        isExactlyOnceMode,
-                        isUnalignedCheckpoint,
-                        alignmentTimeout));
+                        checkpointType, locationRef, alignmentType, alignmentTimeout));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
 
 /**
  * The {@code SubtaskStateMapper} narrows down the subtasks that need to be read during rescaling to
@@ -58,18 +57,6 @@ public enum SubtaskStateMapper {
             // The current implementation uses round robin but that may be changed later.
             return ROUND_ROBIN.getOldSubtasks(
                     newSubtaskIndex, oldNumberOfSubtasks, newNumberOfSubtasks);
-        }
-    },
-
-    /**
-     * Discards extra state. Useful if all subtasks already contain the same information
-     * (broadcast).
-     */
-    DISCARD_EXTRA_STATE {
-        @Override
-        public Set<Integer> getOldSubtasks(
-                int newSubtaskIndex, int oldNumberOfSubtasks, int newNumberOfSubtasks) {
-            return newSubtaskIndex >= oldNumberOfSubtasks ? emptySet() : singleton(newSubtaskIndex);
         }
     },
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapper.java
@@ -180,6 +180,17 @@ public enum SubtaskStateMapper {
             }
             return subtasks;
         }
+    },
+
+    UNSUPPORTED {
+        @Override
+        public Set<Integer> getOldSubtasks(
+                int newSubtaskIndex, int oldNumberOfSubtasks, int newNumberOfSubtasks) {
+            throw new UnsupportedOperationException(
+                    "Cannot rescale the given pointwise partitioner.\n"
+                            + "Did you change the partitioner to forward or rescale?\n"
+                            + "It may also help to add an explicit shuffle().");
+        }
     };
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapperTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/SubtaskStateMapperTest.java
@@ -30,28 +30,6 @@ import static org.junit.Assert.assertEquals;
 /** Tests {@link SubtaskStateMapper}. */
 public class SubtaskStateMapperTest {
     @Test
-    public void testDiscardTaskMappingOnScaleDown() {
-        assertMappingEquals(
-                new int[][] {{0}, {1}},
-                SubtaskStateMapper.DISCARD_EXTRA_STATE.getNewToOldSubtasksMapping(3, 2));
-    }
-
-    @Test
-    public void testDiscardTaskMappingOnNoScale() {
-        // this may be a bit surprising, but the optimization should be done on call-site
-        assertMappingEquals(
-                new int[][] {{0}, {1}, {2}},
-                SubtaskStateMapper.DISCARD_EXTRA_STATE.getNewToOldSubtasksMapping(3, 3));
-    }
-
-    @Test
-    public void testDiscardTaskMappingOnScaleUp() {
-        assertMappingEquals(
-                new int[][] {{0}, {1}, {2}, {}},
-                SubtaskStateMapper.DISCARD_EXTRA_STATE.getNewToOldSubtasksMapping(3, 4));
-    }
-
-    @Test
     public void testFirstTaskMappingOnScaleDown() {
         assertMappingEquals(
                 new int[][] {{0, 1, 2}, {}},

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.RecordingChannelStateWriter;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -361,12 +360,8 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertEquals(0, availablityListener.getNumPriorityEvents());
 
         CheckpointOptions options =
-                new CheckpointOptions(
-                        CheckpointType.CHECKPOINT,
-                        new CheckpointStorageLocationReference(new byte[] {0, 1, 2}),
-                        true,
-                        true,
-                        0);
+                CheckpointOptions.unaligned(
+                        new CheckpointStorageLocationReference(new byte[] {0, 1, 2}));
         channelStateWriter.start(0, options);
         BufferConsumer barrierBuffer =
                 EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options), true);
@@ -408,12 +403,8 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.setChannelStateWriter(ChannelStateWriter.NO_OP);
 
         CheckpointOptions options =
-                new CheckpointOptions(
-                        CheckpointType.CHECKPOINT,
-                        new CheckpointStorageLocationReference(new byte[] {0, 1, 2}),
-                        true,
-                        true,
-                        0);
+                CheckpointOptions.unaligned(
+                        new CheckpointStorageLocationReference(new byte[] {0, 1, 2}));
         BufferConsumer barrierBuffer =
                 EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options), true);
         subpartition.add(barrierBuffer);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/ChannelStatePersisterTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -48,8 +49,7 @@ public class ChannelStatePersisterTest {
                 new ChannelStatePersister(channelStateWriter, channelInfo);
 
         long checkpointId = 1L;
-        channelStateWriter.start(
-                checkpointId, CheckpointOptions.forCheckpointWithDefaultLocation(true, true, 0));
+        channelStateWriter.start(checkpointId, CheckpointOptions.unaligned(getDefault()));
 
         persister.checkForBarrier(barrier(checkpointId));
         persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
@@ -115,8 +115,7 @@ public class ChannelStatePersisterTest {
             persister.stopPersisting(lateCheckpointId);
         }
         persister.checkForBarrier(barrier(lateCheckpointId));
-        channelStateWriter.start(
-                checkpointId, CheckpointOptions.forCheckpointWithDefaultLocation(true, true, 0));
+        channelStateWriter.start(checkpointId, CheckpointOptions.unaligned(getDefault()));
         persister.startPersisting(checkpointId, Arrays.asList(buildSomeBuffer()));
         persister.maybePersist(buildSomeBuffer());
         persister.checkForBarrier(barrier(checkpointId));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -503,7 +503,7 @@ public class LocalInputChannelTest {
         final CheckpointStorageLocationReference location =
                 CheckpointStorageLocationReference.getDefault();
         CheckpointOptions options =
-                new CheckpointOptions(CheckpointType.CHECKPOINT, location, true, true, 0);
+                CheckpointOptions.forConfig(CheckpointType.CHECKPOINT, location, true, true, 0);
         stateWriter.start(0, options);
 
         final CheckpointBarrier barrier = new CheckpointBarrier(0, 123L, options);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -162,9 +162,7 @@ public class RemoteInputChannelTest {
 
         inputChannel.checkpointStarted(
                 new CheckpointBarrier(
-                        42,
-                        System.currentTimeMillis(),
-                        CheckpointOptions.forCheckpointWithDefaultLocation(true, true, 0)));
+                        42, System.currentTimeMillis(), CheckpointOptions.unaligned(getDefault())));
 
         final Buffer buffer = createBuffer(TestBufferFactory.BUFFER_SIZE);
 
@@ -1475,7 +1473,7 @@ public class RemoteInputChannelTest {
     private void sendBarrier(RemoteInputChannel channel, int sequenceNumber, int alignmentTimeout)
             throws IOException {
         CheckpointOptions checkpointOptions =
-                CheckpointOptions.create(CHECKPOINT, getDefault(), true, true, alignmentTimeout);
+                CheckpointOptions.forConfig(CHECKPOINT, getDefault(), true, true, alignmentTimeout);
         send(
                 channel,
                 sequenceNumber,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -62,6 +62,8 @@ public class StreamEdge implements Serializable {
 
     private long bufferTimeout;
 
+    private boolean supportsUnalignedCheckpoints = true;
+
     public StreamEdge(
             StreamNode sourceVertex,
             StreamNode targetVertex,
@@ -154,6 +156,14 @@ public class StreamEdge implements Serializable {
 
     public long getBufferTimeout() {
         return bufferTimeout;
+    }
+
+    public void setSupportsUnalignedCheckpoints(boolean supportsUnalignedCheckpoints) {
+        this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
+    }
+
+    public boolean supportsUnalignedCheckpoints() {
+        return supportsUnalignedCheckpoints;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -270,6 +270,14 @@ public class StreamGraphGenerator {
             transform(transformation);
         }
 
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            if (node.getInEdges().stream().anyMatch(edge -> edge.getPartitioner().isBroadcast())) {
+                for (StreamEdge edge : node.getInEdges()) {
+                    edge.setSupportsUnalignedCheckpoints(false);
+                }
+            }
+        }
+
         final StreamGraph builtStreamGraph = streamGraph;
 
         alreadyTransformed.clear();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.api.operators.Output;
@@ -49,6 +50,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
 
     private final StreamStatusProvider streamStatusProvider;
 
+    private final boolean supportsUnalignedCheckpoints;
+
     private final OutputTag outputTag;
 
     private final WatermarkGauge watermarkGauge = new WatermarkGauge();
@@ -58,7 +61,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
             RecordWriter<SerializationDelegate<StreamRecord<OUT>>> recordWriter,
             TypeSerializer<OUT> outSerializer,
             OutputTag outputTag,
-            StreamStatusProvider streamStatusProvider) {
+            StreamStatusProvider streamStatusProvider,
+            boolean supportsUnalignedCheckpoints) {
 
         checkNotNull(recordWriter);
         this.outputTag = outputTag;
@@ -75,6 +79,8 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
         }
 
         this.streamStatusProvider = checkNotNull(streamStatusProvider);
+
+        this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
     }
 
     @Override
@@ -140,6 +146,13 @@ public class RecordWriterOutput<OUT> implements WatermarkGaugeExposingOutput<Str
     }
 
     public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {
+        if (isPriorityEvent
+                && event instanceof CheckpointBarrier
+                && !supportsUnalignedCheckpoints) {
+            final CheckpointBarrier barrier = (CheckpointBarrier) event;
+            event = barrier.withOptions(barrier.getCheckpointOptions().withUnalignedUnsupported());
+            isPriorityEvent = false;
+        }
         recordWriter.broadcastEvent(event, isPriorityEvent);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
@@ -43,12 +43,12 @@ public class BroadcastPartitioner<T> extends StreamPartitioner<T> {
 
     @Override
     public SubtaskStateMapper getUpstreamSubtaskStateMapper() {
-        return SubtaskStateMapper.DISCARD_EXTRA_STATE;
+        return SubtaskStateMapper.UNSUPPORTED;
     }
 
     @Override
     public SubtaskStateMapper getDownstreamSubtaskStateMapper() {
-        return SubtaskStateMapper.ROUND_ROBIN;
+        return SubtaskStateMapper.UNSUPPORTED;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -712,7 +712,12 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                             taskEnvironment.getUserCodeClassLoader().asClassLoader());
         }
 
-        return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag, this);
+        return new RecordWriterOutput<>(
+                recordWriter,
+                outSerializer,
+                sideOutputTag,
+                this,
+                edge.supportsUnalignedCheckpoints());
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -24,9 +24,11 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -145,7 +147,9 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
 
     private void triggerCheckpointForExternallyInducedSource(long checkpointId) {
         final CheckpointOptions checkpointOptions =
-                CheckpointOptions.forCheckpointWithDefaultLocation(
+                CheckpointOptions.forConfig(
+                        CheckpointType.CHECKPOINT,
+                        CheckpointStorageLocationReference.getDefault(),
                         configuration.isExactlyOnceCheckpointMode(),
                         configuration.isUnalignedCheckpointsEnabled(),
                         configuration.getAlignmentTimeout());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -21,9 +21,11 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.streaming.api.checkpoint.ExternallyInducedSource;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -100,7 +102,9 @@ public class SourceStreamTask<
                             // TODO -   message from the master, and the source's trigger
                             // notification
                             final CheckpointOptions checkpointOptions =
-                                    CheckpointOptions.forCheckpointWithDefaultLocation(
+                                    CheckpointOptions.forConfig(
+                                            CheckpointType.CHECKPOINT,
+                                            CheckpointStorageLocationReference.getDefault(),
                                             configuration.isExactlyOnceCheckpointMode(),
                                             configuration.isUnalignedCheckpointsEnabled(),
                                             configuration.getAlignmentTimeout());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -277,6 +277,13 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             return;
         }
 
+        // if checkpoint has been previously unaligned, but was forced to be aligned,
+        // revert it here so that it can jump over output data
+        if (options.getAlignment() == CheckpointOptions.AlignmentType.FORCED_ALIGNED) {
+            options = options.withUnalignedSupported();
+            initCheckpoint(metadata.getCheckpointId(), options);
+        }
+
         // Step (1): Prepare the checkpoint, allow operators to do some pre-barrier work.
         //           The pre-barrier work should be nothing or minimal in the common case.
         operatorChain.prepareSnapshotPreBarrier(metadata.getCheckpointId());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
@@ -28,6 +29,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
 import org.apache.flink.streaming.api.datastream.ConnectedStreams;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.IterativeStream;
@@ -35,6 +37,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -58,9 +61,11 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.util.NoOpIntMap;
+import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
@@ -70,11 +75,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -287,6 +293,63 @@ public class StreamGraphGeneratorTest extends TestLogger {
         assertEquals(1, streamGraph.getStreamEdges(source2.getId()).size());
         assertEquals(1, streamGraph.getStreamEdges(source3.getId()).size());
         assertEquals(0, streamGraph.getStreamEdges(transform.getId()).size());
+    }
+
+    @Test
+    public void testUnalignedCheckpointDisabledOnBroadcast() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(42);
+
+        DataStream<Long> source1 = env.fromSequence(1L, 10L);
+        DataStream<Long> map1 = source1.broadcast().map(l -> l);
+        DataStream<Long> source2 = env.fromSequence(2L, 11L);
+        DataStream<Long> keyed = source2.keyBy(r -> 0L);
+
+        final MapStateDescriptor<Long, Long> descriptor =
+                new MapStateDescriptor<>(
+                        "broadcast", BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO);
+        final BroadcastStream<Long> broadcast = map1.broadcast(descriptor);
+        final SingleOutputStreamOperator<Long> joined =
+                keyed.connect(broadcast)
+                        .process(
+                                new KeyedBroadcastProcessFunction<Long, Long, Long, Long>() {
+                                    @Override
+                                    public void processElement(
+                                            Long value, ReadOnlyContext ctx, Collector<Long> out) {}
+
+                                    @Override
+                                    public void processBroadcastElement(
+                                            Long value, Context ctx, Collector<Long> out) {}
+                                });
+
+        StreamGraph streamGraph = env.getStreamGraph();
+        assertEquals(4, streamGraph.getStreamNodes().size());
+
+        // single broadcast
+        assertThat(edge(streamGraph, source1, map1), supportsUnalignedCheckpoints(false));
+        // keyed, connected with broadcast
+        assertThat(edge(streamGraph, source2, joined), supportsUnalignedCheckpoints(false));
+        // broadcast, connected with keyed
+        assertThat(edge(streamGraph, map1, joined), supportsUnalignedCheckpoints(false));
+    }
+
+    private static StreamEdge edge(
+            StreamGraph streamGraph, DataStream<Long> op1, DataStream<Long> op2) {
+        List<StreamEdge> streamEdges = streamGraph.getStreamEdges(op1.getId(), op2.getId());
+        assertThat(streamEdges, iterableWithSize(1));
+        return streamEdges.get(0);
+    }
+
+    private static Matcher<StreamEdge> supportsUnalignedCheckpoints(boolean enabled) {
+        return new FeatureMatcher<StreamEdge, Boolean>(
+                equalTo(enabled),
+                "supports unaligned checkpoint",
+                "supports unaligned checkpoint") {
+            @Override
+            protected Boolean featureValueOf(StreamEdge actual) {
+                return actual.supportsUnalignedCheckpoints();
+            }
+        };
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGateTest.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -260,9 +261,7 @@ public class CheckpointedInputGateTest {
 
     private static CheckpointBarrier barrier(long barrierId) {
         return new CheckpointBarrier(
-                barrierId,
-                barrierId,
-                CheckpointOptions.forCheckpointWithDefaultLocation(true, true, 0));
+                barrierId, barrierId, CheckpointOptions.unaligned(getDefault()));
     }
 
     private void assertAddedInputSize(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/InputProcessorUtilTest.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the behaviors of the {@link InputProcessorUtil}. */
@@ -90,11 +91,7 @@ public class InputProcessorUtilTest {
                         channelId < inputGate.getNumberOfInputChannels();
                         channelId++) {
                     barrierHandler.processBarrier(
-                            new CheckpointBarrier(
-                                    1,
-                                    42,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation(
-                                            true, true, 0)),
+                            new CheckpointBarrier(1, 42, CheckpointOptions.unaligned(getDefault())),
                             new InputChannelInfo(inputGate.getGateIndex(), channelId));
                 }
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -30,11 +30,13 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriterImpl;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.writer.NonRecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -106,7 +108,7 @@ public class SubtaskCheckpointCoordinatorTest {
         CheckpointStorageLocationReference locationReference =
                 CheckpointStorageLocationReference.getDefault();
         CheckpointOptions options =
-                new CheckpointOptions(
+                CheckpointOptions.forConfig(
                         checkpointType, locationReference, true, unalignedCheckpointEnabled, 0);
         coordinator.initCheckpoint(1L, options);
         return writer.started;
@@ -171,6 +173,50 @@ public class SubtaskCheckpointCoordinatorTest {
                 () -> true);
 
         assertEquals(false, broadcastedPriorityEvent.get());
+    }
+
+    @Test
+    public void testForceAlignedCheckpointResultingInPriorityEvents() throws Exception {
+        MockEnvironment mockEnvironment = MockEnvironment.builder().build();
+
+        SubtaskCheckpointCoordinator coordinator =
+                new MockSubtaskCheckpointCoordinatorBuilder()
+                        .setUnalignedCheckpointEnabled(true)
+                        .setEnvironment(mockEnvironment)
+                        .build();
+
+        AtomicReference<Boolean> broadcastedPriorityEvent = new AtomicReference<>(null);
+        final OperatorChain<?, ?> operatorChain =
+                new OperatorChain(
+                        new MockStreamTaskBuilder(mockEnvironment).build(),
+                        new NonRecordWriter<>()) {
+                    @Override
+                    public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent)
+                            throws IOException {
+                        super.broadcastEvent(event, isPriorityEvent);
+                        broadcastedPriorityEvent.set(isPriorityEvent);
+                        // test if we can write output data
+                        coordinator
+                                .getChannelStateWriter()
+                                .addOutputData(
+                                        0,
+                                        new ResultSubpartitionInfo(0, 0),
+                                        0,
+                                        BufferBuilderTestUtils.buildSomeBuffer(1337));
+                    }
+                };
+
+        CheckpointOptions forcedAlignedOptions =
+                CheckpointOptions.unaligned(CheckpointStorageLocationReference.getDefault())
+                        .withUnalignedUnsupported();
+        coordinator.checkpointState(
+                new CheckpointMetaData(42, 0),
+                forcedAlignedOptions,
+                new CheckpointMetricsBuilder(),
+                operatorChain,
+                () -> true);
+
+        assertEquals(true, broadcastedPriorityEvent.get());
     }
 
     @Test


### PR DESCRIPTION
This is a backport of parts of #16019 and #15294

Broadcast partitioning can not work with unaligned checkpointing. There are no guarantees that records are consumed at the same rate in all channels. This can result in some tasks applying state changes corresponding to a certain broadcasted event while others don't.

In turn upon restore, it may lead to an inconsistent state. This is especially harmful to the most common pattern for using a broadcast pattern where only a single operator checkpoints its state and that state is copied over to all other operators on restore.