### PR TITLE
[FLINK-23096][Connectors/Hive] Optimize the SessionState exception capture to print out the correct and useful information

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -384,7 +384,7 @@ public class HiveParser extends ParserImpl {
                     FileSystem fs = path.getFileSystem(hiveConf);
                     fs.delete(path, true);
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 LOG.warn("Error closing SessionState", e);
             }
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Optimize the SessionState exception capture to print out the correct and useful information. Because there may be exceptions when generating session state, such as hadoop permission issues, but the exception information is overwritten.*

*Before optimization:*
```
Caused by: java.lang.NullPointerException: Conf non-local session path expected to be non-null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:208)
        at org.apache.hadoop.hive.ql.session.SessionState.getHDFSSessionPath(SessionState.java:669)
        at org.apache.flink.table.planner.delegation.hive.HiveParser.clearSessionState(HiveParser.java:376)
        at org.apache.flink.table.planner.delegation.hive.HiveParser.parse(HiveParser.java:219)
        ...
```

*After optimization:*
```
java.lang.NullPointerException: Conf non-local session path expected to be non-null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:208)
        at org.apache.hadoop.hive.ql.session.SessionState.getHDFSSessionPath(SessionState.java:669)
        at org.apache.flink.table.planner.delegation.hive.HiveParser.clearSessionState(HiveParser.java:376)
        at org.apache.flink.table.planner.delegation.hive.HiveParser.parse(HiveParser.java:219)
	...

Caused by: java.lang.RuntimeException: org.apache.hadoop.security.AccessControlException: Permission denied: user=service, access=WRITE, inode="/tmp":hdfs:supergroup:drwxr-xr-x
        at org.apache.hadoop.hdfs.server.namenode.DefaultAuthorizationProvider.checkFsPermission(DefaultAuthorizationProvider.java:280)
        at org.apache.hadoop.hdfs.server.namenode.DefaultAuthorizationProvider.check(DefaultAuthorizationProvider.java:260)
        at org.apache.hadoop.hdfs.server.namenode.DefaultAuthorizationProvider.check(DefaultAuthorizationProvider.java:240)
        at org.apache.hadoop.hdfs.server.namenode.DefaultAuthorizationProvider.checkPermission(DefaultAuthorizationProvider.java:162)
		...
```


## Brief change log

  - *Optimize the SessionState exception capture in `org.apache.flink.table.planner.delegation.hive.HiveParser#clearSessionState`*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
