### PR TITLE
[FLINK-22730][table-planner-blink] Add per record code when generating table function collector code for lookup joins

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
@@ -397,6 +397,7 @@ object LookupJoinCodeGenerator {
           $input2TypeClass $collectedTerm = ($input2TypeClass) record;
           ${ctx.reuseLocalVariableCode()}
           ${ctx.reuseInputUnboxingCode()}
+          ${ctx.reusePerRecordCode()}
           $bodyCode
         }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -869,6 +869,7 @@ class AggsHandlerCodeGenerator(
 
     s"""
        |${ctx.reuseLocalVariableCode(methodName)}
+       |${ctx.reusePerRecordCode()}
        |${resultExpr.code}
        |return ${resultExpr.resultTerm};
     """.stripMargin
@@ -946,6 +947,7 @@ class AggsHandlerCodeGenerator(
       s"""
          |${ctx.reuseLocalVariableCode(methodName)}
          |${ctx.reuseInputUnboxingCode(ACCUMULATE_INPUT_TERM)}
+         |${ctx.reusePerRecordCode()}
          |$body
          |""".stripMargin
     } else {
@@ -970,6 +972,7 @@ class AggsHandlerCodeGenerator(
       s"""
          |${ctx.reuseLocalVariableCode(methodName)}
          |${ctx.reuseInputUnboxingCode(RETRACT_INPUT_TERM)}
+         |${ctx.reusePerRecordCode()}
          |$body
       """.stripMargin
     } else {
@@ -1005,6 +1008,7 @@ class AggsHandlerCodeGenerator(
       s"""
          |${ctx.reuseLocalVariableCode(methodName)}
          |${ctx.reuseInputUnboxingCode(MERGED_ACC_TERM)}
+         |${ctx.reusePerRecordCode()}
          |$body
       """.stripMargin
     } else {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -553,6 +553,7 @@ abstract class WindowCodeGenerator(
          |  ${ctx.reuseLocalVariableCode()}
          |  // assign timestamp (pane/window)
          |  ${ctx.reuseInputUnboxingCode(inputTerm)}
+         |  ${ctx.reusePerRecordCode()}
          |  ${assignedTsExpr.code}
          |  $processEachInput
          |}


### PR DESCRIPTION
## What is the purpose of the change

Currently lookup join condition with CURRENT_DATE fails to filter records. See FLINK-22730 for details. This PR fixes this issue.

## Brief change log

 - Add per record code when generating table function collector code for lookup joins

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable