### PR TITLE
[FLINK-22993][filesystem] Fix the issue that CompactFileWriter won't emit EndCheckpoint with Long.MAX_VALUE checkpointId even though the inputs end.

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/compact/CompactFileWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/compact/CompactFileWriter.java
@@ -51,8 +51,8 @@ public class CompactFileWriter<T>
     }
 
     @Override
-    public void notifyCheckpointComplete(long checkpointId) throws Exception {
-        super.notifyCheckpointComplete(checkpointId);
+    protected void commitUpToCheckpoint(long checkpointId) throws Exception {
+        super.commitUpToCheckpoint(checkpointId);
         output.collect(
                 new StreamRecord<>(
                         new EndCheckpoint(

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/compact/CompactFileWriterTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/stream/compact/CompactFileWriterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream.compact;
+
+import org.apache.flink.api.common.serialization.SimpleStringEncoder;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.filesystem.stream.compact.CompactMessages.EndCheckpoint;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.apache.flink.table.filesystem.stream.compact.CompactMessages.CoordinatorInput;
+import static org.apache.flink.table.filesystem.stream.compact.CompactMessages.InputFile;
+
+/** Test for {@link CompactFileWriter}. */
+public class CompactFileWriterTest extends AbstractCompactTestBase {
+
+    @Test
+    public void testEmitEndCheckpointAfterEndInput() throws Exception {
+        CompactFileWriter<RowData> compactFileWriter =
+                new CompactFileWriter<>(
+                        1000, StreamingFileSink.forRowFormat(folder, new SimpleStringEncoder<>()));
+        try (OneInputStreamOperatorTestHarness<RowData, CoordinatorInput> harness =
+                new OneInputStreamOperatorTestHarness<>(compactFileWriter)) {
+            harness.setup();
+            harness.open();
+
+            harness.processElement(row("test"), 0);
+            harness.snapshot(1, 1);
+            harness.notifyOfCompletedCheckpoint(1);
+
+            List<CoordinatorInput> coordinatorInputs = harness.extractOutputValues();
+
+            Assert.assertEquals(2, coordinatorInputs.size());
+            // assert emit InputFile
+            Assert.assertTrue(coordinatorInputs.get(0) instanceof InputFile);
+            // assert emit EndCheckpoint
+            Assert.assertEquals(1, ((EndCheckpoint) coordinatorInputs.get(1)).getCheckpointId());
+
+            harness.processElement(row("test1"), 0);
+            harness.processElement(row("test2"), 0);
+
+            harness.getOutput().clear();
+
+            // end input
+            harness.endInput();
+            coordinatorInputs = harness.extractOutputValues();
+            // assert emit EndCheckpoint with Long.MAX_VALUE lastly
+            EndCheckpoint endCheckpoint =
+                    (EndCheckpoint) coordinatorInputs.get(coordinatorInputs.size() - 1);
+            Assert.assertEquals(Long.MAX_VALUE, endCheckpoint.getCheckpointId());
+        }
+    }
+
+    private static RowData row(String s) {
+        return GenericRowData.of(StringData.fromString(s));
+    }
+}


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

* This pull request is to fix the issue that CompactFileWriter won't emit EndCheckpoint with Long.MAX_VALUE checkpointId even though the inputs end. *


## Brief change log

  - *Delete method notifyCheckpointComplete and override method commitUpToCheckpoint in CompactFileWriter*
  - *In method commitUpToCheckpoint fo CompactFileWriter, it call super. commitUpToCheckpoint and emit EndCheckpoint *

## Verifying this change

This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no