### PR TITLE
[FLINK-21089] Skip the execution of the fully finished operators after recovery

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -345,8 +345,11 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                     sourceInput,
                     new ChainedSource(
                             chainedSourceOutput,
-                            new StreamTaskSourceInput<>(
-                                    sourceOperator, sourceInputGateIndex++, inputId)));
+                            finishedOnRestore
+                                    ? new StreamTaskFinishedOnRestoreSourceInput<>(
+                                            sourceOperator, sourceInputGateIndex++, inputId)
+                                    : new StreamTaskSourceInput<>(
+                                            sourceOperator, sourceInputGateIndex++, inputId)));
         }
         return chainedSourceInputs;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -392,6 +392,10 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     }
 
     public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        if (finishedOnRestore) {
+            return;
+        }
+
         // go forward through the operator chain and tell each operator
         // to prepare the checkpoint
         for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators()) {
@@ -420,6 +424,10 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      */
     protected void initializeStateAndOpenOperators(
             StreamTaskStateInitializer streamTaskStateInitializer) throws Exception {
+        if (finishedOnRestore) {
+            return;
+        }
+
         for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
             StreamOperator<?> operator = operatorWrapper.getStreamOperator();
             operator.initializeState(streamTaskStateInitializer);
@@ -433,6 +441,10 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      * heads</b> (see {@link #initializeStateAndOpenOperators(StreamTaskStateInitializer)}).
      */
     protected void finishOperators(StreamTaskActionExecutor actionExecutor) throws Exception {
+        if (finishedOnRestore) {
+            return;
+        }
+
         if (firstOperatorWrapper != null) {
             firstOperatorWrapper.finish(actionExecutor, ignoreEndOfInput);
         }
@@ -443,6 +455,10 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      * StreamTask}. Closing happens from <b>tail to head</b> operator in the chain.
      */
     protected void closeAllOperators() throws Exception {
+        if (finishedOnRestore) {
+            return;
+        }
+
         Exception closingException = null;
         for (StreamOperatorWrapper<?, ?> operatorWrapper : getAllOperators(true)) {
             try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTask.java
@@ -77,7 +77,9 @@ public class SourceOperatorStreamTask<T> extends StreamTask<T, SourceOperator<T,
         final SourceReader<T, ?> sourceReader = sourceOperator.getSourceReader();
         final StreamTaskInput<T> input;
 
-        if (sourceReader instanceof ExternallyInducedSourceReader) {
+        if (operatorChain.isFinishedOnRestore()) {
+            input = new StreamTaskFinishedOnRestoreSourceInput<>(sourceOperator, 0, 0);
+        } else if (sourceReader instanceof ExternallyInducedSourceReader) {
             isExternallyInducedSource = true;
 
             input =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinishedOnRestoreSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinishedOnRestoreSourceInput.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.streaming.api.operators.SourceOperator;
+import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A special source input implementation that immediately emit END_OF_INPUT. It is used for sources
+ * that finished on restore.
+ */
+public class StreamTaskFinishedOnRestoreSourceInput<T> extends StreamTaskSourceInput<T> {
+
+    public StreamTaskFinishedOnRestoreSourceInput(
+            SourceOperator<T, ?> operator, int inputGateIndex, int inputIndex) {
+        super(operator, inputGateIndex, inputIndex);
+    }
+
+    @Override
+    public InputStatus emitNext(DataOutput<T> output) throws Exception {
+        return InputStatus.END_OF_INPUT;
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return AVAILABLE;
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LifeCycleMonitor.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LifeCycleMonitor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/** A utility class to record the number of calls for each phase. */
+class LifeCycleMonitor implements Serializable {
+
+    /** The lifecycle of the one-input operator. */
+    public enum LifeCyclePhase {
+        OPEN,
+        INITIALIZE_STATE,
+        PROCESS_ELEMENT,
+        PREPARE_SNAPSHOT_PRE_BARRIER,
+        SNAPSHOT_STATE,
+        NOTIFY_CHECKPOINT_COMPLETE,
+        NOTIFY_CHECKPOINT_ABORT,
+        FINISH,
+        CLOSE
+    }
+
+    private final Map<LifeCyclePhase, Integer> callTimes = new HashMap<>();
+
+    public void incrementCallTime(LifeCyclePhase phase) {
+        callTimes.compute(phase, (k, v) -> v == null ? 1 : v + 1);
+    }
+
+    public void assertCallTimes(int expectedTimes, LifeCyclePhase... phases) {
+        for (LifeCyclePhase phase : phases) {
+            assertEquals(
+                    String.format("The phase %s has unexpected call times", phase),
+                    expectedTimes,
+                    callTimes.getOrDefault(phase, 0).intValue());
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -58,7 +58,7 @@ import java.util.function.Supplier;
 
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.addSourceRecords;
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.buildTestHarness;
-import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.triggerCheckpoint;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -94,8 +94,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
-import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.processMailTillCheckpointSucceeds;
-import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.triggerCheckpoint;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.processMailTillCheckpointSucceeds;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -83,7 +83,7 @@ import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO;
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT_SUSPEND;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
-import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.triggerCheckpoint;
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -609,8 +609,7 @@ public class SourceStreamTaskTest extends SourceStreamTaskTestBase {
                                     SourceStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
                             .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
                             .addAdditionalOutput(partitionWriters)
-                            .setupOperatorChain(
-                                    new StreamSource<>(new MockSource(0, Integer.MAX_VALUE, 1)))
+                            .setupOperatorChain(new StreamSource<>(new MockSource(0, 0, 1)))
                             .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
                             .build()) {
                 testHarness

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -1,0 +1,418 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
+import org.apache.flink.runtime.io.network.partition.PipelinedResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
+import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests the behavior of {@link StreamTask} related to final checkpoint. */
+public class StreamTaskFinalCheckpointsTest {
+
+    @Test
+    public void testCheckpointDoneOnFinishedOperator() throws Exception {
+        FinishingOperator finishingOperator = new FinishingOperator();
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+        StreamTaskMailboxTestHarness<Integer> harness =
+                builder.setupOutputForSingletonOperatorChain(finishingOperator).build();
+        // keeps the mailbox from suspending
+        harness.setAutoProcess(false);
+        harness.processElement(new StreamRecord<>(1));
+
+        harness.streamTask.operatorChain.finishOperators(harness.streamTask.getActionExecutor());
+        assertTrue(FinishingOperator.finished);
+
+        harness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+        harness.streamTask.triggerCheckpointOnBarrier(
+                new CheckpointMetaData(2, 0),
+                CheckpointOptions.forCheckpointWithDefaultLocation(),
+                new CheckpointMetricsBuilder()
+                        .setBytesProcessedDuringAlignment(0L)
+                        .setAlignmentDurationNanos(0L));
+        harness.getTaskStateManager().getWaitForReportLatch().await();
+        assertEquals(2, harness.getTaskStateManager().getReportedCheckpointId());
+    }
+
+    @Test
+    public void testNotWaitingForAllRecordsProcessedIfCheckpointNotEnabled() throws Exception {
+        ResultPartitionWriter[] partitionWriters = new ResultPartitionWriter[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
+
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    OneInputStreamTask::new, STRING_TYPE_INFO)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(false))
+                            .addInput(STRING_TYPE_INFO)
+                            .addAdditionalOutput(partitionWriters)
+                            .setupOperatorChain(new EmptyOperator())
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
+                testHarness.endInput();
+
+                // In this case the result partition should not emit EndOfUserRecordsEvent.
+                for (ResultPartitionWriter writer : partitionWriters) {
+                    assertEquals(0, ((PipelinedResultPartition) writer).getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTriggeringCheckpointWithFinishedChannels() throws Exception {
+        ResultPartition[] partitionWriters = new ResultPartition[2];
+        try {
+            for (int i = 0; i < partitionWriters.length; ++i) {
+                partitionWriters[i] =
+                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
+                partitionWriters[i].setup();
+            }
+
+            try (StreamTaskMailboxTestHarness<String> testHarness =
+                    new StreamTaskMailboxTestHarnessBuilder<>(
+                                    OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                            .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
+                            .addAdditionalOutput(partitionWriters)
+                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
+                            .setupOperatorChain(new EmptyOperator())
+                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                            .build()) {
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointCoordinator()
+                        .setEnableCheckpointAfterTasksFinished(true);
+                testHarness
+                        .getStreamTask()
+                        .getCheckpointBarrierHandler()
+                        .get()
+                        .setEnableCheckpointAfterTasksFinished(true);
+
+                // Tests triggering checkpoint when all the inputs are alive.
+                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+
+                // Tests triggering checkpoint after some inputs have received EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
+                checkpointFuture = triggerCheckpoint(testHarness, 4);
+                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
+                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
+
+                // Tests triggering checkpoint after received all the inputs have received
+                // EndOfPartition.
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 1);
+                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 2);
+                checkpointFuture = triggerCheckpoint(testHarness, 6);
+
+                // Notifies the result partition that all records are processed after the
+                // last checkpoint is triggered.
+                checkState(
+                        checkpointFuture instanceof CompletableFuture,
+                        "The trigger future should " + " be also CompletableFuture.");
+                ((CompletableFuture<?>) checkpointFuture)
+                        .thenAccept(
+                                (ignored) -> {
+                                    for (ResultPartition resultPartition : partitionWriters) {
+                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
+                                    }
+                                });
+
+                // The checkpoint 6 would be triggered successfully.
+                testHarness.finishProcessing();
+                assertTrue(checkpointFuture.isDone());
+                testHarness.getTaskStateManager().getWaitForReportLatch().await();
+                assertEquals(6, testHarness.getTaskStateManager().getReportedCheckpointId());
+
+                // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
+                for (ResultPartition resultPartition : partitionWriters) {
+                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                }
+            }
+        } finally {
+            for (ResultPartitionWriter writer : partitionWriters) {
+                if (writer != null) {
+                    writer.close();
+                }
+            }
+        }
+    }
+
+    static Future<Boolean> triggerCheckpoint(
+            StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
+        testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+        return testHarness
+                .getStreamTask()
+                .triggerCheckpointAsync(
+                        new CheckpointMetaData(checkpointId, checkpointId * 1000),
+                        CheckpointOptions.alignedNoTimeout(
+                                CheckpointType.CHECKPOINT,
+                                CheckpointStorageLocationReference.getDefault()));
+    }
+
+    static void processMailTillCheckpointSucceeds(
+            StreamTaskMailboxTestHarness<String> testHarness, Future<Boolean> checkpointFuture)
+            throws Exception {
+        while (!checkpointFuture.isDone()) {
+            testHarness.processSingleStep();
+        }
+        testHarness.getTaskStateManager().getWaitForReportLatch().await();
+    }
+
+    @Test
+    public void testWaitingForPendingCheckpointsOnFinished() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        try {
+            OneShotLatch asyncCheckpointExecuted = new OneShotLatch();
+            OneShotLatch canCheckpointBeAcknowledged = new OneShotLatch();
+            OneShotLatch invokeCompleted = new OneShotLatch();
+
+            TestCheckpointResponder responder =
+                    new TestCheckpointResponder() {
+                        @Override
+                        public void acknowledgeCheckpoint(
+                                JobID jobID,
+                                ExecutionAttemptID executionAttemptID,
+                                long checkpointId,
+                                CheckpointMetrics checkpointMetrics,
+                                TaskStateSnapshot subtaskState) {
+
+                            try {
+                                asyncCheckpointExecuted.trigger();
+                                canCheckpointBeAcknowledged.await();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    };
+
+            CompletableFuture<Void> taskClosed =
+                    CompletableFuture.runAsync(
+                            () -> {
+                                try (StreamTaskMailboxTestHarness<String> harness =
+                                        new StreamTaskMailboxTestHarnessBuilder<>(
+                                                        OneInputStreamTask::new,
+                                                        BasicTypeInfo.STRING_TYPE_INFO)
+                                                .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
+                                                .modifyStreamConfig(
+                                                        config ->
+                                                                config.setCheckpointingEnabled(
+                                                                        true))
+                                                .setCheckpointResponder(responder)
+                                                .setupOperatorChain(new EmptyOperator())
+                                                .finishForSingletonOperatorChain(
+                                                        StringSerializer.INSTANCE)
+                                                .build()) {
+
+                                    harness.streamTask
+                                            .getCheckpointCoordinator()
+                                            .setEnableCheckpointAfterTasksFinished(true);
+
+                                    harness.streamTask.triggerCheckpointOnBarrier(
+                                            new CheckpointMetaData(1, 101),
+                                            CheckpointOptions.forCheckpointWithDefaultLocation(),
+                                            new CheckpointMetricsBuilder()
+                                                    .setBytesProcessedDuringAlignment(0L)
+                                                    .setAlignmentDurationNanos(0L));
+
+                                    harness.waitForTaskCompletion();
+                                    invokeCompleted.trigger();
+                                    harness.finishProcessing();
+                                } catch (Exception e) {
+                                    e.printStackTrace();
+                                }
+                            },
+                            executor);
+
+            asyncCheckpointExecuted.await();
+            invokeCompleted.await();
+            // Give some potential time for the task to finish before the
+            // checkpoint is acknowledged
+            Thread.sleep(500);
+            assertFalse(taskClosed.isDone());
+            canCheckpointBeAcknowledged.trigger();
+            taskClosed.get();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testOperatorSkipLifeCycleIfFinishedOnRestore() throws Exception {
+        try (StreamTaskMailboxTestHarness<String> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
+                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED)
+                        .setupOutputForSingletonOperatorChain(new LifeCycleMonitorOperator<>())
+                        .build()) {
+            // Finish the restore, including state initialization and open.
+            harness.processAll();
+
+            // Try trigger a checkpoint.
+            harness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
+            harness.streamTask.triggerCheckpointOnBarrier(
+                    new CheckpointMetaData(2, 2),
+                    new CheckpointOptions(CheckpointType.CHECKPOINT, getDefault()),
+                    new CheckpointMetricsBuilder()
+                            .setBytesProcessedDuringAlignment(0)
+                            .setAlignmentDurationNanos(0));
+            harness.getTaskStateManager().getWaitForReportLatch().await();
+            assertEquals(2, harness.getTaskStateManager().getReportedCheckpointId());
+
+            // Checkpoint notification.
+            harness.streamTask.notifyCheckpointCompleteAsync(2);
+            harness.streamTask.notifyCheckpointAbortAsync(3);
+            harness.processAll();
+
+            // Finish & close operators.
+            harness.waitForTaskCompletion();
+            harness.finishProcessing();
+
+            LifeCycleMonitorOperator<String> operator =
+                    (LifeCycleMonitorOperator<String>) harness.getStreamTask().getMainOperator();
+            operator.getLifeCycleMonitor().assertCallTimes(0, LifeCyclePhase.values());
+        }
+    }
+
+    private static class EmptyOperator extends AbstractStreamOperator<String>
+            implements OneInputStreamOperator<String, String> {
+
+        @Override
+        public void processElement(StreamRecord<String> element) throws Exception {}
+    }
+
+    private static class FinishingOperator extends AbstractStreamOperator<String>
+            implements OneInputStreamOperator<String, String> {
+        static boolean finished = false;
+
+        @Override
+        public void processElement(StreamRecord<String> element) throws Exception {}
+
+        @Override
+        public void finish() throws Exception {
+            finished = true;
+        }
+    }
+
+    /** A special one-input operator that monitors the lifecycle of the operator. */
+    static class LifeCycleMonitorOperator<T> extends AbstractStreamOperator<T>
+            implements OneInputStreamOperator<T, T> {
+
+        private final LifeCycleMonitor lifeCycleMonitor = new LifeCycleMonitor();
+
+        @Override
+        public void open() throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.OPEN);
+        }
+
+        @Override
+        public void initializeState(StateInitializationContext context) throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.INITIALIZE_STATE);
+        }
+
+        @Override
+        public void processElement(StreamRecord<T> element) throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.PROCESS_ELEMENT);
+        }
+
+        @Override
+        public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.PREPARE_SNAPSHOT_PRE_BARRIER);
+        }
+
+        @Override
+        public void snapshotState(StateSnapshotContext context) throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.SNAPSHOT_STATE);
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.NOTIFY_CHECKPOINT_COMPLETE);
+        }
+
+        @Override
+        public void notifyCheckpointAborted(long checkpointId) throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.NOTIFY_CHECKPOINT_ABORT);
+        }
+
+        @Override
+        public void finish() throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.FINISH);
+        }
+
+        @Override
+        public void close() throws Exception {
+            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.CLOSE);
+        }
+
+        public LifeCycleMonitor getLifeCycleMonitor() {
+            return lifeCycleMonitor;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -141,7 +141,12 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
 
     public StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
             SourceOperatorFactory<?> sourceOperatorFactory) {
-        inputs.add(new SourceInputConfigPlaceHolder(sourceOperatorFactory));
+        return addSourceInput(new OperatorID(), sourceOperatorFactory);
+    }
+
+    public StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
+            OperatorID operatorId, SourceOperatorFactory<?> sourceOperatorFactory) {
+        inputs.add(new SourceInputConfigPlaceHolder(operatorId, sourceOperatorFactory));
         return this;
     }
 
@@ -292,7 +297,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         sourceConfig.setOutEdgesInOrder(outEdgesInOrder);
         sourceConfig.setChainedOutputs(outEdgesInOrder);
         sourceConfig.setTypeSerializerOut(outputSerializer);
-        sourceConfig.setOperatorID(new OperatorID());
+        sourceConfig.setOperatorID(sourceInput.getOperatorId());
         sourceConfig.setStreamOperatorFactory(sourceInput.getSourceOperatorFactory());
 
         transitiveChainedTaskConfigs.put(sourceToMainEdge.getSourceId(), sourceConfig);
@@ -379,10 +384,17 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
      * it is replaced with {@link SourceInputConfig}.
      */
     public static class SourceInputConfigPlaceHolder implements InputConfig {
+        private OperatorID operatorId;
         private SourceOperatorFactory<?> sourceOperatorFactory;
 
-        public SourceInputConfigPlaceHolder(SourceOperatorFactory<?> sourceOperatorFactory) {
+        public SourceInputConfigPlaceHolder(
+                OperatorID operatorId, SourceOperatorFactory<?> sourceOperatorFactory) {
+            this.operatorId = operatorId;
             this.sourceOperatorFactory = sourceOperatorFactory;
+        }
+
+        public OperatorID getOperatorId() {
+            return operatorId;
         }
 
         public SourceOperatorFactory<?> getSourceOperatorFactory() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -46,14 +46,9 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
-import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.writer.AvailabilityTestResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
-import org.apache.flink.runtime.io.network.partition.PartitionTestUtils;
-import org.apache.flink.runtime.io.network.partition.PipelinedResultPartition;
-import org.apache.flink.runtime.io.network.partition.ResultPartition;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.metrics.TimerGauge;
@@ -67,7 +62,6 @@ import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
-import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DoneFuture;
@@ -84,7 +78,6 @@ import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackendFactory;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
-import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
@@ -96,7 +89,6 @@ import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
-import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.runtime.taskmanager.TestTaskBuilder;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -120,7 +112,6 @@ import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.streaming.util.MockStreamConfig;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
@@ -162,7 +153,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -1247,33 +1237,6 @@ public class StreamTaskTest extends TestLogger {
         }
     }
 
-    @Test
-    public void testCheckpointDoneOnFinishedOperator() throws Exception {
-        FinishingOperator finishingOperator = new FinishingOperator();
-        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
-                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
-        StreamTaskMailboxTestHarness<Integer> harness =
-                builder.setupOutputForSingletonOperatorChain(finishingOperator).build();
-        // keeps the mailbox from suspending
-        harness.setAutoProcess(false);
-        harness.processElement(new StreamRecord<>(1));
-
-        harness.streamTask.operatorChain.finishOperators(harness.streamTask.getActionExecutor());
-        assertTrue(FinishingOperator.finished);
-
-        harness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
-        harness.streamTask.triggerCheckpointOnBarrier(
-                new CheckpointMetaData(2, 0),
-                CheckpointOptions.forCheckpointWithDefaultLocation(),
-                new CheckpointMetricsBuilder()
-                        .setBytesProcessedDuringAlignment(0L)
-                        .setAlignmentDurationNanos(0L));
-        harness.getTaskStateManager().getWaitForReportLatch().await();
-        assertEquals(2, harness.getTaskStateManager().getReportedCheckpointId());
-    }
-
     /**
      * Tests that checkpoints are declined if operators are (partially) closed.
      *
@@ -1762,258 +1725,6 @@ public class StreamTaskTest extends TestLogger {
 
         // and: The task should clean up all resources even when cancelTask fails.
         assertTrue(OpenFailingOperator.wasClosed);
-    }
-
-    @Test
-    public void testNotWaitingForAllRecordsProcessedIfCheckpointNotEnabled() throws Exception {
-        ResultPartitionWriter[] partitionWriters = new ResultPartitionWriter[2];
-        try {
-            for (int i = 0; i < partitionWriters.length; ++i) {
-                partitionWriters[i] =
-                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
-                partitionWriters[i].setup();
-            }
-
-            try (StreamTaskMailboxTestHarness<String> testHarness =
-                    new StreamTaskMailboxTestHarnessBuilder<>(
-                                    OneInputStreamTask::new, STRING_TYPE_INFO)
-                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(false))
-                            .addInput(STRING_TYPE_INFO)
-                            .addAdditionalOutput(partitionWriters)
-                            .setupOperatorChain(new EmptyOperator())
-                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
-                            .build()) {
-                testHarness.endInput();
-
-                // In this case the result partition should not emit EndOfUserRecordsEvent.
-                for (ResultPartitionWriter writer : partitionWriters) {
-                    assertEquals(0, ((PipelinedResultPartition) writer).getNumberOfQueuedBuffers());
-                }
-            }
-        } finally {
-            for (ResultPartitionWriter writer : partitionWriters) {
-                if (writer != null) {
-                    writer.close();
-                }
-            }
-        }
-    }
-
-    @Test
-    public void testTriggeringCheckpointWithFinishedChannels() throws Exception {
-        ResultPartition[] partitionWriters = new ResultPartition[2];
-        try {
-            for (int i = 0; i < partitionWriters.length; ++i) {
-                partitionWriters[i] =
-                        PartitionTestUtils.createPartition(ResultPartitionType.PIPELINED_BOUNDED);
-                partitionWriters[i].setup();
-            }
-
-            try (StreamTaskMailboxTestHarness<String> testHarness =
-                    new StreamTaskMailboxTestHarnessBuilder<>(
-                                    OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                            .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
-                            .addAdditionalOutput(partitionWriters)
-                            .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
-                            .setupOperatorChain(new EmptyOperator())
-                            .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
-                            .build()) {
-                testHarness
-                        .getStreamTask()
-                        .getCheckpointCoordinator()
-                        .setEnableCheckpointAfterTasksFinished(true);
-                testHarness
-                        .getStreamTask()
-                        .getCheckpointBarrierHandler()
-                        .get()
-                        .setEnableCheckpointAfterTasksFinished(true);
-
-                // Tests triggering checkpoint when all the inputs are alive.
-                Future<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
-                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
-
-                // Tests triggering checkpoint after some inputs have received EndOfPartition.
-                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
-                checkpointFuture = triggerCheckpoint(testHarness, 4);
-                processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
-
-                // Tests triggering checkpoint after received all the inputs have received
-                // EndOfPartition.
-                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 1);
-                testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 2);
-                checkpointFuture = triggerCheckpoint(testHarness, 6);
-
-                // Notifies the result partition that all records are processed after the
-                // last checkpoint is triggered.
-                checkState(
-                        checkpointFuture instanceof CompletableFuture,
-                        "The trigger future should " + " be also CompletableFuture.");
-                ((CompletableFuture<?>) checkpointFuture)
-                        .thenAccept(
-                                (ignored) -> {
-                                    for (ResultPartition resultPartition : partitionWriters) {
-                                        resultPartition.onSubpartitionAllRecordsProcessed(0);
-                                    }
-                                });
-
-                // The checkpoint 6 would be triggered successfully.
-                testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
-                testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(6, testHarness.getTaskStateManager().getReportedCheckpointId());
-
-                // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
-                for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
-                }
-            }
-        } finally {
-            for (ResultPartitionWriter writer : partitionWriters) {
-                if (writer != null) {
-                    writer.close();
-                }
-            }
-        }
-    }
-
-    static Future<Boolean> triggerCheckpoint(
-            StreamTaskMailboxTestHarness<String> testHarness, long checkpointId) {
-        testHarness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
-        return testHarness
-                .getStreamTask()
-                .triggerCheckpointAsync(
-                        new CheckpointMetaData(checkpointId, checkpointId * 1000),
-                        CheckpointOptions.alignedNoTimeout(
-                                CheckpointType.CHECKPOINT,
-                                CheckpointStorageLocationReference.getDefault()));
-    }
-
-    static void processMailTillCheckpointSucceeds(
-            StreamTaskMailboxTestHarness<String> testHarness, Future<Boolean> checkpointFuture)
-            throws Exception {
-        while (!checkpointFuture.isDone()) {
-            testHarness.processSingleStep();
-        }
-        testHarness.getTaskStateManager().getWaitForReportLatch().await();
-    }
-
-    @Test
-    public void testWaitingForPendingCheckpointsOnFinished() throws Exception {
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-
-        try {
-            OneShotLatch asyncCheckpointExecuted = new OneShotLatch();
-            OneShotLatch canCheckpointBeAcknowledged = new OneShotLatch();
-            OneShotLatch invokeCompleted = new OneShotLatch();
-
-            TestCheckpointResponder responder =
-                    new TestCheckpointResponder() {
-                        @Override
-                        public void acknowledgeCheckpoint(
-                                JobID jobID,
-                                ExecutionAttemptID executionAttemptID,
-                                long checkpointId,
-                                CheckpointMetrics checkpointMetrics,
-                                TaskStateSnapshot subtaskState) {
-
-                            try {
-                                asyncCheckpointExecuted.trigger();
-                                canCheckpointBeAcknowledged.await();
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            }
-                        }
-                    };
-
-            CompletableFuture<Void> taskClosed =
-                    CompletableFuture.runAsync(
-                            () -> {
-                                try (StreamTaskMailboxTestHarness<String> harness =
-                                        new StreamTaskMailboxTestHarnessBuilder<>(
-                                                        OneInputStreamTask::new,
-                                                        BasicTypeInfo.STRING_TYPE_INFO)
-                                                .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
-                                                .modifyStreamConfig(
-                                                        config ->
-                                                                config.setCheckpointingEnabled(
-                                                                        true))
-                                                .setCheckpointResponder(responder)
-                                                .setupOperatorChain(new EmptyOperator())
-                                                .finishForSingletonOperatorChain(
-                                                        StringSerializer.INSTANCE)
-                                                .build()) {
-
-                                    harness.streamTask
-                                            .getCheckpointCoordinator()
-                                            .setEnableCheckpointAfterTasksFinished(true);
-
-                                    harness.streamTask.triggerCheckpointOnBarrier(
-                                            new CheckpointMetaData(1, 101),
-                                            CheckpointOptions.forCheckpointWithDefaultLocation(),
-                                            new CheckpointMetricsBuilder()
-                                                    .setBytesProcessedDuringAlignment(0L)
-                                                    .setAlignmentDurationNanos(0L));
-
-                                    harness.waitForTaskCompletion();
-                                    invokeCompleted.trigger();
-                                    harness.finishProcessing();
-                                } catch (Exception e) {
-                                    e.printStackTrace();
-                                }
-                            },
-                            executor);
-
-            asyncCheckpointExecuted.await();
-            invokeCompleted.await();
-            // Give some potential time for the task to finish before the
-            // checkpoint is acknowledged
-            Thread.sleep(500);
-            assertFalse(taskClosed.isDone());
-            canCheckpointBeAcknowledged.trigger();
-            taskClosed.get();
-        } finally {
-            executor.shutdownNow();
-        }
-    }
-
-    @Test
-    public void testOperatorSkipLifeCycleIfFinishedOnRestore() throws Exception {
-        try (StreamTaskMailboxTestHarness<String> harness =
-                new StreamTaskMailboxTestHarnessBuilder<>(
-                                OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                        .addInput(BasicTypeInfo.STRING_TYPE_INFO, 3)
-                        .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED)
-                        .setupOutputForSingletonOperatorChain(new LifeCycleMonitorOperator<>())
-                        .build()) {
-            // Finish the restore, including state initialization and open.
-            harness.processAll();
-
-            // Try trigger a checkpoint.
-            harness.getTaskStateManager().setWaitForReportLatch(new OneShotLatch());
-            harness.streamTask.triggerCheckpointOnBarrier(
-                    new CheckpointMetaData(2, 2),
-                    new CheckpointOptions(CheckpointType.CHECKPOINT, getDefault()),
-                    new CheckpointMetricsBuilder()
-                            .setBytesProcessedDuringAlignment(0)
-                            .setAlignmentDurationNanos(0));
-            harness.getTaskStateManager().getWaitForReportLatch().await();
-            assertEquals(2, harness.getTaskStateManager().getReportedCheckpointId());
-
-            // Checkpoint notification.
-            harness.streamTask.notifyCheckpointCompleteAsync(2);
-            harness.streamTask.notifyCheckpointAbortAsync(3);
-            harness.processAll();
-
-            // Finish & close operators.
-            harness.waitForTaskCompletion();
-            harness.finishProcessing();
-
-            LifeCycleMonitorOperator<String> operator =
-                    (LifeCycleMonitorOperator<String>) harness.getStreamTask().getMainOperator();
-            operator.getLifeCycleMonitor().assertCallTimes(0, LifeCyclePhase.values());
-        }
     }
 
     private MockEnvironment setupEnvironment(boolean... outputAvailabilities) {
@@ -3019,82 +2730,6 @@ public class StreamTaskTest extends TestLogger {
                 @Override
                 public void close() {}
             };
-        }
-    }
-
-    private static class EmptyOperator extends AbstractStreamOperator<String>
-            implements OneInputStreamOperator<String, String> {
-
-        @Override
-        public void processElement(StreamRecord<String> element) throws Exception {}
-    }
-
-    private static class FinishingOperator extends AbstractStreamOperator<String>
-            implements OneInputStreamOperator<String, String> {
-        static boolean finished = false;
-
-        @Override
-        public void processElement(StreamRecord<String> element) throws Exception {}
-
-        @Override
-        public void finish() throws Exception {
-            finished = true;
-        }
-    }
-
-    /** A special one-input operator that monitors the lifecycle of the operator. */
-    static class LifeCycleMonitorOperator<T> extends AbstractStreamOperator<T>
-            implements OneInputStreamOperator<T, T> {
-
-        private final LifeCycleMonitor lifeCycleMonitor = new LifeCycleMonitor();
-
-        @Override
-        public void open() throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.OPEN);
-        }
-
-        @Override
-        public void initializeState(StateInitializationContext context) throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.INITIALIZE_STATE);
-        }
-
-        @Override
-        public void processElement(StreamRecord<T> element) throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.PROCESS_ELEMENT);
-        }
-
-        @Override
-        public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.PREPARE_SNAPSHOT_PRE_BARRIER);
-        }
-
-        @Override
-        public void snapshotState(StateSnapshotContext context) throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.SNAPSHOT_STATE);
-        }
-
-        @Override
-        public void notifyCheckpointComplete(long checkpointId) throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.NOTIFY_CHECKPOINT_COMPLETE);
-        }
-
-        @Override
-        public void notifyCheckpointAborted(long checkpointId) throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.NOTIFY_CHECKPOINT_ABORT);
-        }
-
-        @Override
-        public void finish() throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.FINISH);
-        }
-
-        @Override
-        public void close() throws Exception {
-            lifeCycleMonitor.incrementCallTime(LifeCyclePhase.CLOSE);
-        }
-
-        public LifeCycleMonitor getLifeCycleMonitor() {
-            return lifeCycleMonitor;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR skips the execution for the operator subtasks that have fully finished when restarting. In detail:

1. For non-source operators, it would not call its lifecycle method like `open()/close()`, and it would not process any elements (since all its precedent tasks should have finished).
2. For sources, it would directly emit END_OF_INPUT on startup. The lifecycle of the corresponding operator would also be skipped.
3. The closed operator would not participate in any checkpoint related operations. 

## Brief change log

- 90d12962dd8cd19577f6f056160be1e1fa7d1e58 skips the execution and checkpoints for all the operators.
- 44846ba69df46ec374ac9e9295ce923e9dec88f1 marks legacy source as finished on startup if needed.
- f7e049cbbaeb778948ef23deb4bec490c9d4bb27 marks new source as finished on startup if needed.

## Verifying this change


This change added tests and can be verified via added UT.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers:**no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**