### PR TITLE
[FLINK-20891][metrics][tests] Check that thread is still alive

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/utils/SystemResourcesCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/utils/SystemResourcesCounterTest.java
@@ -42,7 +42,8 @@ public class SystemResourcesCounterTest {
             do {
                 Thread.sleep(1);
                 cpuIdle = systemResources.getCpuIdle();
-            } while (initialCpuIdle == cpuIdle || Double.isNaN(cpuIdle) || cpuIdle == 0.0);
+            } while (systemResources.isAlive()
+                    && (initialCpuIdle == cpuIdle || Double.isNaN(cpuIdle) || cpuIdle == 0.0));
         } finally {
             systemResources.shutdown();
             systemResources.join();


### PR DESCRIPTION
If the SystemResourcesCounter runs into an exception then the tests loops infinitely.