### PR TITLE
[FLINK-22939][azure] Generalize JDK switch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
           run_end_to_end: false
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
           vmImage: 'ubuntu-20.04'

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -70,7 +70,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
           run_end_to_end: false
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
           vmImage: 'ubuntu-20.04'
@@ -115,7 +115,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
           run_end_to_end: true
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - template: jobs-template.yml
         parameters:
           stage_name: cron_hadoop241
@@ -126,7 +126,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.4.1 -Pskip-hive-tests"
           run_end_to_end: true
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - template: jobs-template.yml
         parameters:
           stage_name: cron_hadoop313
@@ -137,7 +137,7 @@ stages:
           environment: PROFILE="-Dinclude_hadoop_aws -Dhadoop.version=3.1.3 -Phadoop3-tests"
           run_end_to_end: true
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - template: jobs-template.yml
         parameters:
           stage_name: cron_scala212
@@ -148,7 +148,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1"
           run_end_to_end: true
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - template: jobs-template.yml
         parameters:
           stage_name: cron_jdk11
@@ -159,7 +159,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11"
           run_end_to_end: true
           container: flink-build-container
-          jdk: jdk11
+          jdk: 11
       - template: jobs-template.yml
         parameters:
           stage_name: cron_adaptive_scheduler
@@ -170,7 +170,7 @@ stages:
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Penable-adaptive-scheduler"
           run_end_to_end: true
           container: flink-build-container
-          jdk: jdk8
+          jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
           vmImage: 'ubuntu-20.04'

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -60,10 +60,9 @@ jobs:
     condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
     displayName: Cache Maven local repo
   - script: |
-      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_8_X64/bin:$PATH"
-    displayName: "Set to jdk8"
-    condition: eq('${{parameters.jdk}}', 'jdk8')
+      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+    displayName: "Set JDK"
   # Compile
   - script: |
       ${{parameters.environment}} ./tools/ci/compile.sh || exit $?
@@ -131,10 +130,9 @@ jobs:
     displayName: Cache Maven local repo
 
   - script: |
-      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_8_X64/bin:$PATH"
-    displayName: "Set to jdk8"
-    condition: eq('${{parameters.jdk}}', 'jdk8')
+      echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+    displayName: "Set JDK"
 
   - script: sudo sysctl -w kernel.core_pattern=core.%p
     displayName: Set coredump pattern
@@ -208,10 +206,9 @@ jobs:
       continueOnError: true
       condition: not(eq(variables['SKIP'], '1'))
     - script: |
-        echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_8_X64"
-        echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_8_X64/bin:$PATH"
-      displayName: "Set to jdk8"
-      condition: eq('${{parameters.jdk}}', 'jdk8')
+        echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+        echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+      displayName: "Set JDK"
     - script: |
         echo "Setting up Maven"
         source ./tools/ci/maven-utils.sh


### PR DESCRIPTION
- we now always setup the JDK, irrespective of what value `jdk` is set to
- the jdk parameter is now just an integer
- establishes a contract for images such that a given JDK Y can be used for builds, if the environment variable `JAVA_HOME_Y_X64` exists