### PR TITLE
[FLINK-23065][table-api-java][planner-blink] Introduce TableEnvironment#createTemporaryTable

### DIFF
--- a/docs/content.zh/docs/dev/table/common.md
+++ b/docs/content.zh/docs/dev/table/common.md
@@ -40,68 +40,91 @@ Table API 和 SQL 程序的结构
 {{< tabs "62be8916-7ab4-4831-bd19-05c591181835" >}}
 {{< tab "Java" >}}
 ```java
+import org.apache.flink.table.api.*;
+import org.apache.flink.table.factories.DataGenOptions;
 
-// create a TableEnvironment for batch or streaming execution
-TableEnvironment tableEnv = ...; // see "Create a TableEnvironment" section
+// Create a TableEnvironment for batch or streaming execution.
+// See the "Create a TableEnvironment" section for details.
+TableEnvironment tableEnv = TableEnvironment.create(/*…*/);
 
-// create an input Table
-tableEnv.executeSql("CREATE TEMPORARY TABLE table1 ... WITH ( 'connector' = ... )");
-// register an output Table
-tableEnv.executeSql("CREATE TEMPORARY TABLE outputTable ... WITH ( 'connector' = ... )");
+// Create a source table
+tableEnv.createTemporaryTable("SourceTable", TableDescriptor.forConnector("datagen")
+    .schema(Schema.newBuilder()
+      .column("f0", DataTypes.STRING())
+      .build())
+    .option(DataGenOptions.ROWS_PER_SECOND, 100)
+    .build())
 
-// create a Table object from a Table API query
-Table table2 = tableEnv.from("table1").select(...);
-// create a Table object from a SQL query
-Table table3 = tableEnv.sqlQuery("SELECT ... FROM table1 ... ");
+// Create a sink table (using SQL DDL)
+tableEnv.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable");
 
-// emit a Table API result Table to a TableSink, same for SQL result
-TableResult tableResult = table2.executeInsert("outputTable");
-tableResult...
+// Create a Table object from a Table API query
+Table table2 = tableEnv.from("SourceTable");
 
+// Create a Table object from a SQL query
+Table table3 = tableEnv.sqlQuery("SELECT * FROM SourceTable");
+
+// Emit a Table API result Table to a TableSink, same for SQL result
+TableResult tableResult = table2.executeInsert("SinkTable");
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
 ```scala
+import org.apache.flink.table.api._
+import org.apache.flink.table.factories.DataGenOptions
 
-// create a TableEnvironment for batch or streaming execution
-val tableEnv = ... // see "Create a TableEnvironment" section
+// Create a TableEnvironment for batch or streaming execution.
+// See the "Create a TableEnvironment" section for details.
+val tableEnv = TableEnvironment.create(/*…*/)
 
-// create an input Table
-tableEnv.executeSql("CREATE TEMPORARY TABLE table1 ... WITH ( 'connector' = ... )")
-// register an output Table
-tableEnv.executeSql("CREATE TEMPORARY TABLE outputTable ... WITH ( 'connector' = ... )")
+// Create a source table
+tableEnv.createTemporaryTable("SourceTable", TableDescriptor.forConnector("datagen")
+  .schema(Schema.newBuilder()
+    .column("f0", DataTypes.STRING())
+    .build())
+  .option(DataGenOptions.ROWS_PER_SECOND, 100)
+  .build())
 
-// create a Table from a Table API query
-val table2 = tableEnv.from("table1").select(...)
-// create a Table from a SQL query
-val table3 = tableEnv.sqlQuery("SELECT ... FROM table1 ...")
+// Create a sink table (using SQL DDL)
+tableEnv.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable");
 
-// emit a Table API result Table to a TableSink, same for SQL result
-val tableResult = table2.executeInsert("outputTable")
-tableResult...
+// Create a Table object from a Table API query
+val table1 = tableEnv.from("SourceTable");
 
+// Create a Table object from a SQL query
+val table2 = tableEnv.sqlQuery("SELECT * FROM SourceTable");
+
+// Emit a Table API result Table to a TableSink, same for SQL result
+val tableResult = table1.executeInsert("SinkTable");
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
+from pyflink.table import *
 
-# create a TableEnvironment for batch or streaming execution
+# Create a TableEnvironment for batch or streaming execution
 table_env = ... # see "Create a TableEnvironment" section
 
-# register an input Table
-table_env.executeSql("CREATE TEMPORARY TABLE table1 ... WITH ( 'connector' = ... )")
-# register an output Table
-table_env.executeSql("CREATE TEMPORARY TABLE outputTable ... WITH ( 'connector' = ... )")
+# Create a source table
+table_env.executeSql("""CREATE TEMPORARY TABLE SourceTable (
+  f0 STRING
+) WITH (
+  'connector' = 'datagen',
+  'rows-per-second' = '100'
+)
+""")
 
-# create a Table from a Table API query
-table2 = table_env.from_path("table1").select(...)
-# create a Table from a SQL query
-table3 = table_env.sql_query("SELECT ... FROM table1 ...")
+# Create a sink table
+table_env.executeSql("CREATE TEMPORARY TABLE SinkTable WITH ('connector' = 'blackhole') LIKE SourceTable")
 
-# emit a Table API result Table to a TableSink, same for SQL result
-table_result = table3.execute_insert("outputTable")
-table_result...
+# Create a Table from a Table API query
+table1 = table_env.from_path("SourceTable").select(...)
 
+# Create a Table from a SQL query
+table2 = table_env.sql_query("SELECT ... FROM SourceTable ...")
+
+# Emit a Table API result Table to a TableSink, same for SQL result
+table_result = table1.execute_insert("SinkTable")
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -297,8 +320,19 @@ table_env.register_table("projectedTable", proj_table)
 
 另外一个方式去创建 `TABLE` 是通过 [connector]({{< ref "docs/connectors/table/overview" >}}) 声明。Connector 描述了存储表数据的外部系统。存储系统例如 Apache Kafka 或者常规的文件系统都可以通过这种方式来声明。
 
-```sql
-tableEnvironment.executeSql("CREATE [TEMPORARY] TABLE MyTable (...) WITH (...)")
+Such tables can either be created using the Table API directly, or by switching to SQL DDL.
+
+```java
+// Using table descriptors
+tableEnv.createTemporaryTable("Source", TableDescriptor.forConnector("datagen")
+    .schema(Schema.newBuilder()
+      .column("f0", DataTypes.STRING())
+      .build())
+    .option(DataGenOptions.ROWS_PER_SECOND, 100)
+    .build())
+
+// Using SQL DDL
+tableEnv.executeSql("CREATE [TEMPORARY] TABLE MyTable (...) WITH (...)")
 ```
 
 <a name="expanding-table-identifiers"></a>

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -41,6 +41,7 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTest
             'getCompletionHints',
             'fromValues',
             'create',
+            'createTemporaryTable',
             'createTemporarySystemFunction',
             'dropTemporarySystemFunction',
             'createFunction',

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FormatDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FormatDescriptor.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.table.connector.format.Format;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Describes a {@link Format format} and its options for use with {@link TableDescriptor}.
+ *
+ * <p>Formats are responsible for encoding and decoding data in table connectors. Note that not
+ * every connector has a format, while others may have multiple formats (e.g. the Kafka connector
+ * has separate formats for keys and values). Common formats are "json", "csv", "avro", etc. See
+ * {@link Format} for more details.
+ */
+@PublicEvolving
+public final class FormatDescriptor {
+
+    private final String format;
+    private final Map<String, String> options;
+
+    private FormatDescriptor(String format, Map<String, String> options) {
+        this.format =
+                Preconditions.checkNotNull(
+                        format, "Format descriptors require the format identifier");
+        this.options = Collections.unmodifiableMap(options);
+    }
+
+    /**
+     * Creates a new {@link Builder} describing a format with the given format identifier.
+     *
+     * @param format The factory identifier for the format.
+     */
+    public static Builder forFormat(String format) {
+        return new Builder(format);
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    @Override
+    public String toString() {
+        return String.format("%s[%s]", format, options);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        FormatDescriptor that = (FormatDescriptor) obj;
+        return format.equals(that.format) && options.equals(that.options);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(format, options);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /** Builder for {@link FormatDescriptor}. */
+    public static class Builder {
+        private final String format;
+        private final Map<String, String> options = new HashMap<>();
+
+        private Builder(String format) {
+            this.format = format;
+        }
+
+        /** Sets the given option on the format. */
+        public <T> Builder option(ConfigOption<T> configOption, T value) {
+            options.put(configOption.key(), ConfigurationUtils.convertValue(value, String.class));
+            return this;
+        }
+
+        /**
+         * Sets the given option on the format.
+         *
+         * <p>Note that format options must not be prefixed with the format identifier itself here.
+         * For example,
+         *
+         * <pre>{@code
+         * FormatDescriptor.forFormat("json")
+         *   .option("ignore-parse-errors", "true")
+         *   .build();
+         * }</pre>
+         *
+         * <p>will automatically be converted into its prefixed form:
+         *
+         * <pre>{@code
+         * 'format' = 'json'
+         * 'json.ignore-parse-errors' = 'true'
+         * }</pre>
+         */
+        public Builder option(String key, String value) {
+            options.put(key, value);
+            return this;
+        }
+
+        /** Returns an immutable instance of {@link FormatDescriptor}. */
+        public FormatDescriptor build() {
+            return new FormatDescriptor(format, options);
+        }
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableDescriptor.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.connector.format.Format;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Describes a {@link CatalogTable} representing a source or sink.
+ *
+ * <p>A {@link TableDescriptor} is a template for creating a {@link CatalogTable} instance. It
+ * closely resembles the "CREATE TABLE" SQL DDL statement, containing schema, connector options, and
+ * other characteristics. Since tables in Flink are typically backed by external systems, the
+ * descriptor describes how a connector (and possibly its format) are configured.
+ *
+ * <p>This can be used to register a table in the Table API, see {@link
+ * TableEnvironment#createTemporaryTable(String, TableDescriptor)}.
+ */
+@PublicEvolving
+public final class TableDescriptor {
+
+    private final Schema schema;
+    private final Map<String, String> options;
+    private final List<String> partitionKeys;
+    private final @Nullable String comment;
+
+    private TableDescriptor(
+            Schema schema,
+            Map<String, String> options,
+            List<String> partitionKeys,
+            @Nullable String comment) {
+        this.schema = Preconditions.checkNotNull(schema, "Table descriptors require a schema");
+        this.options = Collections.unmodifiableMap(options);
+        this.partitionKeys = Collections.unmodifiableList(partitionKeys);
+        this.comment = comment;
+    }
+
+    /**
+     * Creates a new {@link Builder} for a table using the given connector.
+     *
+     * @param connector The factory identifier for the connector.
+     */
+    public static Builder forConnector(String connector) {
+        final Builder descriptorBuilder = new Builder();
+        descriptorBuilder.option(FactoryUtil.CONNECTOR, connector);
+
+        return descriptorBuilder;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public List<String> getPartitionKeys() {
+        return partitionKeys;
+    }
+
+    public Optional<String> getComment() {
+        return Optional.ofNullable(comment);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    @Override
+    public String toString() {
+        final String escapedPartitionKeys =
+                partitionKeys.stream()
+                        .map(EncodingUtils::escapeIdentifier)
+                        .collect(Collectors.joining(", "));
+
+        final String partitionedBy =
+                !partitionKeys.isEmpty()
+                        ? String.format("PARTITIONED BY (%s)", escapedPartitionKeys)
+                        : "";
+
+        final String serializedOptions =
+                options.entrySet().stream()
+                        .map(
+                                entry ->
+                                        String.format(
+                                                "  '%s' = '%s'",
+                                                EncodingUtils.escapeSingleQuotes(entry.getKey()),
+                                                EncodingUtils.escapeSingleQuotes(entry.getValue())))
+                        .collect(Collectors.joining(String.format(",%n")));
+
+        return String.format(
+                "CREATE TABLE … %s%nCOMMENT '%s'%n%s%nWITH (%n%s%n)",
+                schema, comment != null ? comment : "", partitionedBy, serializedOptions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        TableDescriptor that = (TableDescriptor) obj;
+        return Objects.equals(schema, that.schema)
+                && options.equals(that.options)
+                && partitionKeys.equals(that.partitionKeys)
+                && Objects.equals(comment, that.comment);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, options, partitionKeys, comment);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    /** Builder for {@link TableDescriptor}. */
+    public static class Builder {
+
+        private Schema schema;
+        private final Map<String, String> options = new HashMap<>();
+        private final List<String> partitionKeys = new ArrayList<>();
+        private @Nullable String comment;
+
+        /** Define the schema of the {@link TableDescriptor}. */
+        public Builder schema(Schema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        /** Sets the given option on the table. */
+        public <T> Builder option(ConfigOption<T> configOption, T value) {
+            options.put(configOption.key(), ConfigurationUtils.convertValue(value, String.class));
+            return this;
+        }
+
+        /**
+         * Sets the given option on the table.
+         *
+         * <p>Option keys must be fully specified. When defining options for a {@link Format
+         * format}, use {@link #format(FormatDescriptor)} instead.
+         *
+         * <p>Example:
+         *
+         * <pre>{@code
+         * TableDescriptor.forConnector("kafka")
+         *   .option("scan.startup.mode", "latest-offset")
+         *   .build();
+         * }</pre>
+         */
+        public Builder option(String key, String value) {
+            options.put(key, value);
+            return this;
+        }
+
+        /**
+         * Defines the {@link Format format} to be used for this table.
+         *
+         * <p>Note that not every connector requires a format to be specified, while others may use
+         * multiple formats. In the latter case, use {@link #format(ConfigOption, FormatDescriptor)}
+         * instead to specify for which option the format should be configured.
+         */
+        public Builder format(String format) {
+            return format(FactoryUtil.FORMAT, FormatDescriptor.forFormat(format).build());
+        }
+
+        /**
+         * Defines the format to be used for this table.
+         *
+         * <p>Note that not every connector requires a format to be specified, while others may use
+         * multiple formats.
+         *
+         * <p>Options of the provided {@param formatDescriptor} are automatically prefixed. For
+         * example,
+         *
+         * <pre>{@code
+         * descriptorBuilder.format(FormatDescriptor.forFormat("json")
+         *   .option(JsonOptions.IGNORE_PARSE_ERRORS, true)
+         *   .build()
+         * }</pre>
+         *
+         * <p>will result in the options
+         *
+         * <pre>{@code
+         * 'format' = 'json'
+         * 'json.ignore-parse-errors' = 'true'
+         * }</pre>
+         */
+        public Builder format(FormatDescriptor formatDescriptor) {
+            return format(FactoryUtil.FORMAT, formatDescriptor);
+        }
+
+        /**
+         * Defines the format to be used for this table.
+         *
+         * <p>Note that not every connector requires a format to be specified, while others may use
+         * multiple formats.
+         *
+         * <p>Options of the provided {@param formatDescriptor} are automatically prefixed. For
+         * example,
+         *
+         * <pre>{@code
+         * descriptorBuilder.format(KafkaOptions.KEY_FORMAT, FormatDescriptor.forFormat("json")
+         *   .option(JsonOptions.IGNORE_PARSE_ERRORS, true)
+         *   .build()
+         * }</pre>
+         *
+         * <p>will result in the options
+         *
+         * <pre>{@code
+         * 'key.format' = 'json'
+         * 'key.json.ignore-parse-errors' = 'true'
+         * }</pre>
+         */
+        public Builder format(
+                ConfigOption<String> formatOption, FormatDescriptor formatDescriptor) {
+            option(formatOption, formatDescriptor.getFormat());
+
+            final String optionPrefix =
+                    FactoryUtil.getFormatPrefix(formatOption, formatDescriptor.getFormat());
+            formatDescriptor
+                    .getOptions()
+                    .forEach(
+                            (key, value) -> {
+                                if (key.startsWith(optionPrefix)) {
+                                    throw new TableException(
+                                            String.format(
+                                                    "Format options set using #format(FormatDescriptor) should not contain the prefix '%s', but found '%s'.",
+                                                    optionPrefix, key));
+                                }
+
+                                final String prefixedKey = optionPrefix + key;
+                                option(prefixedKey, value);
+                            });
+
+            return this;
+        }
+
+        /** Define which columns this table is partitioned by. */
+        public Builder partitionedBy(String... partitionKeys) {
+            this.partitionKeys.addAll(Arrays.asList(partitionKeys));
+            return this;
+        }
+
+        /** Define the comment for this table. */
+        public Builder comment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        /** Returns an immutable instance of {@link TableDescriptor}. */
+        public TableDescriptor build() {
+            return new TableDescriptor(schema, options, partitionKeys, comment);
+        }
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -585,6 +585,27 @@ public interface TableEnvironment {
     boolean dropTemporaryFunction(String path);
 
     /**
+     * Registers the {@link TableDescriptor} as a temporary table.
+     *
+     * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
+     * it will be inaccessible in the current session. To make the permanent object available again
+     * one can drop the corresponding temporary object.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * tEnv.createTemporaryTable("MyTable", TableDescriptor.forConnector("datagen")
+     *   .schema(Schema.newBuilder()
+     *     .column("f0", DataTypes.STRING())
+     *     .build())
+     *   .option(DataGenOptions.ROWS_PER_SECOND, 10)
+     *   .option("fields.f0.kind", "random")
+     *   .build());
+     * }</pre>
+     */
+    void createTemporaryTable(String path, TableDescriptor descriptor);
+
+    /**
      * Registers a {@link Table} under a unique name in the TableEnvironment's catalog. Registered
      * tables can be referenced in SQL queries.
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
@@ -478,6 +479,21 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     public boolean dropTemporaryFunction(String path) {
         final UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         return functionCatalog.dropTemporaryCatalogFunction(unresolvedIdentifier, true);
+    }
+
+    @Override
+    public void createTemporaryTable(String path, TableDescriptor descriptor) {
+        final ObjectIdentifier tableIdentifier =
+                catalogManager.qualifyIdentifier(getParser().parseIdentifier(path));
+
+        final CatalogTable catalogTable =
+                CatalogTable.of(
+                        descriptor.getSchema(),
+                        descriptor.getComment().orElse(null),
+                        descriptor.getPartitionKeys(),
+                        descriptor.getOptions());
+
+        catalogManager.createTemporaryTable(catalogTable, tableIdentifier, false);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableDescriptorTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableDescriptorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Tests for {@link TableDescriptor}. */
+public class TableDescriptorTest {
+
+    private static final ConfigOption<Boolean> OPTION_A =
+            ConfigOptions.key("a").booleanType().noDefaultValue();
+
+    private static final ConfigOption<Integer> OPTION_B =
+            ConfigOptions.key("b").intType().noDefaultValue();
+
+    private static final ConfigOption<String> KEY_FORMAT =
+            ConfigOptions.key("key.format").stringType().noDefaultValue();
+
+    @Test
+    public void testBasic() {
+        final Schema schema =
+                Schema.newBuilder()
+                        .column("f0", DataTypes.STRING())
+                        .column("f1", DataTypes.BIGINT())
+                        .primaryKey("f0")
+                        .build();
+
+        final TableDescriptor descriptor =
+                TableDescriptor.forConnector("test-connector")
+                        .schema(schema)
+                        .partitionedBy("f0")
+                        .comment("Test Comment")
+                        .build();
+
+        assertEquals(schema, descriptor.getSchema());
+
+        assertEquals(1, descriptor.getPartitionKeys().size());
+        assertEquals("f0", descriptor.getPartitionKeys().get(0));
+
+        assertEquals(1, descriptor.getOptions().size());
+        assertEquals("test-connector", descriptor.getOptions().get("connector"));
+
+        assertEquals("Test Comment", descriptor.getComment().orElse(null));
+    }
+
+    @Test
+    public void testOptions() {
+        final TableDescriptor descriptor =
+                TableDescriptor.forConnector("test-connector")
+                        .schema(Schema.newBuilder().build())
+                        .option(OPTION_A, false)
+                        .option(OPTION_B, 42)
+                        .option("c", "C")
+                        .build();
+
+        assertEquals(4, descriptor.getOptions().size());
+        assertEquals("test-connector", descriptor.getOptions().get("connector"));
+        assertEquals("false", descriptor.getOptions().get("a"));
+        assertEquals("42", descriptor.getOptions().get("b"));
+        assertEquals("C", descriptor.getOptions().get("c"));
+    }
+
+    @Test
+    public void testFormatBasic() {
+        final TableDescriptor descriptor =
+                TableDescriptor.forConnector("test-connector")
+                        .schema(Schema.newBuilder().build())
+                        .format("json")
+                        .build();
+
+        assertEquals(2, descriptor.getOptions().size());
+        assertEquals("test-connector", descriptor.getOptions().get("connector"));
+        assertEquals("json", descriptor.getOptions().get("format"));
+    }
+
+    @Test
+    public void testFormatWithFormatDescriptor() {
+        final TableDescriptor descriptor =
+                TableDescriptor.forConnector("test-connector")
+                        .schema(Schema.newBuilder().build())
+                        .format(
+                                KEY_FORMAT,
+                                FormatDescriptor.forFormat("test-format")
+                                        .option(OPTION_A, true)
+                                        .option(OPTION_B, 42)
+                                        .option("c", "C")
+                                        .build())
+                        .build();
+
+        assertEquals(5, descriptor.getOptions().size());
+        assertEquals("test-connector", descriptor.getOptions().get("connector"));
+        assertEquals("test-format", descriptor.getOptions().get("key.format"));
+        assertEquals("true", descriptor.getOptions().get("key.test-format.a"));
+        assertEquals("42", descriptor.getOptions().get("key.test-format.b"));
+        assertEquals("C", descriptor.getOptions().get("key.test-format.c"));
+    }
+
+    @Test
+    public void testToString() {
+        final Schema schema = Schema.newBuilder().column("f0", DataTypes.STRING()).build();
+
+        final FormatDescriptor formatDescriptor =
+                FormatDescriptor.forFormat("test-format").option(OPTION_A, false).build();
+
+        final TableDescriptor tableDescriptor =
+                TableDescriptor.forConnector("test-connector")
+                        .schema(schema)
+                        .partitionedBy("f0")
+                        .option(OPTION_A, true)
+                        .format(formatDescriptor)
+                        .comment("Test Comment")
+                        .build();
+
+        assertEquals("test-format[{a=false}]", formatDescriptor.toString());
+        assertEquals(
+                "CREATE TABLE … (\n"
+                        + "  `f0` STRING\n"
+                        + ")\n"
+                        + "COMMENT 'Test Comment'\n"
+                        + "PARTITIONED BY (`f0`)\n"
+                        + "WITH (\n"
+                        + "  'a' = 'true',\n"
+                        + "  'connector' = 'test-connector',\n"
+                        + "  'test-format.a' = 'false',\n"
+                        + "  'format' = 'test-format'\n"
+                        + ")",
+                tableDescriptor.toString());
+    }
+
+    @Test
+    public void testFormatDescriptorWithPrefix() {
+        assertThrows(
+                "Format options set using #format(FormatDescriptor) should not contain the prefix 'test-format.', but found 'test-format.a'.",
+                TableException.class,
+                () -> {
+                    TableDescriptor.forConnector("test-connector")
+                            .schema(Schema.newBuilder().build())
+                            .format(
+                                    FormatDescriptor.forFormat("test-format")
+                                            .option("test-format.a", "A")
+                                            .build())
+                            .build();
+                });
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -80,8 +81,8 @@ public final class Schema {
             List<UnresolvedColumn> columns,
             List<UnresolvedWatermarkSpec> watermarkSpecs,
             @Nullable UnresolvedPrimaryKey primaryKey) {
-        this.columns = columns;
-        this.watermarkSpecs = watermarkSpecs;
+        this.columns = Collections.unmodifiableList(columns);
+        this.watermarkSpecs = Collections.unmodifiableList(watermarkSpecs);
         this.primaryKey = primaryKey;
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/SchemaResolver.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/SchemaResolver.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.api.Schema;
 
 /** Resolves a {@link Schema} to a validated {@link ResolvedSchema}. */
+@PublicEvolving
 public interface SchemaResolver {
 
     ResolvedSchema resolve(Schema schema);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -433,6 +433,26 @@ public final class FactoryUtil {
                 factoryIdentifier, allOptionKeys, consumedOptionKeys, Collections.emptySet());
     }
 
+    /** Returns the required option prefix for options of the given format. */
+    public static String getFormatPrefix(
+            ConfigOption<String> formatOption, String formatIdentifier) {
+        final String formatOptionKey = formatOption.key();
+        if (formatOptionKey.equals(FORMAT.key())) {
+            return formatIdentifier + ".";
+        } else if (formatOptionKey.endsWith(FORMAT_SUFFIX)) {
+            // extract the key prefix, e.g. extract 'key' from 'key.format'
+            String keyPrefix =
+                    formatOptionKey.substring(0, formatOptionKey.length() - FORMAT_SUFFIX.length());
+            return keyPrefix + "." + formatIdentifier + ".";
+        } else {
+            throw new ValidationException(
+                    "Format identifier key should be 'format' or suffix with '.format', "
+                            + "don't support format identifier key '"
+                            + formatOptionKey
+                            + "'.");
+        }
+    }
+
     // --------------------------------------------------------------------------------------------
     // Helper methods
     // --------------------------------------------------------------------------------------------
@@ -776,23 +796,8 @@ public final class FactoryUtil {
         }
 
         private String formatPrefix(Factory formatFactory, ConfigOption<String> formatOption) {
-            final String formatOptionKey = formatOption.key();
             String identifier = formatFactory.factoryIdentifier();
-            if (formatOptionKey.equals(FORMAT.key())) {
-                return identifier + ".";
-            } else if (formatOptionKey.endsWith(FORMAT_SUFFIX)) {
-                // extract the key prefix, e.g. extract 'key' from 'key.format'
-                String keyPrefix =
-                        formatOptionKey.substring(
-                                0, formatOptionKey.length() - FORMAT_SUFFIX.length());
-                return keyPrefix + "." + identifier + ".";
-            } else {
-                throw new ValidationException(
-                        "Format identifier key should be 'format' or suffix with '.format', "
-                                + "don't support format identifier key '"
-                                + formatOptionKey
-                                + "'.");
-            }
+            return getFormatPrefix(formatOption, identifier);
         }
 
         private ReadableConfig projectOptions(String formatPrefix) {


### PR DESCRIPTION
## What is the purpose of the change

This introduces `TableEnvironment#createTemporaryTable(String, TableDescriptor)` as part of FLIP-129. `TableDescriptor` is new infrastructure and only loosely related with its same-name cousin which is to be removed during development of the FLIP.

This doesn't yet support the `.like()` which has a separate sub-task.

## Brief change log

* Introduce `TableDescriptor` and `FormatDescriptor`.
* Added `TableEnvironment#createTemporaryTable(String, TableDescriptor)`.

## Verifying this change

This change added tests and can be verified as follows:

* `CalcITCase#testCreateTemporaryTableFromDescriptor`
* (Later on during removal of the old APIs more tests will also start using this API implicitly.)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs + JavaDocs
