### PR TITLE
[FLINK-23029] Extend PluginLoader to allow closing ClassLoader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
@@ -43,7 +43,7 @@ import java.util.ServiceLoader;
  * construction.
  */
 @ThreadSafe
-public class PluginLoader {
+public class PluginLoader implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PluginLoader.class);
 
@@ -100,6 +100,7 @@ public class PluginLoader {
         }
     }
 
+    @Override
     public void close() {
         try {
             pluginClassLoader.close();


### PR DESCRIPTION
With this PR it will be possibly to load a plugin temporarily, for example within a single test that uses a MiniCluster.