### PR TITLE
[FLINK-23001][build] Fix missing Scala suffix for 'flink-formats/flink-avro-glue-schema-registry'

### DIFF
--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -166,13 +166,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>software.amazon.glue</groupId>
 			<artifactId>schema-registry-serde</artifactId>
 			<version>${glue.schema.registry.version}</version>

--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/suffixcheck/ScalaSuffixChecker.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/suffixcheck/ScalaSuffixChecker.java
@@ -146,8 +146,6 @@ public class ScalaSuffixChecker {
         final Collection<String> excludedModules = new ArrayList<>();
         excludedModules.add("flink-docs");
         excludedModules.addAll(getEndToEndTestModules(flinkRootPath));
-        // temporary; see FLINK-23001
-        excludedModules.add("flink-avro-glue-schema-registry");
 
         for (String excludedModule : excludedModules) {
             parseResult.getCleanModules().remove(excludedModule);


### PR DESCRIPTION
## What is the purpose of the change

The `flink-formats/flink-avro-glue-schema-registry` had a Scala dependency, but no Scala version suffix.
This change removes the Scala dependency, which was in fact not needed and not used anywhere in the code (neither prod nor test).

## Verifying this change

This change is a trivial rework and restores automated testing for Scala suffixes for the affected module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no** (removes an internal dependency)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
