### PR TITLE
[FLINK-22821][core] Stabilize NetUtils#getAvailablePort in order to avoid wrongly allocating any used ports

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -86,6 +87,8 @@ public class ClientTest extends TestLogger {
 
     private Plan plan;
 
+    private NetUtils.Port port;
+
     private Configuration config;
 
     private static final String TEST_EXECUTOR_NAME = "test_executor";
@@ -102,12 +105,20 @@ public class ClientTest extends TestLogger {
         env.generateSequence(1, 1000).output(new DiscardingOutputFormat<>());
         plan = env.createProgramPlan();
 
-        final int freePort = NetUtils.getAvailablePort();
         config = new Configuration();
         config.setString(JobManagerOptions.ADDRESS, "localhost");
-        config.setInteger(JobManagerOptions.PORT, freePort);
+        NetUtils.Port port = NetUtils.getAvailablePort();
+        config.setInteger(JobManagerOptions.PORT, port.getPort());
+
         config.set(
                 AkkaOptions.ASK_TIMEOUT_DURATION, AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (port != null) {
+            port.close();
+        }
     }
 
     private Configuration fromPackagedProgram(

--- a/flink-core/src/main/java/org/apache/flink/util/FileLock.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileLock.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/** A file lock used for avoiding race condition among multiple threads/processes. */
+@Internal
+public class FileLock {
+    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
+    private final File file;
+    private FileOutputStream outputStream;
+    private java.nio.channels.FileLock lock;
+
+    /**
+     * Initialize a FileLock using a file located at fullPath.
+     *
+     * @param fullPath The path of the locking file
+     */
+    public FileLock(String fullPath) {
+        Preconditions.checkNotNull(fullPath, "fullPath should not be null");
+        Path path = Paths.get(fullPath);
+        String normalizedFileName = normalizeFileName(path.getFileName().toString());
+        if (normalizedFileName.isEmpty()) {
+            throw new IllegalArgumentException("There are no legal characters in the file name");
+        }
+        this.file =
+                path.getParent() == null
+                        ? new File(normalizedFileName)
+                        : new File(path.getParent().toString(), normalizedFileName);
+    }
+
+    /**
+     * Initialize a FileLock using a file located at parentDir/fileName.
+     *
+     * @param parentDir The parent dir of the locking file
+     * @param fileName The name of the locking file
+     */
+    public FileLock(String parentDir, String fileName) {
+        Preconditions.checkNotNull(parentDir, "parentDir should not be null");
+        Preconditions.checkNotNull(fileName, "fileName should not be null");
+        this.file = new File(parentDir, normalizeFileName(fileName));
+    }
+
+    /**
+     * Initialize a FileLock using a file located inside temp folder.
+     *
+     * @param fileName The name of the locking file
+     * @return The initialized FileLock
+     */
+    public static FileLock inTempFolder(String fileName) {
+        return new FileLock(TEMP_DIR, fileName);
+    }
+
+    /**
+     * Check whether the locking file exists in the file system. Create it if it does not exist.
+     * Then create a FileOutputStream for it.
+     *
+     * @throws IOException If the file path is invalid or the parent dir does not exist
+     */
+    private void init() throws IOException {
+        if (!this.file.exists()) {
+            this.file.createNewFile();
+        }
+        outputStream = new FileOutputStream(this.file);
+    }
+
+    /**
+     * Try to acquire a lock on the locking file. This method immediately returns whenever the lock
+     * is acquired or not.
+     *
+     * @return True if successfully acquired the lock
+     * @throws IOException If the file path is invalid
+     */
+    public boolean tryLock() throws IOException {
+        if (outputStream == null) {
+            init();
+        }
+        try {
+            lock = outputStream.getChannel().tryLock();
+        } catch (Exception e) {
+            return false;
+        }
+
+        return lock != null;
+    }
+
+    /**
+     * Release the file lock.
+     *
+     * @throws IOException If the FileChannel is closed
+     */
+    public void unlock() throws IOException {
+        if (lock != null && lock.channel().isOpen()) {
+            lock.release();
+        }
+    }
+
+    /**
+     * Release the file lock, close the fileChannel and FileOutputStream then try deleting the
+     * locking file if other file lock does not need it, which means the lock will not be used
+     * anymore.
+     *
+     * @throws IOException If an I/O error occurs
+     */
+    public void unlockAndDestroy() throws IOException {
+        try {
+            unlock();
+            if (lock != null) {
+                lock.channel().close();
+                lock = null;
+            }
+            if (outputStream != null) {
+                outputStream.close();
+                outputStream = null;
+            }
+
+        } finally {
+            this.file.delete();
+        }
+    }
+
+    /**
+     * Check whether a FileLock is actually holding the lock.
+     *
+     * @return True if it is actually holding the lock
+     */
+    public boolean isValid() {
+        if (lock != null) {
+            return lock.isValid();
+        }
+        return false;
+    }
+
+    /**
+     * Normalize the file name, which only allows slash, backslash, digits and letters.
+     *
+     * @param fileName Original file name
+     * @return File name with illegal characters stripped
+     */
+    private static String normalizeFileName(String fileName) {
+        return fileName.replaceAll("[^\\w/\\\\]", "");
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -362,8 +362,8 @@ final class PythonEnvUtils {
         Thread thread =
                 new Thread(
                         () -> {
-                            try {
-                                int freePort = NetUtils.getAvailablePort();
+                            try (NetUtils.Port port = NetUtils.getAvailablePort()) {
+                                int freePort = port.getPort();
                                 GatewayServer server =
                                         new GatewayServer.GatewayServerBuilder()
                                                 .gateway(

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
@@ -255,10 +255,10 @@ public class ClientTest extends TestLogger {
 
         Client<KvStateInternalRequest, KvStateResponse> client = null;
 
-        try {
+        try (NetUtils.Port port = NetUtils.getAvailablePort()) {
             client = new Client<>("Test Client", 1, serializer, stats);
 
-            int availablePort = NetUtils.getAvailablePort();
+            int availablePort = port.getPort();
 
             InetSocketAddress serverAddress =
                     new InetSocketAddress(InetAddress.getLocalHost(), availablePort);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -34,6 +34,7 @@ import java.lang.reflect.Field;
 import java.net.InetAddress;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /** Simple netty connection manager test. */
 public class NettyConnectionManagerTest {
@@ -46,17 +47,21 @@ public class NettyConnectionManagerTest {
     public void testMatchingNumberOfArenasAndThreadsAsDefault() throws Exception {
         // Expected number of arenas and threads
         int numberOfSlots = 2;
+        NettyConnectionManager connectionManager;
+        try (NetUtils.Port port = NetUtils.getAvailablePort()) {
+            NettyConfig config =
+                    new NettyConfig(
+                            InetAddress.getLocalHost(),
+                            port.getPort(),
+                            1024,
+                            numberOfSlots,
+                            new Configuration());
 
-        NettyConfig config =
-                new NettyConfig(
-                        InetAddress.getLocalHost(),
-                        NetUtils.getAvailablePort(),
-                        1024,
-                        numberOfSlots,
-                        new Configuration());
-
-        NettyConnectionManager connectionManager = createNettyConnectionManager(config);
-        connectionManager.start();
+            connectionManager = createNettyConnectionManager(config);
+            connectionManager.start();
+        }
+        assertNotNull(
+                "connectionManager is null due to fail to get a free port", connectionManager);
 
         assertEquals(numberOfSlots, connectionManager.getBufferPool().getNumberOfArenas());
 
@@ -111,18 +116,20 @@ public class NettyConnectionManagerTest {
         flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_CLIENT, 3);
         flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_SERVER, 4);
 
-        NettyConfig config =
-                new NettyConfig(
-                        InetAddress.getLocalHost(),
-                        NetUtils.getAvailablePort(),
-                        1024,
-                        1337,
-                        flinkConfig);
+        NettyConnectionManager connectionManager;
+        try (NetUtils.Port port = NetUtils.getAvailablePort()) {
 
-        NettyConnectionManager connectionManager = createNettyConnectionManager(config);
-        connectionManager.start();
+            NettyConfig config =
+                    new NettyConfig(
+                            InetAddress.getLocalHost(), port.getPort(), 1024, 1337, flinkConfig);
 
-        assertEquals(numberOfArenas, connectionManager.getBufferPool().getNumberOfArenas());
+            connectionManager = createNettyConnectionManager(config);
+            connectionManager.start();
+
+            assertEquals(numberOfArenas, connectionManager.getBufferPool().getNumberOfArenas());
+        }
+        assertNotNull(
+                "connectionManager is null due to fail to get a free port", connectionManager);
 
         {
             // Client event loop group

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
@@ -236,16 +236,19 @@ public class NettyPartitionRequestClientTest {
 
     private NettyPartitionRequestClient createPartitionRequestClient(
             Channel tcpChannel, NetworkClientHandler clientHandler) throws Exception {
-        int port = NetUtils.getAvailablePort();
-        ConnectionID connectionID = new ConnectionID(new InetSocketAddress("localhost", port), 0);
-        NettyConfig config =
-                new NettyConfig(InetAddress.getLocalHost(), port, 1024, 1, new Configuration());
-        NettyClient nettyClient = new NettyClient(config);
-        PartitionRequestClientFactory partitionRequestClientFactory =
-                new PartitionRequestClientFactory(nettyClient);
+        try (NetUtils.Port availablePort = NetUtils.getAvailablePort()) {
+            int port = availablePort.getPort();
+            ConnectionID connectionID =
+                    new ConnectionID(new InetSocketAddress("localhost", port), 0);
+            NettyConfig config =
+                    new NettyConfig(InetAddress.getLocalHost(), port, 1024, 1, new Configuration());
+            NettyClient nettyClient = new NettyClient(config);
+            PartitionRequestClientFactory partitionRequestClientFactory =
+                    new PartitionRequestClientFactory(nettyClient);
 
-        return new NettyPartitionRequestClient(
-                tcpChannel, clientHandler, connectionID, partitionRequestClientFactory);
+            return new NettyPartitionRequestClient(
+                    tcpChannel, clientHandler, connectionID, partitionRequestClientFactory);
+        }
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -161,8 +161,10 @@ public class NettyTestUtil {
         checkArgument(segmentSize > 0);
         checkNotNull(config);
 
-        return new NettyConfig(
-                InetAddress.getLocalHost(), NetUtils.getAvailablePort(), segmentSize, 1, config);
+        try (NetUtils.Port port = NetUtils.getAvailablePort()) {
+            return new NettyConfig(
+                    InetAddress.getLocalHost(), port.getPort(), segmentSize, 1, config);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.NetworkClientHandler;
 import org.apache.flink.runtime.io.network.netty.exception.RemoteTransportException;
-import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
@@ -46,8 +45,6 @@ import static org.mockito.Mockito.mock;
 
 /** {@link PartitionRequestClientFactory} test. */
 public class PartitionRequestClientFactoryTest extends TestLogger {
-
-    private static final int SERVER_PORT = NetUtils.getAvailablePort();
 
     @Test
     public void testInterruptsNotCached() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -2182,27 +2182,31 @@ public class TaskExecutorTest extends TestLogger {
 
     @Test(timeout = 10000L)
     public void testLogNotFoundHandling() throws Throwable {
-        final int dataPort = NetUtils.getAvailablePort();
-        configuration.setInteger(NettyShuffleEnvironmentOptions.DATA_PORT, dataPort);
-        configuration.setInteger(
-                NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
-        configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
-        configuration.setString(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY, "/i/dont/exist");
+        try (NetUtils.Port port = NetUtils.getAvailablePort()) {
+            int dataPort = port.getPort();
 
-        try (TaskSubmissionTestEnvironment env =
-                new Builder(jobId)
-                        .setConfiguration(configuration)
-                        .setLocalCommunication(false)
-                        .build()) {
-            TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
-            try {
-                CompletableFuture<TransientBlobKey> logFuture =
-                        tmGateway.requestFileUploadByType(FileType.LOG, timeout);
-                logFuture.get();
-            } catch (Exception e) {
-                assertThat(
-                        e.getMessage(),
-                        containsString("The file LOG does not exist on the TaskExecutor."));
+            configuration.setInteger(NettyShuffleEnvironmentOptions.DATA_PORT, dataPort);
+            configuration.setInteger(
+                    NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
+            configuration.setInteger(
+                    NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
+            configuration.setString(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY, "/i/dont/exist");
+
+            try (TaskSubmissionTestEnvironment env =
+                    new Builder(jobId)
+                            .setConfiguration(configuration)
+                            .setLocalCommunication(false)
+                            .build()) {
+                TaskExecutorGateway tmGateway = env.getTaskExecutorGateway();
+                try {
+                    CompletableFuture<TransientBlobKey> logFuture =
+                            tmGateway.requestFileUploadByType(FileType.LOG, timeout);
+                    logFuture.get();
+                } catch (Exception e) {
+                    assertThat(
+                            e.getMessage(),
+                            containsString("The file LOG does not exist on the TaskExecutor."));
+                }
             }
         }
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -146,15 +146,15 @@ public class IPv6HostnamesITCase extends TestLogger {
 
                             // test whether Akka's netty can bind to the address
                             log.info("Testing whether Akka can use " + addr);
-                            int port = NetUtils.getAvailablePort();
-
-                            final RpcService rpcService =
-                                    RpcSystem.load()
-                                            .localServiceBuilder(new Configuration())
-                                            .withBindAddress(addr.getHostAddress())
-                                            .withBindPort(port)
-                                            .createAndStart();
-                            rpcService.stopService().get();
+                            try (NetUtils.Port port = NetUtils.getAvailablePort()) {
+                                final RpcService rpcService =
+                                        RpcSystem.load()
+                                                .localServiceBuilder(new Configuration())
+                                                .withBindAddress(addr.getHostAddress())
+                                                .withBindPort(port.getPort())
+                                                .createAndStart();
+                                rpcService.stopService().get();
+                            }
 
                             log.info("Using address " + addr);
                             return (Inet6Address) addr;


### PR DESCRIPTION
…with "Address already in use"

## What is the purpose of the change

Fixed the issue that FlinkKafkaProducerMigrationTest fails with "Address already in use".

## Brief change log

- flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no

