### PR TITLE
[FLINK-22927][python] Fix the bug of JobStatus

### DIFF
--- a/flink-python/pyflink/common/job_client.py
+++ b/flink-python/pyflink/common/job_client.py
@@ -52,7 +52,7 @@ class JobClient(object):
 
         .. versionadded:: 1.11.0
         """
-        return CompletableFuture(self._j_job_client.getJobStatus(), JobStatus)
+        return CompletableFuture(self._j_job_client.getJobStatus(), JobStatus._from_j_job_status)
 
     def cancel(self) -> CompletableFuture:
         """

--- a/flink-python/pyflink/common/job_status.py
+++ b/flink-python/pyflink/common/job_status.py
@@ -81,9 +81,6 @@ class JobStatus(Enum):
     SUSPENDED = 8
     RECONCILING = 9
 
-    def __init__(self, j_job_status) -> None:
-        self._j_job_status = j_job_status
-
     def is_globally_terminal_state(self) -> bool:
         """
         Checks whether this state is <i>globally terminal</i>. A globally terminal job
@@ -97,7 +94,7 @@ class JobStatus(Enum):
 
         .. versionadded:: 1.11.0
         """
-        return self._j_job_status.isGloballyTerminalState()
+        return self._to_j_job_status().isGloballyTerminalState()
 
     def is_terminal_state(self) -> bool:
         """
@@ -112,7 +109,7 @@ class JobStatus(Enum):
 
         .. versionadded:: 1.11.0
         """
-        return self._j_job_status.isTerminalState()
+        return self._to_j_job_status().isTerminalState()
 
     @staticmethod
     def _from_j_job_status(j_job_status) -> 'JobStatus':

--- a/flink-python/pyflink/table/tests/test_sql.py
+++ b/flink-python/pyflink/table/tests/test_sql.py
@@ -80,6 +80,9 @@ class StreamSqlTests(PyFlinkBlinkStreamTableTestCase):
             "sinks",
             source_sink_utils.TestAppendSink(field_names, field_types))
         table_result = t_env.execute_sql("insert into sinks select * from tbl")
+        from pyflink.common.job_status import JobStatus
+        self.assertTrue(isinstance(table_result.get_job_client().get_job_status().result(),
+                                   JobStatus))
         job_execution_result = table_result.get_job_client().get_job_execution_result().result()
         self.assertIsNotNone(job_execution_result.get_job_id())
         self.assert_equals(table_result.get_table_schema().get_field_names(),

--- a/flink-python/pyflink/table/tests/test_sql.py
+++ b/flink-python/pyflink/table/tests/test_sql.py
@@ -81,8 +81,13 @@ class StreamSqlTests(PyFlinkBlinkStreamTableTestCase):
             source_sink_utils.TestAppendSink(field_names, field_types))
         table_result = t_env.execute_sql("insert into sinks select * from tbl")
         from pyflink.common.job_status import JobStatus
-        self.assertTrue(isinstance(table_result.get_job_client().get_job_status().result(),
-                                   JobStatus))
+        from py4j.protocol import Py4JJavaError
+        try:
+            self.assertTrue(isinstance(table_result.get_job_client().get_job_status().result(),
+                                       JobStatus))
+        except Py4JJavaError as e:
+            self.assertIn('MiniCluster is not yet running or has already been shut down.', str(e))
+
         job_execution_result = table_result.get_job_client().get_job_execution_result().result()
         self.assertIsNotNone(job_execution_result.get_job_id())
         self.assert_equals(table_result.get_table_schema().get_field_names(),


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of JobStatus*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_execute_sql` in `test_sql.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
