### PR TITLE
[FLINK-23073][formats / CSV] Fix space handling in Row CSV timestamp parser

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDeserializationSchema.java
@@ -321,7 +321,7 @@ public final class CsvRowDeserializationSchema implements DeserializationSchema<
         } else if (info.equals(Types.LOCAL_TIME)) {
             return (node) -> Time.valueOf(node.asText()).toLocalTime();
         } else if (info.equals(Types.LOCAL_DATE_TIME)) {
-            return (node) -> LocalDateTime.parse(node.asText(), SQL_TIMESTAMP_FORMAT);
+            return (node) -> LocalDateTime.parse(node.asText().trim(), SQL_TIMESTAMP_FORMAT);
         } else if (info.equals(Types.INSTANT)) {
             return (node) ->
                     LocalDateTime.parse(node.asText(), SQL_TIMESTAMP_WITH_LOCAL_TIMEZONE_FORMAT)

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvToRowDataConverters.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvToRowDataConverters.java
@@ -259,7 +259,7 @@ public class CsvToRowDataConverters implements Serializable {
     private TimestampData convertToTimestamp(
             JsonNode jsonNode, DateTimeFormatter dateTimeFormatter) {
         return TimestampData.fromLocalDateTime(
-                LocalDateTime.parse(jsonNode.asText(), dateTimeFormatter));
+                LocalDateTime.parse(jsonNode.asText().trim(), dateTimeFormatter));
     }
 
     private StringData convertToString(JsonNode jsonNode) {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
@@ -123,6 +123,12 @@ public class CsvRowDeSerializationSchemaTest {
         testField(Types.INT, "       12          ", 12, deserConfig, ";");
         testField(Types.INT, "12", 12, serConfig, deserConfig, ";");
         testField(
+                Types.LOCAL_DATE_TIME,
+                "    2018-10-12 12:12:12     ",
+                LocalDateTime.parse("2018-10-12T12:12:12"),
+                deserConfig,
+                ";");
+        testField(
                 Types.ROW(Types.STRING, Types.STRING),
                 "1:hello",
                 Row.of("1", "hello"),


### PR DESCRIPTION
## What is the purpose of the change

FLINK-21947 Added support for TIMESTAMP_LTZ in the CSV format by replacing `java.sql.Timestamp.valueOf` with `java.time.LocalDateTime.parse`. `Timestamp.valueOf` internally calls `trim()` on the string before parsing while `LocalDateTime.parse` does not. This caused a breaking change where the CSV format can no longer parse timestamps of CSV's with spaces after the delimiter. We should manually re-add the call to trim to revert the behavior.


## Brief change log

Add trim() to convertToTimestamp


## Verifying this change

- Trivial

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
