### PR TITLE
[FLINK-17775][java] Cannot set batch job name when using collect

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -409,12 +409,23 @@ public abstract class DataSet<T> {
      * @return A List containing the elements of the DataSet
      */
     public List<T> collect() throws Exception {
+        return collect("DataSet Collect");
+    }
+
+    /**
+     * Convenience method to get the elements of a DataSet as a List. As DataSet can contain a lot
+     * of data, this method should be used with caution.
+     *
+     * @param jobExecutionName Job name for this execution
+     * @return A List containing the elements of the DataSet
+     */
+    public List<T> collect(String jobExecutionName) throws Exception {
         final String id = new AbstractID().toString();
         final TypeSerializer<T> serializer =
                 getType().createSerializer(getExecutionEnvironment().getConfig());
 
         this.output(new Utils.CollectHelper<>(id, serializer)).name("collect()");
-        JobExecutionResult res = getExecutionEnvironment().execute();
+        JobExecutionResult res = getExecutionEnvironment().execute(jobExecutionName);
 
         ArrayList<byte[]> accResult = res.getAccumulatorResult(id);
         if (accResult != null) {


### PR DESCRIPTION
## What is the purpose of the change

Fixed the issue that Flink cannot set batch job name when using collect.

## Brief change log

- src/main/java/org/apache/flink/api/java/DataSet.java

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

