### PR TITLE
[FLINK-22766][connector/kafka] Report offsets and Kafka consumer metrics in Flink metric group

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -153,6 +153,8 @@ KafkaSource has following options for configuration:
 - ```partition.discovery.interval.ms``` defines the interval im milliseconds for Kafka source
   to discover new partitions. See <a href="#dynamic-partition-discovery">Dynamic Partition Discovery</a>
   below for more details.
+- ```register.consumer.metrics``` specifies whether to register metrics of KafkaConsumer in Flink
+metric group
 
 For configurations of KafkaConsumer, you can refer to
 <a href="http://kafka.apache.org/documentation/#consumerconfigs">Apache Kafka documentation</a>
@@ -209,6 +211,40 @@ the properties of Kafka consumer.
 
 Note that Kafka source does **NOT** rely on committed offsets for fault tolerance. Committing offset
 is only for exposing the progress of consumer and consuming group for monitoring.
+
+### Monitoring
+Kafka source exposes metrics in Flink's metric group for monitoring and diagnosing.
+#### Scope of Metric
+All metrics of Kafka source reader are registered under group ```KafkaSourceReader```, which is a 
+child group of operator metric group. Metrics related to a specific topic partition will be registered
+in the group ```KafkaSourceReader.topic.<topic_name>.partition.<partition_id>```.
+
+For example, current consuming offset of topic "my-topic" and partition 1 will be reported in metric: 
+```<some_parent_groups>.operator.KafkaSourceReader.topic.my-topic.partition.1.currentOffset``` ,
+
+and number of successful commits will be reported in metric:
+```<some_parent_groups>.operator.KafkaSourceReader.commitsSucceeded``` .
+
+#### List of Metrics
+
+|    Metric Name   |                   Description                   |       Scope       |
+|:----------------:|:-----------------------------------------------:|:-----------------:|
+|   currentOffset  | Current consuming offset of the topic partition |   TopicPartition  |
+|  committedOffset | Committed offset of the topic partition         |   TopicPartition  |
+| commitsSucceeded | Number of successful commits                    | KafkaSourceReader |
+|   commitsFailed  | Number of failed commits                        | KafkaSourceReader |
+
+#### Kafka Consumer Metrics
+All metrics of Kafka consumer are also registered under group ```KafkaSourceReader.KafkaConsumer```.
+For example, Kafka consumer metric "records-consumed-total" will be reported in metric:
+```<some_parent_groups>.operator.KafkaSourceReader.KafkaConsumer.records-consumed-total``` .
+
+You can configure whether to register Kafka consumer's metric by configuring option 
+```register.consumer.metrics```. This option will be set as true by default. 
+
+For metrics of Kafka consumer, you can refer to 
+<a href="http://kafka.apache.org/documentation/#consumer_monitoring">Apache Kafka Documentation</a>
+for more details.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -41,9 +41,16 @@ public class KafkaSourceOptions {
                             "The interval in milliseconds for the Kafka source to discover "
                                     + "the new partitions. A non-positive value disables the partition discovery.");
 
+    public static final ConfigOption<Boolean> REGISTER_KAFKA_CONSUMER_METRICS =
+            ConfigOptions.key("register.consumer.metrics")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to register metrics of KafkaConsumer into Flink metric group");
+
     @SuppressWarnings("unchecked")
     public static <T> T getOption(
-            Properties props, ConfigOption configOption, Function<String, T> parser) {
+            Properties props, ConfigOption<?> configOption, Function<String, T> parser) {
         String value = props.getProperty(configOption.key());
         return (T) (value == null ? configOption.defaultValue() : parser.apply(value));
     }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.metrics;
+
+import org.apache.flink.connector.kafka.source.reader.KafkaSourceReader;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A collection class for handling metrics in {@link KafkaSourceReader}.
+ *
+ * <p>All metrics of Kafka source reader are registered under group "KafkaSourceReader", which is a
+ * child group of {@link org.apache.flink.runtime.metrics.groups.OperatorMetricGroup}. Metrics
+ * related to a specific topic partition will be registered in the group
+ * "KafkaSourceReader.topic.{topic_name}.partition.{partition_id}".
+ *
+ * <p>For example, current consuming offset of topic "my-topic" and partition 1 will be reported in
+ * metric:
+ * "{some_parent_groups}.operator.KafkaSourceReader.topic.my-topic.partition.1.currentOffset"
+ *
+ * <p>and number of successful commits will be reported in metric:
+ * "{some_parent_groups}.operator.KafkaSourceReader.commitsSucceeded"
+ *
+ * <p>All metrics of Kafka consumer are also registered under group
+ * "KafkaSourceReader.KafkaConsumer". For example, Kafka consumer metric "records-consumed-total"
+ * can be found at:
+ * {some_parent_groups}.operator.KafkaSourceReader.KafkaConsumer.records-consumed-total"
+ */
+public class KafkaSourceReaderMetrics {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaSourceReaderMetrics.class);
+
+    // Constants
+    public static final String KAFKA_SOURCE_READER_METRIC_GROUP = "KafkaSourceReader";
+    public static final String TOPIC_GROUP = "topic";
+    public static final String PARTITION_GROUP = "partition";
+    public static final String CURRENT_OFFSET_METRIC_GAUGE = "currentOffset";
+    public static final String COMMITTED_OFFSET_METRIC_GAUGE = "committedOffset";
+    public static final String COMMITS_SUCCEEDED_METRIC_COUNTER = "commitsSucceeded";
+    public static final String COMMITS_FAILED_METRIC_COUNTER = "commitsFailed";
+    public static final String KAFKA_CONSUMER_METRIC_GROUP = "KafkaConsumer";
+
+    public static final long INITIAL_OFFSET = -1;
+
+    // Metric group for registering Kafka related metrics
+    private final MetricGroup kafkaSourceReaderMetricGroup;
+
+    // Successful / Failed commits counters
+    private final Counter commitsSucceeded;
+    private final Counter commitsFailed;
+
+    // Map for tracking current consuming / committing offsets
+    private final Map<TopicPartition, Offset> offsets = new HashMap<>();
+
+    public KafkaSourceReaderMetrics(MetricGroup parentMetricGroup) {
+        this.kafkaSourceReaderMetricGroup =
+                parentMetricGroup.addGroup(KAFKA_SOURCE_READER_METRIC_GROUP);
+        this.commitsSucceeded =
+                this.kafkaSourceReaderMetricGroup.counter(COMMITS_SUCCEEDED_METRIC_COUNTER);
+        this.commitsFailed =
+                this.kafkaSourceReaderMetricGroup.counter(COMMITS_FAILED_METRIC_COUNTER);
+    }
+
+    /**
+     * Register metrics of KafkaConsumer in Kafka metric group.
+     *
+     * @param kafkaConsumer Kafka consumer used by partition split reader.
+     */
+    @SuppressWarnings("Convert2MethodRef")
+    public void registerKafkaConsumerMetrics(KafkaConsumer<?, ?> kafkaConsumer) {
+        final Map<MetricName, ? extends Metric> kafkaConsumerMetrics = kafkaConsumer.metrics();
+        if (kafkaConsumerMetrics == null) {
+            LOG.warn("Consumer implementation does not support metrics");
+            return;
+        }
+
+        final MetricGroup kafkaConsumerMetricGroup =
+                kafkaSourceReaderMetricGroup.addGroup(KAFKA_CONSUMER_METRIC_GROUP);
+
+        kafkaConsumerMetrics.forEach(
+                (name, metric) ->
+                        kafkaConsumerMetricGroup.gauge(name.name(), () -> metric.metricValue()));
+    }
+
+    /**
+     * Register metric groups for the given {@link TopicPartition}.
+     *
+     * @param tp Registering topic partition
+     */
+    public void registerTopicPartition(TopicPartition tp) {
+        offsets.put(tp, new Offset(INITIAL_OFFSET, INITIAL_OFFSET));
+        registerOffsetMetricsForTopicPartition(tp);
+    }
+
+    /**
+     * Update current consuming offset of the given {@link TopicPartition}.
+     *
+     * @param tp Updating topic partition
+     * @param offset Current consuming offset
+     */
+    public void recordCurrentOffset(TopicPartition tp, long offset) {
+        checkTopicPartitionTracked(tp);
+        offsets.get(tp).currentOffset = offset;
+    }
+
+    /**
+     * Update the latest committed offset of the given {@link TopicPartition}.
+     *
+     * @param tp Updating topic partition
+     * @param offset Committing offset
+     */
+    public void recordCommittedOffset(TopicPartition tp, long offset) {
+        checkTopicPartitionTracked(tp);
+        commitsSucceeded.inc();
+        offsets.get(tp).committedOffset = offset;
+    }
+
+    /** Mark a failure commit. */
+    public void recordFailedCommit() {
+        commitsFailed.inc();
+    }
+
+    // -------- Helper functions --------
+    private void registerOffsetMetricsForTopicPartition(TopicPartition tp) {
+        final MetricGroup topicPartitionGroup =
+                this.kafkaSourceReaderMetricGroup
+                        .addGroup(TOPIC_GROUP, tp.topic())
+                        .addGroup(PARTITION_GROUP, String.valueOf(tp.partition()));
+        topicPartitionGroup.gauge(
+                CURRENT_OFFSET_METRIC_GAUGE,
+                () ->
+                        offsets.getOrDefault(tp, new Offset(INITIAL_OFFSET, INITIAL_OFFSET))
+                                .currentOffset);
+        topicPartitionGroup.gauge(
+                COMMITTED_OFFSET_METRIC_GAUGE,
+                () ->
+                        offsets.getOrDefault(tp, new Offset(INITIAL_OFFSET, INITIAL_OFFSET))
+                                .committedOffset);
+    }
+
+    private void checkTopicPartitionTracked(TopicPartition tp) {
+        if (!offsets.containsKey(tp)) {
+            throw new IllegalArgumentException(
+                    String.format("TopicPartition %s is not tracked", tp));
+        }
+    }
+
+    private static class Offset {
+        long currentOffset;
+        long committedOffset;
+
+        Offset(long currentOffset, long committedOffset) {
+            this.currentOffset = currentOffset;
+            this.committedOffset = committedOffset;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.testutils.MetricListener;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+
+import static org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics.PARTITION_GROUP;
+import static org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics.TOPIC_GROUP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Unit test for {@link KafkaSourceReaderMetrics}. */
+public class KafkaSourceReaderMetricsTest {
+
+    private static final TopicPartition FOO_0 = new TopicPartition("foo", 0);
+    private static final TopicPartition FOO_1 = new TopicPartition("foo", 1);
+    private static final TopicPartition BAR_0 = new TopicPartition("bar", 0);
+    private static final TopicPartition BAR_1 = new TopicPartition("bar", 1);
+
+    @Test
+    public void testCurrentOffsetTracking() {
+        MetricListener metricListener = new MetricListener();
+
+        final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
+                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+
+        kafkaSourceReaderMetrics.registerTopicPartition(FOO_0);
+        kafkaSourceReaderMetrics.registerTopicPartition(FOO_1);
+        kafkaSourceReaderMetrics.registerTopicPartition(BAR_0);
+        kafkaSourceReaderMetrics.registerTopicPartition(BAR_1);
+
+        kafkaSourceReaderMetrics.recordCurrentOffset(FOO_0, 15213L);
+        kafkaSourceReaderMetrics.recordCurrentOffset(FOO_1, 18213L);
+        kafkaSourceReaderMetrics.recordCurrentOffset(BAR_0, 18613L);
+        kafkaSourceReaderMetrics.recordCurrentOffset(BAR_1, 15513L);
+
+        assertCurrentOffset(FOO_0, 15213L, metricListener);
+        assertCurrentOffset(FOO_1, 18213L, metricListener);
+        assertCurrentOffset(BAR_0, 18613L, metricListener);
+        assertCurrentOffset(BAR_1, 15513L, metricListener);
+    }
+
+    @Test
+    public void testCommitOffsetTracking() {
+        MetricListener metricListener = new MetricListener();
+
+        final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
+                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+
+        kafkaSourceReaderMetrics.registerTopicPartition(FOO_0);
+        kafkaSourceReaderMetrics.registerTopicPartition(FOO_1);
+        kafkaSourceReaderMetrics.registerTopicPartition(BAR_0);
+        kafkaSourceReaderMetrics.registerTopicPartition(BAR_1);
+
+        kafkaSourceReaderMetrics.recordCommittedOffset(FOO_0, 15213L);
+        kafkaSourceReaderMetrics.recordCommittedOffset(FOO_1, 18213L);
+        kafkaSourceReaderMetrics.recordCommittedOffset(BAR_0, 18613L);
+        kafkaSourceReaderMetrics.recordCommittedOffset(BAR_1, 15513L);
+
+        assertCommittedOffset(FOO_0, 15213L, metricListener);
+        assertCommittedOffset(FOO_1, 18213L, metricListener);
+        assertCommittedOffset(BAR_0, 18613L, metricListener);
+        assertCommittedOffset(BAR_1, 15513L, metricListener);
+
+        assertEquals(
+                4L,
+                metricListener
+                        .getCounter(
+                                KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                                KafkaSourceReaderMetrics.COMMITS_SUCCEEDED_METRIC_COUNTER)
+                        .getCount());
+    }
+
+    @Test
+    public void testNonTrackingTopicPartition() {
+        MetricListener metricListener = new MetricListener();
+        final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
+                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> kafkaSourceReaderMetrics.recordCurrentOffset(FOO_0, 15213L));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> kafkaSourceReaderMetrics.recordCommittedOffset(FOO_0, 15213L));
+    }
+
+    @Test
+    public void testFailedCommit() {
+        MetricListener metricListener = new MetricListener();
+        final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
+                new KafkaSourceReaderMetrics(metricListener.getMetricGroup());
+        kafkaSourceReaderMetrics.recordFailedCommit();
+        assertEquals(
+                1L,
+                metricListener
+                        .getCounter(
+                                KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                                KafkaSourceReaderMetrics.COMMITS_FAILED_METRIC_COUNTER)
+                        .getCount());
+    }
+
+    // ----------- Assertions --------------
+
+    private void assertCurrentOffset(
+            TopicPartition tp, long expectedOffset, MetricListener metricListener) {
+        assertGaugeValueEquals(
+                expectedOffset,
+                metricListener.getGauge(
+                        KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                        TOPIC_GROUP,
+                        tp.topic(),
+                        PARTITION_GROUP,
+                        String.valueOf(tp.partition()),
+                        KafkaSourceReaderMetrics.CURRENT_OFFSET_METRIC_GAUGE),
+                Long.class);
+    }
+
+    private void assertCommittedOffset(
+            TopicPartition tp, long expectedOffset, MetricListener metricListener) {
+        assertGaugeValueEquals(
+                expectedOffset,
+                metricListener.getGauge(
+                        KafkaSourceReaderMetrics.KAFKA_SOURCE_READER_METRIC_GROUP,
+                        TOPIC_GROUP,
+                        tp.topic(),
+                        PARTITION_GROUP,
+                        String.valueOf(tp.partition()),
+                        KafkaSourceReaderMetrics.COMMITTED_OFFSET_METRIC_GAUGE),
+                Long.class);
+    }
+
+    private <T> void assertGaugeValueEquals(T expected, Gauge<?> gauge, Class<T> type) {
+        final T actual = type.cast(gauge.getValue());
+        assertEquals(expected, actual);
+    }
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -23,9 +23,11 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.kafka.source.KafkaSourceTestEnv;
+import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.testutils.source.deserialization.TestingDeserializationContext;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
@@ -178,7 +180,11 @@ public class KafkaPartitionSplitReaderTest {
         KafkaRecordDeserializationSchema<Integer> deserializationSchema =
                 KafkaRecordDeserializationSchema.valueOnly(IntegerDeserializer.class);
         deserializationSchema.open(new TestingDeserializationContext());
-        return new KafkaPartitionSplitReader<>(props, deserializationSchema, 0);
+        KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
+                new KafkaSourceReaderMetrics(
+                        UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup());
+        return new KafkaPartitionSplitReader<>(
+                props, deserializationSchema, 0, kafkaSourceReaderMetrics);
     }
 
     private Map<String, KafkaPartitionSplit> assignSplits(

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingReaderContext.java
@@ -32,7 +32,7 @@ import java.util.List;
 /** A testing implementation of the {@link SourceReaderContext}. */
 public class TestingReaderContext implements SourceReaderContext {
 
-    private final UnregisteredMetricsGroup metrics = new UnregisteredMetricsGroup();
+    private final MetricGroup metrics;
 
     private final Configuration config;
 
@@ -41,11 +41,12 @@ public class TestingReaderContext implements SourceReaderContext {
     private int numSplitRequests;
 
     public TestingReaderContext() {
-        this(new Configuration());
+        this(new Configuration(), new UnregisteredMetricsGroup());
     }
 
-    public TestingReaderContext(Configuration config) {
+    public TestingReaderContext(Configuration config, MetricGroup metricGroup) {
         this.config = config;
+        this.metrics = metricGroup;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/metrics/testutils/MetricListener.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/metrics/testutils/MetricListener.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.testutils;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.GenericMetricGroup;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A MetricListener listens metric and group registration under the provided root metric group, and
+ * stores them in an internal HashMap for fetching.
+ */
+public class MetricListener {
+
+    // Constants
+    public static final String DELIMITER = ".";
+    public static final String ROOT_METRIC_GROUP_NAME = "rootMetricGroup";
+
+    // Root metric group
+    private final MetricGroup rootMetricGroup;
+
+    // Map for storing registered metrics
+    private final Map<String, Metric> metrics = new HashMap<>();
+
+    public MetricListener() {
+        TestingMetricRegistry registry =
+                TestingMetricRegistry.builder()
+                        .setDelimiter(DELIMITER.charAt(0))
+                        .setRegisterConsumer(
+                                (metric, name, group) ->
+                                        this.metrics.put(group.getMetricIdentifier(name), metric))
+                        .build();
+
+        this.rootMetricGroup = new GenericMetricGroup(registry, null, ROOT_METRIC_GROUP_NAME);
+    }
+
+    /**
+     * Get the root metric group of this listener. Note that only metrics and groups registered
+     * under this group will be listened.
+     *
+     * @return Root metric group
+     */
+    public MetricGroup getMetricGroup() {
+        return this.rootMetricGroup;
+    }
+
+    /**
+     * Get registered {@link Metric} with identifier relative to the root metric group.
+     *
+     * <p>For example, identifier of metric "myMetric" registered in group "myGroup" under root
+     * metric group can be reached by identifier ("myGroup", "myMetric")
+     *
+     * @param identifier identifier relative to the root metric group
+     * @return Registered metric
+     */
+    public <T extends Metric> T getMetric(Class<T> metricType, String... identifier) {
+        String actualIdentifier =
+                ROOT_METRIC_GROUP_NAME + DELIMITER + String.join(DELIMITER, identifier);
+        if (!metrics.containsKey(actualIdentifier)) {
+            throw new IllegalArgumentException(
+                    String.format("Metric '%s' is not registered", actualIdentifier));
+        }
+        return metricType.cast(metrics.get(actualIdentifier));
+    }
+
+    /**
+     * Get registered {@link Meter} with identifier relative to the root metric group.
+     *
+     * @param identifier identifier relative to the root metric group
+     * @return Registered meter
+     */
+    public Meter getMeter(String... identifier) {
+        return getMetric(Meter.class, identifier);
+    }
+
+    /**
+     * Get registered {@link Counter} with identifier relative to the root metric group.
+     *
+     * @param identifier identifier relative to the root metric group
+     * @return Registered counter
+     */
+    public Counter getCounter(String... identifier) {
+        return getMetric(Counter.class, identifier);
+    }
+
+    /**
+     * Get registered {@link Histogram} with identifier relative to the root metric group.
+     *
+     * @param identifier identifier relative to the root metric group
+     * @return Registered histogram
+     */
+    public Histogram getHistogram(String... identifier) {
+        return getMetric(Histogram.class, identifier);
+    }
+
+    /**
+     * Get registered {@link Gauge} with identifier relative to the root metric group.
+     *
+     * @param identifier identifier relative to the root metric group
+     * @return Registered gauge
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Gauge<T> getGauge(String... identifier) {
+        return (Gauge<T>) getMetric(Gauge.class, identifier);
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/metric/testutils/MetricListenerTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/metric/testutils/MetricListenerTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metric.testutils;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.testutils.MetricListener;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link MetricListener}. */
+public class MetricListenerTest {
+    public static final String COUNTER_NAME = "testCounter";
+    public static final String GAUGE_NAME = "testGauge";
+    public static final String METER_NAME = "testMeter";
+    public static final String HISTOGRAM_NAME = "testHistogram";
+
+    public static final String GROUP_A = "groupA";
+    public static final String GROUP_B = "groupB";
+    public static final String GROUP_A_1 = "groupA_1";
+    public static final String GROUP_B_1 = "groupB_1";
+    public static final String GROUP_B_2 = "groupB_2";
+
+    @Test
+    public void testRegisterMetrics() {
+        MetricListener metricListener = new MetricListener();
+        final MetricGroup metricGroup = metricListener.getMetricGroup();
+
+        // Counter
+        final Counter counter = metricGroup.counter(COUNTER_NAME);
+        counter.inc(15213);
+        final Counter registeredCounter = metricListener.getCounter(COUNTER_NAME);
+        assertEquals(15213L, registeredCounter.getCount());
+
+        // Gauge
+        metricGroup.gauge(GAUGE_NAME, () -> 15213);
+        final Gauge<Integer> registeredGauge = metricListener.getGauge(GAUGE_NAME);
+        assertEquals(Integer.valueOf(15213), registeredGauge.getValue());
+
+        // Meter
+        metricGroup.meter(
+                METER_NAME,
+                new Meter() {
+                    @Override
+                    public void markEvent() {}
+
+                    @Override
+                    public void markEvent(long n) {}
+
+                    @Override
+                    public double getRate() {
+                        return 15213.0;
+                    }
+
+                    @Override
+                    public long getCount() {
+                        return 18213L;
+                    }
+                });
+        final Meter registeredMeter = metricListener.getMeter(METER_NAME);
+        assertEquals(15213.0, registeredMeter.getRate(), 0.1);
+        assertEquals(18213L, registeredMeter.getCount());
+
+        // Histogram
+        metricGroup.histogram(
+                HISTOGRAM_NAME,
+                new Histogram() {
+                    @Override
+                    public void update(long value) {}
+
+                    @Override
+                    public long getCount() {
+                        return 15213L;
+                    }
+
+                    @Override
+                    public HistogramStatistics getStatistics() {
+                        return null;
+                    }
+                });
+        final Histogram registeredHistogram = metricListener.getHistogram(HISTOGRAM_NAME);
+        assertEquals(15213L, registeredHistogram.getCount());
+    }
+
+    @Test
+    public void testRegisterMetricGroup() {
+        MetricListener metricListener = new MetricListener();
+        final MetricGroup rootGroup = metricListener.getMetricGroup();
+        final MetricGroup groupA1 = rootGroup.addGroup(GROUP_A).addGroup(GROUP_A_1);
+        final MetricGroup groupB = rootGroup.addGroup(GROUP_B);
+        final MetricGroup groupB1 = groupB.addGroup(GROUP_B_1);
+        final MetricGroup groupB2 = groupB.addGroup(GROUP_B_2);
+
+        groupA1.counter(COUNTER_NAME).inc(18213L);
+        groupB1.gauge(GAUGE_NAME, () -> 15213L);
+        groupB2.counter(COUNTER_NAME).inc(15513L);
+
+        // groupA.groupA_1.testCounter
+        assertEquals(
+                18213L, metricListener.getCounter(GROUP_A, GROUP_A_1, COUNTER_NAME).getCount());
+
+        // groupB.groupB_1.testGauge
+        assertEquals(15213L, metricListener.getGauge(GROUP_B, GROUP_B_1, GAUGE_NAME).getValue());
+
+        // groupB.groupB_2.testCounter
+        assertEquals(
+                15513L, metricListener.getCounter(GROUP_B, GROUP_B_2, COUNTER_NAME).getCount());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds offset metrics for Kafka source reader, and register metrics of Kafka consumer in Flink metric group


## Brief change log

- Add ```KafkaSourceReaderMetrics``` for tracking metrics reported in KafkaSourceReader
- Register current consuming offset and committed offset metric
- Register KafkaConsumer's metrics in operator metric group
- Add a KafkaSourceOption to configure whether to register KafkaConsumer metrics


## Verifying this change

This change added tests and can be verified as follows:
- Added unit test for the new ```KafkaSourceReaderMetrics```
- Added integration test for KafkaSourceReader to verify new metrics are reported correctly

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
