### PR TITLE
[FLINK-22992][security] Move SSLUtils#is*Enabled to SecurityOptions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -28,6 +28,7 @@ import static org.apache.flink.configuration.description.LineBreakElement.linebr
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The set of configuration options relating to security. */
 public class SecurityOptions {
@@ -510,4 +511,26 @@ public class SecurityOptions {
                                     + "channel. If the `close_notify` was not flushed in the given timeout the channel will be closed "
                                     + "forcibly. (-1 = use system default)")
                     .withDeprecatedKeys("security.ssl.close-notify-flush-timeout");
+
+    /**
+     * Checks whether SSL for internal communication (rpc, data transport, blob server) is enabled.
+     */
+    public static boolean isInternalSSLEnabled(Configuration sslConfig) {
+        @SuppressWarnings("deprecation")
+        final boolean fallbackFlag = sslConfig.getBoolean(SSL_ENABLED);
+        return sslConfig.getBoolean(SSL_INTERNAL_ENABLED, fallbackFlag);
+    }
+
+    /** Checks whether SSL for the external REST endpoint is enabled. */
+    public static boolean isRestSSLEnabled(Configuration sslConfig) {
+        @SuppressWarnings("deprecation")
+        final boolean fallbackFlag = sslConfig.getBoolean(SSL_ENABLED);
+        return sslConfig.getBoolean(SSL_REST_ENABLED, fallbackFlag);
+    }
+
+    /** Checks whether mutual SSL authentication for the external REST endpoint is enabled. */
+    public static boolean isRestSSLAuthenticationEnabled(Configuration sslConfig) {
+        checkNotNull(sslConfig, "sslConfig");
+        return isRestSSLEnabled(sslConfig) && sslConfig.getBoolean(SSL_REST_AUTHENTICATION_ENABLED);
+    }
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/SecurityOptionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/SecurityOptionsTest.java
@@ -71,8 +71,8 @@ public class SecurityOptionsTest extends TestLogger {
         assertFalse(SecurityOptions.isRestSSLAuthenticationEnabled(defaultOptions));
 
         Configuration options = new Configuration();
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
-        assertTrue(SecurityOptions.isRestSSLAuthenticationEnabled(noSSLOptions));
+        options.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        options.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        assertTrue(SecurityOptions.isRestSSLAuthenticationEnabled(options));
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/SecurityOptionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/SecurityOptionsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the {@link SecurityOptions}. */
+public class SecurityOptionsTest extends TestLogger {
+
+    /** Tests whether activation of internal / REST SSL evaluates the config flags correctly. */
+    @SuppressWarnings("deprecation")
+    @Test
+    public void checkEnableSSL() {
+        // backwards compatibility
+        Configuration oldConf = new Configuration();
+        oldConf.setBoolean(SecurityOptions.SSL_ENABLED, true);
+        assertTrue(SecurityOptions.isInternalSSLEnabled(oldConf));
+        assertTrue(SecurityOptions.isRestSSLEnabled(oldConf));
+
+        // new options take precedence
+        Configuration newOptions = new Configuration();
+        newOptions.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        newOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        assertTrue(SecurityOptions.isInternalSSLEnabled(newOptions));
+        assertFalse(SecurityOptions.isRestSSLEnabled(newOptions));
+
+        // new options take precedence
+        Configuration precedence = new Configuration();
+        precedence.setBoolean(SecurityOptions.SSL_ENABLED, true);
+        precedence.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
+        precedence.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        assertFalse(SecurityOptions.isInternalSSLEnabled(precedence));
+        assertFalse(SecurityOptions.isRestSSLEnabled(precedence));
+    }
+
+    /**
+     * Tests whether activation of REST mutual SSL authentication evaluates the config flags
+     * correctly.
+     */
+    @Test
+    public void checkEnableRestSSLAuthentication() {
+        // SSL has to be enabled
+        Configuration noSSLOptions = new Configuration();
+        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        assertFalse(SecurityOptions.isRestSSLAuthenticationEnabled(noSSLOptions));
+
+        // authentication is disabled by default
+        Configuration defaultOptions = new Configuration();
+        defaultOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        assertFalse(SecurityOptions.isRestSSLAuthenticationEnabled(defaultOptions));
+
+        Configuration options = new Configuration();
+        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        assertTrue(SecurityOptions.isRestSSLAuthenticationEnabled(noSSLOptions));
+    }
+}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServerImpl.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosArtifactServerImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.mesos.util;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
@@ -109,7 +110,7 @@ public class MesosArtifactServerImpl implements MesosArtifactServer {
         // Config to enable https access to the artifact server
         final boolean enableSSL =
                 config.getBoolean(MesosOptions.ARTIFACT_SERVER_SSL_ENABLED)
-                        && SSLUtils.isRestSSLEnabled(config);
+                        && SecurityOptions.isRestSSLEnabled(config);
 
         final SSLHandlerFactory sslFactory;
         if (enableSSL) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -81,7 +82,7 @@ public final class BlobClient implements Closeable {
 
         try {
             // create an SSL socket if configured
-            if (SSLUtils.isInternalSSLEnabled(clientConfig)
+            if (SecurityOptions.isInternalSSLEnabled(clientConfig)
                     && clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
                 LOG.info("Using ssl connection to the blob server");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
@@ -177,7 +178,7 @@ public class BlobServer extends Thread
         final Iterator<Integer> ports = NetUtils.getPortRangeFromString(serverPortRange);
 
         final ServerSocketFactory socketFactory;
-        if (SSLUtils.isInternalSSLEnabled(config)
+        if (SecurityOptions.isInternalSSLEnabled(config)
                 && config.getBoolean(BlobServerOptions.SSL_ENABLED)) {
             try {
                 socketFactory = SSLUtils.createSSLServerSocketFactory(config);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
@@ -34,7 +35,6 @@ import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneHaSe
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperClientHAServices;
 import org.apache.flink.runtime.highavailability.zookeeper.ZooKeeperHaServices;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -205,7 +205,7 @@ public class HighAvailabilityServicesUtils {
         }
 
         final int port = configuration.getInteger(RestOptions.PORT);
-        final boolean enableSSL = SSLUtils.isRestSSLEnabled(configuration);
+        final boolean enableSSL = SecurityOptions.isRestSSLEnabled(configuration);
         final String protocol = enableSSL ? "https://" : "http://";
 
         return String.format("%s%s:%s", protocol, address, port);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.NetUtils;
 
@@ -153,7 +154,7 @@ public class NettyConfig {
 
     public boolean getSSLEnabled() {
         return config.getBoolean(NettyShuffleEnvironmentOptions.DATA_SSL_ENABLED)
-                && SSLUtils.isInternalSSLEnabled(config);
+                && SecurityOptions.isInternalSSLEnabled(config);
     }
 
     public Configuration getConfig() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -67,29 +67,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class SSLUtils {
 
     /**
-     * Checks whether SSL for internal communication (rpc, data transport, blob server) is enabled.
-     */
-    public static boolean isInternalSSLEnabled(Configuration sslConfig) {
-        @SuppressWarnings("deprecation")
-        final boolean fallbackFlag = sslConfig.getBoolean(SecurityOptions.SSL_ENABLED);
-        return sslConfig.getBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, fallbackFlag);
-    }
-
-    /** Checks whether SSL for the external REST endpoint is enabled. */
-    public static boolean isRestSSLEnabled(Configuration sslConfig) {
-        @SuppressWarnings("deprecation")
-        final boolean fallbackFlag = sslConfig.getBoolean(SecurityOptions.SSL_ENABLED);
-        return sslConfig.getBoolean(SecurityOptions.SSL_REST_ENABLED, fallbackFlag);
-    }
-
-    /** Checks whether mutual SSL authentication for the external REST endpoint is enabled. */
-    public static boolean isRestSSLAuthenticationEnabled(Configuration sslConfig) {
-        checkNotNull(sslConfig, "sslConfig");
-        return isRestSSLEnabled(sslConfig)
-                && sslConfig.getBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED);
-    }
-
-    /**
      * Creates a factory for SSL Server Sockets from the given configuration. SSL Server Sockets are
      * always part of internal communication.
      */
@@ -159,7 +136,9 @@ public class SSLUtils {
     public static SSLHandlerFactory createRestServerSSLEngineFactory(final Configuration config)
             throws Exception {
         ClientAuth clientAuth =
-                isRestSSLAuthenticationEnabled(config) ? ClientAuth.REQUIRE : ClientAuth.NONE;
+                SecurityOptions.isRestSSLAuthenticationEnabled(config)
+                        ? ClientAuth.REQUIRE
+                        : ClientAuth.NONE;
         SslContext sslContext = createRestNettySSLContext(config, false, clientAuth);
         if (sslContext == null) {
             throw new IllegalConfigurationException("SSL is not enabled for REST endpoints.");
@@ -176,7 +155,9 @@ public class SSLUtils {
     public static SSLHandlerFactory createRestClientSSLEngineFactory(final Configuration config)
             throws Exception {
         ClientAuth clientAuth =
-                isRestSSLAuthenticationEnabled(config) ? ClientAuth.REQUIRE : ClientAuth.NONE;
+                SecurityOptions.isRestSSLAuthenticationEnabled(config)
+                        ? ClientAuth.REQUIRE
+                        : ClientAuth.NONE;
         SslContext sslContext = createRestNettySSLContext(config, true, clientAuth);
         if (sslContext == null) {
             throw new IllegalConfigurationException("SSL is not enabled for REST endpoints.");
@@ -331,7 +312,7 @@ public class SSLUtils {
             Configuration config, boolean clientMode, SslProvider provider) throws Exception {
         checkNotNull(config, "config");
 
-        if (!isInternalSSLEnabled(config)) {
+        if (!SecurityOptions.isInternalSSLEnabled(config)) {
             return null;
         }
 
@@ -368,7 +349,9 @@ public class SSLUtils {
     public static SSLContext createRestSSLContext(Configuration config, boolean clientMode)
             throws Exception {
         ClientAuth clientAuth =
-                isRestSSLAuthenticationEnabled(config) ? ClientAuth.REQUIRE : ClientAuth.NONE;
+                SecurityOptions.isRestSSLAuthenticationEnabled(config)
+                        ? ClientAuth.REQUIRE
+                        : ClientAuth.NONE;
         JdkSslContext nettySSLContext =
                 (JdkSslContext) createRestNettySSLContext(config, clientMode, clientAuth, JDK);
         if (nettySSLContext != null) {
@@ -394,7 +377,7 @@ public class SSLUtils {
             throws Exception {
         checkNotNull(config, "config");
 
-        if (!isRestSSLEnabled(config)) {
+        if (!SecurityOptions.isRestSSLEnabled(config)) {
             return null;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ConfigurationException;
@@ -99,7 +100,7 @@ public final class RestClientConfiguration {
         Preconditions.checkNotNull(config);
 
         final SSLHandlerFactory sslHandlerFactory;
-        if (SSLUtils.isRestSSLEnabled(config)) {
+        if (SecurityOptions.isRestSSLEnabled(config)) {
             try {
                 sslHandlerFactory = SSLUtils.createRestClientSSLEngineFactory(config);
             } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.io.network.netty.SSLHandlerFactory;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -153,7 +154,7 @@ public final class RestServerEndpointConfiguration {
         final String portRangeDefinition = config.getString(RestOptions.BIND_PORT);
 
         final SSLHandlerFactory sslHandlerFactory;
-        if (SSLUtils.isRestSSLEnabled(config)) {
+        if (SecurityOptions.isRestSSLEnabled(config)) {
             try {
                 sslHandlerFactory = SSLUtils.createRestServerSSLEngineFactory(config);
             } catch (Exception e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -21,10 +21,10 @@ package org.apache.flink.runtime.rpc.akka;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution;
-import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -132,7 +132,8 @@ public class AkkaRpcServiceUtils {
         checkNotNull(config, "config is null");
 
         final boolean sslEnabled =
-                config.getBoolean(AkkaOptions.SSL_ENABLED) && SSLUtils.isInternalSSLEnabled(config);
+                config.getBoolean(AkkaOptions.SSL_ENABLED)
+                        && SecurityOptions.isInternalSSLEnabled(config);
 
         return getRpcUrl(
                 hostname,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerUtils.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.webmonitor.history;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HistoryServerOptions;
-import org.apache.flink.runtime.net.SSLUtils;
+import org.apache.flink.configuration.SecurityOptions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +39,7 @@ public enum HistoryServerUtils {
 
     public static boolean isSSLEnabled(Configuration config) {
         return config.getBoolean(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED)
-                && SSLUtils.isRestSSLEnabled(config);
+                && SecurityOptions.isRestSSLEnabled(config);
     }
 
     public static Optional<URL> getHistoryServerURL(Configuration configuration) {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -30,7 +30,6 @@ import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration._
 import org.apache.flink.runtime.concurrent.FutureUtils
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils
-import org.apache.flink.runtime.net.SSLUtils
 import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools.{FixedThreadPoolExecutorConfiguration, ForkJoinExecutorConfiguration}
 import org.apache.flink.util.NetUtils
 import org.apache.flink.util.TimeUtils
@@ -427,7 +426,7 @@ object AkkaUtils {
     val logLifecycleEvents = if (lifecycleEvents) "on" else "off"
 
     val akkaEnableSSLConfig = configuration.getBoolean(AkkaOptions.SSL_ENABLED) &&
-          SSLUtils.isInternalSSLEnabled(configuration)
+          SecurityOptions.isInternalSSLEnabled(configuration)
 
     val retryGateClosedFor = configuration.getLong(AkkaOptions.RETRY_GATE_CLOSED_FOR)
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -51,7 +51,6 @@ import java.util.Locale;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -88,55 +87,6 @@ public class SSLUtilsTest extends TestLogger {
     @Parameterized.Parameters(name = "SSL provider = {0}")
     public static List<String> parameters() {
         return AVAILABLE_SSL_PROVIDERS;
-    }
-
-    /** Tests whether activation of internal / REST SSL evaluates the config flags correctly. */
-    @SuppressWarnings("deprecation")
-    @Test
-    public void checkEnableSSL() {
-        // backwards compatibility
-        Configuration oldConf = new Configuration();
-        oldConf.setBoolean(SecurityOptions.SSL_ENABLED, true);
-        assertTrue(SSLUtils.isInternalSSLEnabled(oldConf));
-        assertTrue(SSLUtils.isRestSSLEnabled(oldConf));
-
-        // new options take precedence
-        Configuration newOptions = new Configuration();
-        newOptions.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-        newOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
-        assertTrue(SSLUtils.isInternalSSLEnabled(newOptions));
-        assertFalse(SSLUtils.isRestSSLEnabled(newOptions));
-
-        // new options take precedence
-        Configuration precedence = new Configuration();
-        precedence.setBoolean(SecurityOptions.SSL_ENABLED, true);
-        precedence.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
-        precedence.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
-        assertFalse(SSLUtils.isInternalSSLEnabled(precedence));
-        assertFalse(SSLUtils.isRestSSLEnabled(precedence));
-    }
-
-    /**
-     * Tests whether activation of REST mutual SSL authentication evaluates the config flags
-     * correctly.
-     */
-    @Test
-    public void checkEnableRestSSLAuthentication() {
-        // SSL has to be enabled
-        Configuration noSSLOptions = new Configuration();
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
-        assertFalse(SSLUtils.isRestSSLAuthenticationEnabled(noSSLOptions));
-
-        // authentication is disabled by default
-        Configuration defaultOptions = new Configuration();
-        defaultOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        assertFalse(SSLUtils.isRestSSLAuthenticationEnabled(defaultOptions));
-
-        Configuration options = new Configuration();
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
-        assertTrue(SSLUtils.isRestSSLAuthenticationEnabled(noSSLOptions));
     }
 
     @Test


### PR DESCRIPTION
The SSLUtils contain a few methods that check whether certain SSL options are enabled while honoring a fallback "security.ssl.enabled" option.
These are required by RPC, network and REST components.

In order to be able to move our akka rpc stuff into a separate module it is necessary to move these to flink-core.
(There's also no good reason for them to be in flink-runtime in the first place)
