### PR TITLE
[FLINK-22946][runtime] Recycle floating buffer outside the lock to avoid deadlock

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -136,6 +136,13 @@ public class BufferManager implements BufferListener, BufferRecycler {
                 "The number of exclusive buffers per channel should be larger than 0.");
 
         synchronized (bufferQueue) {
+            // AvailableBufferQueue::addExclusiveBuffer may release the previously allocated
+            // floating buffer, which requires the caller to recycle these released floating
+            // buffers. There should be no floating buffers that have been allocated before the
+            // exclusive buffers are initialized, so here only a simple assertion is required
+            checkState(
+                    unsynchronizedGetFloatingBuffersAvailable() == 0,
+                    "Bug in buffer allocation logic: floating buffer is allocated before exclusive buffers are initialized.");
             for (MemorySegment segment : segments) {
                 bufferQueue.addExclusiveBuffer(
                         new NetworkBuffer(segment, this), numRequiredBuffers);
@@ -188,15 +195,16 @@ public class BufferManager implements BufferListener, BufferRecycler {
      */
     @Override
     public void recycle(MemorySegment segment) {
-        int numAddedBuffers = 0;
+        @Nullable Buffer releasedFloatingBuffer = null;
         synchronized (bufferQueue) {
             try {
                 // Similar to notifyBufferAvailable(), make sure that we never add a buffer
                 // after channel released all buffers via releaseAllResources().
                 if (inputChannel.isReleased()) {
                     globalPool.recycleMemorySegments(Collections.singletonList(segment));
+                    return;
                 } else {
-                    numAddedBuffers =
+                    releasedFloatingBuffer =
                             bufferQueue.addExclusiveBuffer(
                                     new NetworkBuffer(segment, this), numRequiredBuffers);
                 }
@@ -207,10 +215,14 @@ public class BufferManager implements BufferListener, BufferRecycler {
             }
         }
 
-        try {
-            inputChannel.notifyBufferAvailable(numAddedBuffers);
-        } catch (Throwable t) {
-            ExceptionUtils.rethrow(t);
+        if (releasedFloatingBuffer != null) {
+            releasedFloatingBuffer.recycleBuffer();
+        } else {
+            try {
+                inputChannel.notifyBufferAvailable(1);
+            } catch (Throwable t) {
+                ExceptionUtils.rethrow(t);
+            }
         }
     }
 
@@ -384,23 +396,23 @@ public class BufferManager implements BufferListener, BufferRecycler {
         }
 
         /**
-         * Adds an exclusive buffer (back) into the queue and recycles one floating buffer if the
-         * number of available buffers in queue is more than the required amount.
+         * Adds an exclusive buffer (back) into the queue and releases one floating buffer if the
+         * number of available buffers in queue is more than the required amount. If floating buffer
+         * is released, the total amount of available buffers after adding this exclusive buffer has
+         * not changed, and no new buffers are available. The caller is responsible for recycling
+         * the release/returned floating buffer.
          *
          * @param buffer The exclusive buffer to add
          * @param numRequiredBuffers The number of required buffers
-         * @return How many buffers were added to the queue
+         * @return An released floating buffer, may be null if the numRequiredBuffers is not met.
          */
-        int addExclusiveBuffer(Buffer buffer, int numRequiredBuffers) {
+        @Nullable
+        Buffer addExclusiveBuffer(Buffer buffer, int numRequiredBuffers) {
             exclusiveBuffers.add(buffer);
             if (getAvailableBufferSize() > numRequiredBuffers) {
-                Buffer floatingBuffer = floatingBuffers.poll();
-                if (floatingBuffer != null) {
-                    floatingBuffer.recycleBuffer();
-                    return 0;
-                }
+                return floatingBuffers.poll();
             }
-            return 1;
+            return null;
         }
 
         void addFloatingBuffer(Buffer buffer) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Recycle floating buffer outside the lock to avoid deadlock


## Brief change log

  - The floting buffer is not recycle in `AvailableBufferQueue::addExclusiveBuffer()`, the released floting buffer is returned, and the caller will reclaim it outside the lock
  - In `BufferManager::recycle()`, if the return value of `AvailableBufferQueue::addExclusiveBuffer()` is not null, the floating buffer(return value) is recycled
  - In addition to `BufferManager::recycle()`, another place to call `AvailableBufferQueue::addExclusiveBuffer()` is `BufferManager::requestExclusiveBuffers()`. There should be no floating buffer released, so simply add an assertion
  - Modify comments and add additional comments


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? 
