### PR TITLE
[hotfix] Improve tuple equal code logic

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 1 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -135,7 +137,7 @@ public class Tuple1<T0> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple1 tuple = (Tuple1) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 10 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -264,34 +266,34 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple10 tuple = (Tuple10) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 11 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -279,37 +281,37 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
         }
         @SuppressWarnings("rawtypes")
         Tuple11 tuple = (Tuple11) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 12 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -316,40 +318,40 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
         }
         @SuppressWarnings("rawtypes")
         Tuple12 tuple = (Tuple12) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 13 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -332,43 +334,43 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
         }
         @SuppressWarnings("rawtypes")
         Tuple13 tuple = (Tuple13) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 14 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -348,46 +350,46 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
         }
         @SuppressWarnings("rawtypes")
         Tuple14 tuple = (Tuple14) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 15 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -365,49 +367,49 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
         }
         @SuppressWarnings("rawtypes")
         Tuple15 tuple = (Tuple15) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 16 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -381,52 +383,52 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
         }
         @SuppressWarnings("rawtypes")
         Tuple16 tuple = (Tuple16) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 17 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -397,55 +399,55 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
         }
         @SuppressWarnings("rawtypes")
         Tuple17 tuple = (Tuple17) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 18 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -413,58 +415,58 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
         }
         @SuppressWarnings("rawtypes")
         Tuple18 tuple = (Tuple18) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 19 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -430,61 +432,61 @@ public class Tuple19<
         }
         @SuppressWarnings("rawtypes")
         Tuple19 tuple = (Tuple19) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 2 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -160,10 +162,10 @@ public class Tuple2<T0, T1> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple2 tuple = (Tuple2) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 20 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -465,64 +467,64 @@ public class Tuple20<
         }
         @SuppressWarnings("rawtypes")
         Tuple20 tuple = (Tuple20) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
-        if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+        if (!Objects.equals(f19, tuple.f19)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 21 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -482,67 +484,67 @@ public class Tuple21<
         }
         @SuppressWarnings("rawtypes")
         Tuple21 tuple = (Tuple21) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
-        if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+        if (!Objects.equals(f19, tuple.f19)) {
             return false;
         }
-        if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+        if (!Objects.equals(f20, tuple.f20)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 22 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -499,70 +501,70 @@ public class Tuple22<
         }
         @SuppressWarnings("rawtypes")
         Tuple22 tuple = (Tuple22) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
-        if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+        if (!Objects.equals(f19, tuple.f19)) {
             return false;
         }
-        if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+        if (!Objects.equals(f20, tuple.f20)) {
             return false;
         }
-        if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+        if (!Objects.equals(f21, tuple.f21)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 23 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -516,73 +518,73 @@ public class Tuple23<
         }
         @SuppressWarnings("rawtypes")
         Tuple23 tuple = (Tuple23) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
-        if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+        if (!Objects.equals(f19, tuple.f19)) {
             return false;
         }
-        if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+        if (!Objects.equals(f20, tuple.f20)) {
             return false;
         }
-        if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+        if (!Objects.equals(f21, tuple.f21)) {
             return false;
         }
-        if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) {
+        if (!Objects.equals(f22, tuple.f22)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 24 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -533,76 +535,76 @@ public class Tuple24<
         }
         @SuppressWarnings("rawtypes")
         Tuple24 tuple = (Tuple24) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
-        if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+        if (!Objects.equals(f19, tuple.f19)) {
             return false;
         }
-        if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+        if (!Objects.equals(f20, tuple.f20)) {
             return false;
         }
-        if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+        if (!Objects.equals(f21, tuple.f21)) {
             return false;
         }
-        if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) {
+        if (!Objects.equals(f22, tuple.f22)) {
             return false;
         }
-        if (f23 != null ? !f23.equals(tuple.f23) : tuple.f23 != null) {
+        if (!Objects.equals(f23, tuple.f23)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 25 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -550,79 +552,79 @@ public class Tuple25<
         }
         @SuppressWarnings("rawtypes")
         Tuple25 tuple = (Tuple25) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
-        if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+        if (!Objects.equals(f9, tuple.f9)) {
             return false;
         }
-        if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+        if (!Objects.equals(f10, tuple.f10)) {
             return false;
         }
-        if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+        if (!Objects.equals(f11, tuple.f11)) {
             return false;
         }
-        if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+        if (!Objects.equals(f12, tuple.f12)) {
             return false;
         }
-        if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+        if (!Objects.equals(f13, tuple.f13)) {
             return false;
         }
-        if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+        if (!Objects.equals(f14, tuple.f14)) {
             return false;
         }
-        if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+        if (!Objects.equals(f15, tuple.f15)) {
             return false;
         }
-        if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+        if (!Objects.equals(f16, tuple.f16)) {
             return false;
         }
-        if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+        if (!Objects.equals(f17, tuple.f17)) {
             return false;
         }
-        if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+        if (!Objects.equals(f18, tuple.f18)) {
             return false;
         }
-        if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+        if (!Objects.equals(f19, tuple.f19)) {
             return false;
         }
-        if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+        if (!Objects.equals(f20, tuple.f20)) {
             return false;
         }
-        if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+        if (!Objects.equals(f21, tuple.f21)) {
             return false;
         }
-        if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) {
+        if (!Objects.equals(f22, tuple.f22)) {
             return false;
         }
-        if (f23 != null ? !f23.equals(tuple.f23) : tuple.f23 != null) {
+        if (!Objects.equals(f23, tuple.f23)) {
             return false;
         }
-        if (f24 != null ? !f24.equals(tuple.f24) : tuple.f24 != null) {
+        if (!Objects.equals(f24, tuple.f24)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 3 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -165,13 +167,13 @@ public class Tuple3<T0, T1, T2> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple3 tuple = (Tuple3) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 4 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -179,16 +181,16 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple4 tuple = (Tuple4) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 5 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -193,19 +195,19 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple5 tuple = (Tuple5) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 6 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -207,22 +209,22 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple6 tuple = (Tuple6) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 7 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -222,25 +224,25 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple7 tuple = (Tuple7) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 8 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -236,28 +238,28 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple8 tuple = (Tuple8) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
         return true;

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
@@ -26,6 +26,8 @@ package org.apache.flink.api.java.tuple;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.util.StringUtils;
 
+import java.util.Objects;
+
 /**
  * A tuple with 9 fields. Tuples are strongly typed; each field may be of a separate type. The
  * fields of the tuple can be accessed directly as public fields (f0, f1, ...) or via their position
@@ -250,31 +252,31 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
         }
         @SuppressWarnings("rawtypes")
         Tuple9 tuple = (Tuple9) o;
-        if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+        if (!Objects.equals(f0, tuple.f0)) {
             return false;
         }
-        if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+        if (!Objects.equals(f1, tuple.f1)) {
             return false;
         }
-        if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+        if (!Objects.equals(f2, tuple.f2)) {
             return false;
         }
-        if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+        if (!Objects.equals(f3, tuple.f3)) {
             return false;
         }
-        if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+        if (!Objects.equals(f4, tuple.f4)) {
             return false;
         }
-        if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+        if (!Objects.equals(f5, tuple.f5)) {
             return false;
         }
-        if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+        if (!Objects.equals(f6, tuple.f6)) {
             return false;
         }
-        if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+        if (!Objects.equals(f7, tuple.f7)) {
             return false;
         }
-        if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+        if (!Objects.equals(f8, tuple.f8)) {
             return false;
         }
         return true;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Make the tuple  equals() method code logic simpler and improve readability*

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
