### PR TITLE
[FLINK-23078][benchmark] Add SchedulerBenchmarkUtils#shutdownTestingUtilDefaultExecutor

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.TestingUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -161,5 +162,9 @@ public class SchedulerBenchmarkUtils {
         final ExecutionAttemptID attemptId =
                 vertex.getTaskVertices()[subtask].getCurrentExecutionAttempt().getAttemptId();
         scheduler.updateTaskExecutionState(new TaskExecutionState(attemptId, executionState));
+    }
+
+    public static void shutdownTestingUtilDefaultExecutor() {
+        TestingUtils.defaultExecutor().shutdownNow();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*In FLINK-22988, TestUtils are ported from Scala to Java. However, SchedulerBenchmarkBase in flink-benchmark calls this method when each benchmark teardowns. This make SchedulerBenchmarks not compiling, as FLINK-23078 says. To solve this issue, we'd like to wrap `TestingUtils.defaultExecutor().shutdownNow()` into `SchedulerBenchmarkUtil`. If this method is changed in the future, its reference must be fixed, too.*


## Brief change log

  - *Wrap `TestingUtils.defaultExecutor().shutdownNow()` into `SchedulerBenchmarkUtil`.*


## Verifying this change

This change only wraps the existing method. It needs no test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
