### PR TITLE
[FLINK-22982][python] Fix the wrong matching in PythonMapMergeRule

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRule.java
@@ -66,7 +66,7 @@ public class PythonMapMergeRule extends RelOptRule {
                         .collect(Collectors.toList());
 
         if (topProjects.size() != 1
-                || PythonUtil.isNonPythonCall(topProjects.get(0))
+                || !PythonUtil.isPythonCall(topProjects.get(0), null)
                 || !PythonUtil.takesRowAsInput((RexCall) topProjects.get(0))) {
             return false;
         }
@@ -76,7 +76,7 @@ public class PythonMapMergeRule extends RelOptRule {
                 bottomProgram.getProjectList().stream()
                         .map(bottomProgram::expandLocalRef)
                         .collect(Collectors.toList());
-        if (bottomProjects.size() != 1 || PythonUtil.isNonPythonCall(bottomProjects.get(0))) {
+        if (bottomProjects.size() != 1 || !PythonUtil.isPythonCall(bottomProjects.get(0), null)) {
             return false;
         }
 
@@ -87,7 +87,9 @@ public class PythonMapMergeRule extends RelOptRule {
         }
 
         RexProgram middleProgram = middleCalc.getProgram();
-        if (middleProgram.getCondition() != null) {
+        if (topProgram.getCondition() != null
+                || middleProgram.getCondition() != null
+                || bottomProgram.getCondition() != null) {
             return false;
         }
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.xml
@@ -48,4 +48,21 @@ FlinkLogicalCalc(select=[f0.f0 AS _c0, f0.f1 AS _c1])
 ]]>
 	</Resource>
   </TestCase>
+  <TestCase name="testProjectWithOneField">
+	<Resource name="ast">
+	  <![CDATA[
+LogicalFilter(condition=[org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$BooleanPythonScalarFunction$98c7b7a8821989c1d64b757ebdb463b9(+($0, 1), $0)])
++- LogicalProject(a=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, source, source: [TestTableSource(a, b, c)]]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+	  <![CDATA[
+FlinkLogicalCalc(select=[a], where=[f0])
++- FlinkLogicalCalc(select=[a, boolean_func(f0, a) AS f0])
+   +- FlinkLogicalCalc(select=[a, +(a, 1) AS f0])
+      +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, source, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonMapMergeRuleTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.optimize.program._
 import org.apache.flink.table.planner.plan.rules.{FlinkBatchRuleSets, FlinkStreamRuleSets}
-import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.{RowPandasScalarFunction, RowPythonScalarFunction}
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.{BooleanPythonScalarFunction, RowPandasScalarFunction, RowPythonScalarFunction}
 import org.apache.flink.table.planner.utils.TableTestBase
 
 import org.apache.calcite.plan.hep.HepMatchOrder
@@ -73,6 +73,14 @@ class PythonMapMergeRuleTest extends TableTestBase {
 
     val result = sourceTable.map(general_func(withColumns('*)))
       .map(pandas_func(withColumns('*)))
+    util.verifyRelPlan(result)
+  }
+
+  @Test
+  def testProjectWithOneField(): Unit = {
+    val sourceTable = util.addTableSource[(Int, Int, Int)]("source", 'a, 'b, 'c)
+    val booleanFunc = new BooleanPythonScalarFunction("boolean_func")
+    val result = sourceTable.select('a).where(booleanFunc('a + 1, 'a))
     util.verifyRelPlan(result)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes will fix the wrong matching in PythonMapMergeRule*


## Brief change log

  - *Fix the wrong matching in PythonMapMergeRule*

## Verifying this change

  - *Original tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
