### PR TITLE
[FLINK-22956][table-runtime] Stream Over TTL should use enableTimeToLive of state instead of timer

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/ProcTimeUnboundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/ProcTimeUnboundedPrecedingFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
@@ -25,7 +26,6 @@ import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.runtime.dataview.PerKeyStateDataViewStore;
-import org.apache.flink.table.runtime.functions.KeyedProcessFunctionWithCleanupState;
 import org.apache.flink.table.runtime.generated.AggsHandleFunction;
 import org.apache.flink.table.runtime.generated.GeneratedAggsHandleFunction;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -40,9 +40,10 @@ import org.apache.flink.util.Collector;
  * UNBOUNDED preceding AND CURRENT ROW) FROM T.
  */
 public class ProcTimeUnboundedPrecedingFunction<K>
-        extends KeyedProcessFunctionWithCleanupState<K, RowData, RowData> {
-    private static final long serialVersionUID = 1L;
+        extends KeyedProcessFunction<K, RowData, RowData> {
+    private static final long serialVersionUID = 2L;
 
+    private final StateTtlConfig ttlConfig;
     private final GeneratedAggsHandleFunction genAggsHandler;
     private final LogicalType[] accTypes;
 
@@ -51,11 +52,10 @@ public class ProcTimeUnboundedPrecedingFunction<K>
     private transient JoinedRowData output;
 
     public ProcTimeUnboundedPrecedingFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             GeneratedAggsHandleFunction genAggsHandler,
             LogicalType[] accTypes) {
-        super(minRetentionTime, maxRetentionTime);
+        this.ttlConfig = ttlConfig;
         this.genAggsHandler = genAggsHandler;
         this.accTypes = accTypes;
     }
@@ -70,9 +70,10 @@ public class ProcTimeUnboundedPrecedingFunction<K>
         InternalTypeInfo<RowData> accTypeInfo = InternalTypeInfo.ofFields(accTypes);
         ValueStateDescriptor<RowData> stateDescriptor =
                 new ValueStateDescriptor<RowData>("accState", accTypeInfo);
+        if (ttlConfig.isEnabled()) {
+            stateDescriptor.enableTimeToLive(ttlConfig);
+        }
         accState = getRuntimeContext().getState(stateDescriptor);
-
-        initCleanupTimeState("ProcTimeUnboundedOverCleanupTime");
     }
 
     @Override
@@ -81,9 +82,6 @@ public class ProcTimeUnboundedPrecedingFunction<K>
             KeyedProcessFunction<K, RowData, RowData>.Context ctx,
             Collector<RowData> out)
             throws Exception {
-        // register state-cleanup timer
-        registerProcessingCleanupTimer(ctx, ctx.timerService().currentProcessingTime());
-
         RowData accumulators = accState.value();
         if (null == accumulators) {
             accumulators = function.createAccumulators();
@@ -102,18 +100,6 @@ public class ProcTimeUnboundedPrecedingFunction<K>
         RowData aggValue = function.getValue();
         output.replace(input, aggValue);
         out.collect(output);
-    }
-
-    @Override
-    public void onTimer(
-            long timestamp,
-            KeyedProcessFunction<K, RowData, RowData>.OnTimerContext ctx,
-            Collector<RowData> out)
-            throws Exception {
-        if (stateCleaningEnabled) {
-            cleanupState(accState);
-            function.cleanup();
-        }
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedAggsHandleFunction;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -38,19 +39,12 @@ public class RowTimeRangeUnboundedPrecedingFunction<K>
     private static final long serialVersionUID = 1L;
 
     public RowTimeRangeUnboundedPrecedingFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             GeneratedAggsHandleFunction genAggsHandler,
             LogicalType[] accTypes,
             LogicalType[] inputFieldTypes,
             int rowTimeIdx) {
-        super(
-                minRetentionTime,
-                maxRetentionTime,
-                genAggsHandler,
-                accTypes,
-                inputFieldTypes,
-                rowTimeIdx);
+        super(ttlConfig, genAggsHandler, accTypes, inputFieldTypes, rowTimeIdx);
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedAggsHandleFunction;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -38,19 +39,12 @@ public class RowTimeRowsUnboundedPrecedingFunction<K>
     private static final long serialVersionUID = 1L;
 
     public RowTimeRowsUnboundedPrecedingFunction(
-            long minRetentionTime,
-            long maxRetentionTime,
+            StateTtlConfig ttlConfig,
             GeneratedAggsHandleFunction genAggsHandler,
             LogicalType[] accTypes,
             LogicalType[] inputFieldTypes,
             int rowTimeIdx) {
-        super(
-                minRetentionTime,
-                maxRetentionTime,
-                genAggsHandler,
-                accTypes,
-                inputFieldTypes,
-                rowTimeIdx);
+        super(ttlConfig, genAggsHandler, accTypes, inputFieldTypes, rowTimeIdx);
     }
 
     @Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRangeUnboundedPrecedingFunctionTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
 
 import org.junit.Test;
 
@@ -36,7 +37,11 @@ public class RowTimeRangeUnboundedPrecedingFunctionTest extends RowTimeOverWindo
     public void testLateRecordMetrics() throws Exception {
         RowTimeRangeUnboundedPrecedingFunction<RowData> function =
                 new RowTimeRangeUnboundedPrecedingFunction<>(
-                        1000, 2000, aggsHandleFunction, accTypes, inputFieldTypes, 2);
+                        StateConfigUtil.createTtlConfig(1000),
+                        aggsHandleFunction,
+                        accTypes,
+                        inputFieldTypes,
+                        2);
         KeyedProcessOperator<RowData, RowData, RowData> operator =
                 new KeyedProcessOperator<>(function);
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsBoundedPrecedingFunctionTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
 
 import org.junit.Test;
 
@@ -36,7 +37,12 @@ public class RowTimeRowsBoundedPrecedingFunctionTest extends RowTimeOverWindowTe
     public void testLateRecordMetrics() throws Exception {
         RowTimeRowsBoundedPrecedingFunction<RowData> function =
                 new RowTimeRowsBoundedPrecedingFunction<>(
-                        1000, 2000, aggsHandleFunction, accTypes, inputFieldTypes, 2000, 2);
+                        StateConfigUtil.createTtlConfig(1000),
+                        aggsHandleFunction,
+                        accTypes,
+                        inputFieldTypes,
+                        2000,
+                        2);
         KeyedProcessOperator<RowData, RowData, RowData> operator =
                 new KeyedProcessOperator<>(function);
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/over/RowTimeRowsUnboundedPrecedingFunctionTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.util.StateConfigUtil;
 
 import org.junit.Test;
 
@@ -36,7 +37,11 @@ public class RowTimeRowsUnboundedPrecedingFunctionTest extends RowTimeOverWindow
     public void testLateRecordMetrics() throws Exception {
         RowTimeRowsUnboundedPrecedingFunction<RowData> function =
                 new RowTimeRowsUnboundedPrecedingFunction<>(
-                        1000, 2000, aggsHandleFunction, accTypes, inputFieldTypes, 2);
+                        StateConfigUtil.createTtlConfig(1000),
+                        aggsHandleFunction,
+                        accTypes,
+                        inputFieldTypes,
+                        2);
         KeyedProcessOperator<RowData, RowData, RowData> operator =
                 new KeyedProcessOperator<>(function);
 


### PR DESCRIPTION
## What is the purpose of the change

Stream Over TTL should use enableTimeToLive of state instead of timer.

We should get rid of `maxIdleStateRetention`.

See https://issues.apache.org/jira/browse/FLINK-18556

## Brief change log

Use enableTimeToLive of state instead of timer

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no