### PR TITLE
[FLINK-23040][table-common] Consider ConfigOption fallback keys in FactoryUtil

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
+import org.apache.flink.configuration.FallbackKey;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.NoMatchingTableFactoryException;
 import org.apache.flink.table.api.TableException;
@@ -44,7 +45,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -55,6 +58,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /** Utility for working with {@link Factory}s. */
 @PublicEvolving
@@ -370,7 +374,10 @@ public final class FactoryUtil {
                 requiredOptions.stream()
                         // Templated options will never appear with their template key, so we need
                         // to ignore them as required properties here
-                        .filter(option -> !option.key().contains(PLACEHOLDER_SYMBOL))
+                        .filter(
+                                option ->
+                                        allKeys(option)
+                                                .noneMatch(k -> k.contains(PLACEHOLDER_SYMBOL)))
                         .filter(option -> readOption(options, option) == null)
                         .map(ConfigOption::key)
                         .sorted()
@@ -390,7 +397,10 @@ public final class FactoryUtil {
 
     /** Validates unconsumed option keys. */
     public static void validateUnconsumedKeys(
-            String factoryIdentifier, Set<String> allOptionKeys, Set<String> consumedOptionKeys) {
+            String factoryIdentifier,
+            Set<String> allOptionKeys,
+            Set<String> consumedOptionKeys,
+            Set<String> deprecatedOptionKeys) {
         final Set<String> remainingOptionKeys = new HashSet<>(allOptionKeys);
         remainingOptionKeys.removeAll(consumedOptionKeys);
         if (!remainingOptionKeys.isEmpty()) {
@@ -404,9 +414,23 @@ public final class FactoryUtil {
                             factoryIdentifier,
                             remainingOptionKeys.stream().sorted().collect(Collectors.joining("\n")),
                             consumedOptionKeys.stream()
+                                    .map(
+                                            k -> {
+                                                if (deprecatedOptionKeys.contains(k)) {
+                                                    return String.format("%s (deprecated)", k);
+                                                }
+                                                return k;
+                                            })
                                     .sorted()
                                     .collect(Collectors.joining("\n"))));
         }
+    }
+
+    /** Validates unconsumed option keys. */
+    public static void validateUnconsumedKeys(
+            String factoryIdentifier, Set<String> allOptionKeys, Set<String> consumedOptionKeys) {
+        validateUnconsumedKeys(
+                factoryIdentifier, allOptionKeys, consumedOptionKeys, Collections.emptySet());
     }
 
     // --------------------------------------------------------------------------------------------
@@ -523,50 +547,69 @@ public final class FactoryUtil {
         }
     }
 
+    private static Stream<String> allKeys(ConfigOption<?> option) {
+        return Stream.concat(Stream.of(option.key()), fallbackKeys(option));
+    }
+
+    private static Stream<String> fallbackKeys(ConfigOption<?> option) {
+        return StreamSupport.stream(option.fallbackKeys().spliterator(), false)
+                .map(FallbackKey::getKey);
+    }
+
+    private static Stream<String> deprecatedKeys(ConfigOption<?> option) {
+        return StreamSupport.stream(option.fallbackKeys().spliterator(), false)
+                .filter(FallbackKey::isDeprecated)
+                .map(FallbackKey::getKey);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Helper classes
     // --------------------------------------------------------------------------------------------
 
-    /**
-     * Helper utility for catalog implementations to validate options provided by {@link
-     * CatalogFactory}.
-     */
-    @PublicEvolving
-    public static class CatalogFactoryHelper {
+    private static class FactoryHelper<F extends Factory> {
 
-        private final CatalogFactory catalogFactory;
-        private final CatalogFactory.Context context;
-        private final Configuration configuration;
+        protected final F factory;
 
-        private final Set<String> consumedOptionKeys;
+        protected final Configuration allOptions;
 
-        public CatalogFactoryHelper(CatalogFactory catalogFactory, CatalogFactory.Context context) {
-            this.catalogFactory = catalogFactory;
-            this.context = context;
-            this.configuration = Configuration.fromMap(context.getOptions());
+        protected final Set<String> consumedOptionKeys;
 
-            consumedOptionKeys = new HashSet<>();
-            consumedOptionKeys.add(PROPERTY_VERSION.key());
-            Stream.concat(
-                            catalogFactory.requiredOptions().stream(),
-                            catalogFactory.optionalOptions().stream())
-                    .map(ConfigOption::key)
-                    .forEach(consumedOptionKeys::add);
+        protected final Set<String> deprecatedOptionKeys;
+
+        FactoryHelper(
+                F factory, Map<String, String> configuration, ConfigOption<?>... implicitOptions) {
+            this.factory = factory;
+            this.allOptions = Configuration.fromMap(configuration);
+
+            final List<ConfigOption<?>> consumedOptions = new ArrayList<>();
+            consumedOptions.addAll(Arrays.asList(implicitOptions));
+            consumedOptions.addAll(factory.requiredOptions());
+            consumedOptions.addAll(factory.optionalOptions());
+
+            consumedOptionKeys =
+                    consumedOptions.stream()
+                            .flatMap(FactoryUtil::allKeys)
+                            .collect(Collectors.toSet());
+
+            deprecatedOptionKeys =
+                    consumedOptions.stream()
+                            .flatMap(FactoryUtil::deprecatedKeys)
+                            .collect(Collectors.toSet());
         }
 
-        /**
-         * Validates the options of the {@link CatalogFactory}. It checks for unconsumed option
-         * keys.
-         */
+        /** Validates the options of the factory. It checks for unconsumed option keys. */
         public void validate() {
-            validateFactoryOptions(catalogFactory, configuration);
+            validateFactoryOptions(factory, allOptions);
             validateUnconsumedKeys(
-                    catalogFactory.factoryIdentifier(), configuration.keySet(), consumedOptionKeys);
+                    factory.factoryIdentifier(),
+                    allOptions.keySet(),
+                    consumedOptionKeys,
+                    deprecatedOptionKeys);
         }
 
         /**
-         * Validates the options of the {@link CatalogFactory}. It checks for unconsumed option keys
-         * while ignoring the options with given prefixes.
+         * Validates the options of the factory. It checks for unconsumed option keys while ignoring
+         * the options with given prefixes.
          *
          * <p>The option keys that have given prefix {@code prefixToSkip} would just be skipped for
          * validation.
@@ -578,15 +621,27 @@ public final class FactoryUtil {
                     prefixesToSkip.length > 0, "Prefixes to skip can not be empty.");
             final List<String> prefixesList = Arrays.asList(prefixesToSkip);
             consumedOptionKeys.addAll(
-                    configuration.keySet().stream()
+                    allOptions.keySet().stream()
                             .filter(key -> prefixesList.stream().anyMatch(key::startsWith))
                             .collect(Collectors.toSet()));
             validate();
         }
 
-        /** Returns all options of the catalog. */
+        /** Returns all options currently being consumed by the factory. */
         public ReadableConfig getOptions() {
-            return configuration;
+            return allOptions;
+        }
+    }
+
+    /**
+     * Helper utility for validating all options for a {@link CatalogFactory}.
+     *
+     * @see #createCatalogFactoryHelper(CatalogFactory, CatalogFactory.Context)
+     */
+    public static class CatalogFactoryHelper extends FactoryHelper<CatalogFactory> {
+
+        public CatalogFactoryHelper(CatalogFactory catalogFactory, CatalogFactory.Context context) {
+            super(catalogFactory, context.getOptions(), PROPERTY_VERSION);
         }
     }
 
@@ -596,32 +651,18 @@ public final class FactoryUtil {
      *
      * @see #createTableFactoryHelper(DynamicTableFactory, DynamicTableFactory.Context)
      */
-    public static class TableFactoryHelper {
-
-        private final DynamicTableFactory tableFactory;
+    public static class TableFactoryHelper extends FactoryHelper<DynamicTableFactory> {
 
         private final DynamicTableFactory.Context context;
 
-        private final Configuration allOptions;
-
-        private final Set<String> consumedOptionKeys;
-
         private TableFactoryHelper(
                 DynamicTableFactory tableFactory, DynamicTableFactory.Context context) {
-            this.tableFactory = tableFactory;
+            super(
+                    tableFactory,
+                    context.getCatalogTable().getOptions(),
+                    PROPERTY_VERSION,
+                    CONNECTOR);
             this.context = context;
-            this.allOptions = Configuration.fromMap(context.getCatalogTable().getOptions());
-            this.consumedOptionKeys = new HashSet<>();
-            this.consumedOptionKeys.add(PROPERTY_VERSION.key());
-            this.consumedOptionKeys.add(CONNECTOR.key());
-            this.consumedOptionKeys.addAll(
-                    tableFactory.requiredOptions().stream()
-                            .map(ConfigOption::key)
-                            .collect(Collectors.toSet()));
-            this.consumedOptionKeys.addAll(
-                    tableFactory.optionalOptions().stream()
-                            .map(ConfigOption::key)
-                            .collect(Collectors.toSet()));
         }
 
         /**
@@ -702,41 +743,6 @@ public final class FactoryUtil {
                                             t);
                                 }
                             });
-        }
-
-        /**
-         * Validates the options of the {@link DynamicTableFactory}. It checks for unconsumed option
-         * keys.
-         */
-        public void validate() {
-            validateFactoryOptions(tableFactory, allOptions);
-            validateUnconsumedKeys(
-                    tableFactory.factoryIdentifier(), allOptions.keySet(), consumedOptionKeys);
-        }
-
-        /**
-         * Validates the options of the {@link DynamicTableFactory}. It checks for unconsumed option
-         * keys while ignoring the options with given prefixes.
-         *
-         * <p>The option keys that have given prefix {@code prefixToSkip} would just be skipped for
-         * validation.
-         *
-         * @param prefixesToSkip Set of option key prefixes to skip validation
-         */
-        public void validateExcept(String... prefixesToSkip) {
-            Preconditions.checkArgument(
-                    prefixesToSkip.length > 0, "Prefixes to skip can not be empty.");
-            final List<String> prefixesList = Arrays.asList(prefixesToSkip);
-            consumedOptionKeys.addAll(
-                    allOptions.keySet().stream()
-                            .filter(key -> prefixesList.stream().anyMatch(key::startsWith))
-                            .collect(Collectors.toSet()));
-            validate();
-        }
-
-        /** Returns all options of the table. */
-        public ReadableConfig getOptions() {
-            return allOptions;
         }
 
         // ----------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -21,11 +21,8 @@ package org.apache.flink.table.factories;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.CatalogBaseTable;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -33,6 +30,7 @@ import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSink
 import org.apache.flink.table.factories.TestDynamicTableFactory.DynamicTableSourceMock;
 import org.apache.flink.table.factories.TestFormatFactory.DecodingFormatMock;
 import org.apache.flink.table.factories.TestFormatFactory.EncodingFormatMock;
+import org.apache.flink.table.factories.utils.FactoryMocks;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,9 +39,7 @@ import org.junit.rules.ExpectedException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -155,6 +151,8 @@ public class FactoryUtilTest {
                         + "Supported options:\n\n"
                         + "buffer-size\n"
                         + "connector\n"
+                        + "deprecated-target (deprecated)\n"
+                        + "fallback-buffer-size\n"
                         + "format\n"
                         + "key.format\n"
                         + "key.test-format.changelog-mode\n"
@@ -286,6 +284,11 @@ public class FactoryUtilTest {
     public void testRequiredPlaceholderOption() {
         final Set<ConfigOption<?>> requiredOptions = new HashSet<>();
         requiredOptions.add(ConfigOptions.key("fields.#.min").intType().noDefaultValue());
+        requiredOptions.add(
+                ConfigOptions.key("no.placeholder.anymore")
+                        .intType()
+                        .noDefaultValue()
+                        .withFallbackKeys("old.fields.#.min"));
 
         FactoryUtil.validateFactoryOptions(requiredOptions, new HashSet<>(), new Configuration());
     }
@@ -339,6 +342,19 @@ public class FactoryUtilTest {
         helper2.validate();
     }
 
+    @Test
+    public void testFactoryHelperWithDeprecatedOptions() {
+        final Map<String, String> options = new HashMap<>();
+        options.put("deprecated-target", "MyTarget");
+        options.put("fallback-buffer-size", "1000");
+
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(
+                        new TestDynamicTableFactory(),
+                        FactoryMocks.createTableContext(SCHEMA, options));
+        helper.validate();
+    }
+
     // --------------------------------------------------------------------------------------------
 
     private void expectError(String message) {
@@ -365,64 +381,5 @@ public class FactoryUtilTest {
         options.put("value.test-format.delimiter", "|");
         options.put("value.test-format.fail-on-missing", "true");
         return options;
-    }
-
-    private static class CatalogTableMock implements CatalogTable {
-
-        final Map<String, String> options;
-
-        CatalogTableMock(Map<String, String> options) {
-            this.options = options;
-        }
-
-        @Override
-        public boolean isPartitioned() {
-            return false;
-        }
-
-        @Override
-        public List<String> getPartitionKeys() {
-            return null;
-        }
-
-        @Override
-        public CatalogTable copy(Map<String, String> options) {
-            return null;
-        }
-
-        @Override
-        public Map<String, String> toProperties() {
-            return null;
-        }
-
-        @Override
-        public Map<String, String> getOptions() {
-            return options;
-        }
-
-        @Override
-        public TableSchema getSchema() {
-            return null;
-        }
-
-        @Override
-        public String getComment() {
-            return null;
-        }
-
-        @Override
-        public CatalogBaseTable copy() {
-            return null;
-        }
-
-        @Override
-        public Optional<String> getDescription() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<String> getDetailedDescription() {
-            return Optional.empty();
-        }
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
@@ -50,10 +50,16 @@ public final class TestDynamicTableFactory
     public static final String IDENTIFIER = "test-connector";
 
     public static final ConfigOption<String> TARGET =
-            ConfigOptions.key("target").stringType().noDefaultValue();
+            ConfigOptions.key("target")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDeprecatedKeys("deprecated-target");
 
     public static final ConfigOption<Long> BUFFER_SIZE =
-            ConfigOptions.key("buffer-size").longType().defaultValue(100L);
+            ConfigOptions.key("buffer-size")
+                    .longType()
+                    .defaultValue(100L)
+                    .withFallbackKeys("fallback-buffer-size");
 
     public static final ConfigOption<String> KEY_FORMAT =
             ConfigOptions.key("key" + FORMAT_SUFFIX).stringType().noDefaultValue();


### PR DESCRIPTION
## What is the purpose of the change

Adds support for fallback keys (incl. deprecated keys) to FactoryUtil. Deprecated keys are highlighted in error messages.

## Brief change log

- Simplify util by abstracting common helper code in a super class.
- Add support for fallback keys in validation.

## Verifying this change

This change added tests and can be verified as follows: `FactoryUtilTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
