### PR TITLE
[FLINK-15031][runtime] Calculate required shuffle memory before allocating slots if resources are specified

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
@@ -58,6 +58,28 @@ public class EdgeManagerBuildUtil {
         }
     }
 
+    /**
+     * Given parallelisms of two job vertices, compute the max number of edges connected to a target
+     * execution vertex from the source execution vertices. Note that edge is considered undirected
+     * here. It can be an edge connected from an upstream job vertex to a downstream job vertex, or
+     * in a reversed way.
+     *
+     * @param targetParallelism parallelism of the target job vertex.
+     * @param sourceParallelism parallelism of the source job vertex.
+     * @param distributionPattern the {@link DistributionPattern} of the connecting edge.
+     */
+    public static int computeMaxEdgesToTargetExecutionVertex(
+            int targetParallelism, int sourceParallelism, DistributionPattern distributionPattern) {
+        switch (distributionPattern) {
+            case POINTWISE:
+                return (sourceParallelism + targetParallelism - 1) / targetParallelism;
+            case ALL_TO_ALL:
+                return sourceParallelism;
+            default:
+                throw new IllegalArgumentException("Unrecognized distribution pattern.");
+        }
+    }
+
     private static void connectAllToAll(
             ExecutionVertex[] taskVertices, IntermediateResult intermediateResult) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -56,7 +56,7 @@ public class NettyShuffleServiceFactory
 
     @Override
     public NettyShuffleMaster createShuffleMaster(Configuration configuration) {
-        return NettyShuffleMaster.INSTANCE;
+        return new NettyShuffleMaster(configuration);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -296,7 +296,7 @@ public class SingleInputGate extends IndexedInputGate {
     }
 
     @VisibleForTesting
-    void convertRecoveredInputChannels() {
+    public void convertRecoveredInputChannels() {
         LOG.debug("Converting recovered input channels ({} channels)", getNumberOfInputChannels());
         for (Map.Entry<IntermediateResultPartitionID, InputChannel> entry :
                 inputChannels.entrySet()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -34,10 +34,12 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.NettyShuffleUtils;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.util.function.SupplierWithException;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -238,9 +240,10 @@ public class SingleInputGateFactory {
             int floatingNetworkBuffersPerGate,
             int size,
             ResultPartitionType type) {
-        // Note that we should guarantee at-least one floating buffer for local channel state
-        // recovery.
-        return () -> bufferPoolFactory.createBufferPool(1, floatingNetworkBuffersPerGate);
+        Pair<Integer, Integer> pair =
+                NettyShuffleUtils.getMinMaxFloatingBuffersPerInputGate(
+                        floatingNetworkBuffersPerGate);
+        return () -> bufferPoolFactory.createBufferPool(pair.getLeft(), pair.getRight());
     }
 
     /** Statistics of input channels. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.topology.Vertex;
 import org.apache.flink.util.ExceptionUtils;
@@ -97,6 +98,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 
     private final Set<ExecutionVertexID> verticesWaitingForRestart;
 
+    private final ShuffleMaster<?> shuffleMaster;
+
     DefaultScheduler(
             final Logger log,
             final JobGraph jobGraph,
@@ -116,7 +119,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
             long initializationTimestamp,
             final ComponentMainThreadExecutor mainThreadExecutor,
             final JobStatusListener jobStatusListener,
-            final ExecutionGraphFactory executionGraphFactory)
+            final ExecutionGraphFactory executionGraphFactory,
+            final ShuffleMaster<?> shuffleMaster)
             throws Exception {
 
         super(
@@ -138,6 +142,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         this.delayExecutor = checkNotNull(delayExecutor);
         this.userCodeLoader = checkNotNull(userCodeLoader);
         this.executionVertexOperations = checkNotNull(executionVertexOperations);
+        this.shuffleMaster = checkNotNull(shuffleMaster);
 
         final FailoverStrategy failoverStrategy =
                 failoverStrategyFactory.create(
@@ -147,6 +152,8 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                 failoverStrategy,
                 jobGraph.getName(),
                 jobGraph.getJobID());
+
+        enrichResourceProfile();
 
         this.executionFailureHandler =
                 new ExecutionFailureHandler(
@@ -614,5 +621,14 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         public Optional<TaskManagerLocation> getStateLocation(ExecutionVertexID executionVertexId) {
             return stateLocationRetriever.getStateLocation(executionVertexId);
         }
+    }
+
+    private void enrichResourceProfile() {
+        Set<SlotSharingGroup> ssgs = new HashSet<>();
+        getJobGraph().getVertices().forEach(jv -> ssgs.add(jv.getSlotSharingGroup()));
+        ssgs.forEach(
+                ssg ->
+                        SsgNetworkMemoryCalculationUtils.enrichNetworkMemory(
+                                ssg, this::getExecutionJobVertex, shuffleMaster));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -133,7 +133,8 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
                 initializationTimestamp,
                 mainThreadExecutor,
                 jobStatusListener,
-                executionGraphFactory);
+                executionGraphFactory,
+                shuffleMaster);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.EdgeManagerBuildUtil;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobEdge;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Util to analyze inputs & outputs of {@link ExecutionJobVertex} and calculate network memory
+ * requirement for slot sharing group (SSG).
+ */
+public class SsgNetworkMemoryCalculationUtils {
+
+    /**
+     * Calculates network memory requirement of {@link ExecutionJobVertex} and update {@link
+     * ResourceProfile} of corresponding slot sharing group.
+     */
+    static void enrichNetworkMemory(
+            SlotSharingGroup ssg,
+            Function<JobVertexID, ExecutionJobVertex> ejvs,
+            ShuffleMaster<?> shuffleMaster) {
+
+        ResourceProfile original = ssg.getResourceProfile();
+
+        // Updating network memory for UNKNOWN is also beneficial, but currently it's not
+        // supported and the enriching logic only works for 'fine-grained resource management'.
+        if (original.equals(ResourceProfile.UNKNOWN)
+                || !original.getNetworkMemory().equals(MemorySize.ZERO)) {
+            return;
+        }
+
+        MemorySize networkMemory = MemorySize.ZERO;
+        for (JobVertexID jvId : ssg.getJobVertexIds()) {
+            ExecutionJobVertex ejv = ejvs.apply(jvId);
+            TaskInputsOutputsDescriptor desc = buildTaskInputsOutputsDescriptor(ejv, ejvs);
+            MemorySize requiredNetworkMemory = shuffleMaster.computeShuffleMemorySizeForTask(desc);
+            networkMemory = networkMemory.add(requiredNetworkMemory);
+        }
+
+        ResourceProfile enriched =
+                ResourceProfile.newBuilder()
+                        .setCpuCores(original.getCpuCores())
+                        .setTaskHeapMemory(original.getTaskHeapMemory())
+                        .setTaskOffHeapMemory(original.getTaskOffHeapMemory())
+                        .setManagedMemory(original.getManagedMemory())
+                        .setNetworkMemory(networkMemory)
+                        .setExtendedResources(original.getExtendedResources().values())
+                        .build();
+        ssg.setResourceProfile(enriched);
+    }
+
+    private static TaskInputsOutputsDescriptor buildTaskInputsOutputsDescriptor(
+            ExecutionJobVertex ejv, Function<JobVertexID, ExecutionJobVertex> ejvs) {
+
+        Map<IntermediateDataSetID, Integer> maxInputChannelNums = getMaxInputChannelNums(ejv);
+        Map<IntermediateDataSetID, Integer> maxSubpartitionNums = getMaxSubpartitionNums(ejv, ejvs);
+        JobVertex jv = ejv.getJobVertex();
+        Map<IntermediateDataSetID, ResultPartitionType> partitionTypes = getPartitionTypes(jv);
+
+        return TaskInputsOutputsDescriptor.from(
+                maxInputChannelNums, maxSubpartitionNums, partitionTypes);
+    }
+
+    private static Map<IntermediateDataSetID, Integer> getMaxInputChannelNums(
+            ExecutionJobVertex ejv) {
+
+        Map<IntermediateDataSetID, Integer> ret = new HashMap<>();
+        List<JobEdge> inputEdges = ejv.getJobVertex().getInputs();
+
+        for (int i = 0; i < inputEdges.size(); i++) {
+            JobEdge inputEdge = inputEdges.get(i);
+            IntermediateResult consumedResult = ejv.getInputs().get(i);
+
+            // the inputs order should match in JobGraph and ExecutionGraph
+            checkState(consumedResult.getId().equals(inputEdge.getSourceId()));
+
+            int maxNum =
+                    EdgeManagerBuildUtil.computeMaxEdgesToTargetExecutionVertex(
+                            ejv.getParallelism(),
+                            consumedResult.getNumberOfAssignedPartitions(),
+                            inputEdge.getDistributionPattern());
+            ret.put(consumedResult.getId(), maxNum);
+        }
+
+        return ret;
+    }
+
+    private static Map<IntermediateDataSetID, Integer> getMaxSubpartitionNums(
+            ExecutionJobVertex ejv, Function<JobVertexID, ExecutionJobVertex> ejvs) {
+
+        Map<IntermediateDataSetID, Integer> ret = new HashMap<>();
+        List<IntermediateDataSet> producedDataSets = ejv.getJobVertex().getProducedDataSets();
+
+        for (int i = 0; i < producedDataSets.size(); i++) {
+            IntermediateDataSet producedDataSet = producedDataSets.get(i);
+
+            checkState(
+                    producedDataSet.getConsumers().size() == 1,
+                    "Currently a result should have exactly one consumer job vertex.");
+
+            JobEdge outputEdge = producedDataSet.getConsumers().get(0);
+            ExecutionJobVertex consumerJobVertex = ejvs.apply(outputEdge.getTarget().getID());
+            int maxNum =
+                    EdgeManagerBuildUtil.computeMaxEdgesToTargetExecutionVertex(
+                            ejv.getParallelism(),
+                            consumerJobVertex.getParallelism(),
+                            outputEdge.getDistributionPattern());
+            ret.put(producedDataSet.getId(), maxNum);
+        }
+
+        return ret;
+    }
+
+    private static Map<IntermediateDataSetID, ResultPartitionType> getPartitionTypes(JobVertex jv) {
+        Map<IntermediateDataSetID, ResultPartitionType> ret = new HashMap<>();
+        jv.getProducedDataSets().forEach(ds -> ret.putIfAbsent(ds.getId(), ds.getResultType()));
+        return ret;
+    }
+
+    /** Private default constructor to avoid being instantiated. */
+    private SsgNetworkMemoryCalculationUtils() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -18,16 +18,45 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.LocalExecutionPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.NetworkPartitionConnectionInfo;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.PartitionConnectionInfo;
+import org.apache.flink.runtime.util.ConfigurationParserUtils;
 
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /** Default {@link ShuffleMaster} for netty and local file based shuffle implementation. */
-public enum NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor> {
-    INSTANCE;
+public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor> {
+
+    private final int buffersPerInputChannel;
+
+    private final int buffersPerInputGate;
+
+    private final int sortShuffleMinParallelism;
+
+    private final int sortShuffleMinBuffers;
+
+    private final int networkBufferSize;
+
+    public NettyShuffleMaster(Configuration conf) {
+        checkNotNull(conf);
+        buffersPerInputChannel =
+                conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL);
+        buffersPerInputGate =
+                conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
+        sortShuffleMinParallelism =
+                conf.getInteger(
+                        NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM);
+        sortShuffleMinBuffers =
+                conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
+        networkBufferSize = ConfigurationParserUtils.getPageSize(conf);
+    }
 
     @Override
     public CompletableFuture<NettyShuffleDescriptor> registerPartitionWithProducer(
@@ -57,5 +86,36 @@ public enum NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor> 
                 ? NetworkPartitionConnectionInfo.fromProducerDescriptor(
                         producerDescriptor, connectionIndex)
                 : LocalExecutionPartitionConnectionInfo.INSTANCE;
+    }
+
+    /**
+     * JM announces network memory requirement from the calculating result of this method. Please
+     * note that the calculating algorithm depends on both I/O details of a vertex and network
+     * configuration, e.g. {@link NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_PER_CHANNEL} and
+     * {@link NettyShuffleEnvironmentOptions#NETWORK_EXTRA_BUFFERS_PER_GATE}, which means we should
+     * always keep the consistency of configurations between JM, RM and TM in fine-grained resource
+     * management, thus to guarantee that the processes of memory announcing and allocating respect
+     * each other.
+     */
+    @Override
+    public MemorySize computeShuffleMemorySizeForTask(TaskInputsOutputsDescriptor desc) {
+        checkNotNull(desc);
+
+        int numTotalInputChannels =
+                desc.getInputChannelNums().values().stream().mapToInt(Integer::intValue).sum();
+        int numTotalInputGates = desc.getInputChannelNums().size();
+
+        int numRequiredNetworkBuffers =
+                NettyShuffleUtils.computeNetworkBuffersForAnnouncing(
+                        buffersPerInputChannel,
+                        buffersPerInputGate,
+                        sortShuffleMinParallelism,
+                        sortShuffleMinBuffers,
+                        numTotalInputChannels,
+                        numTotalInputGates,
+                        desc.getSubpartitionNums(),
+                        desc.getPartitionTypes());
+
+        return new MemorySize((long) networkBufferSize * numRequiredNetworkBuffers);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Utils to calculate network memory requirement of a vertex from network configuration and details
+ * of input and output. The methods help to decide the volume of buffer pools when initializing
+ * shuffle environment and also guide network memory announcing in fine-grained resource management.
+ */
+public class NettyShuffleUtils {
+
+    public static Pair<Integer, Integer> getMinMaxFloatingBuffersPerInputGate(
+            final int numFloatingBuffersPerGate) {
+        // We should guarantee at-least one floating buffer for local channel state recovery.
+        return Pair.of(1, numFloatingBuffersPerGate);
+    }
+
+    public static Pair<Integer, Integer> getMinMaxNetworkBuffersPerResultPartition(
+            final int numBuffersPerChannel,
+            final int numFloatingBuffersPerGate,
+            final int sortShuffleMinParallelism,
+            final int sortShuffleMinBuffers,
+            final int numSubpartitions,
+            final ResultPartitionType type) {
+        int min =
+                type.isBlocking() && numSubpartitions >= sortShuffleMinParallelism
+                        ? sortShuffleMinBuffers
+                        : numSubpartitions + 1;
+        int max =
+                type.isBounded()
+                        ? numSubpartitions * numBuffersPerChannel + numFloatingBuffersPerGate
+                        : Integer.MAX_VALUE;
+        return Pair.of(min, max);
+    }
+
+    public static int computeNetworkBuffersForAnnouncing(
+            final int numBuffersPerChannel,
+            final int numFloatingBuffersPerGate,
+            final int sortShuffleMinParallelism,
+            final int sortShuffleMinBuffers,
+            final int numTotalInputChannels,
+            final int numTotalInputGates,
+            final Map<IntermediateDataSetID, Integer> subpartitionNums,
+            final Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
+
+        // Each input channel will retain N exclusive network buffers, N = numBuffersPerChannel.
+        // Each input gate is guaranteed to have a number of floating buffers.
+        int requirmentForInputs =
+                numBuffersPerChannel * numTotalInputChannels
+                        + getMinMaxFloatingBuffersPerInputGate(numFloatingBuffersPerGate).getRight()
+                                * numTotalInputGates;
+
+        int requirementForOutputs = 0;
+        for (IntermediateDataSetID dataSetId : subpartitionNums.keySet()) {
+            int numSubs = subpartitionNums.get(dataSetId);
+            checkArgument(partitionTypes.containsKey(dataSetId));
+            ResultPartitionType partitionType = partitionTypes.get(dataSetId);
+
+            requirementForOutputs +=
+                    getNumBuffersToAnnounceForResultPartition(
+                            partitionType,
+                            numBuffersPerChannel,
+                            numFloatingBuffersPerGate,
+                            sortShuffleMinParallelism,
+                            sortShuffleMinBuffers,
+                            numSubs);
+        }
+
+        return requirmentForInputs + requirementForOutputs;
+    }
+
+    private static int getNumBuffersToAnnounceForResultPartition(
+            ResultPartitionType type,
+            int numBuffersPerChannel,
+            int floatingBuffersPerGate,
+            int sortShuffleMinParallelism,
+            int sortShuffleMinBuffers,
+            int numSubpartitions) {
+
+        Pair<Integer, Integer> minAndMax =
+                getMinMaxNetworkBuffersPerResultPartition(
+                        numBuffersPerChannel,
+                        floatingBuffersPerGate,
+                        sortShuffleMinParallelism,
+                        sortShuffleMinBuffers,
+                        numSubpartitions,
+                        type);
+
+        // In order to avoid network buffer request timeout (see FLINK-12852), we announce
+        // network buffer requirement by below:
+        // 1. For pipelined shuffle, the floating buffers may not be returned in time due to back
+        // pressure so we need to include all the floating buffers in the announcement, i.e. we
+        // should take the max value;
+        // 2. For blocking shuffle, it is back pressure free and floating buffers can be recycled
+        // in time, so that the minimum required buffers would be enough.
+        int ret = type.isPipelined() ? minAndMax.getRight() : minAndMax.getLeft();
+
+        if (ret == Integer.MAX_VALUE) {
+            // Should never reach this branch. Result partition will allocate an unbounded
+            // buffer pool only when type is ResultPartitionType.PIPELINED. But fine-grained
+            // resource management is disabled in such case.
+            throw new IllegalArgumentException(
+                    "Illegal to announce network memory requirement as Integer.MAX_VALUE, partition type: "
+                            + type);
+        }
+        return ret;
+    }
+
+    /** Private default constructor to avoid being instantiated. */
+    private NettyShuffleUtils() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.configuration.MemorySize;
+
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -61,4 +63,16 @@ public interface ShuffleMaster<T extends ShuffleDescriptor> {
      * @param shuffleDescriptor shuffle descriptor of the result partition to release externally.
      */
     void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor);
+
+    /**
+     * Compute shuffle memory size for a task with the given {@link TaskInputsOutputsDescriptor}.
+     *
+     * @param taskInputsOutputsDescriptor describes task inputs and outputs information for shuffle
+     *     memory calculation.
+     * @return shuffle memory size for a task with the given {@link TaskInputsOutputsDescriptor}.
+     */
+    default MemorySize computeShuffleMemorySizeForTask(
+            TaskInputsOutputsDescriptor taskInputsOutputsDescriptor) {
+        return MemorySize.ZERO;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/TaskInputsOutputsDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/TaskInputsOutputsDescriptor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Describes inputs and outputs information of a task. */
+public class TaskInputsOutputsDescriptor {
+
+    // Number of input channels per dataSet.
+    private final Map<IntermediateDataSetID, Integer> inputChannelNums;
+
+    // Number of subpartitions per dataSet.
+    private final Map<IntermediateDataSetID, Integer> subpartitionNums;
+
+    // ResultPartitionType per dataSet.
+    private final Map<IntermediateDataSetID, ResultPartitionType> partitionTypes;
+
+    private TaskInputsOutputsDescriptor(
+            Map<IntermediateDataSetID, Integer> inputChannelNums,
+            Map<IntermediateDataSetID, Integer> subpartitionNums,
+            Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
+
+        checkNotNull(inputChannelNums);
+        checkNotNull(subpartitionNums);
+        checkNotNull(partitionTypes);
+
+        this.inputChannelNums = inputChannelNums;
+        this.subpartitionNums = subpartitionNums;
+        this.partitionTypes = partitionTypes;
+    }
+
+    public Map<IntermediateDataSetID, Integer> getInputChannelNums() {
+        return Collections.unmodifiableMap(inputChannelNums);
+    }
+
+    public Map<IntermediateDataSetID, Integer> getSubpartitionNums() {
+        return Collections.unmodifiableMap(subpartitionNums);
+    }
+
+    public Map<IntermediateDataSetID, ResultPartitionType> getPartitionTypes() {
+        return Collections.unmodifiableMap(partitionTypes);
+    }
+
+    public static TaskInputsOutputsDescriptor from(
+            Map<IntermediateDataSetID, Integer> inputChannelNums,
+            Map<IntermediateDataSetID, Integer> subpartitionNums,
+            Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
+
+        return new TaskInputsOutputsDescriptor(inputChannelNums, subpartitionNums, partitionTypes);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
@@ -23,11 +23,11 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
 import org.apache.flink.util.TestLogger;
 
@@ -207,7 +207,7 @@ public class ShuffleDescriptorTest extends TestLogger {
         PartitionDescriptor partitionDescriptor =
                 PartitionDescriptorBuilder.newBuilder().setPartitionId(id.getPartitionId()).build();
         ShuffleDescriptor shuffleDescriptor =
-                NettyShuffleMaster.INSTANCE
+                ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER
                         .registerPartitionWithProducer(partitionDescriptor, producerDescriptor)
                         .get();
         return new ResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.scheduler.SchedulerBase;
+import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.ALL_TO_ALL;
+import static org.apache.flink.runtime.jobgraph.DistributionPattern.POINTWISE;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link EdgeManagerBuildUtil} to verify the max number of connecting edges between
+ * vertices for pattern of both {@link DistributionPattern#POINTWISE} and {@link
+ * DistributionPattern#ALL_TO_ALL}.
+ */
+public class EdgeManagerBuildUtilTest {
+
+    @Test
+    public void testGetMaxNumEdgesToTargetInPointwiseConnection() throws Exception {
+        testGetMaxNumEdgesToTarget(17, 17, POINTWISE);
+        testGetMaxNumEdgesToTarget(17, 23, POINTWISE);
+        testGetMaxNumEdgesToTarget(17, 34, POINTWISE);
+        testGetMaxNumEdgesToTarget(34, 17, POINTWISE);
+        testGetMaxNumEdgesToTarget(23, 17, POINTWISE);
+    }
+
+    @Test
+    public void testGetMaxNumEdgesToTargetInAllToAllConnection() throws Exception {
+        testGetMaxNumEdgesToTarget(17, 17, ALL_TO_ALL);
+        testGetMaxNumEdgesToTarget(17, 23, ALL_TO_ALL);
+        testGetMaxNumEdgesToTarget(17, 34, ALL_TO_ALL);
+        testGetMaxNumEdgesToTarget(34, 17, ALL_TO_ALL);
+        testGetMaxNumEdgesToTarget(23, 17, ALL_TO_ALL);
+    }
+
+    private void testGetMaxNumEdgesToTarget(
+            int upstream, int downstream, DistributionPattern pattern) throws Exception {
+
+        Pair<ExecutionJobVertex, ExecutionJobVertex> pair =
+                setupExecutionGraph(upstream, downstream, pattern);
+        ExecutionJobVertex upstreamEJV = pair.getLeft();
+        ExecutionJobVertex downstreamEJV = pair.getRight();
+
+        int calculatedMaxForUpstream =
+                EdgeManagerBuildUtil.computeMaxEdgesToTargetExecutionVertex(
+                        upstream, downstream, pattern);
+        int actualMaxForUpstream = -1;
+        for (ExecutionVertex ev : upstreamEJV.getTaskVertices()) {
+            assertEquals(1, ev.getProducedPartitions().size());
+
+            IntermediateResultPartition partition =
+                    ev.getProducedPartitions().values().iterator().next();
+            assertEquals(1, partition.getConsumerVertexGroups().size());
+
+            ConsumerVertexGroup consumerVertexGroup = partition.getConsumerVertexGroups().get(0);
+            int actual = consumerVertexGroup.size();
+            if (actual > actualMaxForUpstream) {
+                actualMaxForUpstream = actual;
+            }
+        }
+        assertEquals(actualMaxForUpstream, calculatedMaxForUpstream);
+
+        int calculatedMaxForDownstream =
+                EdgeManagerBuildUtil.computeMaxEdgesToTargetExecutionVertex(
+                        downstream, upstream, pattern);
+        int actualMaxForDownstream = -1;
+        for (ExecutionVertex ev : downstreamEJV.getTaskVertices()) {
+            assertEquals(1, ev.getNumberOfInputs());
+
+            int actual = ev.getConsumedPartitionGroup(0).size();
+            if (actual > actualMaxForDownstream) {
+                actualMaxForDownstream = actual;
+            }
+        }
+        assertEquals(actualMaxForDownstream, calculatedMaxForDownstream);
+    }
+
+    private Pair<ExecutionJobVertex, ExecutionJobVertex> setupExecutionGraph(
+            int upstream, int downstream, DistributionPattern pattern) throws Exception {
+        JobVertex v1 = new JobVertex("vertex1");
+        JobVertex v2 = new JobVertex("vertex2");
+
+        v1.setParallelism(upstream);
+        v2.setParallelism(downstream);
+
+        v1.setInvokableClass(AbstractInvokable.class);
+        v2.setInvokableClass(AbstractInvokable.class);
+
+        v2.connectNewDataSetAsInput(v1, pattern, ResultPartitionType.PIPELINED);
+
+        List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+
+        ExecutionGraph eg =
+                TestingDefaultExecutionGraphBuilder.newBuilder()
+                        .setVertexParallelismStore(
+                                SchedulerBase.computeVertexParallelismStore(ordered))
+                        .build();
+        eg.attachJobGraph(ordered);
+        return Pair.of(eg.getAllVertices().get(v1.getID()), eg.getAllVertices().get(v2.getID()));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -40,11 +40,11 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -216,7 +216,7 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
                 ResultPartitionType.BLOCKING,
                 partitionTracker,
                 new SimpleAckingTaskManagerGateway(),
-                NettyShuffleMaster.INSTANCE);
+                ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER);
 
         Tuple2<ResourceID, ResultPartitionDeploymentDescriptor> startTrackingCall =
                 partitionStartTrackingFuture.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -39,8 +39,8 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testutils.TestingUtils;
 
 import org.slf4j.Logger;
@@ -65,7 +65,7 @@ public class TestingDefaultExecutionGraphBuilder {
     private Time rpcTimeout = Time.fromDuration(AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue());
     private ClassLoader userClassLoader = DefaultExecutionGraph.class.getClassLoader();
     private BlobWriter blobWriter = VoidBlobWriter.getInstance();
-    private ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
+    private ShuffleMaster<?> shuffleMaster = ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER;
     private JobMasterPartitionTracker partitionTracker = NoOpJobMasterPartitionTracker.INSTANCE;
     private Configuration jobMasterConfig = new Configuration();
     private JobGraph jobGraph = JobGraphTestUtils.emptyJobGraph();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -43,8 +43,8 @@ import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -74,7 +74,7 @@ public class JobMasterBuilder {
 
     private OnCompletionActions onCompletionActions = new TestingOnCompletionActions();
 
-    private ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
+    private ShuffleMaster<?> shuffleMaster = ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER;
 
     private PartitionTrackerFactory partitionTrackerFactory = NoOpJobMasterPartitionTracker.FACTORY;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactoryTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmaster.DefaultExecutionDeploymentTracker;
 import org.apache.flink.runtime.jobmaster.TestUtils;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.util.TestLogger;
@@ -126,7 +126,7 @@ public class DefaultExecutionGraphFactoryTest extends TestLogger {
                         Time.milliseconds(0L),
                         UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
                         VoidBlobWriter.getInstance(),
-                        NettyShuffleMaster.INSTANCE,
+                        ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER,
                         NoOpJobMasterPartitionTracker.INSTANCE);
         return executionGraphFactory;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -566,7 +566,8 @@ public class SchedulerTestingUtils {
                     System.currentTimeMillis(),
                     mainThreadExecutor,
                     jobStatusListener,
-                    executionGraphFactory);
+                    executionGraphFactory,
+                    shuffleMaster);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -60,8 +60,8 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
@@ -407,7 +407,7 @@ public class SchedulerTestingUtils {
         private BlobWriter blobWriter = VoidBlobWriter.getInstance();
         private JobManagerJobMetricGroup jobManagerJobMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
-        private ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
+        private ShuffleMaster<?> shuffleMaster = ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER;
         private JobMasterPartitionTracker partitionTracker = NoOpJobMasterPartitionTracker.INSTANCE;
         private FailoverStrategy.Factory failoverStrategyFactory =
                 new RestartPipelinedRegionFailoverStrategy.Factory();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler;
+
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.shuffle.PartitionDescriptor;
+import org.apache.flink.runtime.shuffle.ProducerDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.TaskInputsOutputsDescriptor;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link SsgNetworkMemoryCalculationUtils}. */
+public class SsgNetworkMemoryCalculationUtilsTest {
+
+    private static final TestShuffleMaster SHUFFLE_MASTER = new TestShuffleMaster();
+
+    private static final ResourceProfile DEFAULT_RESOURCE = ResourceProfile.fromResources(1.0, 100);
+
+    private JobGraph jobGraph;
+
+    private ExecutionGraph executionGraph;
+
+    private List<SlotSharingGroup> slotSharingGroups;
+
+    @Test
+    public void testGenerateEnrichedResourceProfile() throws Exception {
+        setup(DEFAULT_RESOURCE);
+
+        slotSharingGroups.forEach(
+                ssg ->
+                        SsgNetworkMemoryCalculationUtils.enrichNetworkMemory(
+                                ssg, executionGraph.getAllVertices()::get, SHUFFLE_MASTER));
+
+        assertEquals(
+                new MemorySize(
+                        TestShuffleMaster.computeRequiredShuffleMemoryBytes(0, 2)
+                                + TestShuffleMaster.computeRequiredShuffleMemoryBytes(1, 6)),
+                slotSharingGroups.get(0).getResourceProfile().getNetworkMemory());
+
+        assertEquals(
+                new MemorySize(TestShuffleMaster.computeRequiredShuffleMemoryBytes(5, 0)),
+                slotSharingGroups.get(1).getResourceProfile().getNetworkMemory());
+    }
+
+    @Test
+    public void testGenerateUnknownResourceProfile() throws Exception {
+        setup(ResourceProfile.UNKNOWN);
+
+        slotSharingGroups.forEach(
+                ssg ->
+                        SsgNetworkMemoryCalculationUtils.enrichNetworkMemory(
+                                ssg, executionGraph.getAllVertices()::get, SHUFFLE_MASTER));
+
+        for (SlotSharingGroup slotSharingGroup : slotSharingGroups) {
+            assertEquals(ResourceProfile.UNKNOWN, slotSharingGroup.getResourceProfile());
+        }
+    }
+
+    private void setup(final ResourceProfile resourceProfile) throws Exception {
+        slotSharingGroups = Arrays.asList(new SlotSharingGroup(), new SlotSharingGroup());
+
+        for (SlotSharingGroup slotSharingGroup : slotSharingGroups) {
+            slotSharingGroup.setResourceProfile(resourceProfile);
+        }
+
+        jobGraph = createJobGraph(slotSharingGroups);
+        executionGraph =
+                TestingDefaultExecutionGraphBuilder.newBuilder().setJobGraph(jobGraph).build();
+    }
+
+    private static JobGraph createJobGraph(final List<SlotSharingGroup> slotSharingGroups) {
+
+        JobVertex source = new JobVertex("source");
+        source.setInvokableClass(NoOpInvokable.class);
+        source.setParallelism(4);
+        source.setSlotSharingGroup(slotSharingGroups.get(0));
+
+        JobVertex map = new JobVertex("map");
+        map.setInvokableClass(NoOpInvokable.class);
+        map.setParallelism(5);
+        map.setSlotSharingGroup(slotSharingGroups.get(0));
+
+        JobVertex sink = new JobVertex("sink");
+        sink.setInvokableClass(NoOpInvokable.class);
+        sink.setParallelism(6);
+        sink.setSlotSharingGroup(slotSharingGroups.get(1));
+
+        map.connectNewDataSetAsInput(
+                source, DistributionPattern.POINTWISE, ResultPartitionType.PIPELINED);
+        sink.connectNewDataSetAsInput(
+                map, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
+
+        return JobGraphTestUtils.streamingJobGraph(source, map, sink);
+    }
+
+    private static class TestShuffleMaster implements ShuffleMaster<ShuffleDescriptor> {
+        @Override
+        public CompletableFuture<ShuffleDescriptor> registerPartitionWithProducer(
+                PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+            return null;
+        }
+
+        @Override
+        public void releasePartitionExternally(final ShuffleDescriptor shuffleDescriptor) {}
+
+        @Override
+        public MemorySize computeShuffleMemorySizeForTask(final TaskInputsOutputsDescriptor desc) {
+            int numTotalChannels =
+                    desc.getInputChannelNums().values().stream().mapToInt(Integer::intValue).sum();
+            int numTotalSubpartitions =
+                    desc.getSubpartitionNums().values().stream().mapToInt(Integer::intValue).sum();
+            return new MemorySize(
+                    computeRequiredShuffleMemoryBytes(numTotalChannels, numTotalSubpartitions));
+        }
+
+        static int computeRequiredShuffleMemoryBytes(
+                final int numTotalChannels, final int numTotalSubpartitions) {
+            return numTotalChannels * 10000 + numTotalSubpartitions;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerBuilder.java
@@ -41,8 +41,8 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.scheduler.DefaultExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.SlotAllocator;
-import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 
@@ -70,7 +70,7 @@ public class AdaptiveSchedulerBuilder {
     private BlobWriter blobWriter = VoidBlobWriter.getInstance();
     private JobManagerJobMetricGroup jobManagerJobMetricGroup =
             UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
-    private ShuffleMaster<?> shuffleMaster = NettyShuffleMaster.INSTANCE;
+    private ShuffleMaster<?> shuffleMaster = ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER;
     private JobMasterPartitionTracker partitionTracker = NoOpJobMasterPartitionTracker.INSTANCE;
     private RestartBackoffTimeStrategy restartBackoffTimeStrategy =
             NoRestartBackoffTimeStrategy.INSTANCE;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED_BOUNDED;
+import static org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder.createRemoteWithIdAndLocation;
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link NettyShuffleUtils}. */
+public class NettyShuffleUtilsTest extends TestLogger {
+
+    /**
+     * This test verifies that the {@link NettyShuffleEnvironment} requires buffers as expected, so
+     * that the required shuffle memory size returned by {@link
+     * ShuffleMaster#computeShuffleMemorySizeForTask(TaskInputsOutputsDescriptor)} is correct.
+     */
+    @Test
+    public void testComputeRequiredNetworkBuffers() throws Exception {
+        int numBuffersPerChannel = 5;
+        int numBuffersPerGate = 8;
+        int sortShuffleMinParallelism = 8;
+        int numSortShuffleMinBuffers = 12;
+
+        int numChannels1 = 3;
+        int numChannels2 = 4;
+
+        IntermediateDataSetID ds1 = new IntermediateDataSetID();
+        IntermediateDataSetID ds2 = new IntermediateDataSetID();
+        IntermediateDataSetID ds3 = new IntermediateDataSetID();
+
+        int numSubs1 = 5; // pipelined shuffle
+        int numSubs2 = 6; // hash blocking shuffle
+        int numSubs3 = 10; // sort blocking shuffle
+        Map<IntermediateDataSetID, Integer> subpartitionNums =
+                ImmutableMap.of(ds1, numSubs1, ds2, numSubs2, ds3, numSubs3);
+        Map<IntermediateDataSetID, ResultPartitionType> partitionTypes =
+                ImmutableMap.of(ds1, PIPELINED_BOUNDED, ds2, BLOCKING, ds3, BLOCKING);
+
+        int numTotalBuffers =
+                NettyShuffleUtils.computeNetworkBuffersForAnnouncing(
+                        numBuffersPerChannel,
+                        numBuffersPerGate,
+                        sortShuffleMinParallelism,
+                        numSortShuffleMinBuffers,
+                        numChannels1 + numChannels2,
+                        2,
+                        subpartitionNums,
+                        partitionTypes);
+
+        NettyShuffleEnvironment sEnv =
+                new NettyShuffleEnvironmentBuilder()
+                        .setNumNetworkBuffers(numTotalBuffers)
+                        .setNetworkBuffersPerChannel(numBuffersPerChannel)
+                        .setSortShuffleMinBuffers(numSortShuffleMinBuffers)
+                        .setSortShuffleMinParallelism(sortShuffleMinParallelism)
+                        .build();
+
+        SingleInputGate inputGate1 = createInputGate(sEnv, PIPELINED_BOUNDED, numChannels1);
+        inputGate1.setup();
+
+        SingleInputGate inputGate2 = createInputGate(sEnv, BLOCKING, numChannels2);
+        inputGate2.setup();
+
+        ResultPartition resultPartition1 = createResultPartition(sEnv, PIPELINED_BOUNDED, numSubs1);
+        resultPartition1.setup();
+
+        ResultPartition resultPartition2 = createResultPartition(sEnv, BLOCKING, numSubs2);
+        resultPartition2.setup();
+
+        ResultPartition resultPartition3 = createResultPartition(sEnv, BLOCKING, numSubs3);
+        resultPartition3.setup();
+
+        int expected =
+                calculateBuffersConsumption(inputGate1)
+                        + calculateBuffersConsumption(inputGate2)
+                        + calculateBuffersConsumption(resultPartition1)
+                        + calculateBuffersConsumption(resultPartition2)
+                        + calculateBuffersConsumption(resultPartition3);
+        assertEquals(expected, numTotalBuffers);
+
+        inputGate1.close();
+        inputGate2.close();
+        resultPartition1.close();
+        resultPartition2.close();
+        resultPartition3.close();
+    }
+
+    private SingleInputGate createInputGate(
+            NettyShuffleEnvironment network,
+            ResultPartitionType resultPartitionType,
+            int numInputChannels) {
+
+        ShuffleDescriptor[] shuffleDescriptors = new NettyShuffleDescriptor[numInputChannels];
+        for (int i = 0; i < numInputChannels; i++) {
+            shuffleDescriptors[i] =
+                    createRemoteWithIdAndLocation(
+                            new IntermediateResultPartitionID(), ResourceID.generate());
+        }
+
+        InputGateDeploymentDescriptor inputGateDeploymentDescriptor =
+                new InputGateDeploymentDescriptor(
+                        new IntermediateDataSetID(), resultPartitionType, 0, shuffleDescriptors);
+
+        ExecutionAttemptID consumerID = new ExecutionAttemptID();
+        Collection<SingleInputGate> inputGates =
+                network.createInputGates(
+                        network.createShuffleIOOwnerContext(
+                                "", consumerID, new UnregisteredMetricsGroup()),
+                        SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
+                        Collections.singletonList(inputGateDeploymentDescriptor));
+
+        return inputGates.iterator().next();
+    }
+
+    private ResultPartition createResultPartition(
+            NettyShuffleEnvironment network,
+            ResultPartitionType resultPartitionType,
+            int numSubpartitions) {
+
+        ShuffleDescriptor shuffleDescriptor =
+                createRemoteWithIdAndLocation(
+                        new IntermediateResultPartitionID(), ResourceID.generate());
+
+        PartitionDescriptor partitionDescriptor =
+                new PartitionDescriptor(
+                        new IntermediateDataSetID(),
+                        2,
+                        shuffleDescriptor.getResultPartitionID().getPartitionId(),
+                        resultPartitionType,
+                        numSubpartitions,
+                        0);
+        ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor =
+                new ResultPartitionDeploymentDescriptor(
+                        partitionDescriptor, shuffleDescriptor, 1, true);
+
+        ExecutionAttemptID consumerID = new ExecutionAttemptID();
+        Collection<ResultPartition> resultPartitions =
+                network.createResultPartitionWriters(
+                        network.createShuffleIOOwnerContext(
+                                "", consumerID, new UnregisteredMetricsGroup()),
+                        Collections.singletonList(resultPartitionDeploymentDescriptor));
+
+        return resultPartitions.iterator().next();
+    }
+
+    private int calculateBuffersConsumption(SingleInputGate inputGate) throws Exception {
+        inputGate.setChannelStateWriter(ChannelStateWriter.NO_OP);
+        inputGate.finishReadRecoveredState();
+        while (!inputGate.getStateConsumedFuture().isDone()) {
+            inputGate.pollNext();
+        }
+        inputGate.convertRecoveredInputChannels();
+
+        int ret = 0;
+        for (InputChannel ch : inputGate.getInputChannels().values()) {
+            RemoteInputChannel rChannel = (RemoteInputChannel) ch;
+            ret += rChannel.getNumberOfAvailableBuffers();
+        }
+        ret += inputGate.getBufferPool().getMaxNumberOfMemorySegments();
+        return ret;
+    }
+
+    private int calculateBuffersConsumption(ResultPartition partition) {
+        if (partition.getPartitionType().isBlocking()) {
+            return partition.getBufferPool().getNumberOfRequiredMemorySegments();
+        } else {
+            return partition.getBufferPool().getMaxNumberOfMemorySegments();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleTestUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+
+/** Utils for shuffle related tests. */
+public class ShuffleTestUtils {
+
+    public static final ShuffleMaster<?> DEFAULT_SHUFFLE_MASTER =
+            new NettyShuffleMaster(new Configuration());
+
+    /** Private default constructor to avoid being instantiated. */
+    private ShuffleTestUtils() {}
+}


### PR DESCRIPTION
## What is the purpose of the change

Calculating and announcing the volume of required network memory for shuffle is an important part of 'fine grained resource management'(FLIP-156). This PR proposes the implementation and help user avoid suffering from network memory shortage.


## Brief change log

  - *Add an interface in ShuffleMaster to calculate network memory requirements of ExecutionJobVertex*
  - *SSGNetworkMemoryCalculator sums up network memory requirements of ExecutionJobVertex in the same SlotSharingGroup and update the corresponding ResourceProfile before scheduling*

## Verifying this change

  - unit tests are added for SSGNetworkMemoryCalculator
  - unit tests are added for NettyShuffleUtils
  - unit tests are modified for EdgeManagerBuildUtil

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
