### PR TITLE
[FLINK-22906][docs] Add build time to Flink documentation

### DIFF
--- a/docs/content.zh/_index.md
+++ b/docs/content.zh/_index.md
@@ -86,3 +86,5 @@ release notes if there is a leading '/' and file extension.
 请参阅 [Flink 1.12]({{< ref "/release-notes/flink-1.12.md" >}})，[Flink 1.11]({{< ref "/release-notes/flink-1.11.md" >}})，[Flink 1.10]({{< ref "/release-notes/flink-1.10.md" >}})，[Flink 1.9]({{< ref "/release-notes/flink-1.9.md" >}})，[Flink 1.8]({{< ref "/release-notes/flink-1.8.md" >}})，或者 [Flink 1.7]({{< ref "/release-notes/flink-1.7.md" >}}) 的发行说明。
 
 {{< /columns >}}
+
+{{< build_time >}}

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -86,3 +86,5 @@ release notes if there is a leading '/' and file extension.
 See the release notes for [Flink 1.13]({{< ref "/release-notes/flink-1.13.md" >}}), [Flink 1.12]({{< ref "/release-notes/flink-1.12.md" >}}), [Flink 1.11]({{< ref "/release-notes/flink-1.11.md" >}}), [Flink 1.10]({{< ref "/release-notes/flink-1.10.md" >}}), [Flink 1.9]({{< ref "/release-notes/flink-1.9.md" >}}), [Flink 1.8]({{< ref "/release-notes/flink-1.8.md" >}}), or [Flink 1.7]({{< ref "/release-notes/flink-1.7.md" >}}).
 
 {{< /columns >}}
+
+{{< build_time >}}

--- a/docs/layouts/shortcodes/build_time.html
+++ b/docs/layouts/shortcodes/build_time.html
@@ -1,0 +1,23 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/}}{{/*
+  Shortcode that only renders the build time of the site
+  */}}
+<div>
+Documentation built at {{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}
+</div>


### PR DESCRIPTION
## Brief change log

Renders the documentations build time at the bottom of the home page. 

![Screen Shot 2021-06-07 at 9 53 47 AM](https://user-images.githubusercontent.com/1891970/121038911-43a6b800-c776-11eb-91f0-26823ed81b49.png)

