### PR TITLE
[FLINK-23104] Add scala version variable in pom of flink-statebackend-changelog

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -88,7 +88,7 @@ under the License.
 		</dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_2.11</artifactId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION

## What is the purpose of the change

This PR fix the error in pom of flink-statebackend-changelog, which is introduced by [641c31](https://github.com/apache/flink/commit/641c31e92fd8ff3702d2ac3510a63b0653802a2e) (from FLINK-22678).


## Brief change log

* Using variable for scala version in pom of flink-statebackend-changelog

## Verifying this change

* Manually trigger a pipeline to validate the previously failed compile stage. Result [here](https://dev.azure.com/lzq82555906/flink-for-Zakelly/_build/results?buildId=39&view=logs&j=ed6509f5-1153-558c-557a-5ee0afbcdf24&t=241b1e5e-1a8e-5e6a-469a-a9b8cad87065&l=24462).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no.
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
