### PR TITLE
[FLINK-22678] Configurations and user APIs for ChangelogStateBackend

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>state.backend.changelog.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not beenabled.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>state.backend.changelog.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not beenabled.</td>
+            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not be enabled.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -33,6 +33,12 @@
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (HashMapStateBackend, EmbeddedRocksDBStateBackend).</td>
         </tr>
         <tr>
+            <td><h5>state.backend.changelog.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not beenabled.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -36,7 +36,7 @@
             <td><h5>state.backend.changelog.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not beenabled.</td>
+            <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not be enabled.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -102,13 +102,17 @@ public class CheckpointingOptions {
 
     /** Whether to enable state change log. */
     @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
-    @Documentation.ExcludeFromDocumentation("Hidden for now")
     public static final ConfigOption<Boolean> ENABLE_STATE_CHANGE_LOG =
             ConfigOptions.key("state.backend.changelog.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Whether to enable state backend to write state changes to StateChangelog.");
+                            "Whether to enable state backend to write state changes to StateChangelog. "
+                                    + "If this config is not set explicitly, it means no preference "
+                                    + "for enabling the change log, and the value in lower config "
+                                    + "level will take effect. The default value 'false' here means "
+                                    + "if no value set (job or cluster), the change log will not be"
+                                    + "enabled.");
 
     /** The maximum number of completed checkpoints to retain. */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -111,7 +111,7 @@ public class CheckpointingOptions {
                                     + "If this config is not set explicitly, it means no preference "
                                     + "for enabling the change log, and the value in lower config "
                                     + "level will take effect. The default value 'false' here means "
-                                    + "if no value set (job or cluster), the change log will not be"
+                                    + "if no value set (job or cluster), the change log will not be "
                                     + "enabled.");
 
     /** The maximum number of completed checkpoints to retain. */

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -42,6 +42,7 @@ import org.apache.flink.state.api.output.partitioner.KeyGroupRangePartitioner;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.util.TernaryBoolean;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -214,6 +215,8 @@ public class BootstrapTransformation<T> {
         config.setOperatorName(operatorID.toHexString());
         config.setOperatorID(operatorID);
         config.setStateBackend(stateBackend);
+        // This means leaving this stateBackend unwrapped.
+        config.setChangeLogStateBackendEnabled(TernaryBoolean.FALSE);
         config.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.STATE_BACKEND, 1.0);
         return config;
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/BootstrapTransformation.java
@@ -216,7 +216,7 @@ public class BootstrapTransformation<T> {
         config.setOperatorID(operatorID);
         config.setStateBackend(stateBackend);
         // This means leaving this stateBackend unwrapped.
-        config.setChangeLogStateBackendEnabled(TernaryBoolean.FALSE);
+        config.setChangelogStateBackendEnabled(TernaryBoolean.FALSE);
         config.setManagedMemoryFractionOperatorOfUseCase(ManagedMemoryUseCase.STATE_BACKEND, 1.0);
         return config;
     }

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -49,7 +49,8 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
                 'clearJobListeners', 'getJobListeners', "fromSequence",
-                'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory'}
+                'setDefaultSavepointDirectory', 'getDefaultSavepointDirectory',
+                'enableChangelogStateBackend', 'isChangelogStateBackendEnabled'}
 
 
 if __name__ == '__main__':

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -234,7 +234,11 @@ public class DefaultExecutionGraphBuilder {
             try {
                 rootBackend =
                         StateBackendLoader.fromApplicationOrConfigOrDefault(
-                                applicationConfiguredBackend, jobManagerConfig, classLoader, log);
+                                applicationConfiguredBackend,
+                                snapshotSettings.isChangelogStateBackendEnabled(),
+                                jobManagerConfig,
+                                classLoader,
+                                log);
             } catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
                 throw new JobExecutionException(
                         jobId, "Could not instantiate configured state backend", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobCheckpointingSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/JobCheckpointingSettings.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 
 import javax.annotation.Nullable;
 
@@ -42,6 +43,9 @@ public class JobCheckpointingSettings implements Serializable {
     /** The default state backend, if configured by the user in the job */
     @Nullable private final SerializedValue<StateBackend> defaultStateBackend;
 
+    /** The enable flag for change log state backend, if configured by the user in the job */
+    private final TernaryBoolean changelogStateBackendEnabled;
+
     /** The default checkpoint storage, if configured by the user in the job */
     @Nullable private final SerializedValue<CheckpointStorage> defaultCheckpointStorage;
 
@@ -52,18 +56,23 @@ public class JobCheckpointingSettings implements Serializable {
             CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration,
             @Nullable SerializedValue<StateBackend> defaultStateBackend) {
 
-        this(checkpointCoordinatorConfiguration, defaultStateBackend, null, null);
+        this(checkpointCoordinatorConfiguration, defaultStateBackend, null, null, null);
     }
 
     public JobCheckpointingSettings(
             CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration,
             @Nullable SerializedValue<StateBackend> defaultStateBackend,
+            @Nullable TernaryBoolean changelogStateBackendEnabled,
             @Nullable SerializedValue<CheckpointStorage> defaultCheckpointStorage,
             @Nullable SerializedValue<MasterTriggerRestoreHook.Factory[]> masterHooks) {
 
         this.checkpointCoordinatorConfiguration =
                 Preconditions.checkNotNull(checkpointCoordinatorConfiguration);
         this.defaultStateBackend = defaultStateBackend;
+        this.changelogStateBackendEnabled =
+                changelogStateBackendEnabled == null
+                        ? TernaryBoolean.UNDEFINED
+                        : changelogStateBackendEnabled;
         this.defaultCheckpointStorage = defaultCheckpointStorage;
         this.masterHooks = masterHooks;
     }
@@ -77,6 +86,10 @@ public class JobCheckpointingSettings implements Serializable {
     @Nullable
     public SerializedValue<StateBackend> getDefaultStateBackend() {
         return defaultStateBackend;
+    }
+
+    public TernaryBoolean isChangelogStateBackendEnabled() {
+        return changelogStateBackendEnabled;
     }
 
     @Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.util.DynamicCodeLoadingException;
@@ -175,21 +174,16 @@ public class CheckpointStorageLoader {
                     CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDirectory.toString());
         }
 
-        // Legacy state backends always take precedence for backwards compatibility.
-        StateBackend rootStateBackend =
-                (configuredStateBackend instanceof DelegatingStateBackend)
-                        ? ((DelegatingStateBackend) configuredStateBackend)
-                                .getDelegatedStateBackend()
-                        : configuredStateBackend;
-
-        if (rootStateBackend instanceof CheckpointStorage) {
+        // Legacy state backends always take precedence
+        // for backwards compatibility.
+        if (configuredStateBackend instanceof CheckpointStorage) {
             if (logger != null) {
                 logger.info(
                         "Using legacy state backend {} as Job checkpoint storage",
-                        rootStateBackend);
+                        configuredStateBackend);
             }
 
-            return (CheckpointStorage) rootStateBackend;
+            return (CheckpointStorage) configuredStateBackend;
         } else if (fromApplication instanceof ConfigurableCheckpointStorage) {
             if (logger != null) {
                 logger.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStorageLoader.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.util.DynamicCodeLoadingException;
@@ -174,16 +175,21 @@ public class CheckpointStorageLoader {
                     CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDirectory.toString());
         }
 
-        // Legacy state backends always take precedence
-        // for backwards compatibility.
-        if (configuredStateBackend instanceof CheckpointStorage) {
+        // Legacy state backends always take precedence for backwards compatibility.
+        StateBackend rootStateBackend =
+                (configuredStateBackend instanceof DelegatingStateBackend)
+                        ? ((DelegatingStateBackend) configuredStateBackend)
+                                .getDelegatedStateBackend()
+                        : configuredStateBackend;
+
+        if (rootStateBackend instanceof CheckpointStorage) {
             if (logger != null) {
                 logger.info(
                         "Using legacy state backend {} as Job checkpoint storage",
-                        configuredStateBackend);
+                        rootStateBackend);
             }
 
-            return (CheckpointStorage) configuredStateBackend;
+            return (CheckpointStorage) rootStateBackend;
         } else if (fromApplication instanceof ConfigurableCheckpointStorage) {
             if (logger != null) {
                 logger.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -29,6 +30,7 @@ import org.apache.flink.runtime.state.hashmap.HashMapStateBackendFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackendFactory;
 import org.apache.flink.util.DynamicCodeLoadingException;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +42,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** This class contains utility methods to load state backends from configurations. */
@@ -103,7 +104,7 @@ public class StateBackendLoader {
      * @throws IOException May be thrown by the StateBackendFactory when instantiating the state
      *     backend
      */
-    private static StateBackend loadUnwrappedStateBackendFromConfig(
+    public static StateBackend loadStateBackendFromConfig(
             ReadableConfig config, ClassLoader classLoader, @Nullable Logger logger)
             throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
 
@@ -188,49 +189,6 @@ public class StateBackendLoader {
     }
 
     /**
-     * Loads the state backend from the configuration. It returns a {@code ChangelogStateBackend} if
-     * '{@code CheckpointingOptions.ENABLE_STATE_CHANGE_LOG}' is enabled; otherwise returns an
-     * unwrapped state backend created through {@link
-     * StateBackendLoader#loadUnwrappedStateBackendFromConfig}.
-     *
-     * <p>Refer to {@link StateBackendLoader#loadUnwrappedStateBackendFromConfig} for details on how
-     * an unwrapped state backend is loaded from the configuration.
-     *
-     * @param config The configuration to load the state backend from
-     * @param classLoader The class loader that should be used to load the state backend
-     * @param logger Optionally, a logger to log actions to (may be null)
-     * @return The instantiated {@code ChangelogStateBackend} if '{@code
-     *     CheckpointingOptions.ENABLE_STATE_CHANGE_LOG}' is enabled; An unwrapped state backend
-     *     otherwise
-     * @throws DynamicCodeLoadingException Thrown if a state backend factory is configured and the
-     *     factory class was not found or the factory could not be instantiated
-     * @throws IllegalConfigurationException May be thrown by the StateBackendFactory when creating
-     *     / configuring the state backend in the factory
-     * @throws IOException May be thrown by the StateBackendFactory when instantiating the state
-     *     backend
-     */
-    public static StateBackend loadStateBackendFromConfig(
-            ReadableConfig config, ClassLoader classLoader, @Nullable Logger logger)
-            throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
-
-        checkNotNull(config, "config");
-        checkNotNull(classLoader, "classLoader");
-
-        final StateBackend backend =
-                loadUnwrappedStateBackendFromConfig(config, classLoader, logger);
-
-        checkArgument(
-                !(backend instanceof DelegatingStateBackend),
-                "expecting non-delegating state backend");
-
-        if (config.get(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG) && (backend != null)) {
-            return loadChangelogStateBackend(backend, classLoader);
-        } else {
-            return backend;
-        }
-    }
-
-    /**
      * Checks if an application-defined state backend is given, and if not, loads the state backend
      * from the configuration, from the parameter 'state.backend', as defined in {@link
      * CheckpointingOptions#STATE_BACKEND}. If no state backend is configured, this instantiates the
@@ -240,8 +198,8 @@ public class StateBackendLoader {
      * ConfigurableStateBackend}, this methods calls {@link
      * ConfigurableStateBackend#configure(ReadableConfig, ClassLoader)} on the state backend.
      *
-     * <p>Refer to {@link #loadUnwrappedStateBackendFromConfig(ReadableConfig, ClassLoader, Logger)}
-     * for details on how the state backend is loaded from the configuration.
+     * <p>Refer to {@link #loadStateBackendFromConfig(ReadableConfig, ClassLoader, Logger)} for
+     * details on how the state backend is loaded from the configuration.
      *
      * @param config The configuration to load the state backend from
      * @param classLoader The class loader that should be used to load the state backend
@@ -289,8 +247,7 @@ public class StateBackendLoader {
             }
         } else {
             // (2) check if the config defines a state backend
-            final StateBackend fromConfig =
-                    loadUnwrappedStateBackendFromConfig(config, classLoader, logger);
+            final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, logger);
             if (fromConfig != null) {
                 backend = fromConfig;
             } else {
@@ -314,6 +271,8 @@ public class StateBackendLoader {
      * If delegation is not enabled, the underlying wrapped state backend is returned instead.
      *
      * @param fromApplication StateBackend defined from application
+     * @param isChangeLogStateBackendEnableFromApplication whether to enable the
+     *     ChangeLogStateBackend from application
      * @param config The configuration to load the state backend from
      * @param classLoader The class loader that should be used to load the state backend
      * @param logger Optionally, a logger to log actions to (may be null)
@@ -327,21 +286,37 @@ public class StateBackendLoader {
      */
     public static StateBackend fromApplicationOrConfigOrDefault(
             @Nullable StateBackend fromApplication,
+            TernaryBoolean isChangeLogStateBackendEnableFromApplication,
             Configuration config,
             ClassLoader classLoader,
             @Nullable Logger logger)
             throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
 
-        final StateBackend backend =
+        StateBackend rootBackend =
                 loadFromApplicationOrConfigOrDefaultInternal(
                         fromApplication, config, classLoader, logger);
 
-        if (config.get(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG)
-                && !(fromApplication instanceof DelegatingStateBackend)) {
-            return loadChangelogStateBackend(backend, classLoader);
+        // Configuration from application will override the one from env.
+        boolean enableChangeLog =
+                TernaryBoolean.TRUE.equals(isChangeLogStateBackendEnableFromApplication)
+                        || (TernaryBoolean.UNDEFINED.equals(
+                                        isChangeLogStateBackendEnableFromApplication)
+                                && config.get(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG));
+
+        StateBackend backend;
+        if (enableChangeLog) {
+            backend = loadChangelogStateBackend(rootBackend, classLoader);
+            LOG.info(
+                    "State backend loader loads {} to delegate {}",
+                    backend.getClass().getSimpleName(),
+                    rootBackend.getClass().getSimpleName());
         } else {
-            return backend;
+            backend = rootBackend;
+            LOG.info(
+                    "State backend loader loads the state backend as {}",
+                    backend.getClass().getSimpleName());
         }
+        return backend;
     }
 
     /**
@@ -368,8 +343,7 @@ public class StateBackendLoader {
 
         // (2) check if the config defines a state backend
         try {
-            final StateBackend fromConfig =
-                    loadUnwrappedStateBackendFromConfig(config, classLoader, LOG);
+            final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, LOG);
             if (fromConfig != null) {
                 return fromConfig.useManagedMemory();
             }
@@ -384,6 +358,22 @@ public class StateBackendLoader {
         return false;
     }
 
+    /**
+     * Try to unwrap a DelegatingStateBackend and get the inner delegated StateBackend. If the
+     * provided StateBackend is not a delegated StateBackend, just return itself.
+     *
+     * @param backend the provided StateBackend that may delegate another StateBackend.
+     * @return the root StateBackend W/O delegation.
+     */
+    @VisibleForTesting
+    public static StateBackend unwrapFromDelegatingStateBackend(StateBackend backend) {
+        if (backend != null && backend instanceof DelegatingStateBackend) {
+            return ((DelegatingStateBackend) backend).getDelegatedStateBackend();
+        } else {
+            return backend;
+        }
+    }
+
     private static StateBackend loadChangelogStateBackend(
             StateBackend backend, ClassLoader classLoader) throws DynamicCodeLoadingException {
 
@@ -392,7 +382,8 @@ public class StateBackendLoader {
             Constructor<? extends DelegatingStateBackend> constructor =
                     Class.forName(CHANGELOG_STATE_BACKEND, false, classLoader)
                             .asSubclass(DelegatingStateBackend.class)
-                            .getConstructor(StateBackend.class);
+                            .getDeclaredConstructor(StateBackend.class);
+            constructor.setAccessible(true);
             return constructor.newInstance(backend);
         } catch (ClassNotFoundException e) {
             throw new DynamicCodeLoadingException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -270,8 +270,8 @@ public class StateBackendLoader {
      * If delegation is not enabled, the underlying wrapped state backend is returned instead.
      *
      * @param fromApplication StateBackend defined from application
-     * @param isChangeLogStateBackendEnableFromApplication whether to enable the
-     *     ChangeLogStateBackend from application
+     * @param isChangelogStateBackendEnableFromApplication whether to enable the
+     *     ChangelogStateBackend from application
      * @param config The configuration to load the state backend from
      * @param classLoader The class loader that should be used to load the state backend
      * @param logger Optionally, a logger to log actions to (may be null)
@@ -285,7 +285,7 @@ public class StateBackendLoader {
      */
     public static StateBackend fromApplicationOrConfigOrDefault(
             @Nullable StateBackend fromApplication,
-            TernaryBoolean isChangeLogStateBackendEnableFromApplication,
+            TernaryBoolean isChangelogStateBackendEnableFromApplication,
             Configuration config,
             ClassLoader classLoader,
             @Nullable Logger logger)
@@ -297,9 +297,9 @@ public class StateBackendLoader {
 
         // Configuration from application will override the one from env.
         boolean enableChangeLog =
-                TernaryBoolean.TRUE.equals(isChangeLogStateBackendEnableFromApplication)
+                TernaryBoolean.TRUE.equals(isChangelogStateBackendEnableFromApplication)
                         || (TernaryBoolean.UNDEFINED.equals(
-                                        isChangeLogStateBackendEnableFromApplication)
+                                        isChangelogStateBackendEnableFromApplication)
                                 && config.get(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG));
 
         StateBackend backend;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -356,22 +355,6 @@ public class StateBackendLoader {
 
         // (3) use the default MemoryStateBackend
         return false;
-    }
-
-    /**
-     * Try to unwrap a DelegatingStateBackend and get the inner delegated StateBackend. If the
-     * provided StateBackend is not a delegated StateBackend, just return itself.
-     *
-     * @param backend the provided StateBackend that may delegate another StateBackend.
-     * @return the root StateBackend W/O delegation.
-     */
-    @VisibleForTesting
-    public static StateBackend unwrapFromDelegatingStateBackend(StateBackend backend) {
-        if (backend != null && backend instanceof DelegatingStateBackend) {
-            return ((DelegatingStateBackend) backend).getDelegatedStateBackend();
-        } else {
-            return backend;
-        }
     }
 
     private static StateBackend loadChangelogStateBackend(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointSettingsSerializableTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.testutils.ClassLoaderUtils;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -89,6 +90,7 @@ public class CheckpointSettingsSerializableTest extends TestLogger {
                                 0,
                                 0),
                         new SerializedValue<StateBackend>(new CustomStateBackend(outOfClassPath)),
+                        TernaryBoolean.UNDEFINED,
                         new SerializedValue<CheckpointStorage>(
                                 new CustomCheckpointStorage(outOfClassPath)),
                         serHooks);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -70,6 +70,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,7 +186,11 @@ public class SchedulerTestingUtils {
 
         jobGraph.setSnapshotSettings(
                 new JobCheckpointingSettings(
-                        config, serializedStateBackend, serializedCheckpointStorage, null));
+                        config,
+                        serializedStateBackend,
+                        TernaryBoolean.UNDEFINED,
+                        serializedCheckpointStorage,
+                        null));
     }
 
     public static Collection<ExecutionAttemptID> getAllCurrentExecutionAttempts(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -70,7 +70,7 @@ public class StateBackendLoadingTest {
     public void testInstantiateHashMapStateBackendBackendByDefault() throws Exception {
         StateBackend backend =
                 StateBackendLoader.fromApplicationOrConfigOrDefault(
-                        null, new Configuration(), cl, null);
+                        null, TernaryBoolean.UNDEFINED, new Configuration(), cl, null);
 
         assertTrue(backend instanceof HashMapStateBackend);
     }
@@ -83,7 +83,8 @@ public class StateBackendLoadingTest {
         config.setString(backendKey, "jobmanager");
 
         StateBackend backend =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        appBackend, TernaryBoolean.UNDEFINED, config, cl, null);
         assertEquals(appBackend, backend);
     }
 
@@ -173,7 +174,8 @@ public class StateBackendLoadingTest {
         config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
         StateBackend loadedBackend =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        backend, TernaryBoolean.UNDEFINED, config, cl, null);
         assertTrue(loadedBackend instanceof MemoryStateBackend);
 
         final MemoryStateBackend memBackend = (MemoryStateBackend) loadedBackend;
@@ -206,7 +208,8 @@ public class StateBackendLoadingTest {
         config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
         StateBackend loadedBackend =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        backend, TernaryBoolean.UNDEFINED, config, cl, null);
         assertTrue(loadedBackend instanceof MemoryStateBackend);
 
         final MemoryStateBackend memBackend = (MemoryStateBackend) loadedBackend;
@@ -301,7 +304,8 @@ public class StateBackendLoadingTest {
                 CheckpointingOptions.FS_WRITE_BUFFER_SIZE, 3000000); // this should not be picked up
 
         final StateBackend loadedBackend =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        backend, TernaryBoolean.UNDEFINED, config, cl, null);
         assertTrue(loadedBackend instanceof FsStateBackend);
 
         final FsStateBackend fs = (FsStateBackend) loadedBackend;
@@ -326,7 +330,8 @@ public class StateBackendLoadingTest {
         // try a value that is neither recognized as a name, nor corresponds to a class
         config.setString(backendKey, "does.not.exist");
         try {
-            StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+            StateBackendLoader.fromApplicationOrConfigOrDefault(
+                    null, TernaryBoolean.UNDEFINED, config, cl, null);
             fail("should fail with an exception");
         } catch (DynamicCodeLoadingException ignored) {
             // expected
@@ -335,7 +340,8 @@ public class StateBackendLoadingTest {
         // try a class that is not a factory
         config.setString(backendKey, java.io.File.class.getName());
         try {
-            StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+            StateBackendLoader.fromApplicationOrConfigOrDefault(
+                    null, TernaryBoolean.UNDEFINED, config, cl, null);
             fail("should fail with an exception");
         } catch (DynamicCodeLoadingException ignored) {
             // expected
@@ -344,7 +350,8 @@ public class StateBackendLoadingTest {
         // a factory that fails
         config.setString(backendKey, FailingFactory.class.getName());
         try {
-            StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+            StateBackendLoader.fromApplicationOrConfigOrDefault(
+                    null, TernaryBoolean.UNDEFINED, config, cl, null);
             fail("should fail with an exception");
         } catch (IOException ignored) {
             // expected
@@ -403,11 +410,14 @@ public class StateBackendLoadingTest {
         final MemoryStateBackend appBackend = new MemoryStateBackend();
 
         final StateBackend loaded1 =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config1, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        appBackend, TernaryBoolean.UNDEFINED, config1, cl, null);
         final StateBackend loaded2 =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(null, config1, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        null, TernaryBoolean.UNDEFINED, config1, cl, null);
         final StateBackend loaded3 =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(null, config2, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        null, TernaryBoolean.UNDEFINED, config2, cl, null);
 
         assertTrue(loaded1 instanceof MemoryStateBackend);
         assertTrue(loaded2 instanceof HashMapStateBackend);

--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -86,7 +86,13 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_2.11</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
 </project>

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -58,7 +58,14 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
 
     private final StateBackend delegatedStateBackend;
 
-    public ChangelogStateBackend(StateBackend stateBackend) {
+    /**
+     * Delegate a state backend by a ChangelogStateBackend.
+     *
+     * <p>As FLINK-22678 mentioned, we currently hide this constructor from user.
+     *
+     * @param stateBackend the delegated state backend.
+     */
+    ChangelogStateBackend(StateBackend stateBackend) {
         this.delegatedStateBackend = Preconditions.checkNotNull(stateBackend);
 
         Preconditions.checkArgument(

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -50,6 +51,7 @@ import java.util.Collection;
  * This state backend holds the working state in the underlying delegatedStateBackend, and forwards
  * state changes to State Changelog.
  */
+@Internal
 public class ChangelogStateBackend implements DelegatingStateBackend, ConfigurableStateBackend {
 
     private static final long serialVersionUID = 1000L;

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -29,12 +30,12 @@ import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
-import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -46,8 +47,13 @@ import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
-import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,6 +63,8 @@ import javax.annotation.Nonnull;
 
 import java.util.Collection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -71,12 +79,10 @@ public class ChangelogStateBackendLoadingTest {
     @Test
     public void testLoadingDefault() throws Exception {
         final StateBackend backend =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(null, config(), cl, null);
-        final CheckpointStorage storage =
-                CheckpointStorageLoader.load(null, null, backend, config(), cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        null, TernaryBoolean.UNDEFINED, config(true), cl, null);
 
-        assertDelegateStateBackend(
-                backend, HashMapStateBackend.class, storage, JobManagerCheckpointStorage.class);
+        assertDelegateStateBackend(backend, HashMapStateBackend.class);
     }
 
     @Test
@@ -85,12 +91,9 @@ public class ChangelogStateBackendLoadingTest {
         // "rocksdb" should not take effect
         final StateBackend backend =
                 StateBackendLoader.fromApplicationOrConfigOrDefault(
-                        appBackend, config("rocksdb"), cl, null);
-        final CheckpointStorage storage =
-                CheckpointStorageLoader.load(null, null, backend, config(), cl, null);
+                        appBackend, TernaryBoolean.UNDEFINED, config("rocksdb", true), cl, null);
 
-        assertDelegateStateBackend(
-                backend, MockStateBackend.class, storage, MockStateBackend.class);
+        assertDelegateStateBackend(backend, MockStateBackend.class);
         assertTrue(
                 ((MockStateBackend) (((ChangelogStateBackend) backend).getDelegatedStateBackend()))
                         .isConfigUpdated());
@@ -98,19 +101,34 @@ public class ChangelogStateBackendLoadingTest {
 
     @Test
     public void testApplicationDefinedChangelogStateBackend() throws Exception {
-        final StateBackend appBackend = new ChangelogStateBackend(new MockStateBackend());
+        final StateBackend appBackend = new MockStateBackend();
         // "rocksdb" should not take effect
         final StateBackend backend =
                 StateBackendLoader.fromApplicationOrConfigOrDefault(
-                        appBackend, config("rocksdb"), cl, null);
-        final CheckpointStorage storage =
-                CheckpointStorageLoader.load(null, null, backend, config(), cl, null);
+                        appBackend, TernaryBoolean.TRUE, config("rocksdb", false), cl, null);
 
-        assertDelegateStateBackend(
-                backend, MockStateBackend.class, storage, MockStateBackend.class);
+        assertDelegateStateBackend(backend, MockStateBackend.class);
         assertTrue(
                 ((MockStateBackend) (((ChangelogStateBackend) backend).getDelegatedStateBackend()))
                         .isConfigUpdated());
+    }
+
+    @Test
+    public void testApplicationEnableChangelogStateBackend() throws Exception {
+        final StateBackend backend =
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        null, TernaryBoolean.TRUE, config(false), cl, null);
+
+        assertDelegateStateBackend(backend, HashMapStateBackend.class);
+    }
+
+    @Test
+    public void testApplicationDisableChangelogStateBackend() throws Exception {
+        final StateBackend backend =
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        null, TernaryBoolean.FALSE, config(true), cl, null);
+
+        assertTrue(backend instanceof HashMapStateBackend);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -119,7 +137,7 @@ public class ChangelogStateBackendLoadingTest {
                 new ChangelogStateBackend(new ChangelogStateBackend(new MockStateBackend()));
 
         StateBackendLoader.fromApplicationOrConfigOrDefault(
-                appBackend, config("rocksdb"), cl, null);
+                appBackend, TernaryBoolean.UNDEFINED, config("rocksdb", true), cl, null);
     }
 
     // ----------------------------------------------------------
@@ -131,103 +149,190 @@ public class ChangelogStateBackendLoadingTest {
     //
     @Test
     public void testLoadingMemoryStateBackendFromConfig() throws Exception {
-        testLoadingStateBackend(
-                "jobmanager", MemoryStateBackend.class, MemoryStateBackend.class, true);
+        testLoadingStateBackend("jobmanager", MemoryStateBackend.class, true);
     }
 
     @Test
     public void testLoadingMemoryStateBackend() throws Exception {
-        testLoadingStateBackend(
-                "jobmanager", MemoryStateBackend.class, MemoryStateBackend.class, false);
+        testLoadingStateBackend("jobmanager", MemoryStateBackend.class, false);
     }
 
     @Test
     public void testLoadingFsStateBackendFromConfig() throws Exception {
-        testLoadingStateBackend(
-                "filesystem", HashMapStateBackend.class, JobManagerCheckpointStorage.class, true);
+        testLoadingStateBackend("filesystem", HashMapStateBackend.class, true);
     }
 
     @Test
     public void testLoadingFsStateBackend() throws Exception {
-        testLoadingStateBackend(
-                "filesystem", HashMapStateBackend.class, JobManagerCheckpointStorage.class, false);
+        testLoadingStateBackend("filesystem", HashMapStateBackend.class, false);
     }
 
     @Test
     public void testLoadingHashMapStateBackendFromConfig() throws Exception {
-        testLoadingStateBackend(
-                "hashmap", HashMapStateBackend.class, JobManagerCheckpointStorage.class, true);
+        testLoadingStateBackend("hashmap", HashMapStateBackend.class, true);
     }
 
     @Test
     public void testLoadingHashMapStateBackend() throws Exception {
-        testLoadingStateBackend(
-                "hashmap", HashMapStateBackend.class, JobManagerCheckpointStorage.class, false);
+        testLoadingStateBackend("hashmap", HashMapStateBackend.class, false);
     }
 
     @Test
     public void testLoadingRocksDBStateBackendFromConfig() throws Exception {
-        testLoadingStateBackend(
-                "rocksdb",
-                EmbeddedRocksDBStateBackend.class,
-                JobManagerCheckpointStorage.class,
-                true);
+        testLoadingStateBackend("rocksdb", EmbeddedRocksDBStateBackend.class, true);
     }
 
     @Test
     public void testLoadingRocksDBStateBackend() throws Exception {
-        testLoadingStateBackend(
-                "rocksdb",
-                EmbeddedRocksDBStateBackend.class,
-                JobManagerCheckpointStorage.class,
-                false);
+        testLoadingStateBackend("rocksdb", EmbeddedRocksDBStateBackend.class, false);
     }
 
-    private Configuration config(String stateBackend) {
-        final Configuration config = config();
+    @Test
+    public void testEnableChangelogStateBackendInStreamExecutionEnvironment() throws Exception {
+        StreamExecutionEnvironment env = getEnvironment();
+        assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+                env, TernaryBoolean.UNDEFINED, null);
+
+        // set back and force
+        env.setStateBackend(new MemoryStateBackend());
+        assertTrue(env.getStateBackend() instanceof MemoryStateBackend);
+        assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+                env, TernaryBoolean.UNDEFINED, MemoryStateBackend.class);
+        env.enableChangelogStateBackend(true);
+        assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+                env, TernaryBoolean.TRUE, MemoryStateBackend.class);
+        env.enableChangelogStateBackend(false);
+        assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+                env, TernaryBoolean.FALSE, MemoryStateBackend.class);
+
+        // enable changelog before set statebackend
+        env = getEnvironment();
+        env.enableChangelogStateBackend(true);
+        assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+                env, TernaryBoolean.TRUE, null);
+        env.setStateBackend(new MemoryStateBackend());
+        assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+                env, TernaryBoolean.TRUE, MemoryStateBackend.class);
+    }
+
+    private Configuration config(String stateBackend, boolean enableChangelogStateBackend) {
+        final Configuration config = new Configuration();
+        config.setBoolean(
+                CheckpointingOptions.ENABLE_STATE_CHANGE_LOG, enableChangelogStateBackend);
         config.setString(backendKey, stateBackend);
 
         return config;
     }
 
-    private Configuration config() {
+    private Configuration config(boolean enableChangelogStateBackend) {
         final Configuration config = new Configuration();
-        config.setBoolean(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG, true);
+        config.setBoolean(
+                CheckpointingOptions.ENABLE_STATE_CHANGE_LOG, enableChangelogStateBackend);
+
+        return config;
+    }
+
+    private Configuration config(String stateBackend) {
+        final Configuration config = new Configuration();
+        config.setString(backendKey, stateBackend);
 
         return config;
     }
 
     private void assertDelegateStateBackend(
-            StateBackend backend,
-            Class<?> delegatedStateBackendClass,
-            CheckpointStorage storage,
-            Class<?> storageClass) {
+            StateBackend backend, Class<?> delegatedStateBackendClass) {
         assertTrue(backend instanceof ChangelogStateBackend);
         assertSame(
                 ((DelegatingStateBackend) backend).getDelegatedStateBackend().getClass(),
                 delegatedStateBackendClass);
-        assertSame(storage.getClass(), storageClass);
     }
 
     private void testLoadingStateBackend(
-            String backendName,
-            Class<?> delegatedStateBackendClass,
-            Class<?> storageClass,
-            boolean configOnly)
+            String backendName, Class<?> delegatedStateBackendClass, boolean configOnly)
             throws Exception {
-        final Configuration config = config(backendName);
+        final Configuration config = config(backendName, true);
         StateBackend backend;
+        CheckpointStorage storage;
+        StateBackend appBackend = StateBackendLoader.loadStateBackendFromConfig(config, cl, null);
 
         if (configOnly) {
-            backend = StateBackendLoader.loadStateBackendFromConfig(config, cl, null);
+            backend =
+                    StateBackendLoader.fromApplicationOrConfigOrDefault(
+                            null, TernaryBoolean.UNDEFINED, config, cl, null);
         } else {
-            backend = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
+            backend =
+                    StateBackendLoader.fromApplicationOrConfigOrDefault(
+                            appBackend, TernaryBoolean.TRUE, config, cl, null);
         }
 
-        final CheckpointStorage storage =
-                CheckpointStorageLoader.load(null, null, backend, config, cl, null);
+        assertDelegateStateBackend(backend, delegatedStateBackendClass);
+    }
 
-        assertDelegateStateBackend(backend, delegatedStateBackendClass, storage, storageClass);
+    private StreamExecutionEnvironment getEnvironment() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        SourceFunction<Integer> srcFun =
+                new SourceFunction<Integer>() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public void run(SourceContext<Integer> ctx) throws Exception {}
+
+                    @Override
+                    public void cancel() {}
+                };
+
+        SingleOutputStreamOperator<Object> operator =
+                env.addSource(srcFun)
+                        .flatMap(
+                                new FlatMapFunction<Integer, Object>() {
+
+                                    private static final long serialVersionUID = 1L;
+
+                                    @Override
+                                    public void flatMap(Integer value, Collector<Object> out)
+                                            throws Exception {}
+                                });
+        operator.setParallelism(1);
+        return env;
+    }
+
+    private void assertStateBackendAndChangelogInEnvironmentAndStreamGraphAndJobGraph(
+            StreamExecutionEnvironment env,
+            TernaryBoolean isChangelogEnabled,
+            Class<?> rootStateBackendClass)
+            throws Exception {
+        assertEquals(isChangelogEnabled, env.isChangelogStateBackendEnabled());
+        if (rootStateBackendClass == null) {
+            assertNull(env.getStateBackend());
+        } else {
+            assertSame(rootStateBackendClass, env.getStateBackend().getClass());
+        }
+
+        StreamGraph streamGraph =
+                env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false);
+        assertEquals(isChangelogEnabled, streamGraph.isChangeLogStateBackendEnabled());
+        if (rootStateBackendClass == null) {
+            assertNull(streamGraph.getStateBackend());
+        } else {
+            assertSame(rootStateBackendClass, streamGraph.getStateBackend().getClass());
+        }
+        JobCheckpointingSettings checkpointingSettings =
+                streamGraph.getJobGraph().getCheckpointingSettings();
+        assertEquals(isChangelogEnabled, checkpointingSettings.isChangelogStateBackendEnabled());
+        if (rootStateBackendClass == null) {
+            assertNull(checkpointingSettings.getDefaultStateBackend());
+        } else {
+            assertSame(
+                    rootStateBackendClass,
+                    checkpointingSettings.getDefaultStateBackend().deserializeValue(cl).getClass());
+            assertSame(
+                    rootStateBackendClass,
+                    StateBackendLoader.unwrapFromDelegatingStateBackend(
+                                    checkpointingSettings
+                                            .getDefaultStateBackend()
+                                            .deserializeValue(cl))
+                            .getClass());
+        }
     }
 
     private static class MockStateBackend extends AbstractStateBackend

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
@@ -352,7 +352,7 @@ public class ChangelogStateBackendLoadingTest {
 
         StreamGraph streamGraph =
                 env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false);
-        assertEquals(isChangelogEnabled, streamGraph.isChangeLogStateBackendEnabled());
+        assertEquals(isChangelogEnabled, streamGraph.isChangelogStateBackendEnabled());
         if (rootStateBackendClass == null) {
             assertNull(streamGraph.getStateBackend());
         } else {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -133,7 +134,8 @@ public class RocksDBStateBackendFactoryTest {
                 localDir3 + ":" + localDir4); // this should not be picked up
 
         final StateBackend loadedBackend =
-                StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+                StateBackendLoader.fromApplicationOrConfigOrDefault(
+                        backend, TernaryBoolean.UNDEFINED, config, cl, null);
         assertTrue(loadedBackend instanceof EmbeddedRocksDBStateBackend);
 
         final EmbeddedRocksDBStateBackend loadedRocks = (EmbeddedRocksDBStateBackend) loadedBackend;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -48,6 +48,7 @@ import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -96,6 +97,7 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SplittableIterator;
 import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.WrappingRuntimeException;
 
 import com.esotericsoftware.kryo.Serializer;
@@ -166,6 +168,9 @@ public class StreamExecutionEnvironment {
 
     /** The state backend used for storing k/v state and state snapshots. */
     private StateBackend defaultStateBackend;
+
+    /** Whether to enable ChangelogStateBackend, default value is unset. */
+    private TernaryBoolean changelogStateBackendEnabled = TernaryBoolean.UNDEFINED;
 
     /** The default savepoint directory used by the job. */
     private Path defaultSavepointDirectory;
@@ -608,6 +613,53 @@ public class StreamExecutionEnvironment {
     }
 
     /**
+     * Enable the change log for current state backend. this changelog allows operators to persist
+     * state changes in a very fine-grained manner, as described below:
+     *
+     * <p>Stateful operators write the state changes to that log (logging the state), in addition to
+     * applying them to the state tables in RocksDB or the in-mem Hashtable.
+     *
+     * <p>An operator can acknowledge a checkpoint as soon as the changes in the log have reached
+     * the durable checkpoint storage.
+     *
+     * <p>The state tables are persisted periodically, independent of the checkpoints. We call this
+     * the materialization of the state on the checkpoint storage.
+     *
+     * <p>Once the state is materialized on checkpoint storage, the state changelog can be truncated
+     * to the corresponding point.
+     *
+     * <p>It establish a way to drastically reduce the checkpoint interval for streaming
+     * applications across state backends. For more details please check the FLIP-158.
+     *
+     * <p>If this method is not called explicitly, it means no preference for enabling the change
+     * log. Configs for change log enabling will override in different config levels
+     * (job/local/cluster).
+     *
+     * @param enabled true if enable the change log for state backend explicitly, otherwise disable
+     *     the change log.
+     * @return This StreamExecutionEnvironment itself, to allow chaining of function calls.
+     * @see #isChangelogStateBackendEnabled()
+     */
+    @PublicEvolving
+    public StreamExecutionEnvironment enableChangelogStateBackend(boolean enabled) {
+        this.changelogStateBackendEnabled = TernaryBoolean.fromBoolean(enabled);
+        return this;
+    }
+
+    /**
+     * Gets the enable status of change log for state backend.
+     *
+     * @return a {@link TernaryBoolean} for the enable status of change log for state backend. Could
+     *     be {@link TernaryBoolean#UNDEFINED} if user never specify this by calling {@link
+     *     #enableChangelogStateBackend(boolean)}.
+     * @see #enableChangelogStateBackend(boolean)
+     */
+    @PublicEvolving
+    public TernaryBoolean isChangelogStateBackendEnabled() {
+        return changelogStateBackendEnabled;
+    }
+
+    /**
      * Sets the default savepoint directory, where savepoints will be written to if no is explicitly
      * provided when triggered.
      *
@@ -851,6 +903,9 @@ public class StreamExecutionEnvironment {
         configuration
                 .getOptional(StreamPipelineOptions.TIME_CHARACTERISTIC)
                 .ifPresent(this::setStreamTimeCharacteristic);
+        configuration
+                .getOptional(CheckpointingOptions.ENABLE_STATE_CHANGE_LOG)
+                .ifPresent(this::enableChangelogStateBackend);
         Optional.ofNullable(loadStateBackend(configuration, classLoader))
                 .ifPresent(this::setStateBackend);
         configuration
@@ -2025,6 +2080,7 @@ public class StreamExecutionEnvironment {
         return new StreamGraphGenerator(transformations, config, checkpointCfg, getConfiguration())
                 .setRuntimeExecutionMode(executionMode)
                 .setStateBackend(defaultStateBackend)
+                .setChangeLogStateBackendEnabled(changelogStateBackendEnabled)
                 .setSavepointDir(defaultSavepointDirectory)
                 .setChaining(isChainingEnabled)
                 .setUserArtifacts(cacheFile)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -2082,7 +2082,7 @@ public class StreamExecutionEnvironment {
         return new StreamGraphGenerator(transformations, config, checkpointCfg, getConfiguration())
                 .setRuntimeExecutionMode(executionMode)
                 .setStateBackend(defaultStateBackend)
-                .setChangeLogStateBackendEnabled(changelogStateBackendEnabled)
+                .setChangelogStateBackendEnabled(changelogStateBackendEnabled)
                 .setSavepointDir(defaultSavepointDirectory)
                 .setChaining(isChainingEnabled)
                 .setUserArtifacts(cacheFile)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -613,8 +613,10 @@ public class StreamExecutionEnvironment {
     }
 
     /**
-     * Enable the change log for current state backend. this changelog allows operators to persist
-     * state changes in a very fine-grained manner, as described below:
+     * Enable the change log for current state backend. This change log allows operators to persist
+     * state changes in a very fine-grained manner. Currently, the change log only applies to keyed
+     * state, so non-keyed operator state and channel state are persisted as usual. The 'state' here
+     * refers to 'keyed state'. Details are as follows:
      *
      * <p>Stateful operators write the state changes to that log (logging the state), in addition to
      * applying them to the state tables in RocksDB or the in-mem Hashtable.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -43,6 +43,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamTaskException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TernaryBoolean;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -100,6 +101,7 @@ public class StreamConfig implements Serializable {
     private static final String SAVEPOINT_DIR = "savepointdir";
     private static final String CHECKPOINT_STORAGE = "checkpointstorage";
     private static final String STATE_BACKEND = "statebackend";
+    private static final String ENABLE_CHANGE_LOG_STATE_BACKEND = "enablechangelog";
     private static final String TIMER_SERVICE_PROVIDER = "timerservice";
     private static final String STATE_PARTITIONER = "statePartitioner";
 
@@ -553,6 +555,16 @@ public class StreamConfig implements Serializable {
         }
     }
 
+    public void setChangeLogStateBackendEnabled(TernaryBoolean enabled) {
+        try {
+            InstantiationUtil.writeObjectToConfig(
+                    enabled, this.config, ENABLE_CHANGE_LOG_STATE_BACKEND);
+        } catch (Exception e) {
+            throw new StreamTaskException(
+                    "Could not serialize change log state backend enable flag.", e);
+        }
+    }
+
     @VisibleForTesting
     public void setStateBackendUsesManagedMemory(boolean usesManagedMemory) {
         this.config.setBoolean(STATE_BACKEND_USE_MANAGED_MEMORY, usesManagedMemory);
@@ -563,6 +575,16 @@ public class StreamConfig implements Serializable {
             return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);
         } catch (Exception e) {
             throw new StreamTaskException("Could not instantiate statehandle provider.", e);
+        }
+    }
+
+    public TernaryBoolean isChangeLogStateBackendEnabled(ClassLoader cl) {
+        try {
+            return InstantiationUtil.readObjectFromConfig(
+                    this.config, ENABLE_CHANGE_LOG_STATE_BACKEND, cl);
+        } catch (Exception e) {
+            throw new StreamTaskException(
+                    "Could not instantiate change log state backend enable flag.", e);
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -555,7 +555,7 @@ public class StreamConfig implements Serializable {
         }
     }
 
-    public void setChangeLogStateBackendEnabled(TernaryBoolean enabled) {
+    public void setChangelogStateBackendEnabled(TernaryBoolean enabled) {
         try {
             InstantiationUtil.writeObjectToConfig(
                     enabled, this.config, ENABLE_CHANGE_LOG_STATE_BACKEND);
@@ -578,7 +578,7 @@ public class StreamConfig implements Serializable {
         }
     }
 
-    public TernaryBoolean isChangeLogStateBackendEnabled(ClassLoader cl) {
+    public TernaryBoolean isChangelogStateBackendEnabled(ClassLoader cl) {
         try {
             return InstantiationUtil.readObjectFromConfig(
                     this.config, ENABLE_CHANGE_LOG_STATE_BACKEND, cl);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -59,6 +59,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamIterationHead;
 import org.apache.flink.streaming.runtime.tasks.StreamIterationTail;
 import org.apache.flink.streaming.runtime.tasks.TwoInputStreamTask;
 import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,6 +118,7 @@ public class StreamGraph implements Pipeline {
     protected Map<Integer, String> vertexIDtoBrokerID;
     protected Map<Integer, Long> vertexIDtoLoopTimeout;
     private StateBackend stateBackend;
+    private TernaryBoolean changeLogStateBackendEnabled;
     private CheckpointStorage checkpointStorage;
     private Path savepointDir;
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
@@ -183,6 +185,14 @@ public class StreamGraph implements Pipeline {
 
     public StateBackend getStateBackend() {
         return this.stateBackend;
+    }
+
+    public void setChangeLogStateBackendEnabled(TernaryBoolean changeLogStateBackendEnabled) {
+        this.changeLogStateBackendEnabled = changeLogStateBackendEnabled;
+    }
+
+    public TernaryBoolean isChangeLogStateBackendEnabled() {
+        return changeLogStateBackendEnabled;
     }
 
     public void setCheckpointStorage(CheckpointStorage checkpointStorage) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -118,7 +118,7 @@ public class StreamGraph implements Pipeline {
     protected Map<Integer, String> vertexIDtoBrokerID;
     protected Map<Integer, Long> vertexIDtoLoopTimeout;
     private StateBackend stateBackend;
-    private TernaryBoolean changeLogStateBackendEnabled;
+    private TernaryBoolean changelogStateBackendEnabled;
     private CheckpointStorage checkpointStorage;
     private Path savepointDir;
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
@@ -187,12 +187,12 @@ public class StreamGraph implements Pipeline {
         return this.stateBackend;
     }
 
-    public void setChangeLogStateBackendEnabled(TernaryBoolean changeLogStateBackendEnabled) {
-        this.changeLogStateBackendEnabled = changeLogStateBackendEnabled;
+    public void setChangelogStateBackendEnabled(TernaryBoolean changelogStateBackendEnabled) {
+        this.changelogStateBackendEnabled = changelogStateBackendEnabled;
     }
 
-    public TernaryBoolean isChangeLogStateBackendEnabled() {
-        return changeLogStateBackendEnabled;
+    public TernaryBoolean isChangelogStateBackendEnabled() {
+        return changelogStateBackendEnabled;
     }
 
     public void setCheckpointStorage(CheckpointStorage checkpointStorage) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -74,6 +74,7 @@ import org.apache.flink.streaming.runtime.translators.SourceTransformationTransl
 import org.apache.flink.streaming.runtime.translators.TimestampsAndWatermarksTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.TwoInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.UnionTransformationTranslator;
+import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,6 +147,8 @@ public class StreamGraphGenerator {
     private Path savepointDir;
 
     private StateBackend stateBackend;
+
+    private TernaryBoolean changeLogStateBackendEnabled;
 
     private CheckpointStorage checkpointStorage;
 
@@ -245,6 +248,12 @@ public class StreamGraphGenerator {
 
     public StreamGraphGenerator setStateBackend(StateBackend stateBackend) {
         this.stateBackend = stateBackend;
+        return this;
+    }
+
+    public StreamGraphGenerator setChangeLogStateBackendEnabled(
+            TernaryBoolean changeLogStateBackendEnabled) {
+        this.changeLogStateBackendEnabled = changeLogStateBackendEnabled;
         return this;
     }
 
@@ -348,6 +357,7 @@ public class StreamGraphGenerator {
             setBatchStateBackendAndTimerService(graph);
         } else {
             graph.setStateBackend(stateBackend);
+            graph.setChangeLogStateBackendEnabled(changeLogStateBackendEnabled);
             graph.setCheckpointStorage(checkpointStorage);
             graph.setSavepointDirectory(savepointDir);
 
@@ -377,10 +387,12 @@ public class StreamGraphGenerator {
         if (useStateBackend) {
             LOG.debug("Using BATCH execution state backend and timer service.");
             graph.setStateBackend(new BatchExecutionStateBackend());
+            graph.setChangeLogStateBackendEnabled(TernaryBoolean.FALSE);
             graph.setCheckpointStorage(new BatchExecutionCheckpointStorage());
             graph.setTimerServiceProvider(BatchExecutionInternalTimeServiceManager::create);
         } else {
             graph.setStateBackend(stateBackend);
+            graph.setChangeLogStateBackendEnabled(changeLogStateBackendEnabled);
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -148,7 +148,7 @@ public class StreamGraphGenerator {
 
     private StateBackend stateBackend;
 
-    private TernaryBoolean changeLogStateBackendEnabled;
+    private TernaryBoolean changelogStateBackendEnabled;
 
     private CheckpointStorage checkpointStorage;
 
@@ -251,9 +251,9 @@ public class StreamGraphGenerator {
         return this;
     }
 
-    public StreamGraphGenerator setChangeLogStateBackendEnabled(
-            TernaryBoolean changeLogStateBackendEnabled) {
-        this.changeLogStateBackendEnabled = changeLogStateBackendEnabled;
+    public StreamGraphGenerator setChangelogStateBackendEnabled(
+            TernaryBoolean changelogStateBackendEnabled) {
+        this.changelogStateBackendEnabled = changelogStateBackendEnabled;
         return this;
     }
 
@@ -357,7 +357,7 @@ public class StreamGraphGenerator {
             setBatchStateBackendAndTimerService(graph);
         } else {
             graph.setStateBackend(stateBackend);
-            graph.setChangeLogStateBackendEnabled(changeLogStateBackendEnabled);
+            graph.setChangelogStateBackendEnabled(changelogStateBackendEnabled);
             graph.setCheckpointStorage(checkpointStorage);
             graph.setSavepointDirectory(savepointDir);
 
@@ -387,12 +387,12 @@ public class StreamGraphGenerator {
         if (useStateBackend) {
             LOG.debug("Using BATCH execution state backend and timer service.");
             graph.setStateBackend(new BatchExecutionStateBackend());
-            graph.setChangeLogStateBackendEnabled(TernaryBoolean.FALSE);
+            graph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE);
             graph.setCheckpointStorage(new BatchExecutionCheckpointStorage());
             graph.setTimerServiceProvider(BatchExecutionInternalTimeServiceManager::create);
         } else {
             graph.setStateBackend(stateBackend);
-            graph.setChangeLogStateBackendEnabled(changeLogStateBackendEnabled);
+            graph.setChangelogStateBackendEnabled(changelogStateBackendEnabled);
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -720,6 +720,7 @@ public class StreamingJobGraphGenerator {
         final CheckpointConfig checkpointCfg = streamGraph.getCheckpointConfig();
 
         config.setStateBackend(streamGraph.getStateBackend());
+        config.setChangeLogStateBackendEnabled(streamGraph.isChangeLogStateBackendEnabled());
         config.setCheckpointStorage(streamGraph.getCheckpointStorage());
         config.setSavepointDir(streamGraph.getSavepointDirectory());
         config.setGraphContainingLoops(streamGraph.isIterative());
@@ -1317,6 +1318,7 @@ public class StreamingJobGraphGenerator {
                                 .setAlignmentTimeout(cfg.getAlignmentTimeout().toMillis())
                                 .build(),
                         serializedStateBackend,
+                        streamGraph.isChangeLogStateBackendEnabled(),
                         serializedCheckpointStorage,
                         serializedHooks);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -720,7 +720,7 @@ public class StreamingJobGraphGenerator {
         final CheckpointConfig checkpointCfg = streamGraph.getCheckpointConfig();
 
         config.setStateBackend(streamGraph.getStateBackend());
-        config.setChangeLogStateBackendEnabled(streamGraph.isChangeLogStateBackendEnabled());
+        config.setChangelogStateBackendEnabled(streamGraph.isChangelogStateBackendEnabled());
         config.setCheckpointStorage(streamGraph.getCheckpointStorage());
         config.setSavepointDir(streamGraph.getSavepointDirectory());
         config.setGraphContainingLoops(streamGraph.isIterative());
@@ -1318,7 +1318,7 @@ public class StreamingJobGraphGenerator {
                                 .setAlignmentTimeout(cfg.getAlignmentTimeout().toMillis())
                                 .build(),
                         serializedStateBackend,
-                        streamGraph.isChangeLogStateBackendEnabled(),
+                        streamGraph.isChangelogStateBackendEnabled(),
                         serializedCheckpointStorage,
                         serializedHooks);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -88,6 +88,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
@@ -1213,9 +1214,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     private StateBackend createStateBackend() throws Exception {
         final StateBackend fromApplication =
                 configuration.getStateBackend(getUserCodeClassLoader());
+        final TernaryBoolean isChangeLogStateBackendEnableFromApplication =
+                configuration.isChangeLogStateBackendEnabled(getUserCodeClassLoader());
 
         return StateBackendLoader.fromApplicationOrConfigOrDefault(
                 fromApplication,
+                isChangeLogStateBackendEnableFromApplication == null
+                        ? TernaryBoolean.UNDEFINED
+                        : isChangeLogStateBackendEnableFromApplication,
                 getEnvironment().getTaskManagerInfo().getConfiguration(),
                 getUserCodeClassLoader(),
                 LOG);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1214,14 +1214,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
     private StateBackend createStateBackend() throws Exception {
         final StateBackend fromApplication =
                 configuration.getStateBackend(getUserCodeClassLoader());
-        final TernaryBoolean isChangeLogStateBackendEnableFromApplication =
-                configuration.isChangeLogStateBackendEnabled(getUserCodeClassLoader());
+        final TernaryBoolean isChangelogStateBackendEnableFromApplication =
+                configuration.isChangelogStateBackendEnabled(getUserCodeClassLoader());
 
         return StateBackendLoader.fromApplicationOrConfigOrDefault(
                 fromApplication,
-                isChangeLogStateBackendEnableFromApplication == null
+                isChangelogStateBackendEnableFromApplication == null
                         ? TernaryBoolean.UNDEFINED
-                        : isChangeLogStateBackendEnableFromApplication,
+                        : isChangelogStateBackendEnableFromApplication,
                 getEnvironment().getTaskManagerInfo().getConfiguration(),
                 getUserCodeClassLoader(),
                 LOG);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.util.TernaryBoolean;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static org.apache.flink.configuration.CheckpointingOptions.ENABLE_STATE_CHANGE_LOG;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -137,6 +139,29 @@ public class StreamExecutionEnvironmentComplexConfigurationTest {
 
         StateBackend actualStateBackend = envFromConfiguration.getStateBackend();
         assertThat(actualStateBackend, instanceOf(MemoryStateBackend.class));
+    }
+
+    @Test
+    public void testOverridingChangelogStateBackendWithFromConfigurationWhenSet() {
+        StreamExecutionEnvironment envFromConfiguration =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        assertEquals(
+                TernaryBoolean.UNDEFINED, envFromConfiguration.isChangelogStateBackendEnabled());
+
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(ENABLE_STATE_CHANGE_LOG, true);
+        envFromConfiguration.configure(
+                configuration, Thread.currentThread().getContextClassLoader());
+        assertEquals(TernaryBoolean.TRUE, envFromConfiguration.isChangelogStateBackendEnabled());
+
+        envFromConfiguration.configure(
+                configuration, Thread.currentThread().getContextClassLoader());
+        assertEquals(TernaryBoolean.TRUE, envFromConfiguration.isChangelogStateBackendEnabled());
+
+        configuration.setBoolean(ENABLE_STATE_CHANGE_LOG, false);
+        envFromConfiguration.configure(
+                configuration, Thread.currentThread().getContextClassLoader());
+        assertEquals(TernaryBoolean.FALSE, envFromConfiguration.isChangelogStateBackendEnabled());
     }
 
     @Test

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.scala
 
 import java.net.URI
-
 import com.esotericsoftware.kryo.Serializer
 import org.apache.flink.annotation.{Experimental, Internal, Public, PublicEvolving}
 import org.apache.flink.api.common.RuntimeExecutionMode
@@ -40,7 +39,7 @@ import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment =>
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.streaming.api.functions.source._
 import org.apache.flink.streaming.api.{CheckpointingMode, TimeCharacteristic}
-import org.apache.flink.util.SplittableIterator
+import org.apache.flink.util.{SplittableIterator, TernaryBoolean}
 
 import _root_.scala.language.implicitConversions
 import scala.collection.JavaConverters._
@@ -293,6 +292,49 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   @PublicEvolving
   def getStateBackend: StateBackend = javaEnv.getStateBackend()
+
+  /**
+   * Enable the change log for current state backend. this changelog allows operators to persist
+   * state changes in a very fine-grained manner, as described below:
+   *
+   * Stateful operators write the state changes to that log (logging the state), in addition to
+   * applying them to the state tables in RocksDB or the in-mem Hashtable.
+   *
+   * An operator can acknowledge a checkpoint as soon as the changes in the log have reached
+   * the durable checkpoint storage.
+   *
+   * The state tables are persisted periodically, independent of the checkpoints. We call this
+   * the materialization of the state on the checkpoint storage.
+   *
+   * Once the state is materialized on checkpoint storage, the state changelog can be truncated
+   * to the corresponding point.
+   *
+   * It establish a way to drastically reduce the checkpoint interval for streaming
+   * applications across state backends. For more details please check the FLIP-158.
+   *
+   * If this method is not called explicitly, it means no preference for enabling the change log.
+   * Configs for change log enabling will override in different config levels (job/local/cluster).
+   *
+   * @param enabled true if enable the change log for state backend explicitly, otherwise disable
+   *                the change log.
+   * @return This StreamExecutionEnvironment itself, to allow chaining of function calls.
+   * @see #isChangelogStateBackendEnabled()
+   */
+  @PublicEvolving
+  def enableChangelogStateBackend(enabled: Boolean): StreamExecutionEnvironment = {
+    javaEnv.enableChangelogStateBackend(enabled)
+    this
+  }
+
+  /**
+   * Gets the enable status of change log for state backend.
+   *
+   * @return a [[TernaryBoolean]] for the enable status of change log for state backend. Could
+   *         be [[TernaryBoolean#UNDEFINED]] if user never specify this by calling
+   *         [[enableChangelogStateBackend(boolean)]].
+   */
+  @PublicEvolving
+  def isChangelogStateBackendEnabled: TernaryBoolean = javaEnv.isChangelogStateBackendEnabled
 
   /**
    * Sets the default savepoint directory, where savepoints will be written to

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -294,8 +294,10 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   def getStateBackend: StateBackend = javaEnv.getStateBackend()
 
   /**
-   * Enable the change log for current state backend. this changelog allows operators to persist
-   * state changes in a very fine-grained manner, as described below:
+   * Enable the change log for current state backend. This change log allows operators to persist
+   * state changes in a very fine-grained manner. Currently, the change log only applies to keyed
+   * state, so non-keyed operator state and channel state are persisted as usual. The 'state' here
+   * refers to 'keyed state'. Details are as follows:
    *
    * Stateful operators write the state changes to that log (logging the state), in addition to
    * applying them to the state tables in RocksDB or the in-mem Hashtable.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.util.TernaryBoolean;
 
 import java.util.List;
 
@@ -44,6 +45,7 @@ public class ExecutorUtils {
                 new StreamGraphGenerator(
                                 transformations, execEnv.getConfig(), execEnv.getCheckpointConfig())
                         .setStateBackend(execEnv.getStateBackend())
+                        .setChangeLogStateBackendEnabled(execEnv.isChangelogStateBackendEnabled())
                         .setSavepointDir(execEnv.getDefaultSavepointDirectory())
                         .setChaining(execEnv.isChainingEnabled())
                         .setUserArtifacts(execEnv.getCachedFiles())
@@ -73,6 +75,7 @@ public class ExecutorUtils {
         // scheduler)
         streamGraph.setJobType(JobType.BATCH);
         streamGraph.setStateBackend(null);
+        streamGraph.setChangeLogStateBackendEnabled(TernaryBoolean.FALSE);
         streamGraph.setCheckpointStorage(null);
         if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {
             throw new IllegalArgumentException("Checkpoint is not supported for batch jobs.");

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -45,7 +45,7 @@ public class ExecutorUtils {
                 new StreamGraphGenerator(
                                 transformations, execEnv.getConfig(), execEnv.getCheckpointConfig())
                         .setStateBackend(execEnv.getStateBackend())
-                        .setChangeLogStateBackendEnabled(execEnv.isChangelogStateBackendEnabled())
+                        .setChangelogStateBackendEnabled(execEnv.isChangelogStateBackendEnabled())
                         .setSavepointDir(execEnv.getDefaultSavepointDirectory())
                         .setChaining(execEnv.isChainingEnabled())
                         .setUserArtifacts(execEnv.getCachedFiles())
@@ -75,7 +75,7 @@ public class ExecutorUtils {
         // scheduler)
         streamGraph.setJobType(JobType.BATCH);
         streamGraph.setStateBackend(null);
-        streamGraph.setChangeLogStateBackendEnabled(TernaryBoolean.FALSE);
+        streamGraph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE);
         streamGraph.setCheckpointStorage(null);
         if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {
             throw new IllegalArgumentException("Checkpoint is not supported for batch jobs.");


### PR DESCRIPTION
## What is the purpose of the change

This change provides configurations as well as APIs to configure ChangelogStateBackend. Base on the discussion before (https://lists.apache.org/thread.html/ra178ce29088b1da362d98a5a6d8c7be48051caf1637ee24261738217%40%3Cdev.flink.apache.org%3E) and the design doc (https://docs.google.com/document/d/13AaCf5fczYTDHZ4G1mgYL685FqbnoEhgo0cdwuJlZmw/edit?usp=sharing, see Option 3), we make a refined version of loading ChangelogStateBackend. Please check the brief change log below.

## Brief change log

- Define consistent override and combination policy (flag + state backend) in different config levels.
- Differentiate explicitly the meaning of "enable flag" = true/false/unset.
- Hide ChangelogStateBackend from users.


## Verifying this change

This change added some test cases in ```ChangelogStateBackendLoadingTest```. Including tests for configuration overriding and stream graph validation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, tests in ```flink-statebackend-changelog``` now depends on ```flink-streaming-java_2.11```.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, add ```enableChangelogStateBackend``` and ```isChangelogStateBackendEnabled``` in ```StreamExecutionEnvironment```
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no, but ChangelogStateBackend itself may affect the per-record code paths.
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no
 
## Documentation
  - Does this pull request introduce a new feature? yes.
  - If yes, how is the feature documented? Docs and JavaDocs.
