### PR TITLE
[FLINK-22957][table-runtime] Rank TTL should use enableTimeToLive of state instead of timer

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
@@ -31,8 +31,6 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
-import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
-
 /**
  * A variant of {@link AppendOnlyTopNFunction} to handle first-n case.
  *
@@ -42,13 +40,11 @@ public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
 
     private static final long serialVersionUID = -889227691088906246L;
 
-    private final long minRetentionTime;
     // state stores a counter to record the occurrence of key.
     private ValueState<Integer> state;
 
     public AppendOnlyFirstNFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
             GeneratedRecordComparator sortKeyGeneratedRecordComparator,
             RowDataKeySelector sortKeySelector,
@@ -57,8 +53,7 @@ public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
             boolean generateUpdateBefore,
             boolean outputRankNumber) {
         super(
-                minRetentionTime,
-                maxRetentionTime,
+                ttlConfig,
                 inputRowType,
                 sortKeyGeneratedRecordComparator,
                 sortKeySelector,
@@ -66,7 +61,6 @@ public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
                 rankRange,
                 generateUpdateBefore,
                 outputRankNumber);
-        this.minRetentionTime = minRetentionTime;
     }
 
     @Override
@@ -74,7 +68,6 @@ public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
         super.open(configure);
         ValueStateDescriptor<Integer> stateDesc =
                 new ValueStateDescriptor<>("counterState", Types.INT);
-        StateTtlConfig ttlConfig = createTtlConfig(minRetentionTime);
         if (ttlConfig.isEnabled()) {
             stateDesc.enableTimeToLive(ttlConfig);
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunction.java
@@ -38,7 +38,7 @@ import org.apache.flink.util.Preconditions;
  */
 public class AppendOnlyFirstNFunction extends AbstractTopNFunction {
 
-    private static final long serialVersionUID = -889227691088906246L;
+    private static final long serialVersionUID = -889227691088906247L;
 
     // state stores a counter to record the occurrence of key.
     private ValueState<Integer> state;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -96,12 +96,12 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
         int lruCacheSize = Math.max(1, (int) (cacheSize / getDefaultTopNSize()));
-        kvSortedMap =
-                CacheBuilder.newBuilder()
-                        .expireAfterWrite(
-                                ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS)
-                        .maximumSize(lruCacheSize)
-                        .build();
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (ttlConfig.isEnabled()) {
+            cacheBuilder.expireAfterWrite(
+                    ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS);
+        }
+        kvSortedMap = cacheBuilder.maximumSize(lruCacheSize).build();
         LOG.info(
                 "Top{} operator is using LRU caches key-size: {}",
                 getDefaultTopNSize(),

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.configuration.Configuration;
@@ -28,8 +29,10 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.util.LRUMap;
 import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +42,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A TopN function could handle insert-only stream.
@@ -62,11 +66,10 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
     private transient TopNBuffer buffer;
 
     // the kvSortedMap stores mapping from partition key to it's buffer
-    private transient Map<RowData, TopNBuffer> kvSortedMap;
+    private transient Cache<RowData, TopNBuffer> kvSortedMap;
 
     public AppendOnlyTopNFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
             GeneratedRecordComparator sortKeyGeneratedRecordComparator,
             RowDataKeySelector sortKeySelector,
@@ -76,8 +79,7 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
             boolean outputRankNumber,
             long cacheSize) {
         super(
-                minRetentionTime,
-                maxRetentionTime,
+                ttlConfig,
                 inputRowType,
                 sortKeyGeneratedRecordComparator,
                 sortKeySelector,
@@ -90,10 +92,16 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
         this.cacheSize = cacheSize;
     }
 
+    @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
         int lruCacheSize = Math.max(1, (int) (cacheSize / getDefaultTopNSize()));
-        kvSortedMap = new LRUMap<>(lruCacheSize);
+        kvSortedMap =
+                CacheBuilder.newBuilder()
+                        .expireAfterWrite(
+                                ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS)
+                        .maximumSize(lruCacheSize)
+                        .build();
         LOG.info(
                 "Top{} operator is using LRU caches key-size: {}",
                 getDefaultTopNSize(),
@@ -102,6 +110,9 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
         ListTypeInfo<RowData> valueTypeInfo = new ListTypeInfo<>(inputRowType);
         MapStateDescriptor<RowData, List<RowData>> mapStateDescriptor =
                 new MapStateDescriptor<>("data-state-with-append", sortKeyType, valueTypeInfo);
+        if (ttlConfig.isEnabled()) {
+            mapStateDescriptor.enableTimeToLive(ttlConfig);
+        }
         dataState = getRuntimeContext().getMapState(mapStateDescriptor);
 
         // metrics
@@ -111,10 +122,6 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
     @Override
     public void processElement(RowData input, Context context, Collector<RowData> out)
             throws Exception {
-        long currentTime = context.timerService().currentProcessingTime();
-        // register state-cleanup timer
-        registerProcessingCleanupTimer(context, currentTime);
-
         initHeapStates();
         initRankEnd(input);
 
@@ -139,20 +146,10 @@ public class AppendOnlyTopNFunction extends AbstractTopNFunction {
         }
     }
 
-    @Override
-    public void onTimer(long timestamp, OnTimerContext ctx, Collector<RowData> out)
-            throws Exception {
-        if (stateCleaningEnabled) {
-            // cleanup cache
-            kvSortedMap.remove(keyContext.getCurrentKey());
-            cleanupState(dataState);
-        }
-    }
-
     private void initHeapStates() throws Exception {
         requestCount += 1;
         RowData currentKey = (RowData) keyContext.getCurrentKey();
-        buffer = kvSortedMap.get(currentKey);
+        buffer = kvSortedMap.getIfPresent(currentKey);
         if (buffer == null) {
             buffer = new TopNBuffer(sortKeyComparator, ArrayList::new);
             kvSortedMap.put(currentKey, buffer);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class AppendOnlyTopNFunction extends AbstractTopNFunction {
 
-    private static final long serialVersionUID = -4708453213104128010L;
+    private static final long serialVersionUID = -4708453213104128011L;
 
     private static final Logger LOG = LoggerFactory.getLogger(AppendOnlyTopNFunction.class);
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.rank;
 
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -80,8 +81,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
     private final ComparableRecordComparator serializableComparator;
 
     public RetractableTopNFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
             ComparableRecordComparator comparableRecordComparator,
             RowDataKeySelector sortKeySelector,
@@ -91,8 +91,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             boolean generateUpdateBefore,
             boolean outputRankNumber) {
         super(
-                minRetentionTime,
-                maxRetentionTime,
+                ttlConfig,
                 inputRowType,
                 comparableRecordComparator.getGeneratedRecordComparator(),
                 sortKeySelector,
@@ -116,6 +115,9 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
         ListTypeInfo<RowData> valueTypeInfo = new ListTypeInfo<>(inputRowType);
         MapStateDescriptor<RowData, List<RowData>> mapStateDescriptor =
                 new MapStateDescriptor<>("data-state", sortKeyType, valueTypeInfo);
+        if (ttlConfig.isEnabled()) {
+            mapStateDescriptor.enableTimeToLive(ttlConfig);
+        }
         dataState = getRuntimeContext().getMapState(mapStateDescriptor);
 
         ValueStateDescriptor<SortedMap<RowData, Long>> valueStateDescriptor =
@@ -123,15 +125,15 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
                         "sorted-map",
                         new SortedMapTypeInfo<>(
                                 sortKeyType, BasicTypeInfo.LONG_TYPE_INFO, serializableComparator));
+        if (ttlConfig.isEnabled()) {
+            valueStateDescriptor.enableTimeToLive(ttlConfig);
+        }
         treeMap = getRuntimeContext().getState(valueStateDescriptor);
     }
 
     @Override
     public void processElement(RowData input, Context ctx, Collector<RowData> out)
             throws Exception {
-        long currentTime = ctx.timerService().currentProcessingTime();
-        // register state-cleanup timer
-        registerProcessingCleanupTimer(ctx, currentTime);
         initRankEnd(input);
         SortedMap<RowData, Long> sortedMap = treeMap.value();
         if (sortedMap == null) {
@@ -218,14 +220,6 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
             }
         }
         treeMap.update(sortedMap);
-    }
-
-    @Override
-    public void onTimer(long timestamp, OnTimerContext ctx, Collector<RowData> out)
-            throws Exception {
-        if (stateCleaningEnabled) {
-            cleanupState(dataState, treeMap);
-        }
     }
 
     // ------------- ROW_NUMBER-------------------------------

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -53,7 +53,7 @@ import java.util.TreeMap;
  */
 public class RetractableTopNFunction extends AbstractTopNFunction {
 
-    private static final long serialVersionUID = 1365312180599454479L;
+    private static final long serialVersionUID = 1365312180599454480L;
 
     private static final Logger LOG = LoggerFactory.getLogger(RetractableTopNFunction.class);
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -34,8 +35,13 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.runtime.util.LRUMap;
 import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalCause;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalNotification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +54,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -76,21 +83,17 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     // a buffer stores mapping from sort key to rowKey list
     private transient TopNBuffer buffer;
 
-    // the kvSortedMap stores mapping from partition key to it's buffer
-    private transient Map<RowData, TopNBuffer> kvSortedMap;
-
     // a HashMap stores mapping from rowKey to record, a heap mirror to dataState
     private transient Map<RowData, RankRow> rowKeyMap;
 
     // the kvRowKeyMap store mapping from partitionKey to its rowKeyMap.
-    private transient LRUMap<RowData, Map<RowData, RankRow>> kvRowKeyMap;
+    private transient Cache<RowData, Tuple2<TopNBuffer, Map<RowData, RankRow>>> kvRowKeyMap;
 
     private final TypeSerializer<RowData> inputRowSer;
     private final KeySelector<RowData, RowData> rowKeySelector;
 
     public UpdatableTopNFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
             RowDataKeySelector rowKeySelector,
             GeneratedRecordComparator generatedRecordComparator,
@@ -101,8 +104,7 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
             boolean outputRankNumber,
             long cacheSize) {
         super(
-                minRetentionTime,
-                maxRetentionTime,
+                ttlConfig,
                 inputRowType,
                 generatedRecordComparator,
                 sortKeySelector,
@@ -120,9 +122,13 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
         int lruCacheSize = Math.max(1, (int) (cacheSize / getDefaultTopNSize()));
-        // make sure the cached map is in a fixed size, avoid OOM
-        kvSortedMap = new HashMap<>(lruCacheSize);
-        kvRowKeyMap = new LRUMap<>(lruCacheSize, new CacheRemovalListener());
+        kvRowKeyMap =
+                CacheBuilder.newBuilder()
+                        .expireAfterWrite(
+                                ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS)
+                        .maximumSize(lruCacheSize)
+                        .removalListener(new CacheRemovalListener())
+                        .build();
 
         LOG.info(
                 "Top{} operator is using LRU caches key-size: {}",
@@ -133,22 +139,13 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
                 new TupleTypeInfo<>(inputRowType, Types.INT);
         MapStateDescriptor<RowData, Tuple2<RowData, Integer>> mapStateDescriptor =
                 new MapStateDescriptor<>("data-state-with-update", rowKeyType, valueTypeInfo);
+        if (ttlConfig.isEnabled()) {
+            mapStateDescriptor.enableTimeToLive(ttlConfig);
+        }
         dataState = getRuntimeContext().getMapState(mapStateDescriptor);
 
         // metrics
-        registerMetric(kvSortedMap.size() * getDefaultTopNSize());
-    }
-
-    @Override
-    public void onTimer(long timestamp, OnTimerContext ctx, Collector<RowData> out)
-            throws Exception {
-        if (stateCleaningEnabled) {
-            RowData partitionKey = (RowData) keyContext.getCurrentKey();
-            // cleanup cache
-            kvRowKeyMap.remove(partitionKey);
-            kvSortedMap.remove(partitionKey);
-            cleanupState(dataState);
-        }
+        registerMetric(cacheSize);
     }
 
     @Override
@@ -159,10 +156,6 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     @Override
     public void processElement(RowData input, Context context, Collector<RowData> out)
             throws Exception {
-        long currentTime = context.timerService().currentProcessingTime();
-        // register state-cleanup timer
-        registerProcessingCleanupTimer(context, currentTime);
-
         initHeapStates();
         initRankEnd(input);
         if (outputRankNumber || hasOffset()) {
@@ -176,12 +169,10 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        Iterator<Map.Entry<RowData, Map<RowData, RankRow>>> iter =
-                kvRowKeyMap.entrySet().iterator();
-        while (iter.hasNext()) {
-            Map.Entry<RowData, Map<RowData, RankRow>> entry = iter.next();
+        for (Map.Entry<RowData, Tuple2<TopNBuffer, Map<RowData, RankRow>>> entry :
+                kvRowKeyMap.asMap().entrySet()) {
             RowData partitionKey = entry.getKey();
-            Map<RowData, RankRow> currentRowKeyMap = entry.getValue();
+            Map<RowData, RankRow> currentRowKeyMap = entry.getValue().f1;
             keyContext.setCurrentKey(partitionKey);
             flushBufferToState(currentRowKeyMap);
         }
@@ -190,13 +181,11 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     private void initHeapStates() throws Exception {
         requestCount += 1;
         RowData partitionKey = (RowData) keyContext.getCurrentKey();
-        buffer = kvSortedMap.get(partitionKey);
-        rowKeyMap = kvRowKeyMap.get(partitionKey);
-        if (buffer == null) {
+        Tuple2<TopNBuffer, Map<RowData, RankRow>> tuple2 = kvRowKeyMap.getIfPresent(partitionKey);
+        if (tuple2 == null) {
             buffer = new TopNBuffer(sortKeyComparator, LinkedHashSet::new);
             rowKeyMap = new HashMap<>();
-            kvSortedMap.put(partitionKey, buffer);
-            kvRowKeyMap.put(partitionKey, rowKeyMap);
+            kvRowKeyMap.put(partitionKey, new Tuple2<>(buffer, rowKeyMap));
 
             // restore sorted map
             Iterator<Map.Entry<RowData, Tuple2<RowData, Integer>>> iter = dataState.iterator();
@@ -213,25 +202,17 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 
                     // insert into temp sort map to preserve the record order in the same sort key
                     RowData sortKey = sortKeySelector.getKey(record);
-                    TreeMap<Integer, RowData> treeMap = tempSortedMap.get(sortKey);
-                    if (treeMap == null) {
-                        treeMap = new TreeMap<>();
-                        tempSortedMap.put(sortKey, treeMap);
-                    }
+                    TreeMap<Integer, RowData> treeMap =
+                            tempSortedMap.computeIfAbsent(sortKey, k -> new TreeMap<>());
                     treeMap.put(innerRank, rowKey);
                 }
 
                 // build sorted map from the temp map
-                Iterator<Map.Entry<RowData, TreeMap<Integer, RowData>>> tempIter =
-                        tempSortedMap.entrySet().iterator();
-                while (tempIter.hasNext()) {
-                    Map.Entry<RowData, TreeMap<Integer, RowData>> entry = tempIter.next();
+                for (Map.Entry<RowData, TreeMap<Integer, RowData>> entry :
+                        tempSortedMap.entrySet()) {
                     RowData sortKey = entry.getKey();
                     TreeMap<Integer, RowData> treeMap = entry.getValue();
-                    Iterator<Map.Entry<Integer, RowData>> treeMapIter =
-                            treeMap.entrySet().iterator();
-                    while (treeMapIter.hasNext()) {
-                        Map.Entry<Integer, RowData> treeMapEntry = treeMapIter.next();
+                    for (Map.Entry<Integer, RowData> treeMapEntry : treeMap.entrySet()) {
                         Integer innerRank = treeMapEntry.getKey();
                         RowData recordRowKey = treeMapEntry.getValue();
                         int size = buffer.put(sortKey, recordRowKey);
@@ -251,6 +232,8 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
             }
         } else {
             hitCount += 1;
+            buffer = tuple2.f0;
+            rowKeyMap = tuple2.f1;
         }
     }
 
@@ -413,9 +396,7 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
         while (iterator.hasNext()) {
             Map.Entry<RowData, Collection<RowData>> entry = iterator.next();
             Collection<RowData> rowKeys = entry.getValue();
-            Iterator<RowData> rowKeyIter = rowKeys.iterator();
-            while (rowKeyIter.hasNext()) {
-                RowData rowKey = rowKeyIter.next();
+            for (RowData rowKey : rowKeys) {
                 rowKeyMap.remove(rowKey);
                 dataState.remove(rowKey);
             }
@@ -471,9 +452,7 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     }
 
     private void flushBufferToState(Map<RowData, RankRow> curRowKeyMap) throws Exception {
-        Iterator<Map.Entry<RowData, RankRow>> iter = curRowKeyMap.entrySet().iterator();
-        while (iter.hasNext()) {
-            Map.Entry<RowData, RankRow> entry = iter.next();
+        for (Map.Entry<RowData, RankRow> entry : curRowKeyMap.entrySet()) {
             RowData key = entry.getKey();
             RankRow rankRow = entry.getValue();
             if (rankRow.dirty) {
@@ -502,17 +481,27 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     }
 
     private class CacheRemovalListener
-            implements LRUMap.RemovalListener<RowData, Map<RowData, RankRow>> {
+            implements RemovalListener<RowData, Tuple2<TopNBuffer, Map<RowData, RankRow>>> {
 
         @Override
-        public void onRemoval(Map.Entry<RowData, Map<RowData, RankRow>> eldest) {
+        public void onRemoval(
+                RemovalNotification<RowData, Tuple2<TopNBuffer, Map<RowData, RankRow>>>
+                        notification) {
+            if (notification.getCause() != RemovalCause.SIZE) {
+                // Don't flush values to state if cause is ttl expired
+                return;
+            }
+
+            RowData partitionKey = notification.getKey();
+            Tuple2<TopNBuffer, Map<RowData, RankRow>> value = notification.getValue();
+            if (partitionKey == null || value == null) {
+                return;
+            }
+
             RowData previousKey = (RowData) keyContext.getCurrentKey();
-            RowData partitionKey = eldest.getKey();
-            Map<RowData, RankRow> currentRowKeyMap = eldest.getValue();
             keyContext.setCurrentKey(partitionKey);
-            kvSortedMap.remove(partitionKey);
             try {
-                flushBufferToState(currentRowKeyMap);
+                flushBufferToState(value.f1);
             } catch (Throwable e) {
                 LOG.error("Fail to synchronize state!", e);
                 throw new RuntimeException(e);
@@ -522,7 +511,7 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
         }
     }
 
-    private class RankRow {
+    private static class RankRow {
         private final RowData row;
         private int innerRank;
         private boolean dirty;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -68,7 +68,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public class UpdatableTopNFunction extends AbstractTopNFunction implements CheckpointedFunction {
 
-    private static final long serialVersionUID = 6786508184355952780L;
+    private static final long serialVersionUID = 6786508184355952781L;
 
     private static final Logger LOG = LoggerFactory.getLogger(UpdatableTopNFunction.class);
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -122,10 +122,13 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
         int lruCacheSize = Math.max(1, (int) (cacheSize / getDefaultTopNSize()));
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (ttlConfig.isEnabled()) {
+            cacheBuilder.expireAfterWrite(
+                    ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS);
+        }
         kvRowKeyMap =
-                CacheBuilder.newBuilder()
-                        .expireAfterWrite(
-                                ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS)
+                cacheBuilder
                         .maximumSize(lruCacheSize)
                         .removalListener(new CacheRemovalListener())
                         .build();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
@@ -37,8 +37,7 @@ public class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
             boolean generateUpdateBefore,
             boolean outputRankNumber) {
         return new AppendOnlyFirstNFunction(
-                minTime.toMilliseconds(),
-                maxTime.toMilliseconds(),
+                ttlConfig,
                 inputRowType,
                 generatedSortKeyComparator,
                 sortKeySelector,

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
@@ -39,8 +39,7 @@ public class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
             boolean generateUpdateBefore,
             boolean outputRankNumber) {
         return new AppendOnlyTopNFunction(
-                minTime.toMilliseconds(),
-                maxTime.toMilliseconds(),
+                ttlConfig,
                 inputRowType,
                 generatedSortKeyComparator,
                 sortKeySelector,

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -42,8 +42,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
             boolean generateUpdateBefore,
             boolean outputRankNumber) {
         return new RetractableTopNFunction(
-                minTime.toMilliseconds(),
-                maxTime.toMilliseconds(),
+                ttlConfig,
                 inputRowType,
                 comparableRecordComparator,
                 sortKeySelector,
@@ -367,17 +366,17 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
         testHarness.open();
         // register cleanup timer with 20L
-        testHarness.setProcessingTime(0L);
+        testHarness.setStateTtlProcessingTime(0L);
         testHarness.processElement(insertRecord("book", 1L, 12));
         testHarness.processElement(insertRecord("fruit", 5L, 22));
 
         // register cleanup timer with 29L
-        testHarness.setProcessingTime(9L);
+        testHarness.setStateTtlProcessingTime(9_000_000L);
         testHarness.processElement(updateBeforeRecord("book", 1L, 12));
         testHarness.processElement(insertRecord("fruit", 4L, 11));
 
         // trigger the first cleanup timer and register cleanup timer with 4000
-        testHarness.setProcessingTime(20L);
+        testHarness.setStateTtlProcessingTime(20_000_000L);
         testHarness.processElement(insertRecord("fruit", 8L, 100));
         testHarness.processElement(insertRecord("book", 1L, 12));
         testHarness.close();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.rank;
 
-import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
@@ -34,6 +34,7 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.GenericRowRecordSortComparator;
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.runtime.util.RowDataRecordEqualiser;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -53,8 +54,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBefore
 /** Base Tests for all subclass of {@link AbstractTopNFunction}. */
 abstract class TopNFunctionTestBase {
 
-    Time minTime = Time.milliseconds(10);
-    Time maxTime = Time.milliseconds(20);
+    StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(10_000_000);
     long cacheSize = 10000L;
 
     InternalTypeInfo<RowData> inputRowType =

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -41,8 +41,7 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
             boolean generateUpdateBefore,
             boolean outputRankNumber) {
         return new UpdatableTopNFunction(
-                minTime.toMilliseconds(),
-                maxTime.toMilliseconds(),
+                ttlConfig,
                 inputRowType,
                 rowKeySelector,
                 generatedSortKeyComparator,


### PR DESCRIPTION
## What is the purpose of the change

Rank TTL should use enableTimeToLive of state instead of timer.

We should get rid of `maxIdleStateRetention`.

See https://issues.apache.org/jira/browse/FLINK-18556

## Brief change log

- Use guava LRU Cache in Rank functions for expire ttl.
- Use enableTimeToLive of state instead of timer

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no