### PR TITLE
[FLINK-23120][python] Fix ByteArrayWrapperSerializer.serialize to use writeInt to serialize the length

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializer.java
@@ -68,7 +68,7 @@ public class ByteArrayWrapperSerializer extends TypeSerializerSingleton<ByteArra
 
     @Override
     public void serialize(ByteArrayWrapper record, DataOutputView target) throws IOException {
-        target.write(record.getLimit() - record.getOffset());
+        target.writeInt(record.getLimit() - record.getOffset());
         target.write(record.getData(), record.getOffset(), record.getLimit() - record.getOffset());
     }
 
@@ -76,7 +76,7 @@ public class ByteArrayWrapperSerializer extends TypeSerializerSingleton<ByteArra
     public ByteArrayWrapper deserialize(DataInputView source) throws IOException {
         int length = source.readInt();
         byte[] result = new byte[length];
-        source.read(result);
+        source.readFully(result);
         return new ByteArrayWrapper(result);
     }
 
@@ -85,7 +85,7 @@ public class ByteArrayWrapperSerializer extends TypeSerializerSingleton<ByteArra
             throws IOException {
         int length = source.readInt();
         byte[] result = new byte[length];
-        source.read(result);
+        source.readFully(result);
         reuse.setData(result);
         return reuse;
     }
@@ -94,8 +94,8 @@ public class ByteArrayWrapperSerializer extends TypeSerializerSingleton<ByteArra
     public void copy(DataInputView source, DataOutputView target) throws IOException {
         int length = source.readInt();
         byte[] result = new byte[length];
-        source.read(result);
-        target.write(length);
+        source.readFully(result);
+        target.writeInt(length);
         target.write(result);
     }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializer.java
@@ -87,6 +87,8 @@ public class ByteArrayWrapperSerializer extends TypeSerializerSingleton<ByteArra
         byte[] result = new byte[length];
         source.readFully(result);
         reuse.setData(result);
+        reuse.setOffset(0);
+        reuse.setLimit(result.length);
         return reuse;
     }
 

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializerTest.java
@@ -47,26 +47,18 @@ public class ByteArrayWrapperSerializerTest extends SerializerTestBase<ByteArray
     @Override
     protected ByteArrayWrapper[] getTestData() {
         return new ByteArrayWrapper[] {
-            randomByteArray(),
-            randomByteArray(),
             EMPTY_ARRAY,
-            randomByteArray(),
-            randomByteArray(),
-            randomByteArray(),
-            EMPTY_ARRAY,
-            randomByteArray(),
-            randomByteArray(),
-            randomByteArray(),
-            EMPTY_ARRAY
+            randomByteArray(rnd.nextInt(1024 * 1024)),
+            randomByteArray(1),
+            randomByteArray(2),
+            randomByteArray(1024 * 1024),
+            randomByteArray(32 * 1024 * 1024),
         };
     }
 
-    private ByteArrayWrapper randomByteArray() {
-        int len = rnd.nextInt(1024 * 1024);
+    private ByteArrayWrapper randomByteArray(int len) {
         byte[] data = new byte[len];
-        for (int i = 0; i < len; i++) {
-            data[i] = (byte) rnd.nextInt();
-        }
+        rnd.nextBytes(data);
         return new ByteArrayWrapper(data);
     }
 }

--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/ByteArrayWrapperSerializerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.utils;
+
+import org.apache.flink.api.common.typeutils.SerializerTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import java.util.Random;
+
+/** Test class for {@link ByteArrayWrapperSerializer}. */
+public class ByteArrayWrapperSerializerTest extends SerializerTestBase<ByteArrayWrapper> {
+
+    private final Random rnd = new Random(346283764872L);
+
+    private static final ByteArrayWrapper EMPTY_ARRAY = new ByteArrayWrapper(new byte[] {});
+
+    @Override
+    protected TypeSerializer<ByteArrayWrapper> createSerializer() {
+        return new ByteArrayWrapperSerializer();
+    }
+
+    @Override
+    protected Class<ByteArrayWrapper> getTypeClass() {
+        return ByteArrayWrapper.class;
+    }
+
+    @Override
+    protected int getLength() {
+        return -1;
+    }
+
+    @Override
+    protected ByteArrayWrapper[] getTestData() {
+        return new ByteArrayWrapper[] {
+            randomByteArray(),
+            randomByteArray(),
+            EMPTY_ARRAY,
+            randomByteArray(),
+            randomByteArray(),
+            randomByteArray(),
+            EMPTY_ARRAY,
+            randomByteArray(),
+            randomByteArray(),
+            randomByteArray(),
+            EMPTY_ARRAY
+        };
+    }
+
+    private ByteArrayWrapper randomByteArray() {
+        int len = rnd.nextInt(1024 * 1024);
+        byte[] data = new byte[len];
+        for (int i = 0; i < len; i++) {
+            data[i] = (byte) rnd.nextInt();
+        }
+        return new ByteArrayWrapper(data);
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes ByteArrayWrapperSerializer*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests ByteArrayWrapperSerializerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
