### PR TITLE
[FLINK-22926][datastream] IDLE FLIP-27 source should go ACTIVE when registering a new split

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer;
+import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer.WatermarkOutputWithActive;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
@@ -76,7 +77,7 @@ public abstract class AbstractFetcher<T, KPH> {
      * org.apache.flink.api.common.eventtime.WatermarkGenerator} to emit watermarks and mark
      * idleness.
      */
-    protected final WatermarkOutput watermarkOutput;
+    protected final WatermarkOutputWithActive watermarkOutput;
 
     /** {@link WatermarkOutputMultiplexer} for supporting per-partition watermark generation. */
     private final WatermarkOutputMultiplexer watermarkOutputMultiplexer;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/SourceContextWatermarkOutputAdapter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/SourceContextWatermarkOutputAdapter.java
@@ -18,14 +18,15 @@
 package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.api.common.eventtime.Watermark;
-import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer;
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 
 /**
  * A {@link org.apache.flink.api.common.eventtime.WatermarkOutput} that forwards calls to a {@link
  * org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext}.
  */
-public class SourceContextWatermarkOutputAdapter<T> implements WatermarkOutput {
+public class SourceContextWatermarkOutputAdapter<T>
+        implements WatermarkOutputMultiplexer.WatermarkOutputWithActive {
     private final SourceContext<T> sourceContext;
 
     public SourceContextWatermarkOutputAdapter(SourceContext<T> sourceContext) {
@@ -41,5 +42,10 @@ public class SourceContextWatermarkOutputAdapter<T> implements WatermarkOutput {
     @Override
     public void markIdle() {
         sourceContext.markAsTemporarilyIdle();
+    }
+
+    @Override
+    public void markActive() {
+        // we ignore the active signal, we mark the stream active on records and/or watermarks
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/eventtime/TestingWatermarkOutput.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/eventtime/TestingWatermarkOutput.java
@@ -19,7 +19,7 @@
 package org.apache.flink.api.common.eventtime;
 
 /** A testing implementation of {@link WatermarkOutput}. */
-final class TestingWatermarkOutput implements WatermarkOutput {
+final class TestingWatermarkOutput implements WatermarkOutputMultiplexer.WatermarkOutputWithActive {
 
     private Watermark lastWatermark;
 
@@ -42,5 +42,10 @@ final class TestingWatermarkOutput implements WatermarkOutput {
 
     public boolean isIdle() {
         return isIdle;
+    }
+
+    @Override
+    public void markActive() {
+        isIdle = false;
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexerTest.java
@@ -25,9 +25,9 @@ import java.util.UUID;
 import static org.apache.flink.api.common.eventtime.WatermarkMatchers.watermark;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for the {@link WatermarkOutputMultiplexer}. */
@@ -374,6 +374,19 @@ public class WatermarkOutputMultiplexerTest {
         final boolean unregistered = multiplexer.unregisterOutput("does-not-exist");
 
         assertFalse(unregistered);
+    }
+
+    @Test
+    public void testBecomingActiveOnNewSplit() {
+        final TestingWatermarkOutput underlyingWatermarkOutput = createTestingWatermarkOutput();
+        final WatermarkOutputMultiplexer multiplexer =
+                new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
+
+        multiplexer.onPeriodicEmit();
+        assertThat(underlyingWatermarkOutput.isIdle(), is(true));
+        multiplexer.registerNewOutput("new-output");
+
+        assertThat(underlyingWatermarkOutput.isIdle(), is(false));
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.eventtime.WatermarkGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer;
+import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer.WatermarkOutputWithActive;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
@@ -98,7 +99,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 currentMainOutput == null && currentPerSplitOutputs == null,
                 "already created a main output");
 
-        final WatermarkOutput watermarkOutput = new WatermarkToDataOutput(output);
+        final WatermarkOutputWithActive watermarkOutput = new WatermarkToDataOutput(output);
         final WatermarkGenerator<T> watermarkGenerator =
                 watermarksFactory.createWatermarkGenerator(watermarksContext);
 
@@ -202,7 +203,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
 
         private SplitLocalOutputs(
                 PushingAsyncDataInput.DataOutput<T> recordOutput,
-                WatermarkOutput watermarkOutput,
+                WatermarkOutputWithActive watermarkOutput,
                 TimestampAssigner<T> timestampAssigner,
                 WatermarkGeneratorSupplier<T> watermarksFactory,
                 WatermarkGeneratorSupplier.Context watermarkContext) {


### PR DESCRIPTION
## What is the purpose of the change

When a FLIP-27 source is IDLE and registers a new split it does not go immediately ACTIVE. We should consider watermarks from a newly registered split immediately after registration.

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
