### PR TITLE
[FLINK-18182][kinesis] Fixing bad shading of AWS SDK config file

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -81,6 +81,11 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-cloudwatch</artifactId>
+			<version>${aws.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
 			<artifactId>amazon-kinesis-producer</artifactId>
 			<version>${aws.kinesis-kpl.version}</version>
 		</dependency>
@@ -104,10 +109,6 @@ under the License.
 			<artifactId>dynamodb-streams-kinesis-adapter</artifactId>
 			<version>${aws.dynamodbstreams-kinesis-adapter.version}</version>
 			<exclusions>
-				<exclusion>
-					<groupId>com.amazonaws</groupId>
-					<artifactId>aws-java-sdk-cloudwatch</artifactId>
-				</exclusion>
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
 					<artifactId>jackson-databind</artifactId>

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -14,6 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-kms:1.12.7
 - com.amazonaws:aws-java-sdk-s3:1.12.7
 - com.amazonaws:aws-java-sdk-sts:1.12.7
+- com.amazonaws:aws-java-sdk-cloudwatch:1.12.7
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.3
 - com.amazonaws:jmespath-java:1.12.7
 - org.apache.httpcomponents:httpclient:4.5.9

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/org/apache/flink/kinesis/shaded/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/org/apache/flink/kinesis/shaded/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,0 +1,1 @@
+org.apache.flink.kinesis.shaded.software.amazon.awssdk.core.internal.interceptor.HttpChecksumRequiredInterceptor

--- a/pom.xml
+++ b/pom.xml
@@ -1551,6 +1551,9 @@ under the License.
 						<exclude>flink-python/lib/**</exclude>
 						<exclude>flink-python/dev/download/**</exclude>
 						<exclude>flink-python/docs/_build/**</exclude>
+
+						<!-- AWS SDK config that does not support license headers -->
+						<exclude>**/awssdk/global/handlers/execution.interceptors</exclude>
 					</excludes>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## What is the purpose of the change

Fixing bad shading of AWS SDK config file resulting in errors when consuming from EFO. This is cause by the recent SDK upgrade: https://github.com/apache/flink/pull/16185

## Brief change log

- Adding a custom `execution.interceptors` file that references the shaded `HttpChecksumRequiredInterceptor`

## Verifying this change

Running Flink job locally against AWS Kinesis Data Streams.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
