### PR TITLE
[FLINK-22528][docs] Document latency tracking metrics for state accesses

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1642,7 +1642,7 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
   </tbody>
 </table>
 
-## Latency tracking
+## End-to-End latency tracking
 
 Flink allows to track the latency of records travelling through the system. This feature is disabled by default.
 To enable the latency tracking you must set the `latencyTrackingInterval` to a positive number in either the
@@ -1670,6 +1670,17 @@ up an automated clock synchronisation service (like NTP) to avoid false latency 
 <span class="label label-danger">Warning</span> Enabling latency metrics can significantly impact the performance
 of the cluster (in particular for `subtask` granularity). It is highly recommended to only use them for debugging 
 purposes.
+
+## State access latency tracking
+
+Flink also allows to track the keyed state access latency for standard Flink state-backends or customized state backends which extending from `AbstractStateBackend`. This feature is disabled by default.
+To enable this feature you must set the `state.backend.latency-track.keyed-state-enabled` to true in the [Flink configuration]({{< ref "docs/deployment/config" >}}#state-backends-latency-tracking-options).
+
+Once tracking keyed state access latency is enabled, Flink will sample the state access latency every `N` access, in which `N` is defined by `state.backend.latency-track.sample-interval`.
+This configuration has a default value of 100. A smaller value will get more accurate results but have a higher performance impact since it is sampled more frequently.
+
+As the type of this latency metrics is histogram, `state.backend.latency-track.history-size` will control the maximum number of recorded values in history, which has the default value of 128.
+A larger value of this configuration will require more memory, but will provide a more accurate result.
 
 ## REST API integration
 

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1641,7 +1641,7 @@ logged by `SystemResourcesMetricsInitializer` during the startup.
   </tbody>
 </table>
 
-## Latency tracking
+## End-to-End latency tracking
 
 Flink allows to track the latency of records travelling through the system. This feature is disabled by default.
 To enable the latency tracking you must set the `latencyTrackingInterval` to a positive number in either the
@@ -1669,6 +1669,17 @@ up an automated clock synchronisation service (like NTP) to avoid false latency 
 <span class="label label-danger">Warning</span> Enabling latency metrics can significantly impact the performance
 of the cluster (in particular for `subtask` granularity). It is highly recommended to only use them for debugging 
 purposes.
+
+## State access latency tracking
+
+Flink also allows to track the keyed state access latency for standard Flink state-backends or customized state backends which extending from `AbstractStateBackend`. This feature is disabled by default.
+To enable this feature you must set the `state.backend.latency-track.keyed-state-enabled` to true in the [Flink configuration]({{< ref "docs/deployment/config" >}}#state-backends-latency-tracking-options).
+
+Once tracking keyed state access latency is enabled, Flink will sample the state access latency every `N` access, in which `N` is defined by `state.backend.latency-track.sample-interval`.
+This configuration has a default value of 100. A smaller value will get more accurate results but have a higher performance impact since it is sampled more frequently.
+
+As the type of this latency metrics is histogram, `state.backend.latency-track.history-size` will control the maximum number of recorded values in history, which has the default value of 128.
+A larger value of this configuration will require more memory, but will provide a more accurate result.
 
 ## REST API integration
 


### PR DESCRIPTION
## What is the purpose of the change

Add document of latency tracking metrics for state accesses.

## Brief change log

Add document of latency tracking metrics for state accesses.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
