### PR TITLE
[hotfix] Rename Input#emitStreamStatus to processStreamStatus

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/StateBootstrapWrapperOperator.java
@@ -95,8 +95,8 @@ public final class StateBootstrapWrapperOperator<
     }
 
     @Override
-    public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-        operator.emitStreamStatus(streamStatus);
+    public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+        operator.processStreamStatus(streamStatus);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
@@ -67,8 +67,8 @@ public abstract class AbstractInput<IN, OUT> implements Input<IN> {
     }
 
     @Override
-    public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-        owner.emitStreamStatus(streamStatus, inputId);
+    public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+        owner.processStreamStatus(streamStatus, inputId);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -638,11 +638,11 @@ public abstract class AbstractStreamOperator<OUT>
         processWatermark(mark, 1);
     }
 
-    public final void emitStreamStatus(StreamStatus streamStatus) throws Exception {
+    public final void processStreamStatus(StreamStatus streamStatus) throws Exception {
         output.emitStreamStatus(streamStatus);
     }
 
-    private void emitStreamStatus(StreamStatus streamStatus, int index) throws Exception {
+    private void processStreamStatus(StreamStatus streamStatus, int index) throws Exception {
         boolean wasIdle = combinedWatermark.isIdle();
         if (combinedWatermark.updateStatus(index, streamStatus.isIdle())) {
             processWatermark(new Watermark(combinedWatermark.getCombinedWatermark()));
@@ -652,12 +652,12 @@ public abstract class AbstractStreamOperator<OUT>
         }
     }
 
-    public final void emitStreamStatus1(StreamStatus streamStatus) throws Exception {
-        emitStreamStatus(streamStatus, 0);
+    public final void processStreamStatus1(StreamStatus streamStatus) throws Exception {
+        processStreamStatus(streamStatus, 0);
     }
 
-    public final void emitStreamStatus2(StreamStatus streamStatus) throws Exception {
-        emitStreamStatus(streamStatus, 1);
+    public final void processStreamStatus2(StreamStatus streamStatus) throws Exception {
+        processStreamStatus(streamStatus, 1);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -530,7 +530,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
         }
     }
 
-    public final void emitStreamStatus(StreamStatus streamStatus, int inputId) throws Exception {
+    public final void processStreamStatus(StreamStatus streamStatus, int inputId) throws Exception {
         boolean wasIdle = combinedWatermark.isIdle();
         if (combinedWatermark.updateStatus(inputId - 1, streamStatus.isIdle())) {
             processWatermark(new Watermark(combinedWatermark.getCombinedWatermark()));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Input.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Input.java
@@ -42,6 +42,15 @@ public interface Input<IN> {
     void processWatermark(Watermark mark) throws Exception;
 
     /**
+     * Processes a {@link StreamStatus} that arrived on this input of the {@link
+     * MultipleInputStreamOperator}. This method is guaranteed to not be called concurrently with
+     * other methods of the operator.
+     *
+     * @see StreamStatus
+     */
+    void processStreamStatus(StreamStatus streamStatus) throws Exception;
+
+    /**
      * Processes a {@link LatencyMarker} that arrived on the first input of this two-input operator.
      * This method is guaranteed to not be called concurrently with other methods of the operator.
      *
@@ -50,6 +59,4 @@ public interface Input<IN> {
     void processLatencyMarker(LatencyMarker latencyMarker) throws Exception;
 
     void setKeyContextElement(StreamRecord<IN> record) throws Exception;
-
-    void emitStreamStatus(StreamStatus streamStatus) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TwoInputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TwoInputStreamOperator.java
@@ -81,7 +81,19 @@ public interface TwoInputStreamOperator<IN1, IN2, OUT> extends StreamOperator<OU
      */
     void processLatencyMarker2(LatencyMarker latencyMarker) throws Exception;
 
-    void emitStreamStatus1(StreamStatus streamStatus) throws Exception;
+    /**
+     * Processes a {@link StreamStatus} that arrived on the first input of this two-input operator.
+     * This method is guaranteed to not be called concurrently with other methods of the operator.
+     *
+     * @see org.apache.flink.streaming.runtime.streamstatus.StreamStatus
+     */
+    void processStreamStatus1(StreamStatus streamStatus) throws Exception;
 
-    void emitStreamStatus2(StreamStatus streamStatus) throws Exception;
+    /**
+     * Processes a {@link StreamStatus} that arrived on the second input of this two-input operator.
+     * This method is guaranteed to not be called concurrently with other methods of the operator.
+     *
+     * @see org.apache.flink.streaming.runtime.streamstatus.StreamStatus
+     */
+    void processStreamStatus2(StreamStatus streamStatus) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -267,7 +267,7 @@ public class StreamMultipleInputProcessorFactory {
 
         @Override
         public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-            input.emitStreamStatus(streamStatus);
+            input.processStreamStatus(streamStatus);
         }
 
         @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -264,9 +264,9 @@ public class StreamTwoInputProcessorFactory {
         @Override
         public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
             if (inputIndex == 0) {
-                operator.emitStreamStatus1(streamStatus);
+                operator.processStreamStatus1(streamStatus);
             } else {
-                operator.emitStreamStatus2(streamStatus);
+                operator.processStreamStatus2(streamStatus);
             }
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ChainingOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ChainingOutput.java
@@ -142,7 +142,7 @@ class ChainingOutput<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>>
     @Override
     public void emitStreamStatus(StreamStatus streamStatus) {
         try {
-            input.emitStreamStatus(streamStatus);
+            input.processStreamStatus(streamStatus);
         } catch (Exception e) {
             throw new ExceptionInChainedOperatorException(e);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -209,7 +209,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 
         @Override
         public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-            operator.emitStreamStatus(streamStatus);
+            operator.processStreamStatus(streamStatus);
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -494,7 +494,7 @@ public class AbstractStreamOperatorTest {
             testHarness.processWatermark1(new Watermark(1L));
             assertThat(testHarness.getOutput(), empty());
 
-            testHarness.emitStreamStatus2(StreamStatus.IDLE);
+            testHarness.processStreamStatus2(StreamStatus.IDLE);
             expectedOutput.add(new StreamRecord<>(1L));
             expectedOutput.add(new Watermark(1L));
             TestHarnessUtil.assertOutputEquals(
@@ -506,7 +506,7 @@ public class AbstractStreamOperatorTest {
             TestHarnessUtil.assertOutputEquals(
                     "Output was not correct", expectedOutput, testHarness.getOutput());
 
-            testHarness.emitStreamStatus2(StreamStatus.ACTIVE);
+            testHarness.processStreamStatus2(StreamStatus.ACTIVE);
             // the other input is active now, we should not emit the watermark
             testHarness.processWatermark1(new Watermark(4L));
             TestHarnessUtil.assertOutputEquals(
@@ -528,8 +528,8 @@ public class AbstractStreamOperatorTest {
             testHarness.setup();
             testHarness.open();
 
-            testHarness.emitStreamStatus1(StreamStatus.IDLE);
-            testHarness.emitStreamStatus2(StreamStatus.IDLE);
+            testHarness.processStreamStatus1(StreamStatus.IDLE);
+            testHarness.processStreamStatus2(StreamStatus.IDLE);
             expectedOutput.add(StreamStatus.IDLE);
             TestHarnessUtil.assertOutputEquals(
                     "Output was not correct", expectedOutput, testHarness.getOutput());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2Test.java
@@ -88,10 +88,10 @@ public class AbstractStreamOperatorV2Test extends AbstractStreamOperatorTest {
             testHarness.processWatermark(0, new Watermark(1L));
             assertThat(testHarness.getOutput(), empty());
 
-            testHarness.emitStreamStatus(1, StreamStatus.IDLE);
+            testHarness.processStreamStatus(1, StreamStatus.IDLE);
             TestHarnessUtil.assertOutputEquals(
                     "Output was not correct", expectedOutput, testHarness.getOutput());
-            testHarness.emitStreamStatus(2, StreamStatus.IDLE);
+            testHarness.processStreamStatus(2, StreamStatus.IDLE);
             expectedOutput.add(new StreamRecord<>(1L));
             expectedOutput.add(new Watermark(1L));
             TestHarnessUtil.assertOutputEquals(
@@ -103,7 +103,7 @@ public class AbstractStreamOperatorV2Test extends AbstractStreamOperatorTest {
             TestHarnessUtil.assertOutputEquals(
                     "Output was not correct", expectedOutput, testHarness.getOutput());
 
-            testHarness.emitStreamStatus(1, StreamStatus.ACTIVE);
+            testHarness.processStreamStatus(1, StreamStatus.ACTIVE);
             // the other input is active now, we should not emit the watermark
             testHarness.processWatermark(0, new Watermark(4L));
             TestHarnessUtil.assertOutputEquals(
@@ -120,11 +120,11 @@ public class AbstractStreamOperatorV2Test extends AbstractStreamOperatorTest {
             testHarness.setup();
             testHarness.open();
 
-            testHarness.emitStreamStatus(0, StreamStatus.IDLE);
-            testHarness.emitStreamStatus(1, StreamStatus.IDLE);
+            testHarness.processStreamStatus(0, StreamStatus.IDLE);
+            testHarness.processStreamStatus(1, StreamStatus.IDLE);
             TestHarnessUtil.assertOutputEquals(
                     "Output was not correct", expectedOutput, testHarness.getOutput());
-            testHarness.emitStreamStatus(2, StreamStatus.IDLE);
+            testHarness.processStreamStatus(2, StreamStatus.IDLE);
             expectedOutput.add(StreamStatus.IDLE);
             TestHarnessUtil.assertOutputEquals(
                     "Output was not correct", expectedOutput, testHarness.getOutput());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -610,7 +610,7 @@ public class SubtaskCheckpointCoordinatorTest {
         public void processLatencyMarker(LatencyMarker latencyMarker) {}
 
         @Override
-        public void emitStreamStatus(StreamStatus streamStatus) throws Exception {}
+        public void processStreamStatus(StreamStatus streamStatus) throws Exception {}
     }
 
     private static SubtaskCheckpointCoordinator coordinator(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MultiInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MultiInputStreamOperatorTestHarness.java
@@ -59,7 +59,7 @@ public class MultiInputStreamOperatorTestHarness<OUT>
         getCastedOperator().getInputs().get(idx).processWatermark(mark);
     }
 
-    public void emitStreamStatus(int idx, StreamStatus streamStatus) throws Exception {
+    public void processStreamStatus(int idx, StreamStatus streamStatus) throws Exception {
         getCastedOperator().getInputs().get(idx).processStreamStatus(streamStatus);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MultiInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MultiInputStreamOperatorTestHarness.java
@@ -60,7 +60,7 @@ public class MultiInputStreamOperatorTestHarness<OUT>
     }
 
     public void emitStreamStatus(int idx, StreamStatus streamStatus) throws Exception {
-        getCastedOperator().getInputs().get(idx).emitStreamStatus(streamStatus);
+        getCastedOperator().getInputs().get(idx).processStreamStatus(streamStatus);
     }
 
     private MultipleInputStreamOperator<OUT> getCastedOperator() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
@@ -82,11 +82,11 @@ public class TwoInputStreamOperatorTestHarness<IN1, IN2, OUT>
         twoInputOperator.processWatermark2(mark);
     }
 
-    public void emitStreamStatus1(StreamStatus streamStatus) throws Exception {
+    public void processStreamStatus1(StreamStatus streamStatus) throws Exception {
         twoInputOperator.processStreamStatus1(streamStatus);
     }
 
-    public void emitStreamStatus2(StreamStatus streamStatus) throws Exception {
+    public void processStreamStatus2(StreamStatus streamStatus) throws Exception {
         twoInputOperator.processStreamStatus2(streamStatus);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
@@ -83,10 +83,10 @@ public class TwoInputStreamOperatorTestHarness<IN1, IN2, OUT>
     }
 
     public void emitStreamStatus1(StreamStatus streamStatus) throws Exception {
-        twoInputOperator.emitStreamStatus1(streamStatus);
+        twoInputOperator.processStreamStatus1(streamStatus);
     }
 
     public void emitStreamStatus2(StreamStatus streamStatus) throws Exception {
-        twoInputOperator.emitStreamStatus2(streamStatus);
+        twoInputOperator.processStreamStatus2(streamStatus);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/FirstInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/FirstInputOfTwoInput.java
@@ -51,7 +51,7 @@ public class FirstInputOfTwoInput extends InputBase {
     }
 
     @Override
-    public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-        operator.emitStreamStatus1(streamStatus);
+    public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+        operator.processStreamStatus1(streamStatus);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
@@ -51,7 +51,7 @@ public class OneInput extends InputBase {
     }
 
     @Override
-    public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-        operator.emitStreamStatus(streamStatus);
+    public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+        operator.processStreamStatus(streamStatus);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
@@ -51,7 +51,7 @@ public class SecondInputOfTwoInput extends InputBase {
     }
 
     @Override
-    public void emitStreamStatus(StreamStatus streamStatus) throws Exception {
-        operator.emitStreamStatus2(streamStatus);
+    public void processStreamStatus(StreamStatus streamStatus) throws Exception {
+        operator.processStreamStatus2(streamStatus);
     }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingSecondInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/CopyingSecondInputOfTwoInputStreamOperatorOutput.java
@@ -57,7 +57,7 @@ public class CopyingSecondInputOfTwoInputStreamOperatorOutput extends OutputBase
     @Override
     public void emitStreamStatus(StreamStatus streamStatus) {
         try {
-            operator.emitStreamStatus2(streamStatus);
+            operator.processStreamStatus2(streamStatus);
         } catch (Exception e) {
             throw new ExceptionInMultipleInputOperatorException(e);
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/FirstInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/FirstInputOfTwoInputStreamOperatorOutput.java
@@ -53,7 +53,7 @@ public class FirstInputOfTwoInputStreamOperatorOutput extends OutputBase {
     @Override
     public void emitStreamStatus(StreamStatus streamStatus) {
         try {
-            operator.emitStreamStatus1(streamStatus);
+            operator.processStreamStatus1(streamStatus);
         } catch (Exception e) {
             throw new ExceptionInMultipleInputOperatorException(e);
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/OneInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/OneInputStreamOperatorOutput.java
@@ -52,7 +52,7 @@ public class OneInputStreamOperatorOutput extends OutputBase {
     @Override
     public void emitStreamStatus(StreamStatus streamStatus) {
         try {
-            operator.emitStreamStatus(streamStatus);
+            operator.processStreamStatus(streamStatus);
         } catch (Exception e) {
             throw new ExceptionInMultipleInputOperatorException(e);
         }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/SecondInputOfTwoInputStreamOperatorOutput.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/output/SecondInputOfTwoInputStreamOperatorOutput.java
@@ -53,7 +53,7 @@ public class SecondInputOfTwoInputStreamOperatorOutput extends OutputBase {
     @Override
     public void emitStreamStatus(StreamStatus streamStatus) {
         try {
-            operator.emitStreamStatus2(streamStatus);
+            operator.processStreamStatus2(streamStatus);
         } catch (Exception e) {
             throw new ExceptionInMultipleInputOperatorException(e);
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SortingBoundedInputITCase.java
@@ -690,7 +690,7 @@ public class SortingBoundedInputITCase extends AbstractTestBase {
         public void setKeyContextElement(StreamRecord<Tuple2<Integer, byte[]>> record) {}
 
         @Override
-        public void emitStreamStatus(StreamStatus streamStatus) throws Exception {}
+        public void processStreamStatus(StreamStatus streamStatus) throws Exception {}
     }
 
     private static class InputGenerator extends SplittableIterator<Tuple2<Integer, byte[]>> {


### PR DESCRIPTION
## What is the purpose of the change

Rename `Input#emitStreamStatus` to `processStreamStatus` to better reflect the purpose of said method.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
