### PR TITLE
[FLINK-22980][tests] Set parallelism on job vertex required by adapti…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStoreTest.java
@@ -349,6 +349,8 @@ public class FileExecutionGraphInfoStoreTest extends TestLogger {
                 new PersistingMiniCluster(new MiniClusterConfiguration.Builder().build())) {
             miniCluster.start();
             final JobVertex vertex = new JobVertex("blockingVertex");
+            // The adaptive scheduler expects that every vertex has a configured parallelism
+            vertex.setParallelism(1);
             vertex.setInvokableClass(SignallingBlockingNoOpInvokable.class);
             final JobGraph jobGraph = JobGraphTestUtils.streamingJobGraph(vertex);
             miniCluster.submitJob(jobGraph);


### PR DESCRIPTION
…ve scheduler

## What is the purpose of the change

Setting job vertex parallelism to fulfill adaptive scheduler requirement


## Verifying this change

I enabled the adaptive scheduler locally for the test case with `config.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
