### PR TITLE
[FLINK-22744][table] Update and simplify EnvironmentSettings

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_dialect.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_dialect.md
@@ -69,7 +69,7 @@ Flink SQL> set table.sql-dialect=default; -- to use default dialect
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 // to use hive dialect
 tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
@@ -82,7 +82,7 @@ tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
 ```python
 from pyflink.table import *
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 # to use hive dialect

--- a/docs/content.zh/docs/connectors/table/hive/overview.md
+++ b/docs/content.zh/docs/connectors/table/hive/overview.md
@@ -312,7 +312,7 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 String name            = "myhive";
@@ -330,7 +330,7 @@ tableEnv.useCatalog("myhive");
 
 ```scala
 
-val settings = EnvironmentSettings.newInstance().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(settings)
 
 val name            = "myhive"
@@ -349,7 +349,7 @@ tableEnv.useCatalog("myhive")
 from pyflink.table import *
 from pyflink.table.catalog import HiveCatalog
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 catalog_name = "myhive"

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -355,7 +355,7 @@ USE CATALOG mypg;
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 String name            = "mypg";
@@ -374,7 +374,7 @@ tableEnv.useCatalog("mypg");
 {{< tab "Scala" >}}
 ```scala
 
-val settings = EnvironmentSettings.newInstance().inStreamingMode().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(settings)
 
 val name            = "mypg"
@@ -394,7 +394,7 @@ tableEnv.useCatalog("mypg")
 ```python
 from pyflink.table.catalog import JdbcCatalog
 
-environment_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+environment_settings = EnvironmentSettings.in_streaming_mode()
 t_env = TableEnvironment.create(environment_settings)
 
 name = "mypg"

--- a/docs/content.zh/docs/dev/python/dependency_management.md
+++ b/docs/content.zh/docs/dev/python/dependency_management.md
@@ -294,7 +294,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 
 TableEnvironment tEnv = TableEnvironment.create(
-    EnvironmentSettings.newInstance().inBatchMode().build());
+    EnvironmentSettings.inBatchMode());
 tEnv.getConfig().getConfiguration().set(CoreOptions.DEFAULT_PARALLELISM, 1);
 
 // register the Python UDF

--- a/docs/content.zh/docs/dev/python/python_config.md
+++ b/docs/content.zh/docs/dev/python/python_config.md
@@ -47,7 +47,7 @@ The config options could be set as following in a Table API program:
 ```python
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 t_env = TableEnvironment.create(env_settings)
 
 config = t_env.get_config().get_configuration()

--- a/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
@@ -40,7 +40,7 @@ Python Table API 程序的基本结构
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 1. 创建 TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings) 
 
 # 2. 创建 source 表
@@ -92,11 +92,11 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").wait()
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 # or create a blink batch TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 ```
 
@@ -133,7 +133,7 @@ table_env = TableEnvironment.create(env_settings)
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 创建 blink 批 TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
@@ -197,7 +197,7 @@ print('Now the type of the "id" column is %s.' % type)
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 创建 blink 流 TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table_env.execute_sql("""
@@ -277,7 +277,7 @@ new_table.to_pandas()
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 通过 batch table environment 来执行查询
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
@@ -312,7 +312,7 @@ from pyflink.table.udf import udf
 import pandas as pd
 
 # 通过 batch table environment 来执行查询
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
@@ -348,7 +348,7 @@ Flink 的 SQL 基于 [Apache Calcite](https://calcite.apache.org)，它实现了
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 通过 stream table environment 来执行查询
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 
@@ -634,7 +634,7 @@ Table API 提供了一种机制来查看 `Table` 的逻辑查询计划和优化�
 # 使用流模式 TableEnvironment
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -687,7 +687,7 @@ Stage 136 : Data Source
 # 使用流模式 TableEnvironment
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(environment_settings=env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])

--- a/docs/content.zh/docs/dev/python/table/operations/row_based_operations.md
+++ b/docs/content.zh/docs/dev/python/table/operations/row_based_operations.md
@@ -37,7 +37,7 @@ from pyflink.table import EnvironmentSettings, TableEnvironment
 from pyflink.table.expressions import col
 from pyflink.table.types import DataTypes
 
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -101,7 +101,7 @@ from pyflink.common import Row
 from pyflink.table.udf import udtf
 from pyflink.table import DataTypes, EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi,Flink'), (2, 'Hello')], ['id', 'data'])
@@ -181,7 +181,7 @@ agg = udaf(function,
 
 # aggregate with a python general aggregate function
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
 
@@ -196,7 +196,7 @@ result.to_pandas()
 # 1  2  1  1
 
 # aggregate with a python vectorized aggregate function
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
@@ -256,7 +256,7 @@ class Top2(TableAggregateFunction):
             [DataTypes.FIELD("a", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udtaf decorator:
 # top2 = udtaf(Top2(), result_type=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]), accumulator_type=DataTypes.ARRAY(DataTypes.BIGINT()))

--- a/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content.zh/docs/dev/python/table/python_table_api_connectors.md
@@ -83,7 +83,7 @@ t_env.sql_query("SELECT a FROM source_table") \
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
 def log_processing():
-    env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+    env_settings = EnvironmentSettings.in_streaming_mode()
     t_env = TableEnvironment.create(env_settings)
     # specify connector and format jars
     t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")

--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -38,9 +38,9 @@ under the License.
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 # or a batch TableEnvironment
-# env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+# env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 ```
 

--- a/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
@@ -50,7 +50,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
@@ -80,7 +80,7 @@ public class HashCode extends ScalarFunction {
 '''
 from pyflink.table.expressions import call
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 # 注册 Java 函数
@@ -148,7 +148,7 @@ class Split(TableFunction):
         for s in string.split(" "):
             yield s, len(s)
 
-env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
@@ -186,7 +186,7 @@ public class Split extends TableFunction<Tuple2<String, Integer>> {
 '''
 from pyflink.table.expressions import call
 
-env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
@@ -301,7 +301,7 @@ class WeightedAvg(AggregateFunction):
             DataTypes.FIELD("f1", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udaf decorator:
 # weighted_avg = udaf(WeightedAvg(), result_type=DataTypes.BIGINT(), accumulator_type=...)
@@ -476,7 +476,7 @@ class Top2(TableAggregateFunction):
             [DataTypes.FIELD("a", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udtaf decorator:
 # top2 = udtaf(Top2(), result_type=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]), accumulator_type=DataTypes.ARRAY(DataTypes.BIGINT()))

--- a/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -53,7 +53,7 @@ under the License.
 def add(i, j):
   return i + j
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 # use the vectorized Python scalar function in Python Table API
@@ -87,7 +87,7 @@ and `Over Window Aggregation` 使用它:
 def mean_udaf(v):
     return v.mean()
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 my_table = ...  # type: Table, table schema: [a: String, b: BigInt, c: BigInt]

--- a/docs/content.zh/docs/dev/python/table_api_tutorial.md
+++ b/docs/content.zh/docs/dev/python/table_api_tutorial.md
@@ -67,7 +67,7 @@ $ python -m pip install apache-flink
 编写Flink Python Table API程序的第一步是创建`TableEnvironment`。这是Python Table API作业的入口类。
 
 ```python
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 ```
 
@@ -147,7 +147,7 @@ from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
 from pyflink.table.descriptors import Schema, OldCsv, FileSystem
 from pyflink.table.expressions import lit
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 # write all the data to one file

--- a/docs/content.zh/docs/dev/table/catalogs.md
+++ b/docs/content.zh/docs/dev/table/catalogs.md
@@ -157,7 +157,7 @@ import org.apache.flink.table.catalog.*;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.descriptors.Kafka;
 
-TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
 // Create a HiveCatalog
 Catalog catalog = new HiveCatalog("myhive", null, "<path_of_hive_conf>");
@@ -199,7 +199,7 @@ import org.apache.flink.table.catalog._
 import org.apache.flink.table.catalog.hive.HiveCatalog
 import org.apache.flink.table.descriptors.Kafka
 
-val tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance.build)
+val tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode())
 
 // Create a HiveCatalog
 val catalog = new HiveCatalog("myhive", null, "<path_of_hive_conf>")
@@ -240,7 +240,7 @@ from pyflink.table import *
 from pyflink.table.catalog import HiveCatalog, CatalogDatabase, ObjectPath, CatalogBaseTable
 from pyflink.table.descriptors import Kafka
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 # Create a HiveCatalog

--- a/docs/content.zh/docs/dev/table/common.md
+++ b/docs/content.zh/docs/dev/table/common.md
@@ -161,11 +161,11 @@ val tEnv = TableEnvironment.create(settings)
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().build()
+env_settings = EnvironmentSettings.inStreamingMode()
 table_env = TableEnvironment.create(env_settings)
 
 # create a blink batch TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 ```
@@ -843,7 +843,7 @@ Stage 2 : Data Source
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
 final Schema schema = new Schema()
@@ -882,7 +882,7 @@ System.out.println(explanation);
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance.inStreamingMode.build
+val settings = EnvironmentSettings.inStreamingMode()
 val tEnv = TableEnvironment.create(settings)
 
 val schema = new Schema()
@@ -921,7 +921,7 @@ println(explanation)
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+settings = EnvironmentSettings.in_streaming_mode()
 t_env = TableEnvironment.create(environment_settings=settings)
 
 schema = Schema()

--- a/docs/content.zh/docs/dev/table/concepts/timezone.md
+++ b/docs/content.zh/docs/dev/table/concepts/timezone.md
@@ -87,7 +87,7 @@ Flink SQL> SET 'table.local-time-zone' = 'America/Los_Angeles';
 {{< /tab >}}
 {{< tab "Java" >}}
 ```java
- EnvironmentSettings envSetting = EnvironmentSettings.newInstance().build();
+ EnvironmentSettings envSetting = EnvironmentSettings.inStreamingMode();
  TableEnvironment tEnv = TableEnvironment.create(envSetting);
 
  // 设置为 UTC 时区
@@ -102,7 +102,7 @@ Flink SQL> SET 'table.local-time-zone' = 'America/Los_Angeles';
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val envSetting = EnvironmentSettings.newInstance.build
+val envSetting = EnvironmentSettings.inStreamingMode()
 val tEnv = TableEnvironment.create(envSetting)
 
 // 设置为 UTC 时区

--- a/docs/content.zh/docs/dev/table/modules.md
+++ b/docs/content.zh/docs/dev/table/modules.md
@@ -83,7 +83,7 @@ Users can use SQL to load/unload/use/list modules in both Table API and SQL CLI.
 {{< tabs "SQL snippets" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 // Show initially loaded and enabled modules
@@ -168,7 +168,7 @@ tableEnv.executeSql("SHOW FULL MODULES").print();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(setting)
 
 // Show initially loaded and enabled modules
@@ -256,7 +256,7 @@ tableEnv.executeSql("SHOW FULL MODULES").print()
 from pyflink.table import *
 
 # environment configuration
-settings = EnvironmentSettings.new_instance().build()
+settings = EnvironmentSettings.inStreamingMode()
 t_env = TableEnvironment.create(settings)
 
 # Show initially loaded and enabled modules
@@ -456,7 +456,7 @@ Users can use Java, Scala or Python to load/unload/use/list modules programmatic
 {{< tabs "API snippets" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 // Show initially loaded and enabled modules
@@ -541,7 +541,7 @@ tableEnv.listFullModules();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(setting)
 
 // Show initially loaded and enabled modules
@@ -629,7 +629,7 @@ tableEnv.listFullModules()
 from pyflink.table import *
 
 # environment configuration
-settings = EnvironmentSettings.new_instance().build()
+settings = EnvironmentSettings.inStreamingMode()
 t_env = TableEnvironment.create(settings)
 
 # Show initially loaded and enabled modules

--- a/docs/content.zh/docs/dev/table/sql/alter.md
+++ b/docs/content.zh/docs/dev/table/sql/alter.md
@@ -69,8 +69,7 @@ Flink SQL 目前支持以下 ALTER 语句：
 {{< tabs "147c58e0-44d1-4f78-b995-88b3edba7bec" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tableEnv = TableEnvironment.create(settings);
+TableEnvironment tableEnv = TableEnvironment.create(...);
 
 // 注册名为 “Orders” 的表
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
@@ -89,8 +88,7 @@ String[] tables = tableEnv.listTables();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // 注册名为 “Orders” 的表
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
@@ -109,8 +107,7 @@ val tables = tableEnv.listTables()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # 字符串数组： ["Orders"]
 tables = table_env.list_tables()

--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -92,8 +92,7 @@ tableEnv.executeSql(
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // 对已注册的表进行 SQL 查询
 // 注册名为 “Orders” 的表
@@ -112,8 +111,7 @@ tableEnv.executeSql(
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # 对已经注册的表进行 SQL 查询
 # 注册名为 “Orders” 的表

--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -61,8 +61,7 @@ The following examples show how to run a DESCRIBE statement in SQL CLI.
 {{< tabs "a5de1760-e363-4b8d-9d6f-0bacb35b9dcf" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tableEnv = TableEnvironment.create(settings);
+TableEnvironment tableEnv = TableEnvironment.create(...);
 
 // register a table named "Orders"
 tableEnv.executeSql(
@@ -85,8 +84,7 @@ tableEnv.executeSql("DESC Orders").print();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // register a table named "Orders"
  tableEnv.executeSql(
@@ -109,8 +107,7 @@ tableEnv.executeSql("DESC Orders").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # register a table named "Orders"
 table_env.execute_sql( \

--- a/docs/content.zh/docs/dev/table/sql/drop.md
+++ b/docs/content.zh/docs/dev/table/sql/drop.md
@@ -77,8 +77,7 @@ Flink SQL 目前支持以下 DROP 语句：
 {{< tabs "9f224244-9f9f-4af3-85b9-61225ec3fc0b" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tableEnv = TableEnvironment.create(settings);
+TableEnvironment tableEnv = TableEnvironment.create(...);
 
 // 注册名为 “Orders” 的表
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
@@ -97,8 +96,7 @@ String[] tables = tableEnv.listTables();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // 注册名为 “Orders” 的表
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
@@ -117,8 +115,7 @@ val tables = tableEnv.listTables()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # 字符串数组： ["Orders"]
 tables = table_env.listTables()

--- a/docs/content.zh/docs/dev/table/sql/explain.md
+++ b/docs/content.zh/docs/dev/table/sql/explain.md
@@ -117,8 +117,7 @@ tableResult.print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 t_env.execute_sql("CREATE TABLE MyTable1 (`count` bigint, word VARCHAR(256) WITH (...)")
 t_env.execute_sql("CREATE TABLE MyTable2 (`count` bigint, word VARCHAR(256) WITH (...)")

--- a/docs/content.zh/docs/dev/table/sql/insert.md
+++ b/docs/content.zh/docs/dev/table/sql/insert.md
@@ -68,8 +68,7 @@ INSERT 语句用来向表中添加行。
 {{< tabs "77ed5a01-effa-432c-b089-f922c3964c88" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tEnv = TableEnvironment.create(settings);
+TableEnvironment tEnv = TableEnvironment.create(...);
 
 // 注册一个 "Orders" 源表，和 "RubberOrders" 结果表
 tEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product VARCHAR, amount INT) WITH (...)");
@@ -101,8 +100,7 @@ System.out.println(tableResult1.getJobClient().get().getJobStatus());
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tEnv = TableEnvironment.create(settings)
+val tEnv = TableEnvironment.create(...)
 
 // 注册一个 "Orders" 源表，和 "RubberOrders" 结果表
 tEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
@@ -134,8 +132,7 @@ println(tableResult1.getJobClient().get().getJobStatus())
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # 注册一个 "Orders" 源表，和 "RubberOrders" 结果表
 table_env.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")

--- a/docs/content.zh/docs/dev/table/sql/load.md
+++ b/docs/content.zh/docs/dev/table/sql/load.md
@@ -97,8 +97,7 @@ tEnv.executeSql("SHOW MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # load a hive module
 table_env.execute_sql("LOAD MODULE hive WITH ('hive-version' = '3.1.2')")

--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -270,8 +270,7 @@ tEnv.executeSql("SHOW FULL MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # show catalogs
 table_env.execute_sql("SHOW CATALOGS").print()

--- a/docs/content.zh/docs/dev/table/sql/unload.md
+++ b/docs/content.zh/docs/dev/table/sql/unload.md
@@ -85,8 +85,7 @@ tEnv.executeSql("SHOW MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # unload a core module
 table_env.execute_sql("UNLOAD MODULE core")

--- a/docs/content.zh/docs/dev/table/sql/use.md
+++ b/docs/content.zh/docs/dev/table/sql/use.md
@@ -161,8 +161,7 @@ tEnv.executeSql("SHOW FULL MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # create a catalog
 table_env.execute_sql("CREATE CATALOG cat1 WITH (...)")

--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -117,7 +117,7 @@ from pyflink.table import *
 
 # environment configuration
 t_env = TableEnvironment.create(
-    environment_settings=EnvironmentSettings.new_instance().in_batch_mode().build())
+    environment_settings=EnvironmentSettings.in_batch_mode())
 
 # register Orders table and Result table sink in table environment
 source_data_path = "/path/to/source/directory/"

--- a/docs/content.zh/docs/try-flink/table_api.md
+++ b/docs/content.zh/docs/try-flink/table_api.md
@@ -75,7 +75,7 @@ The required configuration files are available in the [flink-playgrounds](https:
 Once downloaded, open the project `flink-playground/table-walkthrough` in your IDE and navigate to the file `SpendReport`. 
 
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
 tEnv.executeSql("CREATE TABLE transactions (\n" +
@@ -118,7 +118,7 @@ The table environment is how you can set properties for your Job, specify whethe
 This walkthrough creates a standard table environment that uses the streaming execution.
 
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 ```
 
@@ -184,7 +184,7 @@ The project contains a secondary testing class `SpendReportTest` that validates 
 It creates a table environment in batch mode. 
 
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+EnvironmentSettings settings = EnvironmentSettings.inBatchMode();
 TableEnvironment tEnv = TableEnvironment.create(settings); 
 ```
 

--- a/docs/content/docs/connectors/table/hive/hive_dialect.md
+++ b/docs/content/docs/connectors/table/hive/hive_dialect.md
@@ -75,7 +75,7 @@ You can set dialect for your TableEnvironment with Table API.
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 // to use hive dialect
 tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
@@ -88,7 +88,7 @@ tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
 ```python
 from pyflink.table import *
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 # to use hive dialect

--- a/docs/content/docs/connectors/table/hive/overview.md
+++ b/docs/content/docs/connectors/table/hive/overview.md
@@ -319,7 +319,7 @@ Following is an example of how to connect to Hive:
 
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 String name            = "myhive";
@@ -337,7 +337,7 @@ tableEnv.useCatalog("myhive");
 
 ```scala
 
-val settings = EnvironmentSettings.newInstance().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(settings)
 
 val name            = "myhive"
@@ -356,7 +356,7 @@ tableEnv.useCatalog("myhive")
 from pyflink.table import *
 from pyflink.table.catalog import HiveCatalog
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 catalog_name = "myhive"

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -354,7 +354,7 @@ USE CATALOG mypg;
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 String name            = "mypg";
@@ -373,7 +373,7 @@ tableEnv.useCatalog("mypg");
 {{< tab "Scala" >}}
 ```scala
 
-val settings = EnvironmentSettings.newInstance().inStreamingMode().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(settings)
 
 val name            = "mypg"
@@ -393,7 +393,7 @@ tableEnv.useCatalog("mypg")
 ```python
 from pyflink.table.catalog import JdbcCatalog
 
-environment_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+environment_settings = EnvironmentSettings.in_streaming_mode()
 t_env = TableEnvironment.create(environment_settings)
 
 name = "mypg"

--- a/docs/content/docs/dev/python/dependency_management.md
+++ b/docs/content/docs/dev/python/dependency_management.md
@@ -294,7 +294,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 
 TableEnvironment tEnv = TableEnvironment.create(
-    EnvironmentSettings.newInstance().inBatchMode().build());
+    EnvironmentSettings.inBatchMode());
 tEnv.getConfig().getConfiguration().set(CoreOptions.DEFAULT_PARALLELISM, 1);
 
 // register the Python UDF

--- a/docs/content/docs/dev/python/python_config.md
+++ b/docs/content/docs/dev/python/python_config.md
@@ -47,7 +47,7 @@ The config options could be set as following in a Table API program:
 ```python
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 t_env = TableEnvironment.create(env_settings)
 
 config = t_env.get_config().get_configuration()

--- a/docs/content/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content/docs/dev/python/table/intro_to_table_api.md
@@ -38,7 +38,7 @@ All Table API and SQL programs, both batch and streaming, follow the same patter
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # 1. create a TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 # 2. create source Table
@@ -90,11 +90,11 @@ The `TableEnvironment` is a central concept of the Table API and SQL integration
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 # or create a blink batch TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 ```
 
@@ -132,7 +132,7 @@ You can create a Table from a list object:
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink batch TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')])
@@ -196,7 +196,7 @@ You can create a Table using connector DDL:
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink stream TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table_env.execute_sql("""
@@ -276,7 +276,7 @@ The following example shows a simple Table API aggregation query:
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # using batch table environment to execute the queries
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
@@ -311,7 +311,7 @@ from pyflink.table.udf import udf
 import pandas as pd
 
 # using batch table environment to execute the queries
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 orders = table_env.from_elements([('Jack', 'FRANCE', 10), ('Rose', 'ENGLAND', 30), ('Jack', 'FRANCE', 20)],
@@ -347,7 +347,7 @@ The following example shows a simple SQL aggregation query:
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # use a stream TableEnvironment to execute the queries
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 
@@ -634,7 +634,7 @@ The following code shows how to use the `Table.explain()` method:
 # using a stream TableEnvironment
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -687,7 +687,7 @@ The following code shows how to use the `StatementSet.explain()` method:
 # using a stream TableEnvironment
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table1 = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])

--- a/docs/content/docs/dev/python/table/operations/row_based_operations.md
+++ b/docs/content/docs/dev/python/table/operations/row_based_operations.md
@@ -37,7 +37,7 @@ from pyflink.table import EnvironmentSettings, TableEnvironment
 from pyflink.table.expressions import col
 from pyflink.table.types import DataTypes
 
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
@@ -101,7 +101,7 @@ from pyflink.common import Row
 from pyflink.table.udf import udtf
 from pyflink.table import DataTypes, EnvironmentSettings, TableEnvironment
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi,Flink'), (2, 'Hello')], ['id', 'data'])
@@ -181,7 +181,7 @@ agg = udaf(function,
 
 # aggregate with a python general aggregate function
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
 
@@ -196,7 +196,7 @@ result.to_pandas()
 # 1  2  1  1
 
 # aggregate with a python vectorized aggregate function
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
@@ -256,7 +256,7 @@ class Top2(TableAggregateFunction):
             [DataTypes.FIELD("a", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udtaf decorator:
 # top2 = udtaf(Top2(), result_type=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]), accumulator_type=DataTypes.ARRAY(DataTypes.BIGINT()))

--- a/docs/content/docs/dev/python/table/python_table_api_connectors.md
+++ b/docs/content/docs/dev/python/table/python_table_api_connectors.md
@@ -86,7 +86,7 @@ Below is a complete example of how to use a Kafka source/sink and the JSON forma
 from pyflink.table import TableEnvironment, EnvironmentSettings
 
 def log_processing():
-    env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+    env_settings = EnvironmentSettings.in_streaming_mode()
     t_env = TableEnvironment.create(env_settings)
     # specify connector and format jars
     t_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/json.jar")

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -38,10 +38,10 @@ The recommended way to create a `TableEnvironment` is to create from an `Environ
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 
 # or a batch TableEnvironment
-# env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+# env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 ```
 

--- a/docs/content/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/python_udfs.md
@@ -50,7 +50,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
@@ -80,7 +80,7 @@ public class HashCode extends ScalarFunction {
 '''
 from pyflink.table.expressions import call
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 # register the Java function
@@ -150,7 +150,7 @@ class Split(TableFunction):
         for s in string.split(" "):
             yield s, len(s)
 
-env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
@@ -188,7 +188,7 @@ public class Split extends TableFunction<Tuple2<String, Integer>> {
 '''
 from pyflink.table.expressions import call
 
-env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
@@ -302,7 +302,7 @@ class WeightedAvg(AggregateFunction):
             DataTypes.FIELD("f1", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().is_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udaf decorator:
 # weighted_avg = udaf(WeightedAvg(), result_type=DataTypes.BIGINT(), accumulator_type=...)
@@ -477,7 +477,7 @@ class Top2(TableAggregateFunction):
             [DataTypes.FIELD("a", DataTypes.BIGINT())])
 
 
-env_settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 # the result type and accumulator type can also be specified in the udtaf decorator:
 # top2 = udtaf(Top2(), result_type=DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT())]), accumulator_type=DataTypes.ARRAY(DataTypes.BIGINT()))

--- a/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -53,7 +53,7 @@ and use it in a query:
 def add(i, j):
   return i + j
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 # use the vectorized Python scalar function in Python Table API
@@ -86,7 +86,7 @@ and use it in `GroupBy Aggregation`, `GroupBy Window Aggregation` and `Over Wind
 def mean_udaf(v):
     return v.mean()
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
 my_table = ...  # type: Table, table schema: [a: String, b: BigInt, c: BigInt]

--- a/docs/content/docs/dev/python/table_api_tutorial.md
+++ b/docs/content/docs/dev/python/table_api_tutorial.md
@@ -69,7 +69,7 @@ It can be used for setting execution parameters such as restart strategy, defaul
 The table config allows setting Table API specific configurations.
 
 ```python
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 ```
 
@@ -147,7 +147,7 @@ from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
 from pyflink.table.descriptors import Schema, OldCsv, FileSystem
 from pyflink.table.expressions import lit
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 # write all the data to one file

--- a/docs/content/docs/dev/table/catalogs.md
+++ b/docs/content/docs/dev/table/catalogs.md
@@ -163,7 +163,7 @@ import org.apache.flink.table.catalog.*;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.descriptors.Kafka;
 
-TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
 // Create a HiveCatalog 
 Catalog catalog = new HiveCatalog("myhive", null, "<path_of_hive_conf>");
@@ -205,7 +205,7 @@ import org.apache.flink.table.catalog._
 import org.apache.flink.table.catalog.hive.HiveCatalog
 import org.apache.flink.table.descriptors.Kafka
 
-val tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance.build)
+val tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode())
 
 // Create a HiveCatalog 
 val catalog = new HiveCatalog("myhive", null, "<path_of_hive_conf>")
@@ -245,7 +245,7 @@ from pyflink.table import *
 from pyflink.table.catalog import HiveCatalog, CatalogDatabase, ObjectPath, CatalogBaseTable
 from pyflink.table.descriptors import Kafka
 
-settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+settings = EnvironmentSettings.in_batch_mode()
 t_env = TableEnvironment.create(settings)
 
 # Create a HiveCatalog

--- a/docs/content/docs/dev/table/common.md
+++ b/docs/content/docs/dev/table/common.md
@@ -161,11 +161,11 @@ val tEnv = TableEnvironment.create(settings)
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
 # create a blink streaming TableEnvironment
-env_settings = EnvironmentSettings.new_instance().build()
+env_settings = EnvironmentSettings.inStreamingMode()
 table_env = TableEnvironment.create(env_settings)
 
 # create a blink batch TableEnvironment
-env_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
+env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 ```
@@ -841,7 +841,7 @@ The following code shows an example and the corresponding output for multiple-si
 {{< tab "Java" >}}
 ```java
 
-EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
 final Schema schema = new Schema()
@@ -880,7 +880,7 @@ System.out.println(explanation);
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance.inStreamingMode.build
+val settings = EnvironmentSettings.inStreamingMode()
 val tEnv = TableEnvironment.create(settings)
 
 val schema = new Schema()
@@ -919,7 +919,7 @@ println(explanation)
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
+settings = EnvironmentSettings.in_streaming_mode()
 t_env = TableEnvironment.create(environment_settings=settings)
 
 schema = Schema()

--- a/docs/content/docs/dev/table/concepts/timezone.md
+++ b/docs/content/docs/dev/table/concepts/timezone.md
@@ -87,7 +87,7 @@ Flink SQL> SET 'table.local-time-zone' = 'America/Los_Angeles';
 {{< /tab >}}
 {{< tab "Java" >}}
 ```java
- EnvironmentSettings envSetting = EnvironmentSettings.newInstance().build();
+ EnvironmentSettings envSetting = EnvironmentSettings.inStreamingMode();
  TableEnvironment tEnv = TableEnvironment.create(envSetting);
 
  // set to UTC time zone
@@ -102,7 +102,7 @@ Flink SQL> SET 'table.local-time-zone' = 'America/Los_Angeles';
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val envSetting = EnvironmentSettings.newInstance.build
+val envSetting = EnvironmentSettings.inStreamingMode()
 val tEnv = TableEnvironment.create(envSetting)
 
 // set to UTC time zone

--- a/docs/content/docs/dev/table/modules.md
+++ b/docs/content/docs/dev/table/modules.md
@@ -83,7 +83,7 @@ Users can use SQL to load/unload/use/list modules in both Table API and SQL CLI.
 {{< tabs "SQL snippets" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 // Show initially loaded and enabled modules
@@ -168,7 +168,7 @@ tableEnv.executeSql("SHOW FULL MODULES").print();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(setting)
 
 // Show initially loaded and enabled modules
@@ -256,7 +256,7 @@ tableEnv.executeSql("SHOW FULL MODULES").print()
 from pyflink.table import *
 
 # environment configuration
-settings = EnvironmentSettings.new_instance().build()
+settings = EnvironmentSettings.inStreamingMode()
 t_env = TableEnvironment.create(settings)
 
 # Show initially loaded and enabled modules
@@ -456,7 +456,7 @@ Users can use Java, Scala or Python to load/unload/use/list modules programmatic
 {{< tabs "API snippets" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tableEnv = TableEnvironment.create(settings);
 
 // Show initially loaded and enabled modules
@@ -541,7 +541,7 @@ tableEnv.listFullModules();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance().build()
+val settings = EnvironmentSettings.inStreamingMode()
 val tableEnv = TableEnvironment.create(setting)
 
 // Show initially loaded and enabled modules
@@ -629,7 +629,7 @@ tableEnv.listFullModules()
 from pyflink.table import *
 
 # environment configuration
-settings = EnvironmentSettings.new_instance().build()
+settings = EnvironmentSettings.inStreamingMode()
 t_env = TableEnvironment.create(settings)
 
 # Show initially loaded and enabled modules

--- a/docs/content/docs/dev/table/sql/alter.md
+++ b/docs/content/docs/dev/table/sql/alter.md
@@ -89,8 +89,7 @@ String[] tables = tableEnv.listTables();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // register a table named "Orders"
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
@@ -109,8 +108,7 @@ val tables = tableEnv.listTables()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # a string array: ["Orders"]
 tables = table_env.list_tables()

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -69,8 +69,7 @@ The following examples show how to run a CREATE statement in SQL CLI.
 {{< tabs "0b1b298a-b92f-4f95-8d06-49544b487b75" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tableEnv = TableEnvironment.create(settings);
+TableEnvironment tableEnv = TableEnvironment.create(...);
 
 // SQL query with a registered table
 // register a table named "Orders"
@@ -89,8 +88,7 @@ tableEnv.executeSql(
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // SQL query with a registered table
 // register a table named "Orders"
@@ -109,8 +107,7 @@ tableEnv.executeSql(
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # SQL query with a registered table
 # register a table named "Orders"

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -61,8 +61,7 @@ The following examples show how to run a DESCRIBE statement in SQL CLI.
 {{< tabs "a5de1760-e363-4b8d-9d6f-0bacb35b9dcf" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tableEnv = TableEnvironment.create(settings);
+TableEnvironment tableEnv = TableEnvironment.create(...);
 
 // register a table named "Orders"
 tableEnv.executeSql(
@@ -85,8 +84,7 @@ tableEnv.executeSql("DESC Orders").print();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // register a table named "Orders"
  tableEnv.executeSql(
@@ -109,8 +107,7 @@ tableEnv.executeSql("DESC Orders").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # register a table named "Orders"
 table_env.execute_sql( \

--- a/docs/content/docs/dev/table/sql/drop.md
+++ b/docs/content/docs/dev/table/sql/drop.md
@@ -69,8 +69,7 @@ The following examples show how to run a DROP statement in SQL CLI.
 {{< tabs "18a7ab59-662f-45e4-9c5e-a6d96f69388b" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tableEnv = TableEnvironment.create(settings);
+TableEnvironment tableEnv = TableEnvironment.create(...);
 
 // register a table named "Orders"
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)");
@@ -89,8 +88,7 @@ String[] tables = tableEnv.listTables();
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tableEnv = TableEnvironment.create(settings)
+val tableEnv = TableEnvironment.create(...)
 
 // register a table named "Orders"
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
@@ -109,8 +107,7 @@ val tables = tableEnv.listTables()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # a string array: ["Orders"]
 tables = table_env.list_tables()

--- a/docs/content/docs/dev/table/sql/explain.md
+++ b/docs/content/docs/dev/table/sql/explain.md
@@ -118,8 +118,7 @@ tableResult.print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 t_env.execute_sql("CREATE TABLE MyTable1 (`count` bigint, word VARCHAR(256) WITH (...)")
 t_env.execute_sql("CREATE TABLE MyTable2 (`count` bigint, word VARCHAR(256) WITH (...)")

--- a/docs/content/docs/dev/table/sql/insert.md
+++ b/docs/content/docs/dev/table/sql/insert.md
@@ -66,8 +66,7 @@ The following examples show how to run a single INSERT statement in SQL CLI.
 {{< tabs "15bc87ce-93fd-4fdd-8c51-3301a432c048" >}}
 {{< tab "Java" >}}
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance()...
-TableEnvironment tEnv = TableEnvironment.create(settings);
+TableEnvironment tEnv = TableEnvironment.create(...);
 
 // register a source table named "Orders" and a sink table named "RubberOrders"
 tEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product VARCHAR, amount INT) WITH (...)");
@@ -99,8 +98,7 @@ System.out.println(tableResult2.getJobClient().get().getJobStatus());
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
-val settings = EnvironmentSettings.newInstance()...
-val tEnv = TableEnvironment.create(settings)
+val tEnv = TableEnvironment.create(...)
 
 // register a source table named "Orders" and a sink table named "RubberOrders"
 tEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
@@ -132,8 +130,7 @@ println(tableResult2.getJobClient().get().getJobStatus())
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = TableEnvironment.create(settings)
+table_env = TableEnvironment.create(...)
 
 # register a source table named "Orders" and a sink table named "RubberOrders"
 table_env.execute_sql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")

--- a/docs/content/docs/dev/table/sql/load.md
+++ b/docs/content/docs/dev/table/sql/load.md
@@ -97,8 +97,7 @@ tEnv.executeSql("SHOW MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # load a hive module
 table_env.execute_sql("LOAD MODULE hive WITH ('hive-version' = '3.1.2')")

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -269,8 +269,7 @@ tEnv.executeSql("SHOW FULL MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # show catalogs
 table_env.execute_sql("SHOW CATALOGS").print()

--- a/docs/content/docs/dev/table/sql/unload.md
+++ b/docs/content/docs/dev/table/sql/unload.md
@@ -85,8 +85,7 @@ tEnv.executeSql("SHOW MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # unload a core module
 table_env.execute_sql("UNLOAD MODULE core")

--- a/docs/content/docs/dev/table/sql/use.md
+++ b/docs/content/docs/dev/table/sql/use.md
@@ -162,8 +162,7 @@ tEnv.executeSql("SHOW FULL MODULES").print()
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
-settings = EnvironmentSettings.new_instance()...
-table_env = StreamTableEnvironment.create(env, settings)
+table_env = StreamTableEnvironment.create(...)
 
 # create a catalog
 table_env.execute_sql("CREATE CATALOG cat1 WITH (...)")

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -117,7 +117,7 @@ from pyflink.table import *
 
 # environment configuration
 t_env = TableEnvironment.create(
-    environment_settings=EnvironmentSettings.new_instance().in_batch_mode().build())
+    environment_settings=EnvironmentSettings.in_batch_mode())
 
 # register Orders table and Result table sink in table environment
 source_data_path = "/path/to/source/directory/"

--- a/docs/content/docs/try-flink/table_api.md
+++ b/docs/content/docs/try-flink/table_api.md
@@ -75,7 +75,7 @@ The required configuration files are available in the [flink-playgrounds](https:
 Once downloaded, open the project `flink-playground/table-walkthrough` in your IDE and navigate to the file `SpendReport`. 
 
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 
 tEnv.executeSql("CREATE TABLE transactions (\n" +
@@ -118,7 +118,7 @@ The table environment is how you can set properties for your Job, specify whethe
 This walkthrough creates a standard table environment that uses the streaming execution.
 
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().build();
+EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
 TableEnvironment tEnv = TableEnvironment.create(settings);
 ```
 
@@ -184,7 +184,7 @@ The project contains a secondary testing class `SpendReportTest` that validates 
 It creates a table environment in batch mode. 
 
 ```java
-EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+EnvironmentSettings settings = EnvironmentSettings.inBatchMode();
 TableEnvironment tEnv = TableEnvironment.create(settings); 
 ```
 

--- a/docs/layouts/shortcodes/generated/table_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/table_config_configuration.html
@@ -33,12 +33,6 @@
             <td>The local time zone defines current session time zone id. It is used when converting to/from &lt;code&gt;TIMESTAMP WITH LOCAL TIME ZONE&lt;/code&gt;. Internally, timestamps with local time zone are always represented in the UTC time zone. However, when converting to data types that don't include a time zone (e.g. TIMESTAMP, TIME, or simply STRING), the session time zone is used during conversion. The input of option is either a full name such as "America/Los_Angeles", or a custom timezone id such as "GMT-08:00".</td>
         </tr>
         <tr>
-            <td><h5>table.planner</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">BLINK</td>
-            <td><p>Enum</p>Possible values: [BLINK, OLD]</td>
-            <td>Use either 'blink' planner or 'old' planner. Default is blink planner. For TableEnvironment, this option is used to construct a TableEnvironment, but this option can't be changed after that. However, there is no such limitation for SQL Client. Note: The old planner will be removed in Flink 1.14, so this option will become obsolete.</td>
-        </tr>
-        <tr>
             <td><h5>table.sql-dialect</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">"default"</td>
             <td>String</td>

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -160,11 +160,7 @@ public class Elasticsearch6DynamicSinkITCase {
     @Test
     public void testWritingDocumentsFromTableApi() throws Exception {
         TableEnvironment tableEnvironment =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         String index = "table-api";
         String myType = "MyType";
@@ -228,11 +224,7 @@ public class Elasticsearch6DynamicSinkITCase {
     @Test
     public void testWritingDocumentsNoPrimaryKey() throws Exception {
         TableEnvironment tableEnvironment =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         String index = "no-primary-key";
         String myType = "MyType";
@@ -328,11 +320,7 @@ public class Elasticsearch6DynamicSinkITCase {
     @Test
     public void testWritingDocumentsWithDynamicIndex() throws Exception {
         TableEnvironment tableEnvironment =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         String index = "dynamic-index-{b|yyyy-MM-dd}";
         String myType = "MyType";

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch7DynamicSinkITCase.java
@@ -154,11 +154,7 @@ public class Elasticsearch7DynamicSinkITCase {
     @Test
     public void testWritingDocumentsFromTableApi() throws Exception {
         TableEnvironment tableEnvironment =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         String index = "table-api";
         tableEnvironment.executeSql(
@@ -216,11 +212,7 @@ public class Elasticsearch7DynamicSinkITCase {
     @Test
     public void testWritingDocumentsNoPrimaryKey() throws Exception {
         TableEnvironment tableEnvironment =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         String index = "no-primary-key";
         tableEnvironment.executeSql(
@@ -312,11 +304,7 @@ public class Elasticsearch7DynamicSinkITCase {
     @Test
     public void testWritingDocumentsWithDynamicIndex() throws Exception {
         TableEnvironment tableEnvironment =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         String index = "dynamic-index-{b|yyyy-MM-dd}";
         tableEnvironment.executeSql(

--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/util/HBaseTestBase.java
@@ -86,11 +86,8 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 
     @Before
     public void before() {
-        EnvironmentSettings.Builder streamBuilder =
-                EnvironmentSettings.newInstance().inStreamingMode();
-        EnvironmentSettings.Builder batchBuilder = EnvironmentSettings.newInstance().inBatchMode();
-        this.streamSettings = streamBuilder.useBlinkPlanner().build();
-        this.batchSettings = batchBuilder.useBlinkPlanner().build();
+        this.streamSettings = EnvironmentSettings.inStreamingMode();
+        this.batchSettings = EnvironmentSettings.inBatchMode();
     }
 
     private static void prepareTables() throws IOException {

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/util/HBaseTestBase.java
@@ -86,11 +86,8 @@ public abstract class HBaseTestBase extends HBaseTestingClusterAutoStarter {
 
     @Before
     public void before() {
-        EnvironmentSettings.Builder streamBuilder =
-                EnvironmentSettings.newInstance().inStreamingMode();
-        EnvironmentSettings.Builder batchBuilder = EnvironmentSettings.newInstance().inBatchMode();
-        this.streamSettings = streamBuilder.useBlinkPlanner().build();
-        this.batchSettings = batchBuilder.useBlinkPlanner().build();
+        this.streamSettings = EnvironmentSettings.inStreamingMode();
+        this.batchSettings = EnvironmentSettings.inBatchMode();
     }
 
     private static void prepareTables() throws IOException {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
@@ -57,9 +57,7 @@ public class HiveDynamicTableFactoryTest {
 
     @BeforeClass
     public static void setup() {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build();
-        tableEnv = TableEnvironment.create(settings);
+        tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         hiveCatalog = HiveTestUtils.createHiveCatalog();
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
@@ -66,9 +66,7 @@ public class HiveLookupJoinITCase {
 
     @BeforeClass
     public static void setup() {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build();
-        tableEnv = TableEnvironment.create(settings);
+        tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         hiveCatalog = HiveTestUtils.createHiveCatalog();
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTemporalJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTemporalJoinITCase.java
@@ -56,9 +56,7 @@ public class HiveTemporalJoinITCase extends TableTestBase {
         if (!HiveVersionTestUtil.HIVE_310_OR_LATER) {
             return;
         }
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build();
-        tableEnv = TableEnvironment.create(settings);
+        tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         hiveCatalog = HiveTestUtils.createHiveCatalog();
 
         hiveCatalog = HiveTestUtils.createHiveCatalog(CatalogTest.TEST_CATALOG_NAME, "3.1.2");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -105,9 +105,7 @@ public class HiveCatalogITCase {
 
     @Test
     public void testCsvTableViaSQL() {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        TableEnvironment tableEnv = TableEnvironment.create(settings);
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
 
         tableEnv.registerCatalog("myhive", hiveCatalog);
         tableEnv.useCatalog("myhive");
@@ -148,9 +146,7 @@ public class HiveCatalogITCase {
 
     @Test
     public void testCsvTableViaAPI() throws Exception {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        TableEnvironment tableEnv = TableEnvironment.create(settings);
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
         tableEnv.getConfig()
                 .addConfiguration(new Configuration().set(CoreOptions.DEFAULT_PARALLELISM, 1));
 
@@ -229,9 +225,7 @@ public class HiveCatalogITCase {
     @Test
     public void testReadWriteCsv() throws Exception {
         // similar to CatalogTableITCase::testReadWriteCsvUsingDDL but uses HiveCatalog
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        TableEnvironment tableEnv = TableEnvironment.create(settings);
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         tableEnv.getConfig()
                 .getConfiguration()
                 .setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
@@ -311,13 +305,12 @@ public class HiveCatalogITCase {
     }
 
     private TableEnvironment prepareTable(boolean isStreaming) {
-        EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance().useBlinkPlanner();
+        EnvironmentSettings settings;
         if (isStreaming) {
-            builder = builder.inStreamingMode();
+            settings = EnvironmentSettings.inStreamingMode();
         } else {
-            builder = builder.inBatchMode();
+            settings = EnvironmentSettings.inBatchMode();
         }
-        EnvironmentSettings settings = builder.build();
         TableEnvironment tableEnv = TableEnvironment.create(settings);
         tableEnv.getConfig()
                 .getConfiguration()
@@ -349,9 +342,7 @@ public class HiveCatalogITCase {
 
     @Test
     public void testTableWithPrimaryKey() {
-        EnvironmentSettings.Builder builder = EnvironmentSettings.newInstance().useBlinkPlanner();
-        EnvironmentSettings settings = builder.build();
-        TableEnvironment tableEnv = TableEnvironment.create(settings);
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         tableEnv.getConfig()
                 .getConfiguration()
                 .setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
@@ -454,9 +445,7 @@ public class HiveCatalogITCase {
 
     @Test
     public void testTemporaryGenericTable() throws Exception {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        TableEnvironment tableEnv = TableEnvironment.create(settings);
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUseBlinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUseBlinkITCase.java
@@ -148,18 +148,17 @@ public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
     private void testUdf(boolean batch) throws Exception {
         StreamExecutionEnvironment env = null;
         TableEnvironment tEnv;
-        EnvironmentSettings.Builder envBuilder =
-                EnvironmentSettings.newInstance().useBlinkPlanner();
+        EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings.newInstance();
         if (batch) {
-            envBuilder.inBatchMode();
+            settingsBuilder.inBatchMode();
         } else {
-            envBuilder.inStreamingMode();
+            settingsBuilder.inStreamingMode();
         }
         if (batch) {
-            tEnv = TableEnvironment.create(envBuilder.build());
+            tEnv = TableEnvironment.create(settingsBuilder.build());
         } else {
             env = StreamExecutionEnvironment.getExecutionEnvironment();
-            tEnv = StreamTableEnvironment.create(env, envBuilder.build());
+            tEnv = StreamTableEnvironment.create(env, settingsBuilder.build());
         }
 
         BatchTestBase.configForMiniCluster(tEnv.getConfig());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -152,9 +152,7 @@ public class HiveTestUtils {
     }
 
     public static TableEnvironment createTableEnvWithBlinkPlannerBatchMode(SqlDialect dialect) {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        TableEnvironment tableEnv = TableEnvironment.create(settings);
+        TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
         tableEnv.getConfig()
                 .getConfiguration()
                 .setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);
@@ -169,9 +167,7 @@ public class HiveTestUtils {
 
     public static StreamTableEnvironment createTableEnvWithBlinkPlannerStreamMode(
             StreamExecutionEnvironment env, SqlDialect dialect) {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
         tableEnv.getConfig()
                 .getConfiguration()
                 .setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTypeTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTypeTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.jdbc;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
@@ -164,9 +163,7 @@ public class JdbcDataTypeTest {
         String sqlDDL = String.format(DDL_FORMAT, testItem.dataTypeExpr, testItem.dialect);
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         tEnv.executeSql(sqlDDL);
 

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -39,9 +39,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 
     @Before
     public void setup() {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        this.tEnv = TableEnvironment.create(settings);
+        this.tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         tEnv.getConfig()
                 .getConfiguration()
                 .setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSinkITCase.java
@@ -184,9 +184,8 @@ public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
     public void testReal() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+        StreamTableEnvironment tEnv =
+                StreamTableEnvironment.create(env, EnvironmentSettings.inStreamingMode());
 
         tEnv.executeSql(
                 "CREATE TABLE upsertSink ("
@@ -209,9 +208,7 @@ public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
     public void testUpsert() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         Table t =
                 tEnv.fromDataStream(
@@ -316,9 +313,7 @@ public class JdbcDynamicTableSinkITCase extends AbstractTestBase {
 
     @Test
     public void testBatchSink() throws Exception {
-        EnvironmentSettings bsSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        TableEnvironment tEnv = TableEnvironment.create(bsSettings);
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
 
         tEnv.executeSql(
                 "CREATE TABLE USER_RESULT("

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcDynamicTableSourceITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.jdbc.table;
 
 import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
@@ -59,9 +58,7 @@ public class JdbcDynamicTableSourceITCase extends AbstractTestBase {
     @Before
     public void before() throws ClassNotFoundException, SQLException {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        tEnv = StreamTableEnvironment.create(env, envSettings);
+        tEnv = StreamTableEnvironment.create(env);
 
         System.setProperty(
                 "derby.stream.error.field", JdbcTestBase.class.getCanonicalName() + ".DEV_NULL");

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceITCase.java
@@ -20,7 +20,6 @@ package org.apache.flink.connector.jdbc.table;
 
 import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -100,9 +99,7 @@ public class JdbcTableSourceITCase extends AbstractTestBase {
     @Test
     public void testJdbcSource() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         tEnv.executeSql(
                 "CREATE TABLE "
@@ -139,9 +136,7 @@ public class JdbcTableSourceITCase extends AbstractTestBase {
     @Test
     public void testProjectableJdbcSource() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         tEnv.executeSql(
                 "CREATE TABLE "
@@ -178,9 +173,7 @@ public class JdbcTableSourceITCase extends AbstractTestBase {
     @Test
     public void testScanQueryJDBCSource() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        EnvironmentSettings envSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         final String testQuery = "SELECT id FROM " + INPUT_TABLE;
         tEnv.executeSql(

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcUpsertTableSinkITCase.java
@@ -266,9 +266,7 @@ public class JdbcUpsertTableSinkITCase extends AbstractTestBase {
 
     @Test
     public void testBatchSink() throws Exception {
-        EnvironmentSettings bsSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        TableEnvironment tEnv = TableEnvironment.create(bsSettings);
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
 
         tEnv.executeSql(
                 "CREATE TABLE USER_RESULT("

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.connectors.kafka.table;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -58,14 +57,7 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
     @Before
     public void setup() {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
-        tEnv =
-                StreamTableEnvironment.create(
-                        env,
-                        EnvironmentSettings.newInstance()
-                                // Watermark is only supported in blink planner
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+        tEnv = StreamTableEnvironment.create(env);
         env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
     }
 

--- a/flink-end-to-end-tests/flink-batch-sql-test/src/main/java/org/apache/flink/sql/tests/BatchSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-batch-sql-test/src/main/java/org/apache/flink/sql/tests/BatchSQLTestProgram.java
@@ -56,9 +56,7 @@ public class BatchSQLTestProgram {
         String outputPath = params.getRequired("outputPath");
         String sqlStatement = params.getRequired("sqlStatement");
 
-        TableEnvironment tEnv =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build());
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
 
         ((TableEnvironmentInternal) tEnv)
                 .registerTableSourceInternal("table1", new GeneratorTableSource(10, 100, 60, 0));

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkBatchPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkBatchPythonUdfSqlJob.java
@@ -31,9 +31,7 @@ import java.util.List;
 public class BlinkBatchPythonUdfSqlJob {
 
     public static void main(String[] args) {
-        TableEnvironment tEnv =
-                TableEnvironment.create(
-                        EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build());
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
         tEnv.getConfig().getConfiguration().set(CoreOptions.DEFAULT_PARALLELISM, 1);
         tEnv.executeSql(
                 "create temporary system function add_one as 'add_one.add_one' language python");

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkStreamPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkStreamPythonUdfSqlJob.java
@@ -18,7 +18,6 @@
 package org.apache.flink.python.tests;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
 
@@ -33,13 +32,7 @@ public class BlinkStreamPythonUdfSqlJob {
     public static void main(String[] args) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
-        StreamTableEnvironment tEnv =
-                StreamTableEnvironment.create(
-                        env,
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
         tEnv.executeSql(
                 "create temporary system function add_one as 'add_one.add_one' language python");
 

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -134,8 +134,7 @@ public class TpcdsTestProgram {
      */
     private static TableEnvironment prepareTableEnv(String sourceTablePath, Boolean useTableStats) {
         // init Table Env
-        EnvironmentSettings environmentSettings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+        EnvironmentSettings environmentSettings = EnvironmentSettings.inBatchMode();
         TableEnvironment tEnv = TableEnvironment.create(environmentSettings);
 
         // config Optimizer parameters

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -366,7 +366,7 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
 
         t_env = StreamTableEnvironment.create(
             stream_execution_environment=self.env,
-            environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())
+            environment_settings=EnvironmentSettings.in_streaming_mode())
         self.env.add_python_file(python_file_path)
 
         from pyflink.table.udf import udf

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -34,8 +34,7 @@ def word_count():
               "License you may not use this file except in compliance " \
               "with the License"
 
-    env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
-    t_env = TableEnvironment.create(environment_settings=env_settings)
+    t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
 
     # register Results table in table environment
     tmp_dir = tempfile.gettempdir()

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1625,8 +1625,7 @@ class StreamTableEnvironment(TableEnvironment):
             >>> table_config.set_null_check(False)
             >>> table_env = StreamTableEnvironment.create(env, table_config)
             # create with StreamExecutionEnvironment and EnvironmentSettings.
-            >>> environment_settings = EnvironmentSettings.new_instance().use_blink_planner() \\
-            ...     .build()
+            >>> environment_settings = EnvironmentSettings.in_streaming_mode()
             >>> table_env = StreamTableEnvironment.create(
             ...     env, environment_settings=environment_settings)
             # create with EnvironmentSettings.

--- a/flink-python/pyflink/table/tests/test_environment_settings.py
+++ b/flink-python/pyflink/table/tests/test_environment_settings.py
@@ -33,11 +33,6 @@ class EnvironmentSettingsTests(PyFlinkTestCase):
 
         self.check_blink_planner(environment_settings)
 
-        # test use_old_planner
-        environment_settings = builder.use_old_planner().build()
-
-        self.check_old_planner(environment_settings)
-
         # test use_blink_planner
         environment_settings = EnvironmentSettings.new_instance().use_blink_planner().build()
 
@@ -53,19 +48,22 @@ class EnvironmentSettingsTests(PyFlinkTestCase):
         builder = EnvironmentSettings.new_instance()
 
         # test the default behaviour to make sure it is consistent with the python doc
-        envrionment_settings = builder.build()
-
-        self.assertTrue(envrionment_settings.is_streaming_mode())
+        environment_settings = builder.build()
+        self.assertTrue(environment_settings.is_streaming_mode())
 
         # test in_streaming_mode
-        envrionment_settings = builder.in_streaming_mode().build()
+        environment_settings = builder.in_streaming_mode().build()
+        self.assertTrue(environment_settings.is_streaming_mode())
 
-        self.assertTrue(envrionment_settings.is_streaming_mode())
+        environment_settings = EnvironmentSettings.in_streaming_mode()
+        self.assertTrue(environment_settings.is_streaming_mode())
 
         # test in_batch_mode
-        envrionment_settings = builder.in_batch_mode().build()
+        environment_settings = builder.in_batch_mode().build()
+        self.assertFalse(environment_settings.is_streaming_mode())
 
-        self.assertFalse(envrionment_settings.is_streaming_mode())
+        environment_settings = EnvironmentSettings.in_batch_mode()
+        self.assertFalse(environment_settings.is_streaming_mode())
 
     def test_with_built_in_catalog_name(self):
 
@@ -76,13 +74,13 @@ class EnvironmentSettingsTests(PyFlinkTestCase):
         builder = EnvironmentSettings.new_instance()
 
         # test the default behaviour to make sure it is consistent with the python doc
-        envrionment_settings = builder.build()
+        environment_settings = builder.build()
 
-        self.assertEqual(envrionment_settings.get_built_in_catalog_name(), DEFAULT_BUILTIN_CATALOG)
+        self.assertEqual(environment_settings.get_built_in_catalog_name(), DEFAULT_BUILTIN_CATALOG)
 
-        envrionment_settings = builder.with_built_in_catalog_name("my_catalog").build()
+        environment_settings = builder.with_built_in_catalog_name("my_catalog").build()
 
-        self.assertEqual(envrionment_settings.get_built_in_catalog_name(), "my_catalog")
+        self.assertEqual(environment_settings.get_built_in_catalog_name(), "my_catalog")
 
     def test_with_built_in_database_name(self):
 
@@ -93,34 +91,29 @@ class EnvironmentSettingsTests(PyFlinkTestCase):
         builder = EnvironmentSettings.new_instance()
 
         # test the default behaviour to make sure it is consistent with the python doc
-        envrionment_settings = builder.build()
+        environment_settings = builder.build()
 
-        self.assertEqual(envrionment_settings.get_built_in_database_name(),
+        self.assertEqual(environment_settings.get_built_in_database_name(),
                          DEFAULT_BUILTIN_DATABASE)
 
-        envrionment_settings = builder.with_built_in_database_name("my_database").build()
+        environment_settings = builder.with_built_in_database_name("my_database").build()
 
-        self.assertEqual(envrionment_settings.get_built_in_database_name(), "my_database")
+        self.assertEqual(environment_settings.get_built_in_database_name(), "my_database")
 
-    def test_to_Configuration(self):
+    def test_to_configuration(self):
 
-        expected_settings = \
-            EnvironmentSettings.new_instance().use_old_planner().in_batch_mode().build()
+        expected_settings = EnvironmentSettings.new_instance().in_batch_mode().build()
         config = expected_settings.to_configuration()
 
-        self.assertEqual("OLD", config.get_string("table.planner", "blink"))
         self.assertEqual("BATCH", config.get_string("execution.runtime-mode", "stream"))
 
-    def test_from_Configuration(self):
+    def test_from_configuration(self):
 
         config = Configuration()
-        config.set_string("table.planner", "old")
         config.set_string("execution.runtime-mode", "batch")
 
         actual_setting = EnvironmentSettings.from_configuration(config)
         self.assertFalse(actual_setting.is_streaming_mode(), "Use batch mode.")
-
-        self.check_old_planner(actual_setting)
 
     def check_blink_planner(self, settings: EnvironmentSettings):
         gateway = get_gateway()
@@ -137,22 +130,6 @@ class EnvironmentSettingsTests(PyFlinkTestCase):
         self.assertEqual(
             settings._j_environment_settings.toExecutorProperties()[CLASS_NAME],
             BLINK_EXECUTOR_FACTORY)
-
-    def check_old_planner(self, settings: EnvironmentSettings):
-        gateway = get_gateway()
-        CLASS_NAME = gateway.jvm.EnvironmentSettings.CLASS_NAME
-
-        builder = EnvironmentSettings.new_instance()
-        OLD_PLANNER_FACTORY = get_private_field(builder._j_builder, "OLD_PLANNER_FACTORY")
-        OLD_EXECUTOR_FACTORY = get_private_field(builder._j_builder, "OLD_EXECUTOR_FACTORY")
-
-        self.assertEqual(
-            settings._j_environment_settings.toPlannerProperties()[CLASS_NAME],
-            OLD_PLANNER_FACTORY)
-
-        self.assertEqual(
-            settings._j_environment_settings.toExecutorProperties()[CLASS_NAME],
-            OLD_EXECUTOR_FACTORY)
 
     def check_any_planner(self, settings: EnvironmentSettings):
         gateway = get_gateway()

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -227,7 +227,7 @@ class DataStreamConversionTestCases(object):
         self.env.set_parallelism(1)
         t_env = StreamTableEnvironment.create(
             self.env,
-            environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())
+            environment_settings=EnvironmentSettings.in_streaming_mode())
         table = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hi")], ["a", "b", "c"])
         new_table = table.select("a + 1, b + 'flink', c")
         ds = t_env.to_append_stream(table=new_table, type_info=Types.ROW([Types.LONG(),
@@ -244,7 +244,7 @@ class DataStreamConversionTestCases(object):
         self.env.set_parallelism(1)
         t_env = StreamTableEnvironment.create(
             self.env,
-            environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())
+            environment_settings=EnvironmentSettings.in_streaming_mode())
         table = t_env.from_elements([(1, "Hi", "Hello"), (1, "Hi", "Hello")], ["a", "b", "c"])
         new_table = table.group_by("c").select("a.sum, c as b")
         ds = t_env.to_retract_stream(table=new_table, type_info=Types.ROW([Types.LONG(),

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -150,8 +150,7 @@ class PyFlinkBlinkStreamTableTestCase(PyFlinkTestCase):
 
     def setUp(self):
         super(PyFlinkBlinkStreamTableTestCase, self).setUp()
-        self.t_env = TableEnvironment.create(
-            EnvironmentSettings.new_instance().in_streaming_mode().use_blink_planner().build())
+        self.t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")
@@ -164,8 +163,7 @@ class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
 
     def setUp(self):
         super(PyFlinkBlinkBatchTableTestCase, self).setUp()
-        self.t_env = TableEnvironment.create(
-            EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build())
+        self.t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
@@ -18,7 +18,6 @@
 package org.apache.flink.client.python;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -70,13 +69,7 @@ public class PythonFunctionFactoryTest {
             out.write(code.getBytes());
         }
         StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
-        blinkTableEnv =
-                StreamTableEnvironment.create(
-                        sEnv,
-                        EnvironmentSettings.newInstance()
-                                .useBlinkPlanner()
-                                .inStreamingMode()
-                                .build());
+        blinkTableEnv = StreamTableEnvironment.create(sEnv);
         blinkTableEnv
                 .getConfig()
                 .getConfiguration()

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/RowDataPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/RowDataPythonScalarFunctionOperatorTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
@@ -84,8 +83,7 @@ public class RowDataPythonScalarFunctionOperatorTest
 
     @Override
     public StreamTableEnvironment createTableEnvironment(StreamExecutionEnvironment env) {
-        return StreamTableEnvironment.create(
-                env, EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build());
+        return StreamTableEnvironment.create(env);
     }
 
     @Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperatorTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
@@ -86,8 +85,7 @@ public class RowDataArrowPythonScalarFunctionOperatorTest
 
     @Override
     public StreamTableEnvironment createTableEnvironment(StreamExecutionEnvironment env) {
-        return StreamTableEnvironment.create(
-                env, EnvironmentSettings.newInstance().inStreamingMode().useBlinkPlanner().build());
+        return StreamTableEnvironment.create(env);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/EnvironmentSettings.java
@@ -23,8 +23,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.delegation.Executor;
 import org.apache.flink.table.delegation.Planner;
-import org.apache.flink.table.functions.ScalarFunction;
-import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.functions.UserDefinedFunction;
 
 import javax.annotation.Nullable;
 
@@ -44,15 +43,23 @@ import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_PLANNER
  *
  * <pre>{@code
  * EnvironmentSettings.newInstance()
- *   .useBlinkPlanner()
  *   .inStreamingMode()
  *   .withBuiltInCatalogName("default_catalog")
  *   .withBuiltInDatabaseName("default_database")
  *   .build()
  * }</pre>
+ *
+ * <p>{@link EnvironmentSettings#inStreamingMode()} or {@link EnvironmentSettings#inBatchMode()}
+ * might be convenient as shortcuts.
  */
 @PublicEvolving
 public class EnvironmentSettings {
+
+    private static final EnvironmentSettings DEFAULT_STREAMING_MODE_SETTINGS =
+            EnvironmentSettings.newInstance().inStreamingMode().build();
+
+    private static final EnvironmentSettings DEFAULT_BATCH_MODE_SETTINGS =
+            EnvironmentSettings.newInstance().inBatchMode().build();
 
     public static final String STREAMING_MODE = "streaming-mode";
     public static final String CLASS_NAME = "class-name";
@@ -97,11 +104,31 @@ public class EnvironmentSettings {
     }
 
     /**
-     * Creates a builder for creating an instance of {@link EnvironmentSettings}.
+     * Creates a default instance of {@link EnvironmentSettings} in streaming execution mode.
      *
-     * <p>By default, it does not specify a required planner and will use the one that is available
-     * on the classpath via discovery.
+     * <p>In this mode, both bounded and unbounded data streams can be processed.
+     *
+     * <p>This method is a shortcut for creating a {@link TableEnvironment} with little code. Use
+     * the builder provided in {@link EnvironmentSettings#newInstance()} for advanced settings.
      */
+    public static EnvironmentSettings inStreamingMode() {
+        return DEFAULT_STREAMING_MODE_SETTINGS;
+    }
+
+    /**
+     * Creates a default instance of {@link EnvironmentSettings} in batch execution mode.
+     *
+     * <p>This mode is highly optimized for batch scenarios. Only bounded data streams can be
+     * processed in this mode.
+     *
+     * <p>This method is a shortcut for creating a {@link TableEnvironment} with little code. Use
+     * the builder provided in {@link EnvironmentSettings#newInstance()} for advanced settings.
+     */
+    public static EnvironmentSettings inBatchMode() {
+        return DEFAULT_BATCH_MODE_SETTINGS;
+    }
+
+    /** Creates a builder for creating an instance of {@link EnvironmentSettings}. */
     public static Builder newInstance() {
         return new Builder();
     }
@@ -152,7 +179,7 @@ public class EnvironmentSettings {
     public Configuration toConfiguration() {
         Configuration configuration = new Configuration();
         configuration.set(RUNTIME_MODE, isStreamingMode() ? STREAMING : BATCH);
-        configuration.set(TABLE_PLANNER, isBlinkPlanner() ? PlannerType.BLINK : PlannerType.OLD);
+        configuration.set(TABLE_PLANNER, PlannerType.BLINK);
         return configuration;
     }
 
@@ -177,11 +204,16 @@ public class EnvironmentSettings {
         return isStreamingMode;
     }
 
-    /** Tells if the {@link TableEnvironment} should work in the blink planner or old planner. */
+    /**
+     * Tells if the {@link TableEnvironment} should work in the blink planner or old planner.
+     *
+     * @deprecated The old planner has been removed in Flink 1.14. Since there is only one planner
+     *     left (previously called the 'blink' planner), this method is obsolete and will be removed
+     *     in future versions.
+     */
+    @Deprecated
     public boolean isBlinkPlanner() {
-        return (this.plannerClass == null && this.executorClass == null)
-                || (Builder.BLINK_PLANNER_FACTORY.equals(this.plannerClass)
-                        && Builder.BLINK_EXECUTOR_FACTORY.equals(this.executorClass));
+        return true;
     }
 
     @Internal
@@ -210,10 +242,6 @@ public class EnvironmentSettings {
 
     /** A builder for {@link EnvironmentSettings}. */
     public static class Builder {
-        private static final String OLD_PLANNER_FACTORY =
-                "org.apache.flink.table.planner.StreamPlannerFactory";
-        private static final String OLD_EXECUTOR_FACTORY =
-                "org.apache.flink.table.executor.StreamExecutorFactory";
         private static final String BLINK_PLANNER_FACTORY =
                 "org.apache.flink.table.planner.delegation.BlinkPlannerFactory";
         private static final String BLINK_EXECUTOR_FACTORY =
@@ -226,24 +254,28 @@ public class EnvironmentSettings {
         private boolean isStreamingMode = true;
 
         /**
-         * Sets the old Flink planner as the required module. By default, {@link #useBlinkPlanner()}
-         * is enabled.
-         *
-         * @deprecated The old planner will be dropped in Flink 1.14. Please update to the new
-         *     planner (i.e. Blink planner).
+         * @deprecated The old planner has been removed in Flink 1.14. Since there is only one
+         *     planner left (previously called the 'blink' planner), this setting will throw an
+         *     exception.
          */
         @Deprecated
         public Builder useOldPlanner() {
-            this.plannerClass = OLD_PLANNER_FACTORY;
-            this.executorClass = OLD_EXECUTOR_FACTORY;
-            return this;
+            throw new TableException(
+                    "The old planner has been removed in Flink 1.14. "
+                            + "Please upgrade your table program to use the default "
+                            + "planner (previously called the 'blink' planner).");
         }
 
         /**
          * Sets the Blink planner as the required module.
          *
          * <p>This is the default behavior.
+         *
+         * @deprecated The old planner has been removed in Flink 1.14. Since there is only one
+         *     planner left (previously called the 'blink' planner), this setting is obsolete and
+         *     will be removed in future versions.
          */
+        @Deprecated
         public Builder useBlinkPlanner() {
             this.plannerClass = BLINK_PLANNER_FACTORY;
             this.executorClass = BLINK_EXECUTOR_FACTORY;
@@ -256,7 +288,12 @@ public class EnvironmentSettings {
          * <p>A planner will be discovered automatically, if there is only one planner available.
          *
          * <p>By default, {@link #useBlinkPlanner()} is enabled.
+         *
+         * @deprecated The old planner has been removed in Flink 1.14. Since there is only one
+         *     planner left (previously called the 'blink' planner), this setting is obsolete and
+         *     will be removed in future versions.
          */
+        @Deprecated
         public Builder useAnyPlanner() {
             this.plannerClass = null;
             this.executorClass = null;
@@ -277,12 +314,15 @@ public class EnvironmentSettings {
 
         /**
          * Specifies the name of the initial catalog to be created when instantiating a {@link
-         * TableEnvironment}. This catalog will be used to store all non-serializable objects such
-         * as tables and functions registered via e.g. {@link
-         * TableEnvironment#registerTableSink(String, TableSink)} or {@link
-         * TableEnvironment#registerFunction(String, ScalarFunction)}. It will also be the initial
-         * value for the current catalog which can be altered via {@link
-         * TableEnvironment#useCatalog(String)}.
+         * TableEnvironment}.
+         *
+         * <p>This catalog is an in-memory catalog that will be used to store all temporary objects
+         * (e.g. from {@link TableEnvironment#createTemporaryView(String, Table)} or {@link
+         * TableEnvironment#createTemporarySystemFunction(String, UserDefinedFunction)}) that cannot
+         * be persisted because they have no serializable representation.
+         *
+         * <p>It will also be the initial value for the current catalog which can be altered via
+         * {@link TableEnvironment#useCatalog(String)}.
          *
          * <p>Default: "default_catalog".
          */
@@ -293,12 +333,15 @@ public class EnvironmentSettings {
 
         /**
          * Specifies the name of the default database in the initial catalog to be created when
-         * instantiating a {@link TableEnvironment}. The database will be used to store all
-         * non-serializable objects such as tables and functions registered via e.g. {@link
-         * TableEnvironment#registerTableSink(String, TableSink)} or {@link
-         * TableEnvironment#registerFunction(String, ScalarFunction)}. It will also be the initial
-         * value for the current database which can be altered via {@link
-         * TableEnvironment#useDatabase(String)}.
+         * instantiating a {@link TableEnvironment}.
+         *
+         * <p>This database is an in-memory database that will be used to store all temporary
+         * objects (e.g. from {@link TableEnvironment#createTemporaryView(String, Table)} or {@link
+         * TableEnvironment#createTemporarySystemFunction(String, UserDefinedFunction)}) that cannot
+         * be persisted because they have no serializable representation.
+         *
+         * <p>It will also be the initial value for the current database which can be altered via
+         * {@link TableEnvironment#useDatabase(String)}.
          *
          * <p>Default: "default_database".
          */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlannerType.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/PlannerType.java
@@ -24,8 +24,13 @@ import org.apache.flink.table.delegation.Planner;
 /**
  * Determine the type of the {@link Planner}. Except for the optimization, the different planner
  * also differs in the time semantic and so on.
+ *
+ * @deprecated The old planner has been removed in Flink 1.14. Since there is only one planner left
+ *     (previously called the 'blink' planner), this class is obsolete and will be removed in future
+ *     versions.
  */
 @PublicEvolving
+@Deprecated
 public enum PlannerType {
     /** Blink planner is the up-to-date planner in Flink. */
     BLINK,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -36,17 +36,15 @@ public class TableConfigOptions {
     private TableConfigOptions() {}
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    @Deprecated
     public static final ConfigOption<PlannerType> TABLE_PLANNER =
             key("table.planner")
                     .enumType(PlannerType.class)
                     .defaultValue(PlannerType.BLINK)
                     .withDescription(
-                            "Use either 'blink' planner or 'old' planner. Default is blink planner. "
-                                    + "For TableEnvironment, this option is used to construct a TableEnvironment, "
-                                    + "but this option can't be changed after that. "
-                                    + "However, there is no such limitation for SQL Client. "
-                                    + "Note: The old planner will be removed in Flink 1.14, "
-                                    + "so this option will become obsolete.");
+                            "The old planner has been removed in Flink 1.14. "
+                                    + "Since there is only one planner left (previously called the 'blink' planner), "
+                                    + "this option is obsolete and will be removed in future versions.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> TABLE_DML_SYNC =

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/EnvironmentSettingsTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/EnvironmentSettingsTest.java
@@ -21,11 +21,11 @@ package org.apache.flink.table.api;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
-import static org.apache.flink.table.api.config.TableConfigOptions.TABLE_PLANNER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /** Test {@link EnvironmentSettings}. */
 public class EnvironmentSettingsTest {
@@ -34,20 +34,16 @@ public class EnvironmentSettingsTest {
     public void testFromConfiguration() {
         Configuration configuration = new Configuration();
         configuration.setString("execution.runtime-mode", "batch");
-        configuration.setString("table.planner", "old");
         EnvironmentSettings settings = EnvironmentSettings.fromConfiguration(configuration);
 
-        Assert.assertFalse("Expect old planner.", settings.isBlinkPlanner());
-        Assert.assertFalse("Expect batch mode.", settings.isStreamingMode());
+        assertFalse("Expect batch mode.", settings.isStreamingMode());
     }
 
     @Test
     public void testToConfiguration() {
-        EnvironmentSettings settings =
-                new EnvironmentSettings.Builder().useOldPlanner().inBatchMode().build();
+        EnvironmentSettings settings = new EnvironmentSettings.Builder().inBatchMode().build();
         Configuration configuration = settings.toConfiguration();
 
-        Assert.assertEquals(PlannerType.OLD, configuration.get(TABLE_PLANNER));
-        Assert.assertEquals(RuntimeExecutionMode.BATCH, configuration.get(RUNTIME_MODE));
+        assertEquals(RuntimeExecutionMode.BATCH, configuration.get(RUNTIME_MODE));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/internal/StatementSetImplTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/internal/StatementSetImplTest.java
@@ -36,9 +36,9 @@ public class StatementSetImplTest {
 
     @Before
     public void setup() {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        tableEnv = (TableEnvironmentInternal) TableEnvironment.create(settings);
+        tableEnv =
+                (TableEnvironmentInternal)
+                        TableEnvironment.create(EnvironmentSettings.inStreamingMode());
     }
 
     @Test

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/internal/TableEnvironmentInternalTest.java
@@ -98,9 +98,9 @@ public class TableEnvironmentInternalTest extends JsonPlanTestBase {
 
     @Test
     public void testBatchMode() {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        tableEnv = (TableEnvironmentInternal) TableEnvironment.create(settings);
+        tableEnv =
+                (TableEnvironmentInternal)
+                        TableEnvironment.create(EnvironmentSettings.inBatchMode());
 
         String srcTableDdl =
                 "CREATE TABLE src (\n"

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSinkTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/filesystem/FileSystemTableSinkTest.java
@@ -37,9 +37,8 @@ public class FileSystemTableSinkTest {
 
     @Test
     public void testExceptionWhenSettingParallelismWithUpdatingQuery() {
-        final EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        final TableEnvironment tEnv = TableEnvironment.create(settings);
+        final TableEnvironment tEnv =
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
 
         final String testSourceTableName = "test_source_table";
         tEnv.executeSql(buildSourceTableSql(testSourceTableName, false));
@@ -60,9 +59,8 @@ public class FileSystemTableSinkTest {
     @Test
     public void testFileSystemTableSinkWithParallelismInStreaming() {
         final int parallelism = 5;
-        final EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        final TableEnvironment tEnv = TableEnvironment.create(settings);
+        final TableEnvironment tEnv =
+                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         tEnv.getConfig()
                 .getConfiguration()
                 .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 8);
@@ -98,9 +96,7 @@ public class FileSystemTableSinkTest {
     @Test
     public void testFileSystemTableSinkWithParallelismInBatch() {
         final int parallelism = 5;
-        final EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
-        final TableEnvironment tEnv = TableEnvironment.create(settings);
+        final TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
         tEnv.getConfig()
                 .getConfiguration()
                 .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 8);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -117,11 +117,7 @@ public class DynamicTableSourceSpecSerdeTest {
         actual.setReadableConfig(serdeCtx.getConfiguration());
         TableEnvironmentImpl tableEnv =
                 (TableEnvironmentImpl)
-                        TableEnvironment.create(
-                                EnvironmentSettings.newInstance()
-                                        .inStreamingMode()
-                                        .useBlinkPlanner()
-                                        .build());
+                        TableEnvironment.create(EnvironmentSettings.inStreamingMode());
         assertNotNull(actual.getScanTableSource((PlannerBase) tableEnv.getPlanner()));
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -58,9 +58,9 @@ public abstract class JsonPlanTestBase extends AbstractTestBase {
 
     @Before
     public void setup() throws Exception {
-        EnvironmentSettings settings =
-                EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
-        tableEnv = (TableEnvironmentInternal) TableEnvironment.create(settings);
+        tableEnv =
+                (TableEnvironmentInternal)
+                        TableEnvironment.create(EnvironmentSettings.inStreamingMode());
     }
 
     @After


### PR DESCRIPTION
## What is the purpose of the change

This simplifies the creation of table environments. It updates and cleans up `EnvironmentSettings` in Java and Python. 

## Brief change log

- It deprecates the selection of a planner and disables the old planner selection.
- It makes it easy to select an execution mode.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
