### PR TITLE
[FLINK-21084][runtime][checkpoint] Allows tasks to report finished snapshot if finished on restore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -31,6 +31,7 @@ import javax.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -174,12 +175,13 @@ public class TaskStateSnapshot implements CompositeStateHandle {
 
         TaskStateSnapshot that = (TaskStateSnapshot) o;
 
-        return subtaskStatesByOperatorID.equals(that.subtaskStatesByOperatorID);
+        return subtaskStatesByOperatorID.equals(that.subtaskStatesByOperatorID)
+                && isFinished == that.isFinished;
     }
 
     @Override
     public int hashCode() {
-        return subtaskStatesByOperatorID.hashCode();
+        return Objects.hash(subtaskStatesByOperatorID, isFinished);
     }
 
     @Override
@@ -187,6 +189,8 @@ public class TaskStateSnapshot implements CompositeStateHandle {
         return "TaskOperatorSubtaskStates{"
                 + "subtaskStatesByOperatorID="
                 + subtaskStatesByOperatorID
+                + ", isFinished="
+                + isFinished
                 + '}';
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -321,7 +321,12 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
         try {
             if (takeSnapshotSync(
                     snapshotFutures, metadata, metrics, options, operatorChain, isRunning)) {
-                finishAndReportAsync(snapshotFutures, metadata, metrics, isRunning);
+                finishAndReportAsync(
+                        snapshotFutures,
+                        metadata,
+                        metrics,
+                        operatorChain.isFinishedOnRestore(),
+                        isRunning);
             } else {
                 cleanup(snapshotFutures, metadata, metrics, new Exception("Checkpoint declined"));
             }
@@ -559,6 +564,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             Map<OperatorID, OperatorSnapshotFutures> snapshotFutures,
             CheckpointMetaData metadata,
             CheckpointMetricsBuilder metrics,
+            boolean isFinishedOnRestore,
             Supplier<Boolean> isRunning)
             throws IOException {
         AsyncCheckpointRunnable asyncCheckpointRunnable =
@@ -571,6 +577,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                         unregisterConsumer(),
                         env,
                         asyncExceptionHandler,
+                        isFinishedOnRestore,
                         isRunning);
 
         registerAsyncCheckpointRunnable(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -127,6 +127,7 @@ public class LocalStateForwardingTest extends TestLogger {
                         asyncCheckpointRunnable -> {},
                         testStreamTask.getEnvironment(),
                         testStreamTask,
+                        false,
                         () -> true);
 
         checkpointMetrics.setAlignmentDurationNanos(0L);


### PR DESCRIPTION
## What is the purpose of the change

This PR allows the task to report finished snapshot if it is finished on restore (namely it is restored from a finished snapshot). On the JM side it would mark the operators in these tasks as fully finished, thus we could ensure an operator marked as fully finished on restore is also fully finished in all the following checkpoints.

## Brief change log

- a1d70d30240878aafd1ade627e8a9e99ee1af770 Hotfix to fix the `equals` and `hashcode` method to consider `isFinished` attribute.
- 223dd6d952e5be774bc4f6ba89bb46aeb4d8a71d Task reports finished snapshot on checkpoint if it is finished on restore
- e38c1c707865aa3e3e6fe7e376819d6a599d2a15 JM marks the operators as fully finished if it received finished snapshots for that operator.

## Verifying this change

This change added tests and can be verified by added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
