### PR TITLE
[FLINK-22454][table-planner-blink] only ignore casting on interoperable type when extracting lookup keys

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -474,6 +474,54 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
     util.verifyExecPlan(sql)
   }
 
+  @Test
+  def testJoinTemporalTableWithCastOnLookupTable(): Unit = {
+    util.addTable(
+      """
+        |CREATE TABLE LookupTable2 (
+        |  `id` decimal(38, 18),
+        |  `name` STRING,
+        |  `age` INT
+        |) WITH (
+        |  'connector' = 'values'
+        |)
+        |""".stripMargin)
+    val sql =
+      """
+        |SELECT MyTable.b, LookupTable2.id
+        |FROM MyTable
+        |LEFT JOIN LookupTable2 FOR SYSTEM_TIME AS OF MyTable.`proctime`
+        |ON MyTable.a = CAST(LookupTable2.`id` as INT)
+        |""".stripMargin
+    thrown.expect(classOf[TableException])
+    thrown.expectMessage("Temporal table join requires an equality condition on fields of " +
+      "table [default_catalog.default_database.LookupTable2]")
+    verifyTranslationSuccess(sql)
+  }
+
+  @Test
+  def testJoinTemporalTableWithInteroperableCastOnLookupTable(): Unit = {
+    util.addTable(
+      """
+        |CREATE TABLE LookupTable2 (
+        |  `id` INT,
+        |  `name` char(10),
+        |  `age` INT
+        |) WITH (
+        |  'connector' = 'values'
+        |)
+        |""".stripMargin)
+
+    val sql =
+      """
+        |SELECT MyTable.b, LookupTable2.id
+        |FROM MyTable
+        |LEFT JOIN LookupTable2 FOR SYSTEM_TIME AS OF MyTable.`proctime`
+        |ON MyTable.b = CAST(LookupTable2.`name` as String)
+        |""".stripMargin
+    verifyTranslationSuccess(sql)
+  }
+
   // ==========================================================================================
 
   private def createLookupTable(tableName: String, lookupFunction: UserDefinedFunction): Unit = {


### PR DESCRIPTION

## What is the purpose of the change
Currently LookupJoin would throw exception, when there is casting on field of temporal table, this pr fixes the way of extracting lookup keys.

## Brief change log

  - *ignore casting on interoperable type when extracting lookup keys*


## Verifying this change

*(Please pick either of the following options)*


This change added tests and can be verified as follows:
  - *Added test that validates that only cast on interoperable type would be ignored*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
