### PR TITLE
[FLINK-22676][coordination] The partition tracker stops tracking internal partitions when TM disconnects

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/AbstractPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/AbstractPartitionTracker.java
@@ -34,8 +34,8 @@ import java.util.stream.Stream;
  */
 public abstract class AbstractPartitionTracker<K, M> implements PartitionTracker<K, M> {
 
-    private final PartitionTable<K> partitionTable = new PartitionTable<>();
-    private final Map<ResultPartitionID, PartitionInfo<K, M>> partitionInfos = new HashMap<>();
+    protected final PartitionTable<K> partitionTable = new PartitionTable<>();
+    protected final Map<ResultPartitionID, PartitionInfo<K, M>> partitionInfos = new HashMap<>();
 
     void startTrackingPartition(K key, ResultPartitionID resultPartitionId, M metaInfo) {
         partitionInfos.put(resultPartitionId, new PartitionInfo<>(key, metaInfo));
@@ -94,7 +94,8 @@ public abstract class AbstractPartitionTracker<K, M> implements PartitionTracker
                         resultPartitionId, partitionInfo.key, partitionInfo.getMetaInfo()));
     }
 
-    private static class PartitionInfo<K, M> {
+    /** Information of tracked partition. */
+    static class PartitionInfo<K, M> {
 
         private final K key;
         private final M metaInfo;
@@ -104,11 +105,11 @@ public abstract class AbstractPartitionTracker<K, M> implements PartitionTracker
             this.metaInfo = metaInfo;
         }
 
-        public K getKey() {
+        K getKey() {
             return key;
         }
 
-        public M getMetaInfo() {
+        M getMetaInfo() {
             return metaInfo;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTracker.java
@@ -42,14 +42,12 @@ public interface JobMasterPartitionTracker
     void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds);
 
     /**
-     * Releases all partitions for the given task executor ID, and stop the tracking of partitions
-     * that were released.
+     * Releases the job partitions and promotes the cluster partitions, and stops the tracking of
+     * partitions that were released/promoted.
      */
-    void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId);
+    void stopTrackingAndReleaseOrPromotePartitions(
+            Collection<ResultPartitionID> resultPartitionIds);
 
-    /**
-     * Releases all job partitions and promotes all cluster partitions for the given task executor
-     * ID, and stops the tracking of partitions that were released/promoted.
-     */
-    void stopTrackingAndReleaseOrPromotePartitionsFor(ResourceID producingTaskExecutorId);
+    /** Get all the partitions under tracking. */
+    Collection<ResultPartitionDeploymentDescriptor> getAllTrackedPartitions();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/AbstractPartitionTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/AbstractPartitionTrackerTest.java
@@ -64,7 +64,7 @@ public class AbstractPartitionTrackerTest extends TestLogger {
                 is(false));
     }
 
-    static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(
+    public static ResultPartitionDeploymentDescriptor createResultPartitionDeploymentDescriptor(
             ResultPartitionID resultPartitionId, boolean hasLocalResources) {
         return createResultPartitionDeploymentDescriptor(
                 resultPartitionId, ResultPartitionType.BLOCKING, hasLocalResources);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
@@ -32,17 +32,20 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 /** Tests for the {@link JobMasterPartitionTrackerImpl}. */
@@ -73,7 +76,7 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
         partitionTracker.startTrackingPartition(
                 resourceId,
                 AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        resultPartitionId, resultPartitionType, false));
+                        resultPartitionId, resultPartitionType, true));
 
         assertThat(
                 partitionTracker.isTrackingPartitionsFor(resourceId),
@@ -85,117 +88,61 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
         final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
         final JobID jobId = new JobID();
 
-        final Queue<ReleaseCall> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
+        final Queue<ReleaseCall> releaseCalls = new ArrayBlockingQueue<>(4);
         final JobMasterPartitionTracker partitionTracker =
                 new JobMasterPartitionTrackerImpl(
                         jobId,
                         shuffleMaster,
-                        resourceId ->
-                                Optional.of(
-                                        createTaskExecutorGateway(
-                                                resourceId, taskExecutorReleaseCalls)));
+                        tmId -> Optional.of(createTaskExecutorGateway(tmId, releaseCalls)));
 
-        final ResourceID taskExecutorId1 = ResourceID.generate();
-        final ResourceID taskExecutorId2 = ResourceID.generate();
-        final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
-        final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+        final ResourceID tmId = ResourceID.generate();
+        final ResultPartitionID resultPartitionId = new ResultPartitionID();
 
         partitionTracker.startTrackingPartition(
-                taskExecutorId1,
+                tmId,
                 AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        resultPartitionId1, true));
-        partitionTracker.startTrackingPartition(
-                taskExecutorId2,
-                AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        resultPartitionId2, true));
+                        resultPartitionId, true));
 
-        {
-            partitionTracker.stopTrackingAndReleasePartitionsFor(taskExecutorId1);
+        assertThat(partitionTracker.isTrackingPartitionsFor(tmId), is(true));
 
-            assertEquals(1, taskExecutorReleaseCalls.size());
+        partitionTracker.stopTrackingAndReleasePartitions(Arrays.asList(resultPartitionId));
 
-            ReleaseCall taskExecutorReleaseCall = taskExecutorReleaseCalls.remove();
-            assertEquals(taskExecutorId1, taskExecutorReleaseCall.getTaskExecutorId());
-            assertEquals(jobId, taskExecutorReleaseCall.getJobId());
-            assertThat(
-                    taskExecutorReleaseCall.getReleasedPartitions(), contains(resultPartitionId1));
-            assertThat(taskExecutorReleaseCall.getPromotedPartitions(), is(empty()));
-
-            assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
-            assertEquals(resultPartitionId1, shuffleMaster.externallyReleasedPartitions.remove());
-
-            assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId1), is(false));
-        }
-
-        {
-            partitionTracker.stopTrackingAndReleasePartitions(
-                    Collections.singletonList(resultPartitionId2));
-
-            assertEquals(1, taskExecutorReleaseCalls.size());
-
-            ReleaseCall releaseCall = taskExecutorReleaseCalls.remove();
-            assertEquals(taskExecutorId2, releaseCall.getTaskExecutorId());
-            assertEquals(jobId, releaseCall.getJobId());
-            assertThat(releaseCall.getReleasedPartitions(), contains(resultPartitionId2));
-            assertThat(releaseCall.getPromotedPartitions(), is(empty()));
-
-            assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
-            assertEquals(resultPartitionId2, shuffleMaster.externallyReleasedPartitions.remove());
-
-            assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId2), is(false));
-        }
+        assertEquals(1, releaseCalls.size());
+        ReleaseCall releaseCall = releaseCalls.remove();
+        assertEquals(tmId, releaseCall.getTaskExecutorId());
+        assertEquals(jobId, releaseCall.getJobId());
+        assertThat(releaseCall.getReleasedPartitions(), contains(resultPartitionId));
+        assertThat(releaseCall.getPromotedPartitions(), is(empty()));
+        assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
+        assertEquals(resultPartitionId, shuffleMaster.externallyReleasedPartitions.remove());
+        assertThat(partitionTracker.isTrackingPartitionsFor(tmId), is(false));
     }
 
     @Test
     public void testReleaseCallsWithoutLocalResources() {
         final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
 
-        final Queue<ReleaseCall> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
+        final Queue<ReleaseCall> releaseCalls = new ArrayBlockingQueue<>(4);
         final JobMasterPartitionTracker partitionTracker =
                 new JobMasterPartitionTrackerImpl(
                         new JobID(),
                         shuffleMaster,
-                        resourceId ->
-                                Optional.of(
-                                        createTaskExecutorGateway(
-                                                resourceId, taskExecutorReleaseCalls)));
+                        tmId -> Optional.of(createTaskExecutorGateway(tmId, releaseCalls)));
 
-        final ResourceID taskExecutorId1 = ResourceID.generate();
-        final ResourceID taskExecutorId2 = ResourceID.generate();
-        final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
-        final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
+        final ResourceID tmId = ResourceID.generate();
+        final ResultPartitionID resultPartitionId = new ResultPartitionID();
 
         partitionTracker.startTrackingPartition(
-                taskExecutorId1,
+                tmId,
                 AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        resultPartitionId1, false));
-        partitionTracker.startTrackingPartition(
-                taskExecutorId2,
-                AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        resultPartitionId2, false));
+                        resultPartitionId, false));
+        assertThat(partitionTracker.isTrackingPartitionsFor(tmId), is(false));
 
-        {
-            partitionTracker.stopTrackingAndReleasePartitionsFor(taskExecutorId1);
+        partitionTracker.stopTrackingAndReleasePartitions(Arrays.asList(resultPartitionId));
 
-            assertEquals(0, taskExecutorReleaseCalls.size());
-
-            assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
-            assertEquals(resultPartitionId1, shuffleMaster.externallyReleasedPartitions.remove());
-
-            assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId1), is(false));
-        }
-
-        {
-            partitionTracker.stopTrackingAndReleasePartitions(
-                    Collections.singletonList(resultPartitionId2));
-
-            assertEquals(0, taskExecutorReleaseCalls.size());
-
-            assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
-            assertEquals(resultPartitionId2, shuffleMaster.externallyReleasedPartitions.remove());
-
-            assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId2), is(false));
-        }
+        assertEquals(0, releaseCalls.size());
+        assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
+        assertThat(shuffleMaster.externallyReleasedPartitions, contains(resultPartitionId));
     }
 
     @Test
@@ -227,11 +174,11 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
     }
 
     @Test
-    public void testReleaseOrPromote() {
+    public void testTrackingInternalAndExternalPartitionsByTmId() {
         final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
 
         final Queue<ReleaseCall> taskExecutorReleaseCalls = new ArrayBlockingQueue<>(4);
-        final JobMasterPartitionTracker partitionTracker =
+        final JobMasterPartitionTrackerImpl partitionTracker =
                 new JobMasterPartitionTrackerImpl(
                         new JobID(),
                         shuffleMaster,
@@ -240,54 +187,126 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
                                         createTaskExecutorGateway(
                                                 resourceId, taskExecutorReleaseCalls)));
 
-        final ResourceID taskExecutorId1 = ResourceID.generate();
-        final ResultPartitionID jobPartitionId = new ResultPartitionID();
-        final ResultPartitionID clusterPartitionId = new ResultPartitionID();
+        final ResourceID taskExecutorId = ResourceID.generate();
+        final ResultPartitionID resultPartitionId1 = new ResultPartitionID();
+        final ResultPartitionID resultPartitionId2 = new ResultPartitionID();
 
-        // any partition type that is not BLOCKING_PERSISTENT denotes a job partition
-        final ResultPartitionDeploymentDescriptor jobPartition =
+        partitionTracker.startTrackingPartition(
+                taskExecutorId,
                 AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        jobPartitionId, ResultPartitionType.BLOCKING, true);
-        partitionTracker.startTrackingPartition(taskExecutorId1, jobPartition);
+                        resultPartitionId2, false));
+        // No local resource is occupied
+        assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId), is(false));
+
+        partitionTracker.startTrackingPartition(
+                taskExecutorId,
+                AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
+                        resultPartitionId1, true));
+        // Local resource is occupied
+        assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId), is(true));
+
+        assertThat(
+                partitionTracker.getAllTrackedPartitions().stream()
+                        .map(desc -> desc.getShuffleDescriptor().getResultPartitionID())
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(resultPartitionId1, resultPartitionId2));
+
+        partitionTracker.stopTrackingPartitionsFor(taskExecutorId);
+
+        assertThat(partitionTracker.isTrackingPartitionsFor(taskExecutorId), is(false));
+        assertThat(partitionTracker.isPartitionTracked(resultPartitionId1), is(false));
+        assertThat(partitionTracker.isPartitionTracked(resultPartitionId2), is(true));
+        assertThat(
+                Iterables.getOnlyElement(partitionTracker.getAllTrackedPartitions())
+                        .getShuffleDescriptor()
+                        .getResultPartitionID(),
+                is(resultPartitionId2));
+    }
+
+    @Test
+    public void testReleaseOrPromote() {
+        final TestingShuffleMaster shuffleMaster = new TestingShuffleMaster();
+
+        final Queue<ReleaseCall> taskExecutorReleaseOrPromoteCalls = new ArrayBlockingQueue<>(4);
+        final JobMasterPartitionTracker partitionTracker =
+                new JobMasterPartitionTrackerImpl(
+                        new JobID(),
+                        shuffleMaster,
+                        resourceId ->
+                                Optional.of(
+                                        createTaskExecutorGateway(
+                                                resourceId, taskExecutorReleaseOrPromoteCalls)));
+
+        final ResourceID taskExecutorId1 = ResourceID.generate();
+        final ResultPartitionID jobPartitionId0 = new ResultPartitionID();
+        final ResultPartitionID jobPartitionId1 = new ResultPartitionID();
+        final ResultPartitionID clusterPartitionId0 = new ResultPartitionID();
+        final ResultPartitionID clusterPartitionId1 = new ResultPartitionID();
+
+        // Any partition type that is not BLOCKING_PERSISTENT denotes a job partition;
+        // A local job partition (occupies tm local resource)
+        final ResultPartitionDeploymentDescriptor jobPartition0 =
+                AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
+                        jobPartitionId0, ResultPartitionType.BLOCKING, true);
+        partitionTracker.startTrackingPartition(taskExecutorId1, jobPartition0);
+
+        // An external job partition (accommodated by external shuffle service)
+        final ResultPartitionDeploymentDescriptor jobPartition1 =
+                AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
+                        jobPartitionId1, ResultPartitionType.BLOCKING, false);
+        partitionTracker.startTrackingPartition(taskExecutorId1, jobPartition1);
 
         // BLOCKING_PERSISTENT denotes a cluster partition
-        final ResultPartitionDeploymentDescriptor clusterPartition =
+        // An local cluster partition
+        final ResultPartitionDeploymentDescriptor clusterPartition0 =
                 AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
-                        clusterPartitionId, ResultPartitionType.BLOCKING_PERSISTENT, true);
-        partitionTracker.startTrackingPartition(taskExecutorId1, clusterPartition);
+                        clusterPartitionId0, ResultPartitionType.BLOCKING_PERSISTENT, true);
+        partitionTracker.startTrackingPartition(taskExecutorId1, clusterPartition0);
 
-        partitionTracker.stopTrackingAndReleaseOrPromotePartitionsFor(taskExecutorId1);
+        // An external cluster partition
+        final ResultPartitionDeploymentDescriptor clusterPartition1 =
+                AbstractPartitionTrackerTest.createResultPartitionDeploymentDescriptor(
+                        clusterPartitionId1, ResultPartitionType.BLOCKING_PERSISTENT, false);
+        partitionTracker.startTrackingPartition(taskExecutorId1, clusterPartition1);
 
-        // exactly one call should have been made to the hosting task executor
-        assertEquals(1, taskExecutorReleaseCalls.size());
+        partitionTracker.stopTrackingAndReleaseOrPromotePartitions(
+                Arrays.asList(
+                        jobPartitionId0,
+                        jobPartitionId1,
+                        clusterPartitionId0,
+                        clusterPartitionId1));
 
-        // the job partition should have been released on the shuffle master
-        assertEquals(1, shuffleMaster.externallyReleasedPartitions.size());
-        assertEquals(jobPartitionId, shuffleMaster.externallyReleasedPartitions.remove());
+        // Exactly one call should have been made to the hosting task executor
+        assertEquals(1, taskExecutorReleaseOrPromoteCalls.size());
 
-        final ReleaseCall taskExecutorReleaseOrPromoteCall = taskExecutorReleaseCalls.remove();
+        final ReleaseCall taskExecutorReleaseOrPromoteCall =
+                taskExecutorReleaseOrPromoteCalls.remove();
 
-        // the job partition should be passed as a partition to release
+        // One local partition released and one local partition promoted.
         assertEquals(
-                jobPartitionId,
+                jobPartitionId0,
                 Iterables.getOnlyElement(taskExecutorReleaseOrPromoteCall.getReleasedPartitions()));
-
-        // the cluster partition should be passed as a partition to promote
         assertEquals(
-                clusterPartitionId,
+                clusterPartitionId0,
                 Iterables.getOnlyElement(taskExecutorReleaseOrPromoteCall.getPromotedPartitions()));
+
+        // Both internal and external partitions will be fed into shuffle-master for releasing.
+        Collection<ResultPartitionID> externallyReleasedPartitions =
+                new ArrayList<>(shuffleMaster.externallyReleasedPartitions);
+        assertThat(
+                externallyReleasedPartitions, containsInAnyOrder(jobPartitionId0, jobPartitionId1));
     }
 
     private static TaskExecutorGateway createTaskExecutorGateway(
-            ResourceID taskExecutorId, Collection<ReleaseCall> releaseCalls) {
+            ResourceID taskExecutorId, Collection<ReleaseCall> releaseOrPromoteCalls) {
         return new TestingTaskExecutorGatewayBuilder()
                 .setReleaseOrPromotePartitionsConsumer(
-                        (jobId, partitionToRelease, partitionsToPromote) ->
-                                releaseCalls.add(
+                        (jobId, partitionsToRelease, partitionsToPromote) ->
+                                releaseOrPromoteCalls.add(
                                         new ReleaseCall(
                                                 taskExecutorId,
                                                 jobId,
-                                                partitionToRelease,
+                                                partitionsToRelease,
                                                 partitionsToPromote)))
                 .createTestingTaskExecutorGateway();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpJobMasterPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpJobMasterPartitionTracker.java
@@ -45,16 +45,19 @@ public enum NoOpJobMasterPartitionTracker implements JobMasterPartitionTracker {
             Collection<ResultPartitionID> resultPartitionIds) {}
 
     @Override
-    public Collection<PartitionTrackerEntry<ResourceID, ResultPartitionDeploymentDescriptor>>
-            stopTrackingPartitions(Collection<ResultPartitionID> resultPartitionIds) {
+    public void stopTrackingAndReleaseOrPromotePartitions(
+            Collection<ResultPartitionID> resultPartitionIds) {}
+
+    @Override
+    public Collection<ResultPartitionDeploymentDescriptor> getAllTrackedPartitions() {
         return Collections.emptyList();
     }
 
     @Override
-    public void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId) {}
-
-    @Override
-    public void stopTrackingAndReleaseOrPromotePartitionsFor(ResourceID producingTaskExecutorId) {}
+    public Collection<PartitionTrackerEntry<ResourceID, ResultPartitionDeploymentDescriptor>>
+            stopTrackingPartitions(Collection<ResultPartitionID> resultPartitionIds) {
+        return Collections.emptyList();
+    }
 
     @Override
     public boolean isTrackingPartitionsFor(ResourceID producingTaskExecutorId) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingJobMasterPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingJobMasterPartitionTracker.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /** Test {@link JobMasterPartitionTracker} implementation. */
 public class TestingJobMasterPartitionTracker implements JobMasterPartitionTracker {
@@ -32,13 +33,15 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
     private Function<ResourceID, Boolean> isTrackingPartitionsForFunction = ignored -> false;
     private Function<ResultPartitionID, Boolean> isPartitionTrackedFunction = ignored -> false;
     private Consumer<ResourceID> stopTrackingAllPartitionsConsumer = ignored -> {};
-    private Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer = ignored -> {};
-    private Consumer<ResourceID> stopTrackingAndReleaseOrPromotePartitionsConsumer = ignored -> {};
     private BiConsumer<ResourceID, ResultPartitionDeploymentDescriptor>
             startTrackingPartitionsConsumer = (ignoredA, ignoredB) -> {};
     private Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer =
             ignored -> {};
+    private Consumer<Collection<ResultPartitionID>>
+            stopTrackingAndReleaseOrPromotePartitionsConsumer = ignored -> {};
     private Consumer<Collection<ResultPartitionID>> stopTrackingPartitionsConsumer = ignored -> {};
+    private Supplier<Collection<ResultPartitionDeploymentDescriptor>>
+            getAllTrackedPartitionsSupplier = () -> Collections.emptyList();
 
     public void setStartTrackingPartitionsConsumer(
             BiConsumer<ResourceID, ResultPartitionDeploymentDescriptor>
@@ -61,26 +64,27 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
         this.stopTrackingAllPartitionsConsumer = stopTrackingAllPartitionsConsumer;
     }
 
-    public void setStopTrackingAndReleaseAllPartitionsConsumer(
-            Consumer<ResourceID> stopTrackingAndReleaseAllPartitionsConsumer) {
-        this.stopTrackingAndReleaseAllPartitionsConsumer =
-                stopTrackingAndReleaseAllPartitionsConsumer;
-    }
-
-    public void setStopTrackingAndReleaseOrPromotePartitionsConsumer(
-            Consumer<ResourceID> stopTrackingAndReleaseOrPromotePartitionsConsumer) {
-        this.stopTrackingAndReleaseOrPromotePartitionsConsumer =
-                stopTrackingAndReleaseOrPromotePartitionsConsumer;
-    }
-
     public void setStopTrackingAndReleasePartitionsConsumer(
             Consumer<Collection<ResultPartitionID>> stopTrackingAndReleasePartitionsConsumer) {
         this.stopTrackingAndReleasePartitionsConsumer = stopTrackingAndReleasePartitionsConsumer;
     }
 
+    public void setStopTrackingAndReleaseOrPromotePartitionsConsumer(
+            Consumer<Collection<ResultPartitionID>>
+                    stopTrackingAndReleaseOrPromotePartitionsConsumer) {
+        this.stopTrackingAndReleaseOrPromotePartitionsConsumer =
+                stopTrackingAndReleaseOrPromotePartitionsConsumer;
+    }
+
     public void setStopTrackingPartitionsConsumer(
             Consumer<Collection<ResultPartitionID>> stopTrackingPartitionsConsumer) {
         this.stopTrackingPartitionsConsumer = stopTrackingPartitionsConsumer;
+    }
+
+    public void setGetAllTrackedPartitionsSupplier(
+            Supplier<Collection<ResultPartitionDeploymentDescriptor>>
+                    getAllTrackedPartitionsSupplier) {
+        this.getAllTrackedPartitionsSupplier = getAllTrackedPartitionsSupplier;
     }
 
     @Override
@@ -111,13 +115,14 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
     }
 
     @Override
-    public void stopTrackingAndReleasePartitionsFor(ResourceID producingTaskExecutorId) {
-        stopTrackingAndReleaseAllPartitionsConsumer.accept(producingTaskExecutorId);
+    public void stopTrackingAndReleaseOrPromotePartitions(
+            Collection<ResultPartitionID> resultPartitionIds) {
+        stopTrackingAndReleaseOrPromotePartitionsConsumer.accept(resultPartitionIds);
     }
 
     @Override
-    public void stopTrackingAndReleaseOrPromotePartitionsFor(ResourceID producingTaskExecutorId) {
-        stopTrackingAndReleaseOrPromotePartitionsConsumer.accept(producingTaskExecutorId);
+    public Collection<ResultPartitionDeploymentDescriptor> getAllTrackedPartitions() {
+        return getAllTrackedPartitionsSupplier.get();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -26,10 +26,13 @@ import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.AbstractPartitionTrackerTest;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.TestingJobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
@@ -57,6 +60,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
@@ -64,6 +68,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 /** Tests for the partition release logic of the {@link JobMaster}. */
@@ -131,17 +136,17 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
     @Test
     public void testPartitionReleaseOrPromotionOnJobSuccess() throws Exception {
         testPartitionReleaseOrPromotionOnJobTermination(
-                TestSetup::getReleaseOrPromotePartitionsTargetResourceId, ExecutionState.FINISHED);
+                TestSetup::getPartitionsForReleaseOrPromote, ExecutionState.FINISHED);
     }
 
     @Test
     public void testPartitionReleaseOrPromotionOnJobFailure() throws Exception {
         testPartitionReleaseOrPromotionOnJobTermination(
-                TestSetup::getReleasePartitionsTargetResourceId, ExecutionState.FAILED);
+                TestSetup::getPartitionsForRelease, ExecutionState.FAILED);
     }
 
     private void testPartitionReleaseOrPromotionOnJobTermination(
-            Function<TestSetup, CompletableFuture<ResourceID>> taskExecutorCallSelector,
+            Function<TestSetup, CompletableFuture<Collection<ResultPartitionID>>> callSelector,
             ExecutionState finalExecutionState)
             throws Exception {
         final CompletableFuture<TaskDeploymentDescriptor> taskDeploymentDescriptorFuture =
@@ -157,6 +162,23 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
         try (final TestSetup testSetup =
                 new TestSetup(rpcService, testingFatalErrorHandler, testingTaskExecutorGateway)) {
+            ResultPartitionID partitionID0 = new ResultPartitionID();
+            ResultPartitionID partitionID1 = new ResultPartitionID();
+            testSetup
+                    .getPartitionTracker()
+                    .setGetAllTrackedPartitionsSupplier(
+                            () -> {
+                                ResultPartitionDeploymentDescriptor partitionDesc0 =
+                                        AbstractPartitionTrackerTest
+                                                .createResultPartitionDeploymentDescriptor(
+                                                        partitionID0, true);
+                                ResultPartitionDeploymentDescriptor partitionDesc1 =
+                                        AbstractPartitionTrackerTest
+                                                .createResultPartitionDeploymentDescriptor(
+                                                        partitionID1, false);
+                                return Arrays.asList(partitionDesc0, partitionDesc1);
+                            });
+
             final JobMasterGateway jobMasterGateway = testSetup.getJobMasterGateway();
 
             // update the execution state of the only execution to target state
@@ -166,10 +188,9 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
             jobMasterGateway.updateTaskExecutionState(
                     new TaskExecutionState(
                             taskDeploymentDescriptor.getExecutionAttemptId(), finalExecutionState));
-
             assertThat(
-                    taskExecutorCallSelector.apply(testSetup).get(),
-                    equalTo(testSetup.getTaskExecutorResourceID()));
+                    callSelector.apply(testSetup).get(),
+                    containsInAnyOrder(partitionID0, partitionID1));
         }
     }
 
@@ -182,12 +203,16 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
         private final CompletableFuture<ResourceID> taskExecutorIdForStopTracking =
                 new CompletableFuture<>();
-        private final CompletableFuture<ResourceID> taskExecutorIdForPartitionRelease =
-                new CompletableFuture<>();
-        private final CompletableFuture<ResourceID> taskExecutorIdForPartitionReleaseOrPromote =
+
+        private final CompletableFuture<Collection<ResultPartitionID>> partitionsForRelease =
                 new CompletableFuture<>();
 
-        private JobMaster jobMaster;
+        private final CompletableFuture<Collection<ResultPartitionID>>
+                partitionsForReleaseOrPromote = new CompletableFuture<>();
+
+        private final JobMaster jobMaster;
+
+        private final TestingJobMasterPartitionTracker partitionTracker;
 
         public TestSetup(
                 TestingRpcService rpcService,
@@ -203,15 +228,14 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
             haServices.setResourceManagerLeaderRetriever(
                     new SettableLeaderRetrievalService(null, null));
 
-            final TestingJobMasterPartitionTracker partitionTracker =
-                    new TestingJobMasterPartitionTracker();
+            partitionTracker = new TestingJobMasterPartitionTracker();
 
             partitionTracker.setStopTrackingAllPartitionsConsumer(
                     taskExecutorIdForStopTracking::complete);
-            partitionTracker.setStopTrackingAndReleaseAllPartitionsConsumer(
-                    taskExecutorIdForPartitionRelease::complete);
+            partitionTracker.setStopTrackingAndReleasePartitionsConsumer(
+                    partitionsForRelease::complete);
             partitionTracker.setStopTrackingAndReleaseOrPromotePartitionsConsumer(
-                    taskExecutorIdForPartitionReleaseOrPromote::complete);
+                    partitionsForReleaseOrPromote::complete);
 
             Configuration configuration = new Configuration();
             configuration.setString(
@@ -267,6 +291,10 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
                     .get();
         }
 
+        public TestingJobMasterPartitionTracker getPartitionTracker() {
+            return partitionTracker;
+        }
+
         public JobMasterGateway getJobMasterGateway() {
             return jobMaster.getSelfGateway(JobMasterGateway.class);
         }
@@ -279,12 +307,12 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
             return taskExecutorIdForStopTracking;
         }
 
-        public CompletableFuture<ResourceID> getReleasePartitionsTargetResourceId() {
-            return taskExecutorIdForPartitionRelease;
+        public CompletableFuture<Collection<ResultPartitionID>> getPartitionsForRelease() {
+            return partitionsForRelease;
         }
 
-        public CompletableFuture<ResourceID> getReleaseOrPromotePartitionsTargetResourceId() {
-            return taskExecutorIdForPartitionReleaseOrPromote;
+        public CompletableFuture<Collection<ResultPartitionID>> getPartitionsForReleaseOrPromote() {
+            return partitionsForReleaseOrPromote;
         }
 
         public void close() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

When TM disconnects(`JobMaster#disconnectTaskManager`), `JobMasterPartitionTrackerImpl` stops tracking all the partitions the TM ever produced, i.e. the lifecycle of shuffle data is bound to computing resource (TM). It works fine for internal shuffle service, but doesn't for remote shuffle service. Note that if shuffle data is accommodated on remote, the lifecycle of a completed partition is capable to be decoupled with TM, i.e. TM is totally fine to be released when no computing task on it and further shuffle reading requests could be directed to remote shuffle cluster.  
This PR proposes to fix `JobMasterPartitionTrackerImpl` and handle above scenario properly.

## Brief change log

  - Fix `JobMasterPartitionTrackerImpl#stopTrackingPartitionsFor` -- only internal partitions, which are accommodated on TM local, are stopped tracking, 
  - Fix `JobMaster#jobStatusChanged` -- current logic traverses `registeredTaskManagers` and release or promote related partitions, which is incorrect. With above change, external partitions, which are accommodated on external shuffle service, will NOT be released when TM disconnects. Thus release partitions by traversing existing `registeredTaskManagers` might cause leak of external partitions. 
  - Exclude internal partitions when invoke `internalReleasePartitionsOnShuffleMaster`


## Verifying this change

Added new tests in JobMasterPartitionTrackerImplTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
