### PR TITLE
[FLINK-23061] Split BootstrapTools 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -18,25 +18,18 @@
 
 package org.apache.flink.runtime.clusterframework;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineOptions;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils;
-import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.OperatingSystem;
 
 import org.apache.flink.shaded.guava18.com.google.common.escape.Escaper;
 import org.apache.flink.shaded.guava18.com.google.common.escape.Escapers;
-import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
 
-import akka.actor.ActorSystem;
-import com.typesafe.config.Config;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.slf4j.Logger;
@@ -48,22 +41,13 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.BindException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
-
-import scala.Some;
-import scala.Tuple2;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
-/**
- * Tools for starting JobManager and TaskManager processes, including the Actor Systems used to run
- * the JobManager and TaskManager actors.
- */
+/** Tools for starting JobManager and TaskManager processes. */
 public class BootstrapTools {
     /** Internal option which says if default value is used for {@link CoreOptions#TMP_DIRS}. */
     private static final ConfigOption<Boolean> USE_LOCAL_DEFAULT_TMP_DIRS =
@@ -76,228 +60,6 @@ public class BootstrapTools {
 
     private static final Escaper WINDOWS_DOUBLE_QUOTE_ESCAPER =
             Escapers.builder().addEscape('"', "\\\"").addEscape('^', "\"^^\"").build();
-
-    /**
-     * Starts a remote ActorSystem at given address and specific port range.
-     *
-     * @param configuration The Flink configuration
-     * @param externalAddress The external address to access the ActorSystem.
-     * @param externalPortRange The choosing range of the external port to access the ActorSystem.
-     * @param logger The logger to output log information.
-     * @return The ActorSystem which has been started
-     * @throws Exception Thrown when actor system cannot be started in specified port range
-     */
-    @VisibleForTesting
-    public static ActorSystem startRemoteActorSystem(
-            Configuration configuration,
-            String externalAddress,
-            String externalPortRange,
-            Logger logger)
-            throws Exception {
-        return startRemoteActorSystem(
-                configuration,
-                AkkaUtils.getFlinkActorSystemName(),
-                externalAddress,
-                externalPortRange,
-                NetUtils.getWildcardIPAddress(),
-                Optional.empty(),
-                logger,
-                ForkJoinExecutorConfiguration.fromConfiguration(configuration),
-                null);
-    }
-
-    /**
-     * Starts a remote ActorSystem at given address and specific port range.
-     *
-     * @param configuration The Flink configuration
-     * @param actorSystemName Name of the started {@link ActorSystem}
-     * @param externalAddress The external address to access the ActorSystem.
-     * @param externalPortRange The choosing range of the external port to access the ActorSystem.
-     * @param bindAddress The local address to bind to.
-     * @param bindPort The local port to bind to. If not present, then the external port will be
-     *     used.
-     * @param logger The logger to output log information.
-     * @param actorSystemExecutorConfiguration configuration for the ActorSystem's underlying
-     *     executor
-     * @param customConfig Custom Akka config to be combined with the config derived from Flink
-     *     configuration.
-     * @return The ActorSystem which has been started
-     * @throws Exception Thrown when actor system cannot be started in specified port range
-     */
-    public static ActorSystem startRemoteActorSystem(
-            Configuration configuration,
-            String actorSystemName,
-            String externalAddress,
-            String externalPortRange,
-            String bindAddress,
-            @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Integer> bindPort,
-            Logger logger,
-            ActorSystemExecutorConfiguration actorSystemExecutorConfiguration,
-            Config customConfig)
-            throws Exception {
-
-        // parse port range definition and create port iterator
-        Iterator<Integer> portsIterator;
-        try {
-            portsIterator = NetUtils.getPortRangeFromString(externalPortRange);
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Invalid port range definition: " + externalPortRange);
-        }
-
-        while (portsIterator.hasNext()) {
-            final int externalPort = portsIterator.next();
-
-            try {
-                return startRemoteActorSystem(
-                        configuration,
-                        actorSystemName,
-                        externalAddress,
-                        externalPort,
-                        bindAddress,
-                        bindPort.orElse(externalPort),
-                        logger,
-                        actorSystemExecutorConfiguration,
-                        customConfig);
-            } catch (Exception e) {
-                // we can continue to try if this contains a netty channel exception
-                Throwable cause = e.getCause();
-                if (!(cause instanceof org.jboss.netty.channel.ChannelException
-                        || cause instanceof java.net.BindException)) {
-                    throw e;
-                } // else fall through the loop and try the next port
-            }
-        }
-
-        // if we come here, we have exhausted the port range
-        throw new BindException(
-                "Could not start actor system on any port in port range " + externalPortRange);
-    }
-
-    /**
-     * Starts a remote Actor System at given address and specific port.
-     *
-     * @param configuration The Flink configuration.
-     * @param actorSystemName Name of the started {@link ActorSystem}
-     * @param externalAddress The external address to access the ActorSystem.
-     * @param externalPort The external port to access the ActorSystem.
-     * @param bindAddress The local address to bind to.
-     * @param bindPort The local port to bind to.
-     * @param logger the logger to output log information.
-     * @param actorSystemExecutorConfiguration configuration for the ActorSystem's underlying
-     *     executor
-     * @param customConfig Custom Akka config to be combined with the config derived from Flink
-     *     configuration.
-     * @return The ActorSystem which has been started.
-     * @throws Exception
-     */
-    private static ActorSystem startRemoteActorSystem(
-            Configuration configuration,
-            String actorSystemName,
-            String externalAddress,
-            int externalPort,
-            String bindAddress,
-            int bindPort,
-            Logger logger,
-            ActorSystemExecutorConfiguration actorSystemExecutorConfiguration,
-            Config customConfig)
-            throws Exception {
-
-        String externalHostPortUrl =
-                NetUtils.unresolvedHostAndPortToNormalizedString(externalAddress, externalPort);
-        String bindHostPortUrl =
-                NetUtils.unresolvedHostAndPortToNormalizedString(bindAddress, bindPort);
-        logger.info(
-                "Trying to start actor system, external address {}, bind address {}.",
-                externalHostPortUrl,
-                bindHostPortUrl);
-
-        try {
-            Config akkaConfig =
-                    AkkaUtils.getAkkaConfig(
-                            configuration,
-                            new Some<>(new Tuple2<>(externalAddress, externalPort)),
-                            new Some<>(new Tuple2<>(bindAddress, bindPort)),
-                            actorSystemExecutorConfiguration.getAkkaConfig());
-
-            if (customConfig != null) {
-                akkaConfig = customConfig.withFallback(akkaConfig);
-            }
-
-            return startActorSystem(akkaConfig, actorSystemName, logger);
-        } catch (Throwable t) {
-            if (t instanceof ChannelException) {
-                Throwable cause = t.getCause();
-                if (cause != null && t.getCause() instanceof BindException) {
-                    throw new IOException(
-                            "Unable to create ActorSystem at address "
-                                    + bindHostPortUrl
-                                    + " : "
-                                    + cause.getMessage(),
-                            t);
-                }
-            }
-            throw new Exception("Could not create actor system", t);
-        }
-    }
-
-    /**
-     * Starts a local Actor System.
-     *
-     * @param configuration The Flink configuration.
-     * @param actorSystemName Name of the started ActorSystem.
-     * @param logger The logger to output log information.
-     * @param actorSystemExecutorConfiguration Configuration for the ActorSystem's underlying
-     *     executor.
-     * @param customConfig Custom Akka config to be combined with the config derived from Flink
-     *     configuration.
-     * @return The ActorSystem which has been started.
-     * @throws Exception
-     */
-    public static ActorSystem startLocalActorSystem(
-            Configuration configuration,
-            String actorSystemName,
-            Logger logger,
-            ActorSystemExecutorConfiguration actorSystemExecutorConfiguration,
-            Config customConfig)
-            throws Exception {
-
-        logger.info("Trying to start local actor system");
-
-        try {
-            Config akkaConfig =
-                    AkkaUtils.getAkkaConfig(
-                            configuration,
-                            scala.Option.empty(),
-                            scala.Option.empty(),
-                            actorSystemExecutorConfiguration.getAkkaConfig());
-
-            if (customConfig != null) {
-                akkaConfig = customConfig.withFallback(akkaConfig);
-            }
-
-            return startActorSystem(akkaConfig, actorSystemName, logger);
-        } catch (Throwable t) {
-            throw new Exception("Could not create actor system", t);
-        }
-    }
-
-    /**
-     * Starts an Actor System with given Akka config.
-     *
-     * @param akkaConfig Config of the started ActorSystem.
-     * @param actorSystemName Name of the started ActorSystem.
-     * @param logger The logger to output log information.
-     * @return The ActorSystem which has been started.
-     */
-    private static ActorSystem startActorSystem(
-            Config akkaConfig, String actorSystemName, Logger logger) {
-        logger.debug("Using akka configuration\n {}", akkaConfig);
-        ActorSystem actorSystem = AkkaUtils.createActorSystem(actorSystemName, akkaConfig);
-
-        logger.info("Actor system started at {}", AkkaUtils.getAddress(actorSystem));
-        return actorSystem;
-    }
 
     /**
      * Writes a Flink YAML config file from a Flink Configuration object.
@@ -550,106 +312,6 @@ public class BootstrapTools {
         }
 
         return clonedConfiguration;
-    }
-
-    /** Configuration interface for {@link ActorSystem} underlying executor. */
-    public interface ActorSystemExecutorConfiguration {
-
-        /**
-         * Create the executor {@link Config} for the respective executor.
-         *
-         * @return Akka config for the respective executor
-         */
-        Config getAkkaConfig();
-    }
-
-    /** Configuration for a fork join executor. */
-    public static class ForkJoinExecutorConfiguration implements ActorSystemExecutorConfiguration {
-
-        private final double parallelismFactor;
-
-        private final int minParallelism;
-
-        private final int maxParallelism;
-
-        public ForkJoinExecutorConfiguration(
-                double parallelismFactor, int minParallelism, int maxParallelism) {
-            this.parallelismFactor = parallelismFactor;
-            this.minParallelism = minParallelism;
-            this.maxParallelism = maxParallelism;
-        }
-
-        public double getParallelismFactor() {
-            return parallelismFactor;
-        }
-
-        public int getMinParallelism() {
-            return minParallelism;
-        }
-
-        public int getMaxParallelism() {
-            return maxParallelism;
-        }
-
-        @Override
-        public Config getAkkaConfig() {
-            return AkkaUtils.getForkJoinExecutorConfig(this);
-        }
-
-        public static ForkJoinExecutorConfiguration fromConfiguration(
-                final Configuration configuration) {
-            final double parallelismFactor =
-                    configuration.getDouble(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
-            final int minParallelism =
-                    configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
-            final int maxParallelism =
-                    configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
-
-            return new ForkJoinExecutorConfiguration(
-                    parallelismFactor, minParallelism, maxParallelism);
-        }
-    }
-
-    /** Configuration for a fixed thread pool executor. */
-    public static class FixedThreadPoolExecutorConfiguration
-            implements ActorSystemExecutorConfiguration {
-
-        private final int minNumThreads;
-
-        private final int maxNumThreads;
-
-        private final int threadPriority;
-
-        public FixedThreadPoolExecutorConfiguration(
-                int minNumThreads, int maxNumThreads, int threadPriority) {
-            if (threadPriority < Thread.MIN_PRIORITY || threadPriority > Thread.MAX_PRIORITY) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "The thread priority must be within (%s, %s) but it was %s.",
-                                Thread.MIN_PRIORITY, Thread.MAX_PRIORITY, threadPriority));
-            }
-
-            this.minNumThreads = minNumThreads;
-            this.maxNumThreads = maxNumThreads;
-            this.threadPriority = threadPriority;
-        }
-
-        public int getMinNumThreads() {
-            return minNumThreads;
-        }
-
-        public int getMaxNumThreads() {
-            return maxNumThreads;
-        }
-
-        public int getThreadPriority() {
-            return threadPriority;
-        }
-
-        @Override
-        public Config getAkkaConfig() {
-            return AkkaUtils.getThreadPoolExecutorConfig(this);
-        }
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -36,6 +35,7 @@ import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.ProcessMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.taskexecutor.slot.SlotNotFoundException;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -214,7 +214,7 @@ public class MetricUtils {
         return rpcServiceBuilder
                 .withActorSystemName(METRICS_ACTOR_SYSTEM_NAME)
                 .withActorSystemExecutorConfiguration(
-                        new BootstrapTools.FixedThreadPoolExecutorConfiguration(
+                        new AkkaBootstrapTools.FixedThreadPoolExecutorConfiguration(
                                 1, 1, threadPriority))
                 .createAndStart();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBootstrapTools.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.util.NetUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
+
+import akka.actor.ActorSystem;
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.util.Iterator;
+import java.util.Optional;
+
+import scala.Some;
+import scala.Tuple2;
+
+/** Tools for starting the Actor Systems used to run the JobManager and TaskManager actors. */
+public class AkkaBootstrapTools {
+    /**
+     * Starts a remote ActorSystem at given address and specific port range.
+     *
+     * @param configuration The Flink configuration
+     * @param externalAddress The external address to access the ActorSystem.
+     * @param externalPortRange The choosing range of the external port to access the ActorSystem.
+     * @param logger The logger to output log information.
+     * @return The ActorSystem which has been started
+     * @throws Exception Thrown when actor system cannot be started in specified port range
+     */
+    @VisibleForTesting
+    public static ActorSystem startRemoteActorSystem(
+            Configuration configuration,
+            String externalAddress,
+            String externalPortRange,
+            Logger logger)
+            throws Exception {
+        return startRemoteActorSystem(
+                configuration,
+                AkkaUtils.getFlinkActorSystemName(),
+                externalAddress,
+                externalPortRange,
+                NetUtils.getWildcardIPAddress(),
+                Optional.empty(),
+                logger,
+                ForkJoinExecutorConfiguration.fromConfiguration(configuration),
+                null);
+    }
+
+    /**
+     * Starts a remote ActorSystem at given address and specific port range.
+     *
+     * @param configuration The Flink configuration
+     * @param actorSystemName Name of the started {@link ActorSystem}
+     * @param externalAddress The external address to access the ActorSystem.
+     * @param externalPortRange The choosing range of the external port to access the ActorSystem.
+     * @param bindAddress The local address to bind to.
+     * @param bindPort The local port to bind to. If not present, then the external port will be
+     *     used.
+     * @param logger The logger to output log information.
+     * @param actorSystemExecutorConfiguration configuration for the ActorSystem's underlying
+     *     executor
+     * @param customConfig Custom Akka config to be combined with the config derived from Flink
+     *     configuration.
+     * @return The ActorSystem which has been started
+     * @throws Exception Thrown when actor system cannot be started in specified port range
+     */
+    public static ActorSystem startRemoteActorSystem(
+            Configuration configuration,
+            String actorSystemName,
+            String externalAddress,
+            String externalPortRange,
+            String bindAddress,
+            @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Integer> bindPort,
+            Logger logger,
+            ActorSystemExecutorConfiguration actorSystemExecutorConfiguration,
+            Config customConfig)
+            throws Exception {
+
+        // parse port range definition and create port iterator
+        Iterator<Integer> portsIterator;
+        try {
+            portsIterator = NetUtils.getPortRangeFromString(externalPortRange);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Invalid port range definition: " + externalPortRange);
+        }
+
+        while (portsIterator.hasNext()) {
+            final int externalPort = portsIterator.next();
+
+            try {
+                return startRemoteActorSystem(
+                        configuration,
+                        actorSystemName,
+                        externalAddress,
+                        externalPort,
+                        bindAddress,
+                        bindPort.orElse(externalPort),
+                        logger,
+                        actorSystemExecutorConfiguration,
+                        customConfig);
+            } catch (Exception e) {
+                // we can continue to try if this contains a netty channel exception
+                Throwable cause = e.getCause();
+                if (!(cause instanceof org.jboss.netty.channel.ChannelException
+                        || cause instanceof java.net.BindException)) {
+                    throw e;
+                } // else fall through the loop and try the next port
+            }
+        }
+
+        // if we come here, we have exhausted the port range
+        throw new BindException(
+                "Could not start actor system on any port in port range " + externalPortRange);
+    }
+
+    /**
+     * Starts a remote Actor System at given address and specific port.
+     *
+     * @param configuration The Flink configuration.
+     * @param actorSystemName Name of the started {@link ActorSystem}
+     * @param externalAddress The external address to access the ActorSystem.
+     * @param externalPort The external port to access the ActorSystem.
+     * @param bindAddress The local address to bind to.
+     * @param bindPort The local port to bind to.
+     * @param logger the logger to output log information.
+     * @param actorSystemExecutorConfiguration configuration for the ActorSystem's underlying
+     *     executor
+     * @param customConfig Custom Akka config to be combined with the config derived from Flink
+     *     configuration.
+     * @return The ActorSystem which has been started.
+     * @throws Exception
+     */
+    private static ActorSystem startRemoteActorSystem(
+            Configuration configuration,
+            String actorSystemName,
+            String externalAddress,
+            int externalPort,
+            String bindAddress,
+            int bindPort,
+            Logger logger,
+            ActorSystemExecutorConfiguration actorSystemExecutorConfiguration,
+            Config customConfig)
+            throws Exception {
+
+        String externalHostPortUrl =
+                NetUtils.unresolvedHostAndPortToNormalizedString(externalAddress, externalPort);
+        String bindHostPortUrl =
+                NetUtils.unresolvedHostAndPortToNormalizedString(bindAddress, bindPort);
+        logger.info(
+                "Trying to start actor system, external address {}, bind address {}.",
+                externalHostPortUrl,
+                bindHostPortUrl);
+
+        try {
+            Config akkaConfig =
+                    AkkaUtils.getAkkaConfig(
+                            configuration,
+                            new Some<>(new Tuple2<>(externalAddress, externalPort)),
+                            new Some<>(new Tuple2<>(bindAddress, bindPort)),
+                            actorSystemExecutorConfiguration.getAkkaConfig());
+
+            if (customConfig != null) {
+                akkaConfig = customConfig.withFallback(akkaConfig);
+            }
+
+            return startActorSystem(akkaConfig, actorSystemName, logger);
+        } catch (Throwable t) {
+            if (t instanceof ChannelException) {
+                Throwable cause = t.getCause();
+                if (cause != null && t.getCause() instanceof BindException) {
+                    throw new IOException(
+                            "Unable to create ActorSystem at address "
+                                    + bindHostPortUrl
+                                    + " : "
+                                    + cause.getMessage(),
+                            t);
+                }
+            }
+            throw new Exception("Could not create actor system", t);
+        }
+    }
+
+    /**
+     * Starts a local Actor System.
+     *
+     * @param configuration The Flink configuration.
+     * @param actorSystemName Name of the started ActorSystem.
+     * @param logger The logger to output log information.
+     * @param actorSystemExecutorConfiguration Configuration for the ActorSystem's underlying
+     *     executor.
+     * @param customConfig Custom Akka config to be combined with the config derived from Flink
+     *     configuration.
+     * @return The ActorSystem which has been started.
+     * @throws Exception
+     */
+    public static ActorSystem startLocalActorSystem(
+            Configuration configuration,
+            String actorSystemName,
+            Logger logger,
+            ActorSystemExecutorConfiguration actorSystemExecutorConfiguration,
+            Config customConfig)
+            throws Exception {
+
+        logger.info("Trying to start local actor system");
+
+        try {
+            Config akkaConfig =
+                    AkkaUtils.getAkkaConfig(
+                            configuration,
+                            scala.Option.empty(),
+                            scala.Option.empty(),
+                            actorSystemExecutorConfiguration.getAkkaConfig());
+
+            if (customConfig != null) {
+                akkaConfig = customConfig.withFallback(akkaConfig);
+            }
+
+            return startActorSystem(akkaConfig, actorSystemName, logger);
+        } catch (Throwable t) {
+            throw new Exception("Could not create actor system", t);
+        }
+    }
+
+    /**
+     * Starts an Actor System with given Akka config.
+     *
+     * @param akkaConfig Config of the started ActorSystem.
+     * @param actorSystemName Name of the started ActorSystem.
+     * @param logger The logger to output log information.
+     * @return The ActorSystem which has been started.
+     */
+    private static ActorSystem startActorSystem(
+            Config akkaConfig, String actorSystemName, Logger logger) {
+        logger.debug("Using akka configuration\n {}", akkaConfig);
+        ActorSystem actorSystem = AkkaUtils.createActorSystem(actorSystemName, akkaConfig);
+
+        logger.info("Actor system started at {}", AkkaUtils.getAddress(actorSystem));
+        return actorSystem;
+    }
+
+    // ------------------------------------------------------------------------
+
+    /** Private constructor to prevent instantiation. */
+    private AkkaBootstrapTools() {}
+
+    /** Configuration interface for {@link ActorSystem} underlying executor. */
+    public interface ActorSystemExecutorConfiguration {
+
+        /**
+         * Create the executor {@link Config} for the respective executor.
+         *
+         * @return Akka config for the respective executor
+         */
+        Config getAkkaConfig();
+    }
+
+    /** Configuration for a fork join executor. */
+    public static class ForkJoinExecutorConfiguration implements ActorSystemExecutorConfiguration {
+
+        private final double parallelismFactor;
+
+        private final int minParallelism;
+
+        private final int maxParallelism;
+
+        public ForkJoinExecutorConfiguration(
+                double parallelismFactor, int minParallelism, int maxParallelism) {
+            this.parallelismFactor = parallelismFactor;
+            this.minParallelism = minParallelism;
+            this.maxParallelism = maxParallelism;
+        }
+
+        public double getParallelismFactor() {
+            return parallelismFactor;
+        }
+
+        public int getMinParallelism() {
+            return minParallelism;
+        }
+
+        public int getMaxParallelism() {
+            return maxParallelism;
+        }
+
+        @Override
+        public Config getAkkaConfig() {
+            return AkkaUtils.getForkJoinExecutorConfig(this);
+        }
+
+        public static ForkJoinExecutorConfiguration fromConfiguration(
+                final Configuration configuration) {
+            final double parallelismFactor =
+                    configuration.getDouble(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
+            final int minParallelism =
+                    configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
+            final int maxParallelism =
+                    configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
+
+            return new ForkJoinExecutorConfiguration(
+                    parallelismFactor, minParallelism, maxParallelism);
+        }
+    }
+
+    /** Configuration for a fixed thread pool executor. */
+    public static class FixedThreadPoolExecutorConfiguration
+            implements ActorSystemExecutorConfiguration {
+
+        private final int minNumThreads;
+
+        private final int maxNumThreads;
+
+        private final int threadPriority;
+
+        public FixedThreadPoolExecutorConfiguration(
+                int minNumThreads, int maxNumThreads, int threadPriority) {
+            if (threadPriority < Thread.MIN_PRIORITY || threadPriority > Thread.MAX_PRIORITY) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "The thread priority must be within (%s, %s) but it was %s.",
+                                Thread.MIN_PRIORITY, Thread.MAX_PRIORITY, threadPriority));
+            }
+
+            this.minNumThreads = minNumThreads;
+            this.maxNumThreads = maxNumThreads;
+            this.threadPriority = threadPriority;
+        }
+
+        public int getMinNumThreads() {
+            return minNumThreads;
+        }
+
+        public int getMaxNumThreads() {
+            return maxNumThreads;
+        }
+
+        public int getThreadPriority() {
+            return threadPriority;
+        }
+
+        @Override
+        public Config getAkkaConfig() {
+            return AkkaUtils.getThreadPoolExecutorConfig(this);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution;
 import org.apache.flink.runtime.net.SSLUtils;
@@ -281,8 +280,8 @@ public class AkkaRpcServiceUtils {
         private String actorSystemName = AkkaUtils.getFlinkActorSystemName();
 
         @Nullable
-        private BootstrapTools.ActorSystemExecutorConfiguration actorSystemExecutorConfiguration =
-                null;
+        private AkkaBootstrapTools.ActorSystemExecutorConfiguration
+                actorSystemExecutorConfiguration = null;
 
         @Nullable private Config customConfig = null;
         private String bindAddress = NetUtils.getWildcardIPAddress();
@@ -317,7 +316,7 @@ public class AkkaRpcServiceUtils {
         }
 
         public AkkaRpcServiceBuilder withActorSystemExecutorConfiguration(
-                final BootstrapTools.ActorSystemExecutorConfiguration
+                final AkkaBootstrapTools.ActorSystemExecutorConfiguration
                         actorSystemExecutorConfiguration) {
             this.actorSystemExecutorConfiguration = actorSystemExecutorConfiguration;
             return this;
@@ -349,7 +348,7 @@ public class AkkaRpcServiceUtils {
                 throws Exception {
             if (actorSystemExecutorConfiguration == null) {
                 actorSystemExecutorConfiguration =
-                        BootstrapTools.ForkJoinExecutorConfiguration.fromConfiguration(
+                        AkkaBootstrapTools.ForkJoinExecutorConfiguration.fromConfiguration(
                                 configuration);
             }
 
@@ -358,7 +357,7 @@ public class AkkaRpcServiceUtils {
             if (externalAddress == null) {
                 // create local actor system
                 actorSystem =
-                        BootstrapTools.startLocalActorSystem(
+                        AkkaBootstrapTools.startLocalActorSystem(
                                 configuration,
                                 actorSystemName,
                                 logger,
@@ -367,7 +366,7 @@ public class AkkaRpcServiceUtils {
             } else {
                 // create remote actor system
                 actorSystem =
-                        BootstrapTools.startRemoteActorSystem(
+                        AkkaBootstrapTools.startRemoteActorSystem(
                                 configuration,
                                 actorSystemName,
                                 externalAddress,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -28,10 +28,10 @@ import akka.pattern.{ask => akkaAsk}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration._
-import org.apache.flink.runtime.clusterframework.BootstrapTools.{FixedThreadPoolExecutorConfiguration, ForkJoinExecutorConfiguration}
 import org.apache.flink.runtime.concurrent.FutureUtils
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils
 import org.apache.flink.runtime.net.SSLUtils
+import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools.{FixedThreadPoolExecutorConfiguration, ForkJoinExecutorConfiguration}
 import org.apache.flink.util.NetUtils
 import org.apache.flink.util.TimeUtils
 import org.apache.flink.util.function.FunctionUtils

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -71,7 +71,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-/** Tests for {@link BootstrapToolsTest}. */
+/** Tests for {@link BootstrapTools}. */
 public class BootstrapToolsTest extends TestLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(BootstrapToolsTest.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -27,15 +27,9 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.function.CheckedSupplier;
 
-import akka.actor.ActorSystem;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,31 +39,19 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.BindException;
-import java.net.InetAddress;
-import java.net.ServerSocket;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.configuration.GlobalConfiguration.FLINK_CONF_FILENAME;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 /** Tests for {@link BootstrapTools}. */
 public class BootstrapToolsTest extends TestLogger {
@@ -471,68 +453,6 @@ public class BootstrapToolsTest extends TestLogger {
         Configuration config = new Configuration();
         BootstrapTools.updateTmpDirectoriesInConfiguration(config, null);
         assertEquals(config.getString(CoreOptions.TMP_DIRS), CoreOptions.TMP_DIRS.defaultValue());
-    }
-
-    /**
-     * Tests that we can concurrently create two {@link ActorSystem} without port conflicts. This
-     * effectively tests that we don't open a socket to check for a ports availability. See
-     * FLINK-10580 for more details.
-     */
-    @Test
-    public void testConcurrentActorSystemCreation() throws Exception {
-        final int concurrentCreations = 10;
-        final ExecutorService executorService = Executors.newFixedThreadPool(concurrentCreations);
-        final CyclicBarrier cyclicBarrier = new CyclicBarrier(concurrentCreations);
-
-        try {
-            final List<CompletableFuture<Void>> actorSystemFutures =
-                    IntStream.range(0, concurrentCreations)
-                            .mapToObj(
-                                    ignored ->
-                                            CompletableFuture.supplyAsync(
-                                                    CheckedSupplier.unchecked(
-                                                            () -> {
-                                                                cyclicBarrier.await();
-
-                                                                return BootstrapTools
-                                                                        .startRemoteActorSystem(
-                                                                                new Configuration(),
-                                                                                "localhost",
-                                                                                "0",
-                                                                                LOG);
-                                                            }),
-                                                    executorService))
-                            .map(
-                                    // terminate ActorSystems
-                                    actorSystemFuture ->
-                                            actorSystemFuture.thenCompose(
-                                                    AkkaUtils::terminateActorSystem))
-                            .collect(Collectors.toList());
-
-            FutureUtils.completeAll(actorSystemFutures).get();
-        } finally {
-            ExecutorUtils.gracefulShutdown(10000L, TimeUnit.MILLISECONDS, executorService);
-        }
-    }
-
-    /**
-     * Tests that the {@link ActorSystem} fails with an expressive exception if it cannot be
-     * instantiated due to an occupied port.
-     */
-    @Test
-    public void testActorSystemInstantiationFailureWhenPortOccupied() throws Exception {
-        final ServerSocket portOccupier = new ServerSocket(0, 10, InetAddress.getByName("0.0.0.0"));
-
-        try {
-            final int port = portOccupier.getLocalPort();
-            BootstrapTools.startRemoteActorSystem(
-                    new Configuration(), "0.0.0.0", String.valueOf(port), LOG);
-            fail("Expected to fail with a BindException");
-        } catch (Exception e) {
-            assertThat(ExceptionUtils.findThrowable(e, BindException.class).isPresent(), is(true));
-        } finally {
-            portOccupier.close();
-        }
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaBootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaBootstrapToolsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import akka.actor.ActorSystem;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/** Tests for the {@link AkkaBootstrapTools}. */
+public class AkkaBootstrapToolsTest extends TestLogger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AkkaBootstrapToolsTest.class);
+
+    /**
+     * Tests that we can concurrently create two {@link ActorSystem} without port conflicts. This
+     * effectively tests that we don't open a socket to check for a ports availability. See
+     * FLINK-10580 for more details.
+     */
+    @Test
+    public void testConcurrentActorSystemCreation() throws Exception {
+        final int concurrentCreations = 10;
+        final ExecutorService executorService = Executors.newFixedThreadPool(concurrentCreations);
+        final CyclicBarrier cyclicBarrier = new CyclicBarrier(concurrentCreations);
+
+        try {
+            final List<CompletableFuture<Void>> actorSystemFutures =
+                    IntStream.range(0, concurrentCreations)
+                            .mapToObj(
+                                    ignored ->
+                                            CompletableFuture.supplyAsync(
+                                                    CheckedSupplier.unchecked(
+                                                            () -> {
+                                                                cyclicBarrier.await();
+
+                                                                return AkkaBootstrapTools
+                                                                        .startRemoteActorSystem(
+                                                                                new Configuration(),
+                                                                                "localhost",
+                                                                                "0",
+                                                                                LOG);
+                                                            }),
+                                                    executorService))
+                            .map(
+                                    // terminate ActorSystems
+                                    actorSystemFuture ->
+                                            actorSystemFuture.thenCompose(
+                                                    AkkaUtils::terminateActorSystem))
+                            .collect(Collectors.toList());
+
+            FutureUtils.completeAll(actorSystemFutures).get();
+        } finally {
+            ExecutorUtils.gracefulShutdown(10000L, TimeUnit.MILLISECONDS, executorService);
+        }
+    }
+
+    /**
+     * Tests that the {@link ActorSystem} fails with an expressive exception if it cannot be
+     * instantiated due to an occupied port.
+     */
+    @Test
+    public void testActorSystemInstantiationFailureWhenPortOccupied() throws Exception {
+        final ServerSocket portOccupier = new ServerSocket(0, 10, InetAddress.getByName("0.0.0.0"));
+
+        try {
+            final int port = portOccupier.getLocalPort();
+            AkkaBootstrapTools.startRemoteActorSystem(
+                    new Configuration(), "0.0.0.0", String.valueOf(port), LOG);
+            fail("Expected to fail with a BindException");
+        } catch (Exception e) {
+            assertThat(ExceptionUtils.findThrowable(e, BindException.class).isPresent(), is(true));
+        } finally {
+            portOccupier.close();
+        }
+    }
+}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -22,8 +22,8 @@ import java.net.{InetAddress, InetSocketAddress}
 import java.util.Collections
 
 import org.apache.flink.configuration.{AkkaOptions, Configuration, IllegalConfigurationException, SecurityOptions}
-import org.apache.flink.runtime.clusterframework.BootstrapTools.FixedThreadPoolExecutorConfiguration
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution
+import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools.FixedThreadPoolExecutorConfiguration
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils.AkkaProtocol
 import org.apache.flink.util.NetUtils


### PR DESCRIPTION
Splits the BootstrapTools such that it is easier to move the akka-related parts into another module in the future.