### PR TITLE
[FLINK-23025][upsert-kafka] Fix upsert-kafka produce duplicates when enable object reuse

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BufferedUpsertSinkFunction.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BufferedUpsertSinkFunction.java
@@ -132,8 +132,8 @@ public class BufferedUpsertSinkFunction extends RichSinkFunction<RowData>
                 consumedRowDataTypeInfo.createSerializer(getRuntimeContext().getExecutionConfig());
         this.valueCopier =
                 getRuntimeContext().getExecutionConfig().isObjectReuseEnabled()
-                        ? Function.identity()
-                        : typeSerializer::copy;
+                        ? typeSerializer::copy
+                        : Function.identity();
 
         // register timer
         this.scheduler =

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/BufferedUpsertSinkFunctionTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/BufferedUpsertSinkFunctionTest.java
@@ -36,14 +36,19 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +59,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** Test for {@link BufferedUpsertSinkFunction}. */
+@RunWith(Parameterized.class)
 public class BufferedUpsertSinkFunctionTest {
+
+    @Parameterized.Parameters(name = "object reuse = {0}")
+    public static Object[] enableObjectReuse() {
+        return new Boolean[] {true, false};
+    }
 
     private static final ResolvedSchema SCHEMA =
             ResolvedSchema.of(
@@ -129,17 +140,23 @@ public class BufferedUpsertSinkFunctionTest {
                 TimestampData.fromInstant(Instant.parse("2021-03-30T21:00:00Z")))
     };
 
+    private final boolean enableObjectReuse;
+
+    public BufferedUpsertSinkFunctionTest(boolean enableObjectReuse) {
+        this.enableObjectReuse = enableObjectReuse;
+    }
+
     @Test
     public void testWriteData() throws Exception {
-        MockedSinkFunction sinkFunction = new MockedSinkFunction();
+        MockedSinkFunction sinkFunction = new MockedSinkFunction(enableObjectReuse);
         BufferedUpsertSinkFunction bufferedSink = createBufferedSink(sinkFunction);
 
         // write 3 records which doesn't trigger batch size
-        writeData(bufferedSink, TEST_DATA, 0, 3);
+        writeData(bufferedSink, new ReusableIterator(0, 3, enableObjectReuse));
         assertTrue(sinkFunction.rowDataCollectors.isEmpty());
 
         // write one more record, and should flush the buffer
-        writeData(bufferedSink, TEST_DATA, 3, 1);
+        writeData(bufferedSink, new ReusableIterator(3, 1, enableObjectReuse));
 
         HashMap<Integer, List<RowData>> expected = new HashMap<>();
         expected.put(
@@ -180,16 +197,16 @@ public class BufferedUpsertSinkFunctionTest {
 
         sinkFunction.rowDataCollectors.clear();
         // write remaining data, and they are still buffered
-        writeData(bufferedSink, TEST_DATA, 4, 3);
+        writeData(bufferedSink, new ReusableIterator(4, 3, enableObjectReuse));
         assertTrue(sinkFunction.rowDataCollectors.isEmpty());
     }
 
     @Test
     public void testFlushDataWhenCheckpointing() throws Exception {
-        MockedSinkFunction sinkFunction = new MockedSinkFunction();
+        MockedSinkFunction sinkFunction = new MockedSinkFunction(enableObjectReuse);
         BufferedUpsertSinkFunction bufferedFunction = createBufferedSink(sinkFunction);
         // write all data, there should be 3 records are still buffered
-        writeData(bufferedFunction, TEST_DATA, 0, TEST_DATA.length);
+        writeData(bufferedFunction, new ReusableIterator(0, TEST_DATA.length, enableObjectReuse));
         // snapshot should flush the buffer
         bufferedFunction.snapshotState(null);
 
@@ -256,17 +273,17 @@ public class BufferedUpsertSinkFunctionTest {
                         new int[] {keyIndices},
                         typeInformation,
                         BUFFER_FLUSH_MODE);
+        bufferedSinkFunction.getRuntimeContext().getExecutionConfig().enableObjectReuse();
         bufferedSinkFunction.open(new Configuration());
-
         return bufferedSinkFunction;
     }
 
-    private void writeData(BufferedUpsertSinkFunction sink, RowData[] data, int startPos, int size)
+    private void writeData(BufferedUpsertSinkFunction sink, Iterator<RowData> iterator)
             throws Exception {
-        for (int i = startPos; i < startPos + size; i++) {
-            RowData row = data[i];
-            long rowtime = row.getTimestamp(TIMESTAMP_INDICES, 3).getMillisecond();
-            sink.invoke(row, SinkContextUtil.forTimestamp(rowtime));
+        while (iterator.hasNext()) {
+            RowData next = iterator.next();
+            long rowtime = next.getTimestamp(TIMESTAMP_INDICES, 3).getMillisecond();
+            sink.invoke(next, SinkContextUtil.forTimestamp(rowtime));
         }
     }
 
@@ -291,11 +308,18 @@ public class BufferedUpsertSinkFunctionTest {
             implements CheckpointedFunction, CheckpointListener {
 
         private static final long serialVersionUID = 1L;
+        private final RuntimeContext context = new MockStreamingRuntimeContext(true, 1, 1);
         transient List<RowData> rowDataCollectors;
+
+        MockedSinkFunction(boolean enableObjectReuse) {
+            if (enableObjectReuse) {
+                context.getExecutionConfig().enableObjectReuse();
+            }
+        }
 
         @Override
         public RuntimeContext getRuntimeContext() {
-            return new MockStreamingRuntimeContext(true, 1, 1);
+            return context;
         }
 
         @Override
@@ -325,6 +349,37 @@ public class BufferedUpsertSinkFunctionTest {
                     value.getTimestamp(TIMESTAMP_INDICES, 3).toInstant(),
                     Instant.ofEpochMilli(context.timestamp()));
             rowDataCollectors.add(value);
+        }
+    }
+
+    private static class ReusableIterator implements Iterator<RowData> {
+
+        private static final RowDataSerializer SERIALIZER =
+                InternalTypeInfo.of(SCHEMA.toSinkRowDataType().getLogicalType()).toRowSerializer();
+        private static final RowData REUSED_ROW = new GenericRowData(SCHEMA.getColumnCount());
+
+        private int begin;
+        private final int end;
+        private final boolean enableObjectReuse;
+
+        ReusableIterator(int begin, int size, boolean enableObjectReuse) {
+            this.begin = begin;
+            this.end = begin + size;
+            this.enableObjectReuse = enableObjectReuse;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return begin < end;
+        }
+
+        @Override
+        public RowData next() {
+            if (enableObjectReuse) {
+                return SERIALIZER.copy(TEST_DATA[begin++], REUSED_ROW);
+            } else {
+                return TEST_DATA[begin++];
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Fix upsert-kafka produce duplicates when enable object reuse.*

## Verifying this change

  - *Add tests in `BufferedUpsertSinkFunctionTest` to verify the results  if enable object reuse.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
