### PR TITLE
[FLINK-21195][Connectors/FileSystem]LimitableBulkFormat is invalid wh…

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFileSystemITCase.java
@@ -18,12 +18,16 @@
 
 package org.apache.flink.formats.parquet;
 
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -34,9 +38,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.range;
 import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
+import static org.junit.Assert.assertEquals;
 
 /** ITCase for {@link ParquetFileFormatFactory}. */
 @RunWith(Parameterized.class)
@@ -51,6 +57,23 @@ public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {
 
     public ParquetFileSystemITCase(boolean configure) {
         this.configure = configure;
+    }
+
+    @Override
+    public void before() {
+        super.before();
+        super.tableEnv()
+                .executeSql(
+                        String.format(
+                                "create table parquetLimitTable ("
+                                        + "x string,"
+                                        + "y int,"
+                                        + "a int"
+                                        + ") with ("
+                                        + "'connector' = 'filesystem',"
+                                        + "'path' = '%s',"
+                                        + "%s)",
+                                super.resultPath(), String.join(",\n", formatProperties())));
     }
 
     @Override
@@ -90,5 +113,23 @@ public class ParquetFileSystemITCase extends BatchFileSystemITCaseBase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void testLimitableBulkFormat() throws ExecutionException, InterruptedException {
+        super.tableEnv()
+                .executeSql(
+                        "insert into parquetLimitTable select x, y, "
+                                + "1 as a "
+                                + "from originalT")
+                .await();
+        TableResult tableResult1 =
+                super.tableEnv().executeSql("SELECT * FROM parquetLimitTable limit 5");
+        List<Row> rows1 = CollectionUtil.iteratorToList(tableResult1.collect());
+        assertEquals(5, rows1.size());
+
+        check(
+                "select a from parquetLimitTable limit 5",
+                Arrays.asList(Row.of(1), Row.of(1), Row.of(1), Row.of(1), Row.of(1)));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The orc file will read a stripe data in advance in the createReader() method (see the construction method of RecordReaderImpl in detail), and the parquet file will start to read the block data when the readBatch() method is called, so if all orc files have only one stripe, limitableBulkFormat will be invalid

## Brief change log

If the number of received data rows exceeds the limit, the reader will not be created

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)