### PR TITLE
[Hotfix][docs] Update usages of RESET to new syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -626,7 +626,7 @@ When the path to savepoint is specified, Flink will try to restore the state fro
 Because the specified savepoint path will affect all the following DML statements, you can use `RESET` command to reset this config option, i.e. disable restoring from savepoint.
 
 ```sql
-Flink SQL> RESET execution.savepoint.path;
+Flink SQL> RESET 'execution.savepoint.path';
 [INFO] Session property has been reset.
 ```
 
@@ -647,7 +647,7 @@ Flink SQL> INSERT INTO ...
 Because the specified job name will affect all the following queries and DML statements, you can also use `RESET` command to reset this configuration, i.e. use default job names.
 
 ```sql
-Flink SQL> RESET pipeline.name;
+Flink SQL> RESET 'pipeline.name';
 [INFO] Session property has been reset.
 ```
 

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -675,7 +675,7 @@ When the path to savepoint is specified, Flink will try to restore the state fro
 Because the specified savepoint path will affect all the following DML statements, you can use `RESET` command to reset this config option, i.e. disable restoring from savepoint.
 
 ```sql
-Flink SQL> RESET execution.savepoint.path;
+Flink SQL> RESET 'execution.savepoint.path';
 [INFO] Session property has been reset.
 ```
 
@@ -696,7 +696,7 @@ Flink SQL> INSERT INTO ...
 Because the specified job name will affect all the following queries and DML statements, you can also use `RESET` command to reset this configuration, i.e. use default job names.
 
 ```sql
-Flink SQL> RESET pipeline.name;
+Flink SQL> RESET 'pipeline.name';
 [INFO] Session property has been reset.
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

Updates a couple of usages of `RESET` which were forgotten when changing to the new syntax using quotes.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
