### PR TITLE
[FLINK-20219][coordination] Shutdown cluster externally should only clean up the HA data if all the jobs have finished

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/cli/KubernetesSessionCli.java
@@ -115,7 +115,6 @@ public class KubernetesSessionCli {
                                         kubernetesClusterClientFactory.getClusterSpecification(
                                                 configuration))
                                 .getClusterClient();
-                clusterId = clusterClient.getClusterId();
             }
 
             try {
@@ -131,7 +130,7 @@ public class KubernetesSessionCli {
                                 e);
                     }
                     if (continueRepl.f1) {
-                        kubernetesClusterDescriptor.killCluster(clusterId);
+                        clusterClient.shutDownCluster();
                     }
                 }
                 clusterClient.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/NotAllJobsFinishedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/NotAllJobsFinishedException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+/** Exception indicating that not all jobs in dispatcher have finished. */
+public class NotAllJobsFinishedException extends DispatcherException {
+    private static final long serialVersionUID = 1L;
+
+    public NotAllJobsFinishedException(String message) {
+        super(message);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.dispatcher.ExecutionGraphInfoStore;
 import org.apache.flink.runtime.dispatcher.MiniDispatcher;
+import org.apache.flink.runtime.dispatcher.NotAllJobsFinishedException;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
@@ -266,7 +267,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                             (ApplicationStatus applicationStatus, Throwable throwable) -> {
                                 if (throwable != null) {
                                     shutDownAsync(
-                                            ApplicationStatus.UNKNOWN,
+                                            throwable instanceof NotAllJobsFinishedException
+                                                    ? ApplicationStatus.CANCELED
+                                                    : ApplicationStatus.UNKNOWN,
                                             ShutdownBehaviour.STOP_APPLICATION,
                                             ExceptionUtils.stringifyException(throwable),
                                             false);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

FLINK-20695 has supported to clean up the HA related data(ZNode/ConfigMaps, as well as HA storage) once the job reached to the global terminal state. This PR now is focused on graceful shutdown cluster once received an external signal.

What is the graceful shutdown behavior?
* If Flink cluster still has running jobs, then the HA related data will be retained.
* If no jobs running, all the ZNodes/ConfigMaps and the HA storage will be cleaned up.


## Brief change log

* Shutdown cluster externally should only clean up the HA data if all the jobs have finished


## Verifying this change

* Add corresponding unit tests
  * `testShutDownClusterWithRunningJobsShouldCompleteShutDownFutureExceptionally` 
  * `testShutDownFutureCompleteExceptionallyShouldNotCleanUpHAData`
  * `testShutDownFutureCompleteWithNotAllJobsFinishedExceptionShouldNotCleanUpHAData`
  * `testShutDownFutureCompleteNormallyShouldCleanUpHAData`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
