### PR TITLE
[FLINK-22878][core] Allow prefix syntax for ConfigOption.mapType

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -674,7 +674,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
             } else if (configOption.hasFallbackKeys()) {
                 // try the fallback keys
                 for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
-                    if (containsInternal(configOption.key(), canBePrefixMap)) {
+                    if (containsInternal(fallbackKey.getKey(), canBePrefixMap)) {
                         loggingFallback(fallbackKey, configOption);
                         return true;
                     }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -490,6 +490,41 @@ public class ConfigurationUtils {
         return Double.parseDouble(o.toString());
     }
 
+    // --------------------------------------------------------------------------------------------
+    //  Prefix map handling
+    // --------------------------------------------------------------------------------------------
+
+    static boolean canBePrefixMap(ConfigOption<?> configOption) {
+        // maps might span multiple entries by using a prefix key like "key.prop1", "key.prop2"
+        return configOption.getClazz() == Map.class && !configOption.isList();
+    }
+
+    static Map<String, String> convertToPropertiesPrefixed(
+            Map<String, Object> confData, String key) {
+        final String prefixKey = key + ".";
+        return confData.keySet().stream()
+                .filter(k -> k.startsWith(prefixKey))
+                .collect(
+                        Collectors.toMap(
+                                k -> k.substring(prefixKey.length()),
+                                k -> convertToString(confData.get(k))));
+    }
+
+    static boolean containsPrefixMap(Map<String, Object> confData, String key) {
+        final String prefixKey = key + ".";
+        return confData.keySet().stream().anyMatch(k -> k.startsWith(prefixKey));
+    }
+
+    static boolean removePrefixMap(Map<String, Object> confData, String key) {
+        final String prefixKey = key + ".";
+        final List<String> prefixKeys =
+                confData.keySet().stream()
+                        .filter(k -> k.startsWith(prefixKey))
+                        .collect(Collectors.toList());
+        prefixKeys.forEach(confData::remove);
+        return !prefixKeys.isEmpty();
+    }
+
     // Make sure that we cannot instantiate this class
     private ConfigurationUtils() {}
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -57,6 +57,17 @@ public class ConfigurationTest extends TestLogger {
     private static final ConfigOption<Duration> DURATION_OPTION =
             ConfigOptions.key("test-duration-key").durationType().noDefaultValue();
 
+    private static final Map<String, String> PROPERTIES_MAP = new HashMap<>();
+
+    static {
+        PROPERTIES_MAP.put("prop1", "value1");
+        PROPERTIES_MAP.put("prop2", "12");
+    }
+
+    private static final String MAP_PROPERTY_1 = MAP_OPTION.key() + ".prop1";
+
+    private static final String MAP_PROPERTY_2 = MAP_OPTION.key() + ".prop2";
+
     /** This test checks the serialization/deserialization of configuration objects. */
     @Test
     public void testConfigurationSerializationAndGetters() {
@@ -348,68 +359,71 @@ public class ConfigurationTest extends TestLogger {
     }
 
     @Test
-    public void testPrefixAndNonPrefixMap() {
-        final Map<String, String> map = new HashMap<>();
-        map.put("prop1", "value1");
-        map.put("prop2", "12");
+    public void testMapNotContained() {
+        final Configuration cfg = new Configuration();
 
-        // not contained
-        {
-            final Configuration cfg = new Configuration();
-            assertFalse(cfg.getOptional(MAP_OPTION).isPresent());
-            assertFalse(cfg.contains(MAP_OPTION));
-        }
-
-        // read with prefix
-        {
-            final Configuration cfg = new Configuration();
-            cfg.setString("test-map-key.prop1", "value1");
-            cfg.setInteger("test-map-key.prop2", 12);
-            assertEquals(cfg.get(MAP_OPTION), map);
-            assertTrue(cfg.contains(MAP_OPTION));
-        }
-
-        // read without prefix
-        {
-            final Configuration cfg = new Configuration();
-            cfg.set(MAP_OPTION, map);
-            assertEquals(cfg.get(MAP_OPTION), map);
-            assertTrue(cfg.contains(MAP_OPTION));
-        }
-
-        // read non-prefix with precedence
-        {
-            final Configuration cfg = new Configuration();
-            cfg.set(MAP_OPTION, map);
-            cfg.setString("test-map-key.prop1", "value1");
-            cfg.setInteger("test-map-key.prop2", 99999);
-            assertEquals(cfg.get(MAP_OPTION), map);
-            assertTrue(cfg.contains(MAP_OPTION));
-            assertTrue(cfg.containsKey("test-map-key.prop1"));
-        }
-
-        // overwrite prefix
-        {
-            final Configuration cfg = new Configuration();
-            cfg.setString("test-map-key.prop1", "value1");
-            cfg.setInteger("test-map-key.prop2", 99999);
-            cfg.set(MAP_OPTION, map);
-            assertEquals(cfg.get(MAP_OPTION), map);
-            assertTrue(cfg.contains(MAP_OPTION));
-            assertFalse(cfg.containsKey("test-map-key.prop1"));
-        }
-
-        // remove prefix
-        {
-            final Configuration cfg = new Configuration();
-            cfg.setString("test-map-key.prop1", "value1");
-            cfg.setInteger("test-map-key.prop2", 99999);
-            cfg.removeConfig(MAP_OPTION);
-            assertFalse(cfg.contains(MAP_OPTION));
-            assertFalse(cfg.containsKey("test-map-key.prop1"));
-            assertFalse(cfg.containsKey("test-map-key.prop2"));
-        }
+        assertFalse(cfg.getOptional(MAP_OPTION).isPresent());
+        assertFalse(cfg.contains(MAP_OPTION));
     }
+
+    @Test
+    public void testMapWithPrefix() {
+        final Configuration cfg = new Configuration();
+        cfg.setString(MAP_PROPERTY_1, "value1");
+        cfg.setInteger(MAP_PROPERTY_2, 12);
+
+        assertEquals(cfg.get(MAP_OPTION), PROPERTIES_MAP);
+        assertTrue(cfg.contains(MAP_OPTION));
+    }
+
+    @Test
+    public void testMapWithoutPrefix() {
+        final Configuration cfg = new Configuration();
+        cfg.set(MAP_OPTION, PROPERTIES_MAP);
+
+        assertEquals(cfg.get(MAP_OPTION), PROPERTIES_MAP);
+        assertTrue(cfg.contains(MAP_OPTION));
+    }
+
+    @Test
+    public void testMapNonPrefixHasPrecedence() {
+        final Configuration cfg = new Configuration();
+        cfg.set(MAP_OPTION, PROPERTIES_MAP);
+        cfg.setString(MAP_PROPERTY_1, "value1");
+        cfg.setInteger(MAP_PROPERTY_2, 99999);
+
+        assertEquals(cfg.get(MAP_OPTION), PROPERTIES_MAP);
+        assertTrue(cfg.contains(MAP_OPTION));
+        assertTrue(cfg.containsKey(MAP_PROPERTY_1));
+    }
+
+    @Test
+    public void testMapThatOverwritesPrefix() {
+        final Configuration cfg = new Configuration();
+        cfg.setString(MAP_PROPERTY_1, "value1");
+        cfg.setInteger(MAP_PROPERTY_2, 99999);
+        cfg.set(MAP_OPTION, PROPERTIES_MAP);
+
+        assertEquals(cfg.get(MAP_OPTION), PROPERTIES_MAP);
+        assertTrue(cfg.contains(MAP_OPTION));
+        assertFalse(cfg.containsKey(MAP_PROPERTY_1));
+    }
+
+    @Test
+    public void testMapRemovePrefix() {
+        final Configuration cfg = new Configuration();
+        cfg.setString(MAP_PROPERTY_1, "value1");
+        cfg.setInteger(MAP_PROPERTY_2, 99999);
+        cfg.removeConfig(MAP_OPTION);
+
+        assertFalse(cfg.contains(MAP_OPTION));
+        assertFalse(cfg.containsKey(MAP_PROPERTY_1));
+        assertFalse(cfg.containsKey(MAP_PROPERTY_2));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Test classes
+    // --------------------------------------------------------------------------------------------
 
     enum TestEnum {
         VALUE1,

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -44,6 +44,18 @@ import static org.junit.Assert.fail;
  */
 public class ConfigurationTest extends TestLogger {
 
+    private static final ConfigOption<String> STRING_OPTION =
+            ConfigOptions.key("test-string-key").noDefaultValue();
+
+    private static final ConfigOption<List<String>> LIST_STRING_OPTION =
+            ConfigOptions.key("test-list-key").stringType().asList().noDefaultValue();
+
+    private static final ConfigOption<Map<String, String>> MAP_OPTION =
+            ConfigOptions.key("test-map-key").mapType().noDefaultValue();
+
+    private static final ConfigOption<Duration> DURATION_OPTION =
+            ConfigOptions.key("test-duration-key").durationType().noDefaultValue();
+
     /** This test checks the serialization/deserialization of configuration objects. */
     @Test
     public void testConfigurationSerializationAndGetters() {
@@ -278,41 +290,35 @@ public class ConfigurationTest extends TestLogger {
 
     @Test
     public void testShouldParseValidStringToEnum() {
-        final ConfigOption<String> configOption = createStringConfigOption();
-
         final Configuration configuration = new Configuration();
-        configuration.setString(configOption.key(), TestEnum.VALUE1.toString());
+        configuration.setString(STRING_OPTION.key(), TestEnum.VALUE1.toString());
 
-        final TestEnum parsedEnumValue = configuration.getEnum(TestEnum.class, configOption);
+        final TestEnum parsedEnumValue = configuration.getEnum(TestEnum.class, STRING_OPTION);
         assertEquals(TestEnum.VALUE1, parsedEnumValue);
     }
 
     @Test
     public void testShouldParseValidStringToEnumIgnoringCase() {
-        final ConfigOption<String> configOption = createStringConfigOption();
-
         final Configuration configuration = new Configuration();
-        configuration.setString(configOption.key(), TestEnum.VALUE1.toString().toLowerCase());
+        configuration.setString(STRING_OPTION.key(), TestEnum.VALUE1.toString().toLowerCase());
 
-        final TestEnum parsedEnumValue = configuration.getEnum(TestEnum.class, configOption);
+        final TestEnum parsedEnumValue = configuration.getEnum(TestEnum.class, STRING_OPTION);
         assertEquals(TestEnum.VALUE1, parsedEnumValue);
     }
 
     @Test
     public void testThrowsExceptionIfTryingToParseInvalidStringForEnum() {
-        final ConfigOption<String> configOption = createStringConfigOption();
-
         final Configuration configuration = new Configuration();
         final String invalidValueForTestEnum = "InvalidValueForTestEnum";
-        configuration.setString(configOption.key(), invalidValueForTestEnum);
+        configuration.setString(STRING_OPTION.key(), invalidValueForTestEnum);
 
         try {
-            configuration.getEnum(TestEnum.class, configOption);
+            configuration.getEnum(TestEnum.class, STRING_OPTION);
             fail("Expected exception not thrown");
         } catch (IllegalArgumentException e) {
             final String expectedMessage =
                     "Value for config option "
-                            + configOption.key()
+                            + STRING_OPTION.key()
                             + " must be one of [VALUE1, VALUE2] (was "
                             + invalidValueForTestEnum
                             + ")";
@@ -322,45 +328,26 @@ public class ConfigurationTest extends TestLogger {
 
     @Test
     public void testToMap() {
-        final ConfigOption<List<String>> listConfigOption = createListStringConfigOption();
         final Configuration configuration = new Configuration();
         final String listValues = "value1;value2;value3";
-        configuration.set(listConfigOption, Arrays.asList(listValues.split(";")));
+        configuration.set(LIST_STRING_OPTION, Arrays.asList(listValues.split(";")));
 
-        final ConfigOption<Map<String, String>> mapConfigOption = createMapConfigOption();
         final String mapValues = "key1:value1,key2:value2";
         configuration.set(
-                mapConfigOption,
+                MAP_OPTION,
                 Arrays.stream(mapValues.split(","))
                         .collect(Collectors.toMap(e -> e.split(":")[0], e -> e.split(":")[1])));
 
-        final ConfigOption<Duration> durationConfigOption = createDurationConfigOption();
         final Duration duration = Duration.ofMillis(3000);
-        configuration.set(durationConfigOption, duration);
+        configuration.set(DURATION_OPTION, duration);
 
-        assertEquals(listValues, configuration.toMap().get(listConfigOption.key()));
-        assertEquals(mapValues, configuration.toMap().get(mapConfigOption.key()));
-        assertEquals("3 s", configuration.toMap().get(durationConfigOption.key()));
+        assertEquals(listValues, configuration.toMap().get(LIST_STRING_OPTION.key()));
+        assertEquals(mapValues, configuration.toMap().get(MAP_OPTION.key()));
+        assertEquals("3 s", configuration.toMap().get(DURATION_OPTION.key()));
     }
 
     enum TestEnum {
         VALUE1,
         VALUE2
-    }
-
-    private static ConfigOption<String> createStringConfigOption() {
-        return ConfigOptions.key("test-string-key").noDefaultValue();
-    }
-
-    private static ConfigOption<List<String>> createListStringConfigOption() {
-        return ConfigOptions.key("test-list-key").stringType().asList().noDefaultValue();
-    }
-
-    private static ConfigOption<Map<String, String>> createMapConfigOption() {
-        return ConfigOptions.key("test-map-key").mapType().noDefaultValue();
-    }
-
-    private static ConfigOption<Duration> createDurationConfigOption() {
-        return ConfigOptions.key("test-duration-key").durationType().noDefaultValue();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This adds support for prefix syntax in `ConfigOption`s of map type.

Current syntax 1:

```
value.avro-confluent.properties = schema: 1, other-prop: 2
```

Additional syntax 2:

```
value.avro-confluent.properties.schema = 1
value.avro-confluent.properties.other-prop = 2

```

Syntax 1 has precedence and is the default when calling `WritableConfig.set`.

Thus, we still advertise syntax 1 with constant key spaces.

However, esp. when working with connectors, formats, or other external systems, it is useful to forward property maps unchanged. Syntax 2 is more convenient for users that define options via strings. Syntax 2 is used already in the project by custom parsers at multiple locations and was requested multiple times by different teams. By introducing syntax 2, we simplify the code base for connector implementers.

## Brief change log

- Search for prefixes if ConfigOption has a map type
- Everything else works as before.

## Verifying this change

This change added tests and can be verified as follows: `ConfigurationTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
