### PR TITLE
[FLINK-23060] Move FutureUtils#toJava to separate class

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactoryImpl.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactoryImpl.java
@@ -25,7 +25,7 @@ import org.apache.flink.mesos.scheduler.ReconciliationCoordinator;
 import org.apache.flink.mesos.scheduler.TaskMonitor;
 import org.apache.flink.mesos.scheduler.TaskSchedulerBuilder;
 import org.apache.flink.mesos.scheduler.Tasks;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;;
 import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorRef;
@@ -121,7 +121,7 @@ public class MesosResourceManagerActorFactoryImpl implements MesosResourceManage
             return CompletableFuture.completedFuture(true);
         }
 
-        return FutureUtils.toJava(Patterns.gracefulStop(actorRef, timeout))
+        return AkkaFutureUtils.toJava(Patterns.gracefulStop(actorRef, timeout))
                 .exceptionally(
                         (Throwable throwable) -> {
                             // The actor did not stop gracefully in time, try to directly stop it

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactoryImpl.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerActorFactoryImpl.java
@@ -25,7 +25,7 @@ import org.apache.flink.mesos.scheduler.ReconciliationCoordinator;
 import org.apache.flink.mesos.scheduler.TaskMonitor;
 import org.apache.flink.mesos.scheduler.TaskSchedulerBuilder;
 import org.apache.flink.mesos.scheduler.Tasks;
-import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorRef;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -26,8 +26,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
-import akka.dispatch.OnComplete;
-
 import javax.annotation.Nullable;
 
 import java.time.Duration;
@@ -54,8 +52,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-
-import scala.concurrent.Future;
 
 import static org.apache.flink.util.Preconditions.checkCompletedNormally;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -1059,33 +1055,6 @@ public class FutureUtils {
     // ------------------------------------------------------------------------
     //  Converting futures
     // ------------------------------------------------------------------------
-
-    /**
-     * Converts a Scala {@link Future} to a {@link CompletableFuture}.
-     *
-     * @param scalaFuture to convert to a Java 8 CompletableFuture
-     * @param <T> type of the future value
-     * @param <U> type of the original future
-     * @return Java 8 CompletableFuture
-     */
-    public static <T, U extends T> CompletableFuture<T> toJava(Future<U> scalaFuture) {
-        final CompletableFuture<T> result = new CompletableFuture<>();
-
-        scalaFuture.onComplete(
-                new OnComplete<U>() {
-                    @Override
-                    public void onComplete(Throwable failure, U success) {
-                        if (failure != null) {
-                            result.completeExceptionally(failure);
-                        } else {
-                            result.complete(success);
-                        }
-                    }
-                },
-                Executors.directExecutionContext());
-
-        return result;
-    }
 
     /**
      * This function takes a {@link CompletableFuture} and a function to apply to this future. If

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/akka/AkkaFutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/akka/AkkaFutureUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent.akka;
+
+import org.apache.flink.runtime.concurrent.Executors;
+
+import akka.dispatch.OnComplete;
+
+import java.util.concurrent.CompletableFuture;
+
+import scala.concurrent.Future;
+
+/** Utilities to convert Scala types into Java types. */
+public class AkkaFutureUtils {
+    /**
+     * Converts a Scala {@link Future} to a {@link CompletableFuture}.
+     *
+     * @param scalaFuture to convert to a Java 8 CompletableFuture
+     * @param <T> type of the future value
+     * @param <U> type of the original future
+     * @return Java 8 CompletableFuture
+     */
+    public static <T, U extends T> CompletableFuture<T> toJava(Future<U> scalaFuture) {
+        final CompletableFuture<T> result = new CompletableFuture<>();
+
+        scalaFuture.onComplete(
+                new OnComplete<U>() {
+                    @Override
+                    public void onComplete(Throwable failure, U success) {
+                        if (failure != null) {
+                            result.completeExceptionally(failure);
+                        } else {
+                            result.complete(success);
+                        }
+                    }
+                },
+                Executors.directExecutionContext());
+
+        return result;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
 import org.apache.flink.runtime.rpc.RpcGateway;
@@ -369,7 +369,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
      * @return Response future
      */
     protected CompletableFuture<?> ask(Object message, Time timeout) {
-        return FutureUtils.toJava(Patterns.ask(rpcEndpoint, message, timeout.toMilliseconds()));
+        return AkkaFutureUtils.toJava(Patterns.ask(rpcEndpoint, message, timeout.toMilliseconds()));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.akka.ActorSystemScheduledExecutorAdapter;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -414,7 +415,7 @@ public class AkkaRpcService implements RpcService {
         final CompletableFuture<Void> actorSystemTerminationFuture =
                 FutureUtils.composeAfterwards(
                         supervisorTerminationFuture,
-                        () -> FutureUtils.toJava(actorSystem.terminate()));
+                        () -> AkkaFutureUtils.toJava(actorSystem.terminate()));
 
         actorSystemTerminationFuture.whenComplete(
                 (Void ignored, Throwable throwable) -> {
@@ -487,7 +488,7 @@ public class AkkaRpcService implements RpcService {
     public <T> CompletableFuture<T> execute(Callable<T> callable) {
         Future<T> scalaFuture = Futures.<T>future(callable, actorSystem.dispatcher());
 
-        return FutureUtils.toJava(scalaFuture);
+        return AkkaFutureUtils.toJava(scalaFuture);
     }
 
     // ---------------------------------------------------------------------------------------
@@ -523,7 +524,7 @@ public class AkkaRpcService implements RpcService {
         final CompletableFuture<HandshakeSuccessMessage> handshakeFuture =
                 actorRefFuture.thenCompose(
                         (ActorRef actorRef) ->
-                                FutureUtils.toJava(
+                                AkkaFutureUtils.toJava(
                                         Patterns.ask(
                                                         actorRef,
                                                         new RemoteHandshakeMessage(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.FencedMainThreadExecutable;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -113,7 +113,7 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
             @SuppressWarnings("unchecked")
             CompletableFuture<V> resultFuture =
                     (CompletableFuture<V>)
-                            FutureUtils.toJava(
+                            AkkaFutureUtils.toJava(
                                     Patterns.ask(
                                             getActorRef(),
                                             new UnfencedMessage<>(new CallAsync(callable)),

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration._
 import org.apache.flink.runtime.clusterframework.BootstrapTools.{FixedThreadPoolExecutorConfiguration, ForkJoinExecutorConfiguration}
 import org.apache.flink.runtime.concurrent.FutureUtils
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils
 import org.apache.flink.runtime.net.SSLUtils
 import org.apache.flink.util.NetUtils
 import org.apache.flink.util.TimeUtils
@@ -909,7 +910,7 @@ object AkkaUtils {
     * @return Termination future
     */
   def terminateActorSystem(actorSystem: ActorSystem): CompletableFuture[Void] = {
-    FutureUtils.toJava(actorSystem.terminate).thenAccept(FunctionUtils.ignoreFn())
+    AkkaFutureUtils.toJava(actorSystem.terminate).thenAccept(FunctionUtils.ignoreFn())
   }
 }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
@@ -69,7 +69,7 @@ public class AsyncCallsTest extends TestLogger {
             throws InterruptedException, ExecutionException, TimeoutException {
         final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
         final CompletableFuture<Terminated> actorSystemTerminationFuture =
-                FutureUtils.toJava(actorSystem.terminate());
+                AkkaFutureUtils.toJava(actorSystem.terminate());
 
         FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
                 .get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
@@ -95,7 +95,7 @@ public class RpcConnectionTest extends TestLogger {
             final CompletableFuture<Terminated> actorSystemTerminationFuture;
 
             if (actorSystem != null) {
-                actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
+                actorSystemTerminationFuture = AkkaFutureUtils.toJava(actorSystem.terminate());
             } else {
                 actorSystemTerminationFuture = CompletableFuture.completedFuture(null);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
@@ -41,7 +42,8 @@ import java.util.concurrent.TimeoutException;
 import scala.Option;
 import scala.Tuple2;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This test validates that the RPC service gives a good message when it cannot connect to an

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -42,8 +42,7 @@ import java.util.concurrent.TimeoutException;
 import scala.Option;
 import scala.Tuple2;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * This test validates that the RPC service gives a good message when it cannot connect to an

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
@@ -68,8 +69,7 @@ public class RpcEndpointTest extends TestLogger {
         final CompletableFuture<Terminated> actorSystemTerminationFuture =
                 AkkaFutureUtils.toJava(actorSystem.terminate());
 
-        FutureUtils.waitForAll(
-                        Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+        FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
                 .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.util.TestLogger;
@@ -66,9 +66,10 @@ public class RpcEndpointTest extends TestLogger {
 
         final CompletableFuture<Void> rpcTerminationFuture = rpcService.stopService();
         final CompletableFuture<Terminated> actorSystemTerminationFuture =
-                FutureUtils.toJava(actorSystem.terminate());
+                AkkaFutureUtils.toJava(actorSystem.terminate());
 
-        FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+        FutureUtils.waitForAll(
+                        Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
                 .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -281,7 +282,7 @@ public class AkkaRpcActorTest extends TestLogger {
             terminationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
         } finally {
             rpcActorSystem.terminate();
-            FutureUtils.toJava(rpcActorSystem.whenTerminated())
+            AkkaFutureUtils.toJava(rpcActorSystem.whenTerminated())
                     .get(timeout.getSize(), timeout.getUnit());
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rpc.akka;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcService;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.rpc.akka;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.util.ExceptionUtils;
@@ -80,7 +80,7 @@ public class AkkaRpcServiceTest extends TestLogger {
             throws InterruptedException, ExecutionException, TimeoutException {
         final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
         final CompletableFuture<Terminated> actorSystemTerminationFuture =
-                FutureUtils.toJava(actorSystem.terminate());
+                AkkaFutureUtils.toJava(actorSystem.terminate());
 
         FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
                 .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/TimeoutCallStackTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/TimeoutCallStackTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -68,7 +68,7 @@ public class TimeoutCallStackTest {
 
         final CompletableFuture<Void> rpcTerminationFuture = rpcService.stopService();
         final CompletableFuture<Terminated> actorSystemTerminationFuture =
-                FutureUtils.toJava(actorSystem.terminate());
+                AkkaFutureUtils.toJava(actorSystem.terminate());
 
         FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
                 .get(10_000, TimeUnit.MILLISECONDS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/TimeoutCallStackTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/TimeoutCallStackTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;


### PR DESCRIPTION
Small preemptive refactoring so that we can later move this method into another module more easily.