### PR TITLE
[FLINK-22908][tests] Wait until cluster is started before testing shu…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
@@ -22,16 +22,20 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponent;
 import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerComponentFactory;
+import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -344,8 +348,31 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
         try (final MiniCluster miniCluster =
                 new PersistingMiniCluster(new MiniClusterConfiguration.Builder().build())) {
             miniCluster.start();
-            final JobGraph jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
+            final JobVertex vertex = new JobVertex("blockingVertex");
+            vertex.setInvokableClass(SignallingBlockingNoOpInvokable.class);
+            final JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
             miniCluster.submitJob(jobGraph);
+            SignallingBlockingNoOpInvokable.LATCH.await();
+        }
+    }
+
+    /**
+     * Invokable which signals with {@link SignallingBlockingNoOpInvokable#LATCH} when it is invoked
+     * and blocks forever afterwards.
+     */
+    public static class SignallingBlockingNoOpInvokable extends AbstractInvokable {
+
+        /** Latch used to signal an initial invocation. */
+        public static final OneShotLatch LATCH = new OneShotLatch();
+
+        public SignallingBlockingNoOpInvokable(Environment environment) {
+            super(environment);
+        }
+
+        @Override
+        public void invoke() throws Exception {
+            LATCH.trigger();
+            Thread.sleep(Long.MAX_VALUE);
         }
     }
 


### PR DESCRIPTION
…tdown

Before this commit it was possible that the minicluster shutdown
happened before the resource manager rpc endpoint was available.
This led to an rpc exception failing the test.