### PR TITLE
[FLINK-23030][network] PartitionRequestClientFactory#createPartitionRequestClient should throw when network failure

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -131,7 +131,7 @@ class PartitionRequestClientFactory {
     private NettyPartitionRequestClient connect(ConnectionID connectionId)
             throws RemoteTransportException, InterruptedException {
         try {
-            Channel channel = nettyClient.connect(connectionId.getAddress()).await().channel();
+            Channel channel = nettyClient.connect(connectionId.getAddress()).sync().channel();
             NetworkClientHandler clientHandler = channel.pipeline().get(NetworkClientHandler.class);
             return new NettyPartitionRequestClient(channel, clientHandler, connectionId, this);
         } catch (InterruptedException e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NeverCompletingChannelFuture.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NeverCompletingChannelFuture.java
@@ -74,8 +74,10 @@ class NeverCompletingChannelFuture implements ChannelFuture {
     }
 
     @Override
-    public ChannelFuture sync() {
-        throw new UnsupportedOperationException();
+    public ChannelFuture sync() throws InterruptedException {
+        while (true) {
+            Thread.sleep(50);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

In current `PartitionRequestClientFactory#createPartitionRequestClient`, `ChannelFuture#await()` is invoked, thus to build a connection to remote synchronously.

But with the doc of `io.netty.util.concurrent.Future`[1] and its implementation `io.netty.channel.DefaultChannelPromise`[2], `ChannelFuture#await()` never throws when completed with failure. I guess what Flink needs is `ChannelFuture#sync()`.

[1]  https://netty.io/4.1/api/io/netty/util/concurrent/class-use/Future.html
[2] https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/DefaultChannelPromise.java
      https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java

## Brief change log

  - Replace `ChannelFuture#await` with `ChannelFuture#sync` in `PartitionRequestClientFactory#connect`
  - Removed some unused codes in `PartitionRequestClientFactoryTest`


## Verifying this change

Added test `PartitionRequestClientFactoryTest#testThrowsWhenNetworkFailure`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
