### PR TITLE
[FLINK-23040][table-common] Consider ConfigOption fallback keys of formats in FactoryUtil

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -157,14 +157,18 @@ public class FactoryUtilTest {
                         + "key.format\n"
                         + "key.test-format.changelog-mode\n"
                         + "key.test-format.delimiter\n"
+                        + "key.test-format.deprecated-delimiter (deprecated)\n"
                         + "key.test-format.fail-on-missing\n"
+                        + "key.test-format.fallback-fail-on-missing\n"
                         + "key.test-format.readable-metadata\n"
                         + "property-version\n"
                         + "target\n"
                         + "value.format\n"
                         + "value.test-format.changelog-mode\n"
                         + "value.test-format.delimiter\n"
+                        + "value.test-format.deprecated-delimiter (deprecated)\n"
                         + "value.test-format.fail-on-missing\n"
+                        + "value.test-format.fallback-fail-on-missing\n"
                         + "value.test-format.readable-metadata");
         testError(
                 options -> {
@@ -347,11 +351,16 @@ public class FactoryUtilTest {
         final Map<String, String> options = new HashMap<>();
         options.put("deprecated-target", "MyTarget");
         options.put("fallback-buffer-size", "1000");
+        options.put("value.format", "test-format");
+        options.put("value.test-format.deprecated-delimiter", "|");
+        options.put("value.test-format.fallback-fail-on-missing", "true");
 
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(
                         new TestDynamicTableFactory(),
                         FactoryMocks.createTableContext(SCHEMA, options));
+        helper.discoverDecodingFormat(
+                DeserializationFormatFactory.class, TestDynamicTableFactory.VALUE_FORMAT);
         helper.validate();
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
@@ -57,10 +57,16 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
     public static final String IDENTIFIER = "test-format";
 
     public static final ConfigOption<String> DELIMITER =
-            ConfigOptions.key("delimiter").stringType().noDefaultValue();
+            ConfigOptions.key("delimiter")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDeprecatedKeys("deprecated-delimiter");
 
     public static final ConfigOption<Boolean> FAIL_ON_MISSING =
-            ConfigOptions.key("fail-on-missing").booleanType().defaultValue(false);
+            ConfigOptions.key("fail-on-missing")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys("fallback-fail-on-missing");
 
     public static final ConfigOption<List<String>> CHANGELOG_MODE =
             ConfigOptions.key("changelog-mode").stringType().asList().noDefaultValue();


### PR DESCRIPTION
## What is the purpose of the change

Adds support for fallback (incl. deprecated keys) for formats. This was missing in the previous PR.

## Brief change log

Add support for format fallback keys in validation.

## Verifying this change

This change added tests and can be verified as follows: `FactoryUtilTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
