### PR TITLE
[BP-1.13][FLINK-23045][tests] Harden RunnablesTest by not relying on timeout 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.util;
 
+import org.apache.flink.util.TestLogger;
+
 import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.junit.Assert;
@@ -31,7 +33,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class RunnablesTest {
+public class RunnablesTest extends TestLogger {
 
     private static final int TIMEOUT_MS = 100;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
@@ -55,9 +55,9 @@ public class RunnablesTest extends TestLogger {
                 () -> {
                     throw new RuntimeException("foo");
                 });
-        Assert.assertTrue(
-                "Expected handler to be called.",
-                handlerCalled.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        // expect handler to be called
+        handlerCalled.await();
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/RunnablesTest.java
@@ -49,9 +49,8 @@ public class RunnablesTest extends TestLogger {
                         .setDaemon(true)
                         .setUncaughtExceptionHandler((t, e) -> handlerCalled.countDown())
                         .build();
-        final ExecutorService scheduledExecutorService =
-                Executors.newSingleThreadExecutor(threadFactory);
-        scheduledExecutorService.execute(
+        final ExecutorService executorService = Executors.newSingleThreadExecutor(threadFactory);
+        executorService.execute(
                 () -> {
                     throw new RuntimeException("foo");
                 });


### PR DESCRIPTION
Backport of #16261 to `release-1.13`.