### PR TITLE
[hotfix][ci] Make NoticeFileChecker log severe issues at error level.

### DIFF
--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/NoticeFileChecker.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/licensecheck/NoticeFileChecker.java
@@ -108,7 +108,7 @@ public class NoticeFileChecker {
                         .collect(Collectors.toList()));
         for (String moduleWithoutNotice : shadingModules) {
             if (!MODULES_SKIPPING_DEPLOYMENT.contains(moduleWithoutNotice)) {
-                LOG.warn(
+                LOG.error(
                         "Module {} is missing a NOTICE file. It has shaded dependencies: {}",
                         moduleWithoutNotice,
                         modulesWithShadedDependencies.get(moduleWithoutNotice));


### PR DESCRIPTION
This PR upgrades logging level of severe issues in NoticeFileChecker from WARN to ERROR

Currently, it's a bit confusing which issue is causing the check failure when there are multiple warning logs.
https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=18950&view=logs&j=52b61abe-a3cc-5bde-cc35-1bbe89bb7df5&t=54421a62-0c80-5aad-3319-094ff69180bb&l=23626