### PR TITLE
[hotfix][docs] use non deprecated syntax in SinkFunction code sample

### DIFF
--- a/docs/content.zh/docs/dev/datastream/testing.md
+++ b/docs/content.zh/docs/dev/datastream/testing.md
@@ -473,7 +473,7 @@ public class ExampleIntegrationTest {
         public static final List<Long> values = Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public void invoke(Long value) throws Exception {
+        public void invoke(Long value, SinkFunction.Context context) throws Exception {
             values.add(value);
         }
     }
@@ -520,10 +520,11 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
     CollectSink.values should contain allOf (2, 22, 23)
     }
 }
+
 // create a testing sink
 class CollectSink extends SinkFunction[Long] {
 
-  override def invoke(value: Long): Unit = {
+  override def invoke(value: Long, context: SinkFunction.Context): Unit = {
     CollectSink.values.add(value)
   }
 }

--- a/docs/content/docs/dev/datastream/testing.md
+++ b/docs/content/docs/dev/datastream/testing.md
@@ -471,7 +471,7 @@ public class ExampleIntegrationTest {
         public static final List<Long> values = Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public void invoke(Long value) throws Exception {
+        public void invoke(Long value, SinkFunction.Context context) throws Exception {
             values.add(value);
         }
     }
@@ -518,10 +518,11 @@ class StreamingJobIntegrationTest extends FlatSpec with Matchers with BeforeAndA
     CollectSink.values should contain allOf (2, 22, 23)
     }
 }
+
 // create a testing sink
 class CollectSink extends SinkFunction[Long] {
 
-  override def invoke(value: Long): Unit = {
+  override def invoke(value: Long, context: SinkFunction.Context): Unit = {
     CollectSink.values.add(value)
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

The current code samples in the [Testing Flink Job](https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/datastream/testing/#testing-flink-jobs) documentation contain a code sample relying on a deprecated method of `SinkFunction`.

This PR updates the English and Chinese documentation to use the non-deprecated variant of the method.

## Brief change log

Updated the example of `SinkFunction` shown as part of the documentation on testing with `MiniClusterWithClientResource` to use the `invoke` method that accepts a `Context` instance.


## Verifying this change

Checked manually with `hugo -b "" serve`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
