### PR TITLE
[FLINK-23059][docs] describe creating dirs in ops playground docs

### DIFF
--- a/docs/content/docs/try-flink/flink-operations-playground.md
+++ b/docs/content/docs/try-flink/flink-operations-playground.md
@@ -93,13 +93,24 @@ We assume that you have [Docker](https://docs.docker.com/) (1.12+) and
 [docker-compose](https://docs.docker.com/compose/) (2.1+) installed on your machine.
 
 The required configuration files are available in the 
-[flink-playgrounds](https://github.com/apache/flink-playgrounds) repository. Check it out and spin
-up the environment:
+[flink-playgrounds](https://github.com/apache/flink-playgrounds) repository. First checkout the code and build the docker image:
 
 ```bash
-git clone --branch release-{{ site.version_title }} https://github.com/apache/flink-playgrounds.git
+git clone https://github.com/apache/flink-playgrounds.git
 cd flink-playgrounds/operations-playground
 docker-compose build
+```
+
+Then before starting the playground, create the checkpoint and savepoint directories on the Docker host machine (these volumes are mounted by the jobmanager and taskmanager, as specified in docker-compose.yaml):
+
+```bash
+mkdir -p /tmp/flink-checkpoints-directory
+mkdir -p /tmp/flink-savepoints-directory
+```
+
+Then start the playground:
+
+```bash
 docker-compose up -d
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

Since Flink 1.12 it has been necessary to manually create (on the Docker host) the checkpoint and savepoint directories used by the Flink Operations Playground. While this was documented in the README file in the playground repository, the step-by-step instructions in the documentation were not updated to include this crucial step.

Also, with jekyll we had this bit of cleverness to create the instructions 

 ```bash
git clone --branch release-{{ site.version_title }} https://github.com/apache/flink-playgrounds.git
```

This no longer works, and I don't believe it is worth trying to reproduce. I'm proposing we simply have them work from master, which is always the latest stable version of the playground.

## Brief change log

- added the missing step
- point to the master version of the playground, rather than a specific release branch

## Verifying this change

This change is a small update to the docs.
