### PR TITLE
[FLINK-23092][python] Fix the issue that built-in UDAF could not be mixed use with Python UDAF in group window

### DIFF
--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -543,24 +543,25 @@ class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
 
         from pyflink.testing import source_sink_utils
         table_sink = source_sink_utils.TestAppendSink(
-            ['a', 'b', 'c', 'd'],
+            ['a', 'b', 'c', 'd', 'e'],
             [
                 DataTypes.TINYINT(),
                 DataTypes.TIMESTAMP(3),
                 DataTypes.TIMESTAMP(3),
+                DataTypes.BIGINT(),
                 DataTypes.BIGINT()])
         self.t_env.register_table_sink("Results", table_sink)
         t.window(Tumble.over("1.hours").on("rowtime").alias("w")) \
             .group_by("a, w") \
-            .select("a, w.start, w.end, my_count(c) as c") \
+            .select("a, w.start, w.end, COUNT(c) as c, my_count(c) as d") \
             .execute_insert("Results") \
             .wait()
         actual = source_sink_utils.results()
         self.assert_equals(actual,
-                           ["+I[2, 2018-03-11 03:00:00.0, 2018-03-11 04:00:00.0, 1]",
-                            "+I[3, 2018-03-11 03:00:00.0, 2018-03-11 04:00:00.0, 1]",
-                            "+I[1, 2018-03-11 03:00:00.0, 2018-03-11 04:00:00.0, 2]",
-                            "+I[1, 2018-03-11 04:00:00.0, 2018-03-11 05:00:00.0, 1]"])
+                           ["+I[2, 2018-03-11 03:00:00.0, 2018-03-11 04:00:00.0, 2, 1]",
+                            "+I[3, 2018-03-11 03:00:00.0, 2018-03-11 04:00:00.0, 1, 1]",
+                            "+I[1, 2018-03-11 03:00:00.0, 2018-03-11 04:00:00.0, 2, 2]",
+                            "+I[1, 2018-03-11 04:00:00.0, 2018-03-11 05:00:00.0, 1, 1]"])
 
     def test_tumbling_group_window_over_count(self):
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
@@ -77,7 +77,11 @@ public class StreamPhysicalPythonGroupWindowAggregateRule extends ConverterRule 
                 aggCalls.stream()
                         .anyMatch(x -> PythonUtil.isPythonAggregate(x, PythonFunctionKind.PANDAS));
         boolean existJavaFunction =
-                aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null));
+                aggCalls.stream()
+                        .anyMatch(
+                                x ->
+                                        !PythonUtil.isPythonAggregate(x, null)
+                                                && !PythonUtil.isBuiltInAggregate(x));
         if (existPandasFunction && existGeneralPythonFunction) {
             throw new TableException(
                     "Pandas UDAFs and General Python UDAFs are not supported in used together currently.");


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix built-in functions are unsupported in Python Group Window UDAF*


## Brief change log

  - *Fix built-in functions are unsupported in Python Group Window UDAF*


## Verifying this change

This change added tests and can be verified as follows:

  - *Change original IT `test_tumbling_group_window_over_time` to cover this patch*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
