### PR TITLE
[FLINK-22952][azure] Remove Ruby usage

### DIFF
--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -87,11 +87,6 @@ stages:
                 echo "##vso[task.setvariable variable=skip;]0"
               fi
             displayName: Check if PR contains docs change
-          - task: UseRubyVersion@0
-            condition: not(eq(variables['SKIP'], '1'))
-            inputs:
-              versionSpec: '= 2.4'
-              addToPath: true
           - script: ./tools/ci/docs.sh
             condition: not(eq(variables['SKIP'], '1'))
   # Special stage for nightly builds:


### PR DESCRIPTION
Since the docs have been migrated to hugo we no longer need ruby.

This PR is applicable to master and release-1.13.