### PR TITLE
[FLINK-23081] Move Executors#directExecutorContext to AkkaFutureUtils

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -21,12 +21,7 @@ package org.apache.flink.runtime.concurrent;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
-import scala.concurrent.ExecutionContext;
-
-/**
- * Collection of {@link Executor}, {@link ExecutorService} and {@link ExecutionContext}
- * implementations.
- */
+/** Collection of {@link Executor} and {@link ExecutorService} implementations. */
 public class Executors {
 
     /**
@@ -49,38 +44,5 @@ public class Executors {
      */
     public static ExecutorService newDirectExecutorService() {
         return new DirectExecutorService();
-    }
-
-    /**
-     * Return a direct execution context. The direct execution context executes the runnable
-     * directly in the calling thread.
-     *
-     * @return Direct execution context.
-     */
-    public static ExecutionContext directExecutionContext() {
-        return DirectExecutionContext.INSTANCE;
-    }
-
-    /** Direct execution context. */
-    private static class DirectExecutionContext implements ExecutionContext {
-
-        static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
-
-        private DirectExecutionContext() {}
-
-        @Override
-        public void execute(Runnable runnable) {
-            runnable.run();
-        }
-
-        @Override
-        public void reportFailure(Throwable cause) {
-            throw new IllegalStateException("Error in direct execution context.", cause);
-        }
-
-        @Override
-        public ExecutionContext prepare() {
-            return this;
-        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/akka/AkkaFutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/akka/AkkaFutureUtils.java
@@ -17,12 +17,11 @@
 
 package org.apache.flink.runtime.concurrent.akka;
 
-import org.apache.flink.runtime.concurrent.Executors;
-
 import akka.dispatch.OnComplete;
 
 import java.util.concurrent.CompletableFuture;
 
+import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
 
 /** Utilities to convert Scala types into Java types. */
@@ -49,8 +48,31 @@ public class AkkaFutureUtils {
                         }
                     }
                 },
-                Executors.directExecutionContext());
+                DirectExecutionContext.INSTANCE);
 
         return result;
+    }
+
+    /** Direct execution context. */
+    private static class DirectExecutionContext implements ExecutionContext {
+
+        static final DirectExecutionContext INSTANCE = new DirectExecutionContext();
+
+        private DirectExecutionContext() {}
+
+        @Override
+        public void execute(Runnable runnable) {
+            runnable.run();
+        }
+
+        @Override
+        public void reportFailure(Throwable cause) {
+            throw new IllegalStateException("Error in direct execution context.", cause);
+        }
+
+        @Override
+        public ExecutionContext prepare() {
+            return this;
+        }
     }
 }


### PR DESCRIPTION
The DirectExecutionContext is only used by the AkkaFutureUtils. The goal is to further split runtime&scala code.