### PR TITLE
[FLINK-23090] Introduce RpcSystem abstraction

### DIFF
--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -80,6 +80,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
@@ -85,7 +86,7 @@ public class ScheduledDropwizardReporterTest {
         configuration.setString(MetricOptions.SCOPE_DELIMITER, "_");
 
         MetricRegistryConfiguration metricRegistryConfiguration =
-                MetricRegistryConfiguration.fromConfiguration(configuration);
+                MetricRegistryTestUtils.fromConfiguration(configuration);
 
         MetricRegistryImpl metricRegistry =
                 new MetricRegistryImpl(

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.dropwizard.ScheduledDropwizardReporter;
 import org.apache.flink.metrics.AbstractHistogramTest;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 
@@ -87,7 +87,7 @@ public class DropwizardFlinkHistogramWrapperTest extends AbstractHistogramTest {
         try {
             registry =
                     new MetricRegistryImpl(
-                            MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                            MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                             Collections.singletonList(
                                     ReporterSetup.forReporter(
                                             "test", config, new TestingReporter())));

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -72,6 +72,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 

--- a/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
+++ b/flink-metrics/flink-metrics-influxdb/src/test/java/org/apache/flink/metrics/influxdb/InfluxdbReporterTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.util.TestLogger;
@@ -145,7 +145,7 @@ public class InfluxdbReporterTest extends TestLogger {
                 InfluxdbReporterOptions.CONSISTENCY.key(), consistencyLevel.name());
 
         return new MetricRegistryImpl(
-                MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                 Collections.singletonList(
                         ReporterSetup.forReporter("test", metricConfig, new InfluxdbReporter())));
     }

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -24,8 +24,8 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.runtime.management.JMXService;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.runtime.metrics.groups.ReporterScopedSettings;
@@ -112,7 +112,7 @@ public class JMXReporterTest extends TestLogger {
 
         MetricRegistryImpl reg =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(reporterSetup1, reporterSetup2));
 
         TaskManagerMetricGroup mg = new TaskManagerMetricGroup(reg, "host", "tm");
@@ -179,7 +179,7 @@ public class JMXReporterTest extends TestLogger {
 
         MetricRegistryImpl reg =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(reporterSetup1, reporterSetup2));
 
         TaskManagerMetricGroup mg = new TaskManagerMetricGroup(reg, "host", "tm");
@@ -272,7 +272,7 @@ public class JMXReporterTest extends TestLogger {
         try {
             registry =
                     new MetricRegistryImpl(
-                            MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                            MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                             Collections.singletonList(
                                     ReporterSetup.forReporter("test", new JMXReporter(null))));
 
@@ -336,7 +336,7 @@ public class JMXReporterTest extends TestLogger {
         try {
             registry =
                     new MetricRegistryImpl(
-                            MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                            MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                             Collections.singletonList(
                                     ReporterSetup.forReporter("test", new JMXReporter(null))));
 

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -91,6 +91,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -28,8 +28,8 @@ import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
@@ -113,7 +113,7 @@ public class PrometheusReporterTaskScopeTest {
     public void setupReporter() {
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Collections.singletonList(createReporterSetup("test1", "9400-9500")));
         reporter = (PrometheusReporter) registry.getReporters().get(0);
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -28,8 +28,8 @@ import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.runtime.metrics.groups.ReporterScopedSettings;
@@ -85,7 +85,7 @@ public class PrometheusReporterTest extends TestLogger {
     public void setupReporter() {
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Collections.singletonList(
                                 createReporterSetup("test1", portRangeProvider.next())));
         metricGroup =

--- a/flink-metrics/flink-metrics-slf4j/pom.xml
+++ b/flink-metrics/flink-metrics-slf4j/pom.xml
@@ -73,6 +73,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 

--- a/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
+++ b/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
@@ -29,8 +29,8 @@ import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
@@ -75,7 +75,7 @@ public class Slf4jReporterTest extends TestLogger {
 
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.fromConfiguration(configuration),
+                        MetricRegistryTestUtils.fromConfiguration(configuration),
                         Collections.singletonList(
                                 ReporterSetup.forReporter("slf4j", new Slf4jReporter())));
         delimiter = registry.getDelimiter();

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -73,6 +73,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 	</dependencies>

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -35,8 +35,8 @@ import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
@@ -89,7 +89,7 @@ public class StatsDReporterTest extends TestLogger {
 
         MetricRegistryImpl metricRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.fromConfiguration(configuration),
+                        MetricRegistryTestUtils.fromConfiguration(configuration),
                         Collections.singletonList(
                                 ReporterSetup.forReporter("test", new TestingStatsDReporter())));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -295,7 +295,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             final RpcSystem rpcSystem = RpcSystem.load();
 
             commonRpcService =
-                    RpcSystemUtils.createRemoteRpcService(
+                    RpcUtils.createRemoteRpcService(
                             rpcSystem,
                             configuration,
                             configuration.getString(JobManagerOptions.ADDRESS),
@@ -354,9 +354,10 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
     }
 
     protected HighAvailabilityServices createHaServices(
-            Configuration configuration, Executor executor, RpcSystem rpcSystem) throws Exception {
+            Configuration configuration, Executor executor, RpcSystemUtils rpcSystemUtils)
+            throws Exception {
         return HighAvailabilityServicesUtils.createHighAvailabilityServices(
-                configuration, executor, AddressResolution.NO_ADDRESS_RESOLUTION, rpcSystem);
+                configuration, executor, AddressResolution.NO_ADDRESS_RESOLUTION, rpcSystemUtils);
     }
 
     protected HeartbeatServices createHeartbeatServices(Configuration configuration) {
@@ -364,10 +365,12 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
     }
 
     protected MetricRegistryImpl createMetricRegistry(
-            Configuration configuration, PluginManager pluginManager, RpcSystem rpcSystem) {
+            Configuration configuration,
+            PluginManager pluginManager,
+            RpcSystemUtils rpcSystemUtils) {
         return new MetricRegistryImpl(
                 MetricRegistryConfiguration.fromConfiguration(
-                        configuration, rpcSystem.getMaximumMessageSizeInBytes(configuration)),
+                        configuration, rpcSystemUtils.getMaximumMessageSizeInBytes(configuration)),
                 ReporterSetup.fromConfiguration(configuration, pluginManager));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -56,8 +56,9 @@ import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.contexts.SecurityContext;
@@ -291,8 +292,11 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         LOG.info("Initializing cluster services.");
 
         synchronized (lock) {
+            final RpcSystem rpcSystem = RpcSystem.load();
+
             commonRpcService =
-                    AkkaRpcServiceUtils.createRemoteRpcService(
+                    RpcSystemUtils.createRemoteRpcService(
+                            rpcSystem,
                             configuration,
                             configuration.getString(JobManagerOptions.ADDRESS),
                             getRPCPortRange(configuration),
@@ -309,15 +313,15 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                     Executors.newFixedThreadPool(
                             ClusterEntrypointUtils.getPoolSize(configuration),
                             new ExecutorThreadFactory("cluster-io"));
-            haServices = createHaServices(configuration, ioExecutor);
+            haServices = createHaServices(configuration, ioExecutor, rpcSystem);
             blobServer = new BlobServer(configuration, haServices.createBlobStore());
             blobServer.start();
             heartbeatServices = createHeartbeatServices(configuration);
-            metricRegistry = createMetricRegistry(configuration, pluginManager);
+            metricRegistry = createMetricRegistry(configuration, pluginManager, rpcSystem);
 
             final RpcService metricQueryServiceRpcService =
                     MetricUtils.startRemoteMetricsRpcService(
-                            configuration, commonRpcService.getAddress());
+                            configuration, commonRpcService.getAddress(), rpcSystem);
             metricRegistry.startQueryService(metricQueryServiceRpcService, null);
 
             final String hostname = RpcUtils.getHostname(commonRpcService);
@@ -350,9 +354,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
     }
 
     protected HighAvailabilityServices createHaServices(
-            Configuration configuration, Executor executor) throws Exception {
+            Configuration configuration, Executor executor, RpcSystem rpcSystem) throws Exception {
         return HighAvailabilityServicesUtils.createHighAvailabilityServices(
-                configuration, executor, AddressResolution.NO_ADDRESS_RESOLUTION);
+                configuration, executor, AddressResolution.NO_ADDRESS_RESOLUTION, rpcSystem);
     }
 
     protected HeartbeatServices createHeartbeatServices(Configuration configuration) {
@@ -360,9 +364,10 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
     }
 
     protected MetricRegistryImpl createMetricRegistry(
-            Configuration configuration, PluginManager pluginManager) {
+            Configuration configuration, PluginManager pluginManager, RpcSystem rpcSystem) {
         return new MetricRegistryImpl(
-                MetricRegistryConfiguration.fromConfiguration(configuration),
+                MetricRegistryConfiguration.fromConfiguration(
+                        configuration, rpcSystem.getMaximumMessageSizeInBytes(configuration)),
                 ReporterSetup.fromConfiguration(configuration, pluginManager));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
@@ -83,7 +83,10 @@ public class HighAvailabilityServicesUtils {
     }
 
     public static HighAvailabilityServices createHighAvailabilityServices(
-            Configuration configuration, Executor executor, AddressResolution addressResolution)
+            Configuration configuration,
+            Executor executor,
+            AddressResolution addressResolution,
+            RpcSystem rpcSystem)
             throws Exception {
 
         HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);
@@ -93,7 +96,7 @@ public class HighAvailabilityServicesUtils {
                 final Tuple2<String, Integer> hostnamePort = getJobManagerAddress(configuration);
 
                 final String resourceManagerRpcUrl =
-                        AkkaRpcServiceUtils.getRpcUrl(
+                        rpcSystem.getRpcUrl(
                                 hostnamePort.f0,
                                 hostnamePort.f1,
                                 RpcServiceUtils.createWildcardName(
@@ -101,7 +104,7 @@ public class HighAvailabilityServicesUtils {
                                 addressResolution,
                                 configuration);
                 final String dispatcherRpcUrl =
-                        AkkaRpcServiceUtils.getRpcUrl(
+                        rpcSystem.getRpcUrl(
                                 hostnamePort.f0,
                                 hostnamePort.f1,
                                 RpcServiceUtils.createWildcardName(Dispatcher.DISPATCHER_NAME),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
-import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
@@ -86,7 +86,7 @@ public class HighAvailabilityServicesUtils {
             Configuration configuration,
             Executor executor,
             AddressResolution addressResolution,
-            RpcSystem rpcSystem)
+            RpcSystemUtils rpcSystemUtils)
             throws Exception {
 
         HighAvailabilityMode highAvailabilityMode = HighAvailabilityMode.fromConfig(configuration);
@@ -96,7 +96,7 @@ public class HighAvailabilityServicesUtils {
                 final Tuple2<String, Integer> hostnamePort = getJobManagerAddress(configuration);
 
                 final String resourceManagerRpcUrl =
-                        rpcSystem.getRpcUrl(
+                        rpcSystemUtils.getRpcUrl(
                                 hostnamePort.f0,
                                 hostnamePort.f1,
                                 RpcServiceUtils.createWildcardName(
@@ -104,7 +104,7 @@ public class HighAvailabilityServicesUtils {
                                 addressResolution,
                                 configuration);
                 final String dispatcherRpcUrl =
-                        rpcSystem.getRpcUrl(
+                        rpcSystemUtils.getRpcUrl(
                                 hostnamePort.f0,
                                 hostnamePort.f1,
                                 RpcServiceUtils.createWildcardName(Dispatcher.DISPATCHER_NAME),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.metrics;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
@@ -31,8 +30,6 @@ import org.slf4j.LoggerFactory;
 public class MetricRegistryConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetricRegistryConfiguration.class);
-
-    private static volatile MetricRegistryConfiguration defaultConfiguration;
 
     // scope formats for the different components
     private final ScopeFormats scopeFormats;
@@ -70,11 +67,6 @@ public class MetricRegistryConfiguration {
     //  Static factory methods
     // ------------------------------------------------------------------------
 
-    @VisibleForTesting
-    public static MetricRegistryConfiguration fromConfiguration(Configuration configuration) {
-        return fromConfiguration(configuration, 10485760);
-    }
-
     /**
      * Create a metric registry configuration object from the given {@link Configuration}.
      *
@@ -104,18 +96,5 @@ public class MetricRegistryConfiguration {
 
         return new MetricRegistryConfiguration(
                 scopeFormats, delim, maximumFrameSize - messageSizeLimitPadding);
-    }
-
-    public static MetricRegistryConfiguration defaultMetricRegistryConfiguration() {
-        // create the default metric registry configuration only once
-        if (defaultConfiguration == null) {
-            synchronized (MetricRegistryConfiguration.class) {
-                if (defaultConfiguration == null) {
-                    defaultConfiguration = fromConfiguration(new Configuration());
-                }
-            }
-        }
-
-        return defaultConfiguration;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.runtime.metrics;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -70,13 +70,19 @@ public class MetricRegistryConfiguration {
     //  Static factory methods
     // ------------------------------------------------------------------------
 
+    @VisibleForTesting
+    public static MetricRegistryConfiguration fromConfiguration(Configuration configuration) {
+        return fromConfiguration(configuration, 10485760);
+    }
+
     /**
      * Create a metric registry configuration object from the given {@link Configuration}.
      *
      * @param configuration to generate the metric registry configuration from
      * @return Metric registry configuration generated from the configuration
      */
-    public static MetricRegistryConfiguration fromConfiguration(Configuration configuration) {
+    public static MetricRegistryConfiguration fromConfiguration(
+            Configuration configuration, long maximumFrameSize) {
         ScopeFormats scopeFormats;
         try {
             scopeFormats = ScopeFormats.fromConfig(configuration);
@@ -92,8 +98,6 @@ public class MetricRegistryConfiguration {
             LOG.warn("Failed to parse delimiter, using default delimiter.", e);
             delim = '.';
         }
-
-        final long maximumFrameSize = AkkaRpcServiceUtils.extractMaximumFramesize(configuration);
 
         // padding to account for serialization overhead
         final long messageSizeLimitPadding = 256;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -276,7 +276,10 @@ public class MiniCluster implements AutoCloseableAsync {
                 final RpcSystem rpcSystem = RpcSystem.load();
 
                 LOG.info("Starting Metrics Registry");
-                metricRegistry = createMetricRegistry(configuration);
+                metricRegistry =
+                        createMetricRegistry(
+                                configuration,
+                                rpcSystem.getMaximumMessageSizeInBytes(configuration));
 
                 // bring up all the RPC services
                 LOG.info("Starting RPC Service(s)");
@@ -897,10 +900,12 @@ public class MiniCluster implements AutoCloseableAsync {
      * Factory method to create the metric registry for the mini cluster.
      *
      * @param config The configuration of the mini cluster
+     * @param maximumMessageSizeInBytes the maximum message size
      */
-    protected MetricRegistryImpl createMetricRegistry(Configuration config) {
+    protected MetricRegistryImpl createMetricRegistry(
+            Configuration config, long maximumMessageSizeInBytes) {
         return new MetricRegistryImpl(
-                MetricRegistryConfiguration.fromConfiguration(config),
+                MetricRegistryConfiguration.fromConfiguration(config, maximumMessageSizeInBytes),
                 ReporterSetup.fromConfiguration(config, null));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -30,7 +30,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.BlobServer;
@@ -73,8 +72,8 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
@@ -274,6 +273,8 @@ public class MiniCluster implements AutoCloseableAsync {
             try {
                 initializeIOFormatClasses(configuration);
 
+                final RpcSystem rpcSystem = RpcSystem.load();
+
                 LOG.info("Starting Metrics Registry");
                 metricRegistry = createMetricRegistry(configuration);
 
@@ -285,13 +286,13 @@ public class MiniCluster implements AutoCloseableAsync {
 
                 if (useSingleRpcService) {
                     // we always need the 'commonRpcService' for auxiliary calls
-                    commonRpcService = createLocalRpcService(configuration);
+                    commonRpcService = createLocalRpcService(configuration, rpcSystem);
                     final CommonRpcServiceFactory commonRpcServiceFactory =
                             new CommonRpcServiceFactory(commonRpcService);
                     taskManagerRpcServiceFactory = commonRpcServiceFactory;
                     dispatcherResourceManagerComponentRpcServiceFactory = commonRpcServiceFactory;
                     metricQueryServiceRpcService =
-                            MetricUtils.startLocalMetricsRpcService(configuration);
+                            MetricUtils.startLocalMetricsRpcService(configuration, rpcSystem);
                 } else {
 
                     // start a new service per component, possibly with custom bind addresses
@@ -313,21 +314,24 @@ public class MiniCluster implements AutoCloseableAsync {
                                     configuration,
                                     jobManagerExternalAddress,
                                     jobManagerExternalPortRange,
-                                    jobManagerBindAddress);
+                                    jobManagerBindAddress,
+                                    rpcSystem);
                     taskManagerRpcServiceFactory =
                             new DedicatedRpcServiceFactory(
                                     configuration,
                                     taskManagerExternalAddress,
                                     taskManagerExternalPortRange,
-                                    taskManagerBindAddress);
+                                    taskManagerBindAddress,
+                                    rpcSystem);
 
                     // we always need the 'commonRpcService' for auxiliary calls
                     // bind to the JobManager address with port 0
                     commonRpcService =
-                            createRemoteRpcService(configuration, jobManagerBindAddress, 0);
+                            createRemoteRpcService(
+                                    configuration, jobManagerBindAddress, 0, rpcSystem);
                     metricQueryServiceRpcService =
                             MetricUtils.startRemoteMetricsRpcService(
-                                    configuration, commonRpcService.getAddress());
+                                    configuration, commonRpcService.getAddress(), rpcSystem);
                 }
 
                 metricRegistry.startQueryService(metricQueryServiceRpcService, null);
@@ -906,15 +910,17 @@ public class MiniCluster implements AutoCloseableAsync {
      * @param configuration Flink configuration.
      * @param bindAddress The address to bind the RPC service to.
      * @param bindPort The port range to bind the RPC service to.
+     * @param rpcSystem
      * @return The instantiated RPC service
      */
     protected RpcService createRemoteRpcService(
-            Configuration configuration, String bindAddress, int bindPort) throws Exception {
-        return AkkaRpcServiceUtils.remoteServiceBuilder(
-                        configuration, bindAddress, String.valueOf(bindPort))
+            Configuration configuration, String bindAddress, int bindPort, RpcSystem rpcSystem)
+            throws Exception {
+        return rpcSystem
+                .remoteServiceBuilder(configuration, bindAddress, String.valueOf(bindPort))
                 .withBindAddress(bindAddress)
                 .withBindPort(bindPort)
-                .withCustomConfig(AkkaUtils.testDispatcherConfig())
+                .withExecutorConfiguration(RpcUtils.getTestForkJoinExecutorConfiguration())
                 .createAndStart();
     }
 
@@ -925,18 +931,20 @@ public class MiniCluster implements AutoCloseableAsync {
      * @param externalAddress The external address to access the RPC service.
      * @param externalPortRange The external port range to access the RPC service.
      * @param bindAddress The address to bind the RPC service to.
+     * @param rpcSystem
      * @return The instantiated RPC service
      */
     protected RpcService createRemoteRpcService(
             Configuration configuration,
             String externalAddress,
             String externalPortRange,
-            String bindAddress)
+            String bindAddress,
+            RpcSystem rpcSystem)
             throws Exception {
-        return AkkaRpcServiceUtils.remoteServiceBuilder(
-                        configuration, externalAddress, externalPortRange)
+        return rpcSystem
+                .remoteServiceBuilder(configuration, externalAddress, externalPortRange)
                 .withBindAddress(bindAddress)
-                .withCustomConfig(AkkaUtils.testDispatcherConfig())
+                .withExecutorConfiguration(RpcUtils.getTestForkJoinExecutorConfiguration())
                 .createAndStart();
     }
 
@@ -944,11 +952,14 @@ public class MiniCluster implements AutoCloseableAsync {
      * Factory method to instantiate the local RPC service.
      *
      * @param configuration Flink configuration.
+     * @param rpcSystem
      * @return The instantiated RPC service
      */
-    protected RpcService createLocalRpcService(Configuration configuration) throws Exception {
-        return AkkaRpcServiceUtils.localServiceBuilder(configuration)
-                .withCustomConfig(AkkaUtils.testDispatcherConfig())
+    protected RpcService createLocalRpcService(Configuration configuration, RpcSystem rpcSystem)
+            throws Exception {
+        return rpcSystem
+                .localServiceBuilder(configuration)
+                .withExecutorConfiguration(RpcUtils.getTestForkJoinExecutorConfiguration())
                 .createAndStart();
     }
 
@@ -1113,23 +1124,30 @@ public class MiniCluster implements AutoCloseableAsync {
         private final String externalAddress;
         private final String externalPortRange;
         private final String bindAddress;
+        private final RpcSystem rpcSystem;
 
         DedicatedRpcServiceFactory(
                 Configuration configuration,
                 String externalAddress,
                 String externalPortRange,
-                String bindAddress) {
+                String bindAddress,
+                RpcSystem rpcSystem) {
             this.configuration = configuration;
             this.externalAddress = externalAddress;
             this.externalPortRange = externalPortRange;
             this.bindAddress = bindAddress;
+            this.rpcSystem = rpcSystem;
         }
 
         @Override
         public RpcService createRpcService() throws Exception {
             final RpcService rpcService =
                     MiniCluster.this.createRemoteRpcService(
-                            configuration, externalAddress, externalPortRange, bindAddress);
+                            configuration,
+                            externalAddress,
+                            externalPortRange,
+                            bindAddress,
+                            rpcSystem);
 
             synchronized (lock) {
                 rpcServices.add(rpcService);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.runtime.net;
 
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
+import org.apache.flink.runtime.rpc.RpcSystem;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -367,6 +367,12 @@ public class ConnectionUtils {
 
         private static final Duration defaultLoggingDelay = Duration.ofMillis(400);
 
+        private final RpcSystem rpcSystem;
+
+        public LeaderConnectingAddressListener(RpcSystem rpcSystem) {
+            this.rpcSystem = rpcSystem;
+        }
+
         private enum LeaderRetrievalState {
             NOT_RETRIEVED,
             RETRIEVED,
@@ -410,7 +416,7 @@ public class ConnectionUtils {
                                                 + "while waiting for the leader retrieval.");
                             }
                         } else if (retrievalState == LeaderRetrievalState.NEWLY_RETRIEVED) {
-                            targetAddress = AkkaUtils.getInetSocketAddressFromAkkaURL(akkaURL);
+                            targetAddress = rpcSystem.getInetSocketAddressFromRpcUrl(akkaURL);
 
                             LOG.debug(
                                     "Retrieved new target address {} for akka URL {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.net;
 
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
-import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -367,10 +367,10 @@ public class ConnectionUtils {
 
         private static final Duration defaultLoggingDelay = Duration.ofMillis(400);
 
-        private final RpcSystem rpcSystem;
+        private final RpcSystemUtils rpcSystemUtils;
 
-        public LeaderConnectingAddressListener(RpcSystem rpcSystem) {
-            this.rpcSystem = rpcSystem;
+        public LeaderConnectingAddressListener(RpcSystemUtils rpcSystemUtils) {
+            this.rpcSystemUtils = rpcSystemUtils;
         }
 
         private enum LeaderRetrievalState {
@@ -416,7 +416,7 @@ public class ConnectionUtils {
                                                 + "while waiting for the leader retrieval.");
                             }
                         } else if (retrievalState == LeaderRetrievalState.NEWLY_RETRIEVED) {
-                            targetAddress = rpcSystem.getInetSocketAddressFromRpcUrl(akkaURL);
+                            targetAddress = rpcSystemUtils.getInetSocketAddressFromRpcUrl(akkaURL);
 
                             LOG.debug(
                                     "Retrieved new target address {} for akka URL {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -22,14 +22,11 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcSystem;
 
 import javax.annotation.Nullable;
 
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-
 /**
  * This interface serves as a factory interface for RPC services, with some additional utilities
  * that are reliant on implementation details of the RPC service.
  */
-public interface RpcSystem {
+public interface RpcSystem extends RpcSystemUtils {
 
     /**
      * Returns a builder for an {@link RpcService} that is only reachable from the local machine.
@@ -52,45 +49,6 @@ public interface RpcSystem {
             Configuration configuration,
             @Nullable String externalAddress,
             String externalPortRange);
-
-    /**
-     * Constructs an RPC URL for the given parameters, that can be used to connect to the targeted
-     * RpcService.
-     *
-     * @param hostname The hostname or address where the target RPC service is listening.
-     * @param port The port where the target RPC service is listening.
-     * @param endpointName The name of the RPC endpoint.
-     * @param addressResolution Whether to try address resolution of the given hostname or not. This
-     *     allows to fail fast in case that the hostname cannot be resolved.
-     * @param config The configuration from which to deduce further settings.
-     * @return The RPC URL of the specified RPC endpoint.
-     */
-    String getRpcUrl(
-            String hostname,
-            int port,
-            String endpointName,
-            AddressResolution addressResolution,
-            Configuration config)
-            throws UnknownHostException;
-
-    /**
-     * Returns an {@link InetSocketAddress} corresponding to the given RPC url.
-     *
-     * @see #getRpcUrl
-     * @param url RPC url
-     * @return inet socket address
-     * @throws Exception if the URL is invalid
-     */
-    InetSocketAddress getInetSocketAddressFromRpcUrl(String url) throws Exception;
-
-    /**
-     * Returns the maximum number of bytes that an RPC message may carry according to the given
-     * configuration. If no limit exists then {@link Long#MAX_VALUE} should be returned.
-     *
-     * @param config Flink configuration
-     * @return maximum number of bytes that an RPC message may carry
-     */
-    long getMaximumMessageSizeInBytes(Configuration config);
 
     /** Builder for {@link RpcService}. */
     interface RpcServiceBuilder {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.akka.AkkaRpcSystem;
+
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+/**
+ * This interface serves as a factory interface for RPC services, with some additional utilities
+ * that are reliant on implementation details of the RPC service.
+ */
+public interface RpcSystem {
+
+    /**
+     * Returns a builder for an {@link RpcService} that is only reachable from the local machine.
+     *
+     * @param configuration Flink configuration
+     * @return rpc service builder
+     */
+    RpcServiceBuilder localServiceBuilder(Configuration configuration);
+
+    /**
+     * Returns a builder for an {@link RpcService} that is reachable from other machines.
+     *
+     * @param configuration Flink configuration
+     * @param externalAddress optional address under which the RpcService should be reachable
+     * @param externalPortRange port range from which 1 port will be chosen under which the
+     *     RpcService should be reachable
+     * @return rpc service builder
+     */
+    RpcServiceBuilder remoteServiceBuilder(
+            Configuration configuration,
+            @Nullable String externalAddress,
+            String externalPortRange);
+
+    /**
+     * Constructs an RPC URL for the given parameters, that can be used to connect to the targeted
+     * RpcService.
+     *
+     * @param hostname The hostname or address where the target RPC service is listening.
+     * @param port The port where the target RPC service is listening.
+     * @param endpointName The name of the RPC endpoint.
+     * @param addressResolution Whether to try address resolution of the given hostname or not. This
+     *     allows to fail fast in case that the hostname cannot be resolved.
+     * @param config The configuration from which to deduce further settings.
+     * @return The RPC URL of the specified RPC endpoint.
+     */
+    String getRpcUrl(
+            String hostname,
+            int port,
+            String endpointName,
+            AddressResolution addressResolution,
+            Configuration config)
+            throws UnknownHostException;
+
+    /**
+     * Returns an {@link InetSocketAddress} corresponding to the given RPC url.
+     *
+     * @see #getRpcUrl
+     * @param url RPC url
+     * @return inet socket address
+     * @throws Exception if the URL is invalid
+     */
+    InetSocketAddress getInetSocketAddressFromRpcUrl(String url) throws Exception;
+
+    /**
+     * Returns the maximum number of bytes that an RPC message may carry according to the given
+     * configuration. If no limit exists then {@link Long#MAX_VALUE} should be returned.
+     *
+     * @param config Flink configuration
+     * @return maximum number of bytes that an RPC message may carry
+     */
+    long getMaximumMessageSizeInBytes(Configuration config);
+
+    /** Builder for {@link RpcService}. */
+    interface RpcServiceBuilder {
+        RpcServiceBuilder withComponentName(String name);
+
+        RpcServiceBuilder withBindAddress(String bindAddress);
+
+        RpcServiceBuilder withBindPort(int bindPort);
+
+        RpcServiceBuilder withExecutorConfiguration(
+                FixedThreadPoolExecutorConfiguration executorConfiguration);
+
+        RpcServiceBuilder withExecutorConfiguration(
+                ForkJoinExecutorConfiguration executorConfiguration);
+
+        RpcService createAndStart() throws Exception;
+    }
+
+    /**
+     * Loads the RpcSystem.
+     *
+     * @return loaded RpcSystem
+     */
+    static RpcSystem load() {
+        return new AkkaRpcSystem();
+    }
+
+    /** Descriptor for creating a fork-join thread-pool. */
+    class ForkJoinExecutorConfiguration {
+
+        private final double parallelismFactor;
+
+        private final int minParallelism;
+
+        private final int maxParallelism;
+
+        public ForkJoinExecutorConfiguration(
+                double parallelismFactor, int minParallelism, int maxParallelism) {
+            this.parallelismFactor = parallelismFactor;
+            this.minParallelism = minParallelism;
+            this.maxParallelism = maxParallelism;
+        }
+
+        public double getParallelismFactor() {
+            return parallelismFactor;
+        }
+
+        public int getMinParallelism() {
+            return minParallelism;
+        }
+
+        public int getMaxParallelism() {
+            return maxParallelism;
+        }
+    }
+
+    /** Descriptor for creating a thread-pool with a fixed number of threads. */
+    class FixedThreadPoolExecutorConfiguration {
+
+        private final int minNumThreads;
+
+        private final int maxNumThreads;
+
+        private final int threadPriority;
+
+        public FixedThreadPoolExecutorConfiguration(
+                int minNumThreads, int maxNumThreads, int threadPriority) {
+            if (threadPriority < Thread.MIN_PRIORITY || threadPriority > Thread.MAX_PRIORITY) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "The thread priority must be within (%s, %s) but it was %s.",
+                                Thread.MIN_PRIORITY, Thread.MAX_PRIORITY, threadPriority));
+            }
+
+            this.minNumThreads = minNumThreads;
+            this.maxNumThreads = maxNumThreads;
+            this.threadPriority = threadPriority;
+        }
+
+        public int getMinNumThreads() {
+            return minNumThreads;
+        }
+
+        public int getMaxNumThreads() {
+            return maxNumThreads;
+        }
+
+        public int getThreadPriority() {
+            return threadPriority;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcSystemUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcSystemUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.configuration.Configuration;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+/** Utils related to the {@link RpcSystem}. */
+public final class RpcSystemUtils {
+
+    /**
+     * Convenient shortcut for constructing a remote RPC Service that takes care of checking for
+     * null and empty optionals.
+     *
+     * @see RpcSystem#remoteServiceBuilder(Configuration, String, String)
+     */
+    public static RpcService createRemoteRpcService(
+            RpcSystem rpcSystem,
+            Configuration configuration,
+            @Nullable String externalAddress,
+            String externalPortRange,
+            @Nullable String bindAddress,
+            @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Integer> bindPort)
+            throws Exception {
+        RpcSystem.RpcServiceBuilder rpcServiceBuilder =
+                rpcSystem.remoteServiceBuilder(configuration, externalAddress, externalPortRange);
+        if (bindAddress != null) {
+            rpcServiceBuilder = rpcServiceBuilder.withBindAddress(bindAddress);
+        }
+        if (bindPort.isPresent()) {
+            rpcServiceBuilder = rpcServiceBuilder.withBindPort(bindPort.get());
+        }
+        return rpcServiceBuilder.createAndStart();
+    }
+
+    private RpcSystemUtils() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -158,6 +158,10 @@ public class RpcUtils {
                 : rpcServiceAddress;
     }
 
+    public static RpcSystem.ForkJoinExecutorConfiguration getTestForkJoinExecutorConfiguration() {
+        return new RpcSystem.ForkJoinExecutorConfiguration(1.0, 2, 4);
+    }
+
     // We don't want this class to be instantiable
     private RpcUtils() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystem.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.rpc.AddressResolution;
+import org.apache.flink.runtime.rpc.RpcSystem;
+
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+/** {@link RpcSystem} implementation based on Akka. */
+public class AkkaRpcSystem implements RpcSystem {
+
+    @Override
+    public RpcServiceBuilder localServiceBuilder(Configuration configuration) {
+        return AkkaRpcServiceUtils.localServiceBuilder(configuration);
+    }
+
+    @Override
+    public RpcServiceBuilder remoteServiceBuilder(
+            Configuration configuration,
+            @Nullable String externalAddress,
+            String externalPortRange) {
+        return AkkaRpcServiceUtils.remoteServiceBuilder(
+                configuration, externalAddress, externalPortRange);
+    }
+
+    @Override
+    public InetSocketAddress getInetSocketAddressFromRpcUrl(String url) throws Exception {
+        return AkkaUtils.getInetSocketAddressFromAkkaURL(url);
+    }
+
+    @Override
+    public String getRpcUrl(
+            String hostname,
+            int port,
+            String endpointName,
+            AddressResolution addressResolution,
+            Configuration config)
+            throws UnknownHostException {
+        return AkkaRpcServiceUtils.getRpcUrl(
+                hostname, port, endpointName, addressResolution, config);
+    }
+
+    @Override
+    public long getMaximumMessageSizeInBytes(Configuration config) {
+        return AkkaRpcServiceUtils.extractMaximumFramesize(config);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -51,7 +51,8 @@ import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
@@ -133,6 +134,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
             throws Exception {
         this.configuration = checkNotNull(configuration);
 
+        final RpcSystem rpcSystem = RpcSystem.load();
+
         timeout = Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
 
         this.executor =
@@ -142,11 +145,14 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
         highAvailabilityServices =
                 HighAvailabilityServicesUtils.createHighAvailabilityServices(
-                        configuration, executor, AddressResolution.NO_ADDRESS_RESOLUTION);
+                        configuration,
+                        executor,
+                        AddressResolution.NO_ADDRESS_RESOLUTION,
+                        rpcSystem);
 
         JMXService.startInstance(configuration.getString(JMXServerOptions.JMX_SERVER_PORT));
 
-        rpcService = createRpcService(configuration, highAvailabilityServices);
+        rpcService = createRpcService(configuration, highAvailabilityServices, rpcSystem);
 
         this.resourceId =
                 getTaskManagerResourceID(
@@ -156,11 +162,14 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
         metricRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.fromConfiguration(configuration),
+                        MetricRegistryConfiguration.fromConfiguration(
+                                configuration,
+                                rpcSystem.getMaximumMessageSizeInBytes(configuration)),
                         ReporterSetup.fromConfiguration(configuration, pluginManager));
 
         final RpcService metricQueryServiceRpcService =
-                MetricUtils.startRemoteMetricsRpcService(configuration, rpcService.getAddress());
+                MetricUtils.startRemoteMetricsRpcService(
+                        configuration, rpcService.getAddress(), rpcSystem);
         metricRegistry.startQueryService(metricQueryServiceRpcService, resourceId);
 
         blobCacheService =
@@ -543,22 +552,27 @@ public class TaskManagerRunner implements FatalErrorHandler {
      */
     @VisibleForTesting
     static RpcService createRpcService(
-            final Configuration configuration, final HighAvailabilityServices haServices)
+            final Configuration configuration,
+            final HighAvailabilityServices haServices,
+            final RpcSystem rpcSystem)
             throws Exception {
 
         checkNotNull(configuration);
         checkNotNull(haServices);
 
-        return AkkaRpcServiceUtils.createRemoteRpcService(
+        return RpcSystemUtils.createRemoteRpcService(
+                rpcSystem,
                 configuration,
-                determineTaskManagerBindAddress(configuration, haServices),
+                determineTaskManagerBindAddress(configuration, haServices, rpcSystem),
                 configuration.getString(TaskManagerOptions.RPC_PORT),
                 configuration.getString(TaskManagerOptions.BIND_HOST),
                 configuration.getOptional(TaskManagerOptions.RPC_BIND_PORT));
     }
 
     private static String determineTaskManagerBindAddress(
-            final Configuration configuration, final HighAvailabilityServices haServices)
+            final Configuration configuration,
+            final HighAvailabilityServices haServices,
+            RpcSystem rpcSystem)
             throws Exception {
 
         final String configuredTaskManagerHostname =
@@ -571,19 +585,21 @@ public class TaskManagerRunner implements FatalErrorHandler {
             return configuredTaskManagerHostname;
         } else {
             return determineTaskManagerBindAddressByConnectingToResourceManager(
-                    configuration, haServices);
+                    configuration, haServices, rpcSystem);
         }
     }
 
     private static String determineTaskManagerBindAddressByConnectingToResourceManager(
-            final Configuration configuration, final HighAvailabilityServices haServices)
+            final Configuration configuration,
+            final HighAvailabilityServices haServices,
+            RpcSystem rpcSystem)
             throws LeaderRetrievalException {
 
         final Duration lookupTimeout = configuration.get(AkkaOptions.LOOKUP_TIMEOUT_DURATION);
 
         final InetAddress taskManagerAddress =
                 LeaderRetrievalUtils.findConnectingAddress(
-                        haServices.getResourceManagerLeaderRetriever(), lookupTimeout);
+                        haServices.getResourceManagerLeaderRetriever(), lookupTimeout, rpcSystem);
 
         LOG.info(
                 "TaskManager will use hostname/address '{}' ({}) for communication.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.net.ConnectionUtils;
-import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,11 +73,13 @@ public class LeaderRetrievalUtils {
     }
 
     public static InetAddress findConnectingAddress(
-            LeaderRetrievalService leaderRetrievalService, Duration timeout, RpcSystem rpcSystem)
+            LeaderRetrievalService leaderRetrievalService,
+            Duration timeout,
+            RpcSystemUtils rpcSystemUtils)
             throws LeaderRetrievalException {
 
         ConnectionUtils.LeaderConnectingAddressListener listener =
-                new ConnectionUtils.LeaderConnectingAddressListener(rpcSystem);
+                new ConnectionUtils.LeaderConnectingAddressListener(rpcSystemUtils);
 
         try {
             leaderRetrievalService.start(listener);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.net.ConnectionUtils;
+import org.apache.flink.runtime.rpc.RpcSystem;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,11 +73,11 @@ public class LeaderRetrievalUtils {
     }
 
     public static InetAddress findConnectingAddress(
-            LeaderRetrievalService leaderRetrievalService, Duration timeout)
+            LeaderRetrievalService leaderRetrievalService, Duration timeout, RpcSystem rpcSystem)
             throws LeaderRetrievalException {
 
         ConnectionUtils.LeaderConnectingAddressListener listener =
-                new ConnectionUtils.LeaderConnectingAddressListener();
+                new ConnectionUtils.LeaderConnectingAddressListener(rpcSystem);
 
         try {
             leaderRetrievalService.start(listener);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -369,25 +369,6 @@ object AkkaUtils {
     ConfigFactory.parseString(configString)
   }
 
-  def testDispatcherConfig: Config = {
-    val config =
-      s"""
-         |akka {
-         |  actor {
-         |    default-dispatcher {
-         |      fork-join-executor {
-         |        parallelism-factor = 1.0
-         |        parallelism-min = 2
-         |        parallelism-max = 4
-         |      }
-         |    }
-         |  }
-         |}
-      """.stripMargin
-
-    ConfigFactory.parseString(config)
-  }
-
   /**
    * Creates a Akka config for a remote actor system listening on port on the network interface
    * identified by bindAddress.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -28,7 +28,8 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.configuration._
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils
-import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools.{FixedThreadPoolExecutorConfiguration, ForkJoinExecutorConfiguration}
+import org.apache.flink.runtime.rpc.RpcSystem.{FixedThreadPoolExecutorConfiguration, ForkJoinExecutorConfiguration}
+import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools
 import org.apache.flink.util.NetUtils
 import org.apache.flink.util.TimeUtils
 import org.apache.flink.util.concurrent.FutureUtils
@@ -191,7 +192,7 @@ object AkkaUtils {
       configuration,
       externalAddress,
       None,
-      getForkJoinExecutorConfig(ForkJoinExecutorConfiguration.fromConfiguration(configuration)))
+      getForkJoinExecutorConfig(AkkaBootstrapTools.getForkJoinExecutorConfiguration(configuration)))
   }
 
   /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -42,7 +42,7 @@ import org.apache.flink.runtime.resourcemanager.TestingResourceManagerFactory;
 import org.apache.flink.runtime.rest.SessionRestEndpointFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.testutils.TestJvmProcess;
 import org.apache.flink.runtime.testutils.TestingClusterEntrypointProcess;
 import org.apache.flink.runtime.util.SignalHandler;
@@ -276,7 +276,7 @@ public class ClusterEntrypointTest extends TestLogger {
 
         @Override
         protected HighAvailabilityServices createHaServices(
-                Configuration configuration, Executor executor, RpcSystem rpcSystem) {
+                Configuration configuration, Executor executor, RpcSystemUtils rpcSystemUtils) {
             return haService;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.resourcemanager.TestingResourceManagerFactory;
 import org.apache.flink.runtime.rest.SessionRestEndpointFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.testutils.TestJvmProcess;
 import org.apache.flink.runtime.testutils.TestingClusterEntrypointProcess;
 import org.apache.flink.runtime.util.SignalHandler;
@@ -275,7 +276,7 @@ public class ClusterEntrypointTest extends TestLogger {
 
         @Override
         protected HighAvailabilityServices createHaServices(
-                Configuration configuration, Executor executor) {
+                Configuration configuration, Executor executor, RpcSystem rpcSystem) {
             return haService;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.rpc.AddressResolution;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 
@@ -64,7 +65,11 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
         // when
         actualHaServices =
                 HighAvailabilityServicesUtils.createHighAvailabilityServices(
-                        config, executor, AddressResolution.NO_ADDRESS_RESOLUTION);
+                        config,
+                        executor,
+                        AddressResolution.NO_ADDRESS_RESOLUTION,
+                        RpcSystem.load());
+
         // then
         assertSame(haServices, actualHaServices);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -69,7 +69,7 @@ public class MetricRegistryImplTest extends TestLogger {
     public void testIsShutdown() throws Exception {
         MetricRegistryImpl metricRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
 
         Assert.assertFalse(metricRegistry.isShutdown());
 
@@ -92,7 +92,7 @@ public class MetricRegistryImplTest extends TestLogger {
     public void testMetricQueryServiceSetup() throws Exception {
         MetricRegistryImpl metricRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
 
         Assert.assertNull(metricRegistry.getMetricQueryServiceGatewayRpcAddress());
 
@@ -146,7 +146,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Collections.singletonList(
                                 ReporterSetup.forReporter("test", config, new TestReporter3())));
 
@@ -187,7 +187,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Collections.singletonList(
                                 ReporterSetup.forReporter("test", config, new TestReporter3())),
                         manuallyTriggeredScheduledExecutorService);
@@ -230,7 +230,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(
                                 ReporterSetup.forReporter("test1", new TestReporter6()),
                                 ReporterSetup.forReporter("test2", new TestReporter7())));
@@ -329,7 +329,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.fromConfiguration(config),
+                        MetricRegistryTestUtils.fromConfiguration(config),
                         ReporterSetup.fromConfiguration(config, null));
 
         TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
@@ -351,7 +351,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(
                                 ReporterSetup.forReporter("test1", config1, new TestReporter()),
                                 ReporterSetup.forReporter("test2", config2, new TestReporter()),
@@ -419,7 +419,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.fromConfiguration(config),
+                        MetricRegistryTestUtils.fromConfiguration(config),
                         Arrays.asList(
                                 ReporterSetup.forReporter("test1", config1, new TestReporter8()),
                                 ReporterSetup.forReporter("test2", config2, new TestReporter8()),
@@ -449,7 +449,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
 
         final RpcService rpcService = new TestingRpcService();
 
@@ -492,7 +492,7 @@ public class MetricRegistryImplTest extends TestLogger {
     public void testExceptionIsolation() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(
                                 ReporterSetup.forReporter("test1", new FailingReporter()),
                                 ReporterSetup.forReporter("test2", new TestReporter7())));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTestUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.configuration.Configuration;
+
+/** Test utilities for the metric registries. */
+public class MetricRegistryTestUtils {
+
+    private static volatile MetricRegistryConfiguration defaultConfiguration;
+
+    public static MetricRegistryConfiguration fromConfiguration(Configuration configuration) {
+        return MetricRegistryConfiguration.fromConfiguration(configuration, 10485760);
+    }
+
+    public static MetricRegistryConfiguration defaultMetricRegistryConfiguration() {
+        // create the default metric registry configuration only once
+        if (defaultConfiguration == null) {
+            synchronized (MetricRegistryConfiguration.class) {
+                if (defaultConfiguration == null) {
+                    defaultConfiguration = fromConfiguration(new Configuration());
+                }
+            }
+        }
+
+        return defaultConfiguration;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -28,8 +28,8 @@ import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
@@ -61,7 +61,7 @@ public class AbstractMetricGroupTest extends TestLogger {
     public void testGetAllVariables() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
 
         AbstractMetricGroup group =
                 new AbstractMetricGroup<AbstractMetricGroup<?>>(registry, new String[0], null) {
@@ -179,7 +179,7 @@ public class AbstractMetricGroupTest extends TestLogger {
 
         MetricRegistryImpl testRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.fromConfiguration(config),
+                        MetricRegistryTestUtils.fromConfiguration(config),
                         Arrays.asList(
                                 ReporterSetup.forReporter(
                                         "test1", metricConfig1, new TestReporter1()),
@@ -207,7 +207,7 @@ public class AbstractMetricGroupTest extends TestLogger {
     public void testLogicalScopeCachingForMultipleReporters() throws Exception {
         MetricRegistryImpl testRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Arrays.asList(
                                 ReporterSetup.forReporter("test1", new LogicalScopeReporter1()),
                                 ReporterSetup.forReporter("test2", new LogicalScopeReporter2())));
@@ -341,7 +341,7 @@ public class AbstractMetricGroupTest extends TestLogger {
         Configuration config = new Configuration();
         config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
         MetricRegistryImpl testRegistry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
 
         try {
             TaskManagerMetricGroup group = new TaskManagerMetricGroup(testRegistry, "host", "id");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.util.TestLogger;
@@ -45,7 +45,7 @@ public class JobManagerGroupTest extends TestLogger {
     public void addAndRemoveJobs() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
         final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
         final JobID jid1 = new JobID();
@@ -94,7 +94,7 @@ public class JobManagerGroupTest extends TestLogger {
     public void testCloseClosesAll() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
         final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
         final JobID jid1 = new JobID();
@@ -132,7 +132,7 @@ public class JobManagerGroupTest extends TestLogger {
     public void testGenerateScopeDefault() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
         JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
         assertArrayEquals(new String[] {"localhost", "jobmanager"}, group.getScopeComponents());
@@ -146,7 +146,7 @@ public class JobManagerGroupTest extends TestLogger {
         Configuration cfg = new Configuration();
         cfg.setString(MetricOptions.SCOPE_NAMING_JM, "constant.<host>.foo.<host>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "host");
 
@@ -161,7 +161,7 @@ public class JobManagerGroupTest extends TestLogger {
     public void testCreateQueryServiceMetricInfo() {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
         JobManagerMetricGroup jm = new JobManagerMetricGroup(registry, "host");
 
         QueryScopeInfo.JobManagerQueryScopeInfo info =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.util.TestLogger;
@@ -39,7 +39,7 @@ public class JobManagerJobGroupTest extends TestLogger {
     public void testGenerateScopeDefault() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
 
         JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName");
         JobMetricGroup jmGroup =
@@ -60,7 +60,7 @@ public class JobManagerJobGroupTest extends TestLogger {
         cfg.setString(MetricOptions.SCOPE_NAMING_JM, "abc");
         cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "some-constant.<job_name>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         JobID jid = new JobID();
 
@@ -81,7 +81,7 @@ public class JobManagerJobGroupTest extends TestLogger {
         cfg.setString(MetricOptions.SCOPE_NAMING_JM, "peter");
         cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         JobID jid = new JobID();
 
@@ -102,7 +102,7 @@ public class JobManagerJobGroupTest extends TestLogger {
         JobID jid = new JobID();
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
         JobManagerMetricGroup jm = new JobManagerMetricGroup(registry, "host");
         JobManagerJobMetricGroup jmj = new JobManagerJobMetricGroup(registry, jm, jid, "jobname");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
@@ -25,8 +25,8 @@ import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.util.TestReporter;
 import org.apache.flink.util.TestLogger;
@@ -45,7 +45,7 @@ public class MetricGroupRegistrationTest extends TestLogger {
     public void testMetricInstantiation() throws Exception {
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration(),
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration(),
                         Collections.singletonList(
                                 ReporterSetup.forReporter("test", new TestReporter1())));
 
@@ -113,7 +113,7 @@ public class MetricGroupRegistrationTest extends TestLogger {
         Configuration config = new Configuration();
 
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
 
         MetricGroup root = new TaskManagerMetricGroup(registry, "host", "id");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
@@ -55,7 +56,7 @@ import static org.junit.Assert.fail;
 public class MetricGroupTest extends TestLogger {
 
     private static final MetricRegistryConfiguration defaultMetricRegistryConfiguration =
-            MetricRegistryConfiguration.defaultMetricRegistryConfiguration();
+            MetricRegistryTestUtils.defaultMetricRegistryConfiguration();
 
     private MetricRegistryImpl registry;
 
@@ -245,7 +246,7 @@ public class MetricGroupTest extends TestLogger {
                 TestReporter.class.getName());
 
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
         try {
             GenericMetricGroup root =
                     new GenericMetricGroup(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -24,8 +24,8 @@ import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
@@ -50,7 +50,7 @@ public class OperatorGroupTest extends TestLogger {
     public void setup() {
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
     }
 
     @After
@@ -96,7 +96,7 @@ public class OperatorGroupTest extends TestLogger {
                 MetricOptions.SCOPE_NAMING_OPERATOR,
                 "<tm_id>.<job_id>.<task_id>.<operator_name>.<operator_id>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
         try {
             String tmID = "test-tm-id";
             JobID jid = new JobID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.util.AbstractID;
@@ -50,7 +50,7 @@ public class TaskManagerGroupTest extends TestLogger {
     public void setup() {
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
     }
 
     @After
@@ -173,7 +173,7 @@ public class TaskManagerGroupTest extends TestLogger {
         Configuration cfg = new Configuration();
         cfg.setString(MetricOptions.SCOPE_NAMING_TM, "constant.<host>.foo.<host>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
         TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "host", "id");
 
         assertArrayEquals(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.util.TestLogger;
@@ -43,7 +43,7 @@ public class TaskManagerJobGroupTest extends TestLogger {
     public void setup() {
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
     }
 
     @After
@@ -75,7 +75,7 @@ public class TaskManagerJobGroupTest extends TestLogger {
         cfg.setString(MetricOptions.SCOPE_NAMING_TM, "abc");
         cfg.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "some-constant.<job_name>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         JobID jid = new JobID();
 
@@ -96,7 +96,7 @@ public class TaskManagerJobGroupTest extends TestLogger {
         cfg.setString(MetricOptions.SCOPE_NAMING_TM, "peter.<tm_id>");
         cfg.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "*.some-constant.<job_id>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         JobID jid = new JobID();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -24,8 +24,8 @@ import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
@@ -49,7 +49,7 @@ public class TaskMetricGroupTest extends TestLogger {
     public void setup() {
         registry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
     }
 
     @After
@@ -94,7 +94,7 @@ public class TaskMetricGroupTest extends TestLogger {
         cfg.setString(
                 MetricOptions.SCOPE_NAMING_TASK, "<tm_id>.<job_id>.<task_id>.<task_attempt_id>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         JobID jid = new JobID();
         JobVertexID vertexId = new JobVertexID();
@@ -124,7 +124,7 @@ public class TaskMetricGroupTest extends TestLogger {
         Configuration cfg = new Configuration();
         cfg.setString(MetricOptions.SCOPE_NAMING_TASK, "*.<task_attempt_id>.<subtask_index>");
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
         ExecutionAttemptID executionId = new ExecutionAttemptID();
 
@@ -204,7 +204,7 @@ public class TaskMetricGroupTest extends TestLogger {
         Configuration cfg = new Configuration();
         cfg.setString(MetricOptions.SCOPE_NAMING_OPERATOR, ScopeFormat.SCOPE_OPERATOR_NAME);
         MetricRegistryImpl registry =
-                new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
         TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
         TaskManagerJobMetricGroup job =
                 new TaskManagerJobMetricGroup(registry, tm, new JobID(), "jobname");
@@ -228,7 +228,7 @@ public class TaskMetricGroupTest extends TestLogger {
         private int counter = 0;
 
         CountingMetricRegistry(Configuration config) {
-            super(MetricRegistryConfiguration.fromConfiguration(config));
+            super(MetricRegistryTestUtils.fromConfiguration(config));
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -97,7 +96,7 @@ public class MetricUtilsTest extends TestLogger {
 
             assertThat(threadPriority, is(expectedThreadPriority));
         } finally {
-            AkkaUtils.terminateActorSystem(actorSystem).get();
+            rpcService.stopService().get();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServicesBuilder;
@@ -70,8 +71,8 @@ public class MetricUtilsTest extends TestLogger {
     }
 
     /**
-     * Tests that the {@link MetricUtils#startRemoteMetricsRpcService(Configuration, String)}
-     * respects the given {@link MetricOptions#QUERY_SERVICE_THREAD_PRIORITY}.
+     * Tests that the {@link MetricUtils#startRemoteMetricsRpcService(Configuration, String,
+     * RpcSystem)} respects the given {@link MetricOptions#QUERY_SERVICE_THREAD_PRIORITY}.
      */
     @Test
     public void testStartMetricActorSystemRespectsThreadPriority() throws Exception {
@@ -81,7 +82,8 @@ public class MetricUtilsTest extends TestLogger {
                 MetricOptions.QUERY_SERVICE_THREAD_PRIORITY, expectedThreadPriority);
 
         final RpcService rpcService =
-                MetricUtils.startRemoteMetricsRpcService(configuration, "localhost");
+                MetricUtils.startRemoteMetricsRpcService(
+                        configuration, "localhost", RpcSystem.load());
         assertThat(rpcService, instanceOf(AkkaRpcService.class));
 
         final ActorSystem actorSystem = ((AkkaRpcService) rpcService).getActorSystem();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -19,23 +19,17 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.concurrent.FutureUtils;
 
-import akka.actor.ActorSystem;
-import akka.actor.Terminated;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -58,22 +52,19 @@ public class AsyncCallsTest extends TestLogger {
     //  shared test members
     // ------------------------------------------------------------------------
 
-    private static final ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
-
     private static final Time timeout = Time.seconds(10L);
 
-    private static final AkkaRpcService akkaRpcService =
-            new AkkaRpcService(actorSystem, AkkaRpcServiceConfiguration.defaultConfiguration());
+    private static RpcService rpcService;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        rpcService = RpcSystem.load().localServiceBuilder(new Configuration()).createAndStart();
+    }
 
     @AfterClass
     public static void shutdown()
             throws InterruptedException, ExecutionException, TimeoutException {
-        final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
-        final CompletableFuture<Terminated> actorSystemTerminationFuture =
-                AkkaFutureUtils.toJava(actorSystem.terminate());
-
-        FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
-                .get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+        rpcService.stopService().get();
     }
 
     // ------------------------------------------------------------------------
@@ -95,7 +86,7 @@ public class AsyncCallsTest extends TestLogger {
         final ReentrantLock lock = new ReentrantLock();
         final AtomicBoolean concurrentAccess = new AtomicBoolean(false);
 
-        RpcEndpoint rpcEndpoint = factory.create(akkaRpcService, lock, concurrentAccess);
+        RpcEndpoint rpcEndpoint = factory.create(rpcService, lock, concurrentAccess);
         rpcEndpoint.start();
 
         try {
@@ -160,7 +151,7 @@ public class AsyncCallsTest extends TestLogger {
 
         final long delay = 10L;
 
-        RpcEndpoint rpcEndpoint = factory.create(akkaRpcService, lock, concurrentAccess);
+        RpcEndpoint rpcEndpoint = factory.create(rpcService, lock, concurrentAccess);
         rpcEndpoint.start();
 
         try {
@@ -306,7 +297,7 @@ public class AsyncCallsTest extends TestLogger {
         final OneShotLatch triggerSetNewFencingToken = new OneShotLatch();
         final FencedTestEndpoint fencedTestEndpoint =
                 new FencedTestEndpoint(
-                        akkaRpcService,
+                        rpcService,
                         initialFencingToken,
                         enterSetNewFencingToken,
                         triggerSetNewFencingToken);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -20,28 +20,17 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.concurrent.FutureUtils;
 
-import akka.actor.ActorSystem;
-import akka.actor.Terminated;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import scala.Option;
-import scala.Tuple2;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -54,23 +43,18 @@ public class RpcConnectionTest extends TestLogger {
 
     @Test
     public void testConnectFailure() throws Exception {
-        ActorSystem actorSystem = null;
-        RpcService rpcService = null;
+        // we start the RPC service with a very long timeout to ensure that the test
+        // can only pass if the connection problem is not recognized merely via a timeout
+        Configuration configuration = new Configuration();
+        configuration.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(10000000));
+
+        final RpcService rpcService =
+                RpcSystem.load()
+                        .localServiceBuilder(configuration)
+                        .withBindAddress("localhost")
+                        .withBindPort(0)
+                        .createAndStart();
         try {
-            actorSystem =
-                    AkkaUtils.createActorSystem(
-                            new Configuration(),
-                            Option.<Tuple2<String, Object>>apply(new Tuple2<>("localhost", 0)));
-
-            // we start the RPC service with a very long timeout to ensure that the test
-            // can only pass if the connection problem is not recognized merely via a timeout
-            Configuration configuration = new Configuration();
-            configuration.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(10000000));
-            rpcService =
-                    new AkkaRpcService(
-                            actorSystem,
-                            AkkaRpcServiceConfiguration.fromConfiguration(configuration));
-
             CompletableFuture<TaskExecutorGateway> future =
                     rpcService.connect("foo.bar.com.test.invalid", TaskExecutorGateway.class);
 
@@ -87,25 +71,7 @@ public class RpcConnectionTest extends TestLogger {
         } catch (Throwable t) {
             fail("wrong exception: " + t);
         } finally {
-            final CompletableFuture<Void> rpcTerminationFuture;
-
-            if (rpcService != null) {
-                rpcTerminationFuture = rpcService.stopService();
-            } else {
-                rpcTerminationFuture = CompletableFuture.completedFuture(null);
-            }
-
-            final CompletableFuture<Terminated> actorSystemTerminationFuture;
-
-            if (actorSystem != null) {
-                actorSystemTerminationFuture = AkkaFutureUtils.toJava(actorSystem.terminate());
-            } else {
-                actorSystemTerminationFuture = CompletableFuture.completedFuture(null);
-            }
-
-            FutureUtils.waitForAll(
-                            Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
-                    .get();
+            rpcService.stopService().get();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -19,21 +19,14 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.concurrent.FutureUtils;
 
-import akka.actor.ActorSystem;
-import akka.actor.Terminated;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -52,25 +45,16 @@ import static org.junit.Assert.fail;
 public class RpcEndpointTest extends TestLogger {
 
     private static final Time TIMEOUT = Time.seconds(10L);
-    private static ActorSystem actorSystem = null;
     private static RpcService rpcService = null;
 
     @BeforeClass
-    public static void setup() {
-        actorSystem = AkkaUtils.createDefaultActorSystem();
-        rpcService =
-                new AkkaRpcService(actorSystem, AkkaRpcServiceConfiguration.defaultConfiguration());
+    public static void setup() throws Exception {
+        rpcService = RpcSystem.load().localServiceBuilder(new Configuration()).createAndStart();
     }
 
     @AfterClass
     public static void teardown() throws Exception {
-
-        final CompletableFuture<Void> rpcTerminationFuture = rpcService.stopService();
-        final CompletableFuture<Terminated> actorSystemTerminationFuture =
-                AkkaFutureUtils.toJava(actorSystem.terminate());
-
-        FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
-                .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+        rpcService.stopService().get();
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
@@ -21,14 +21,10 @@ package org.apache.flink.runtime.rpc;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import akka.actor.ActorSystem;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -57,6 +53,9 @@ public class RpcSSLAuthITCase extends TestLogger {
     public void testConnectFailure() throws Exception {
         final Configuration baseConfig = new Configuration();
         baseConfig.setString(AkkaOptions.TCP_TIMEOUT, "1 s");
+        // we start the RPC service with a very long timeout to ensure that the test
+        // can only pass if the connection problem is not recognized merely via a timeout
+        baseConfig.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(10000000));
 
         // !!! This config has KEY_STORE_FILE / TRUST_STORE_FILE !!!
         Configuration sslConfig1 = new Configuration(baseConfig);
@@ -80,28 +79,26 @@ public class RpcSSLAuthITCase extends TestLogger {
         sslConfig2.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
         sslConfig2.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
 
-        ActorSystem actorSystem1 = null;
-        ActorSystem actorSystem2 = null;
         RpcService rpcService1 = null;
         RpcService rpcService2 = null;
 
         try {
-            actorSystem1 = AkkaUtils.createActorSystem(sslConfig1, "localhost", 0);
-            actorSystem2 = AkkaUtils.createActorSystem(sslConfig2, "localhost", 0);
-
             // to test whether the test is still good:
             //   - create actorSystem2 with sslConfig1 (same as actorSystem1) and see that both can
             // connect
             //   - set 'require-mutual-authentication = off' in the AkkaUtils ssl config section
-
-            // we start the RPC service with a very long timeout to ensure that the test
-            // can only pass if the connection problem is not recognized merely via a timeout
-            Configuration configuration = new Configuration();
-            configuration.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(10000000));
-            AkkaRpcServiceConfiguration akkaRpcServiceConfig =
-                    AkkaRpcServiceConfiguration.fromConfiguration(configuration);
-            rpcService1 = new AkkaRpcService(actorSystem1, akkaRpcServiceConfig);
-            rpcService2 = new AkkaRpcService(actorSystem2, akkaRpcServiceConfig);
+            rpcService1 =
+                    RpcSystem.load()
+                            .localServiceBuilder(sslConfig1)
+                            .withBindAddress("localhost")
+                            .withBindPort(0)
+                            .createAndStart();
+            rpcService2 =
+                    RpcSystem.load()
+                            .localServiceBuilder(sslConfig2)
+                            .withBindAddress("localhost")
+                            .withBindPort(0)
+                            .createAndStart();
 
             TestEndpoint endpoint = new TestEndpoint(rpcService1);
             endpoint.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorOperatorEventHandlingTest.java
@@ -31,8 +31,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
-import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.TestOperatorEvent;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -68,7 +68,7 @@ public class TaskExecutorOperatorEventHandlingTest extends TestLogger {
         rpcService = new TestingRpcService();
         metricRegistry =
                 new MetricRegistryImpl(
-                        MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
         metricRegistry.startQueryService(rpcService, new ResourceID("mqs"));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/AddressResolutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/AddressResolutionTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.util;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.rpc.AddressResolution;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.BeforeClass;
@@ -34,6 +34,8 @@ import static org.junit.Assume.assumeTrue;
 
 /** Unit tests for respecting {@link AddressResolution}. */
 public class AddressResolutionTest extends TestLogger {
+
+    private static final RpcSystem RPC_SYSTEM = RpcSystem.load();
 
     private static final String ENDPOINT_NAME = "endpoint";
     private static final String NON_EXISTING_HOSTNAME = "foo.bar.com.invalid";
@@ -63,7 +65,7 @@ public class AddressResolutionTest extends TestLogger {
 
     @Test
     public void testNoAddressResolution() throws UnknownHostException {
-        AkkaRpcServiceUtils.getRpcUrl(
+        RPC_SYSTEM.getRpcUrl(
                 NON_EXISTING_HOSTNAME,
                 PORT,
                 ENDPOINT_NAME,
@@ -74,7 +76,7 @@ public class AddressResolutionTest extends TestLogger {
     @Test
     public void testTryAddressResolution() {
         try {
-            AkkaRpcServiceUtils.getRpcUrl(
+            RPC_SYSTEM.getRpcUrl(
                     NON_EXISTING_HOSTNAME,
                     PORT,
                     ENDPOINT_NAME,

--- a/flink-runtime/src/test/scala/akka/actor/RobustActorSystemTest.scala
+++ b/flink-runtime/src/test/scala/akka/actor/RobustActorSystemTest.scala
@@ -19,6 +19,7 @@
 package akka.actor
 
 import org.apache.flink.runtime.akka.AkkaUtils
+import org.apache.flink.runtime.rpc.RpcUtils
 import org.apache.flink.util.concurrent.TestingUncaughtExceptionHandler
 import org.junit.{After, Before, Test}
 import org.scalatest.Matchers
@@ -36,7 +37,7 @@ class RobustActorSystemTest extends JUnitSuite with Matchers {
     testingUncaughtExceptionHandler = new TestingUncaughtExceptionHandler
     robustActorSystem = RobustActorSystem.create(
       "testSystem",
-      AkkaUtils.testDispatcherConfig,
+      AkkaUtils.getForkJoinExecutorConfig(RpcUtils.getTestForkJoinExecutorConfiguration),
       testingUncaughtExceptionHandler)
   }
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -22,7 +22,7 @@ import java.net.{InetAddress, InetSocketAddress}
 import java.util.Collections
 import org.apache.flink.configuration.{AkkaOptions, Configuration, IllegalConfigurationException, SecurityOptions}
 import org.apache.flink.runtime.rpc.AddressResolution
-import org.apache.flink.runtime.rpc.akka.AkkaBootstrapTools.FixedThreadPoolExecutorConfiguration
+import org.apache.flink.runtime.rpc.RpcSystem
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils.AkkaProtocol
 import org.apache.flink.util.NetUtils
@@ -175,8 +175,9 @@ class AkkaUtilsTest
       "localhost",
       1234,
       AkkaUtils.getThreadPoolExecutorConfig(
-        new FixedThreadPoolExecutorConfiguration(minThreads, maxThreads, threadPriority)
-      ))
+        new RpcSystem.FixedThreadPoolExecutorConfiguration(
+          minThreads, maxThreads, threadPriority))
+    )
 
     akkaConfig.getString("akka.actor.default-dispatcher.executor") should
       equal("thread-pool-executor")

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -576,7 +577,11 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
             localRpcCreated = true;
 
             return new InterceptingRpcService(
-                    rpcSystem.localServiceBuilder(configuration).createAndStart());
+                    rpcSystem
+                            .localServiceBuilder(configuration)
+                            .withExecutorConfiguration(
+                                    RpcUtils.getTestForkJoinExecutorConfiguration())
+                            .createAndStart());
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -31,18 +31,18 @@ import org.apache.flink.api.connector.source.lib.util.IteratorSourceReader;
 import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.rpc.FencedRpcGateway;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceConfiguration;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -53,15 +53,16 @@ import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
 import org.apache.flink.util.function.TriFunction;
 
-import akka.actor.ActorSystem;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -69,7 +70,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -450,17 +454,85 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
         }
     }
 
-    private static class InterceptingRpcService extends AkkaRpcService {
+    private static class InterceptingRpcService implements RpcService {
 
-        public InterceptingRpcService(
-                ActorSystem actorSystem, AkkaRpcServiceConfiguration configuration) {
-            super(actorSystem, configuration);
+        private final RpcService rpcService;
+
+        public InterceptingRpcService(RpcService rpcService) {
+            this.rpcService = rpcService;
+        }
+
+        @Override
+        public String getAddress() {
+            return rpcService.getAddress();
+        }
+
+        @Override
+        public int getPort() {
+            return rpcService.getPort();
         }
 
         @Override
         public <C extends RpcGateway> CompletableFuture<C> connect(String address, Class<C> clazz) {
-            final CompletableFuture<C> future = super.connect(address, clazz);
+            final CompletableFuture<C> future = rpcService.connect(address, clazz);
             return clazz == TaskExecutorGateway.class ? decorateTmGateway(future) : future;
+        }
+
+        @Override
+        public <F extends Serializable, C extends FencedRpcGateway<F>> CompletableFuture<C> connect(
+                String address, F fencingToken, Class<C> clazz) {
+            return rpcService.connect(address, fencingToken, clazz);
+        }
+
+        @Override
+        public <C extends RpcEndpoint & RpcGateway> RpcServer startServer(C rpcEndpoint) {
+            return rpcService.startServer(rpcEndpoint);
+        }
+
+        @Override
+        public <F extends Serializable> RpcServer fenceRpcServer(
+                RpcServer rpcServer, F fencingToken) {
+            return rpcService.fenceRpcServer(rpcServer, fencingToken);
+        }
+
+        @Override
+        public void stopServer(RpcServer selfGateway) {
+            rpcService.stopServer(selfGateway);
+        }
+
+        @Override
+        public CompletableFuture<Void> stopService() {
+            return rpcService.stopService();
+        }
+
+        @Override
+        public CompletableFuture<Void> getTerminationFuture() {
+            return rpcService.getTerminationFuture();
+        }
+
+        @Override
+        public Executor getExecutor() {
+            return rpcService.getExecutor();
+        }
+
+        @Override
+        public ScheduledExecutor getScheduledExecutor() {
+            return rpcService.getScheduledExecutor();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleRunnable(Runnable runnable, long delay, TimeUnit unit) {
+            return rpcService.scheduleRunnable(runnable, delay, unit);
+        }
+
+        @Override
+        public void execute(Runnable runnable) {
+            rpcService.execute(runnable);
+        }
+
+        @Override
+        public <T> CompletableFuture<T> execute(Callable<T> callable) {
+            return rpcService.execute(callable);
         }
 
         @SuppressWarnings("unchecked")
@@ -499,12 +571,12 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
         }
 
         @Override
-        protected RpcService createLocalRpcService(Configuration configuration) throws Exception {
+        protected RpcService createLocalRpcService(Configuration configuration, RpcSystem rpcSystem)
+                throws Exception {
             localRpcCreated = true;
 
-            return AkkaRpcServiceUtils.localServiceBuilder(configuration)
-                    .withCustomConfig(AkkaUtils.testDispatcherConfig())
-                    .createAndStart(InterceptingRpcService::new);
+            return new InterceptingRpcService(
+                    rpcSystem.localServiceBuilder(configuration).createAndStart());
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -41,8 +41,8 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.leaderelection.TestingListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.testutils.DispatcherProcess;
@@ -272,7 +272,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
         TaskExecutorResourceUtils.adjustForLocalExecution(config);
 
         final RpcService rpcService =
-                AkkaRpcServiceUtils.remoteServiceBuilder(config, "localhost", 0).createAndStart();
+                RpcSystem.load().remoteServiceBuilder(config, "localhost", "0").createAndStart();
 
         try {
             final Deadline deadline = Deadline.fromNow(TEST_TIMEOUT);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -44,8 +44,8 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.runtime.util.BlobServerResource;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -115,7 +115,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
         config.setInteger(RestOptions.PORT, 0);
 
         final RpcService rpcService =
-                AkkaRpcServiceUtils.remoteServiceBuilder(config, "localhost", 0).createAndStart();
+                RpcSystem.load().remoteServiceBuilder(config, "localhost", "0").createAndStart();
         final int jobManagerPort = rpcService.getPort();
         config.setInteger(JobManagerOptions.PORT, jobManagerPort);
 
@@ -127,7 +127,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
         final ScheduledExecutorService ioExecutor = TestingUtils.defaultExecutor();
         final HighAvailabilityServices haServices =
                 HighAvailabilityServicesUtils.createHighAvailabilityServices(
-                        config, ioExecutor, AddressResolution.NO_ADDRESS_RESOLUTION);
+                        config,
+                        ioExecutor,
+                        AddressResolution.NO_ADDRESS_RESOLUTION,
+                        RpcSystem.load());
 
         final AtomicReference<Throwable> programException = new AtomicReference<>();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -26,7 +26,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
@@ -35,7 +36,6 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.ActorSystem;
 import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,8 +48,6 @@ import java.net.NetworkInterface;
 import java.net.ServerSocket;
 import java.util.Enumeration;
 import java.util.List;
-
-import scala.Some;
 
 import static org.junit.Assert.fail;
 
@@ -149,13 +147,14 @@ public class IPv6HostnamesITCase extends TestLogger {
                             // test whether Akka's netty can bind to the address
                             log.info("Testing whether Akka can use " + addr);
                             int port = NetUtils.getAvailablePort();
-                            ActorSystem as =
-                                    AkkaUtils.createActorSystem(
-                                            new Configuration(),
-                                            new Some<scala.Tuple2<String, Object>>(
-                                                    new scala.Tuple2<String, Object>(
-                                                            addr.getHostAddress(), port)));
-                            as.terminate();
+
+                            final RpcService rpcService =
+                                    RpcSystem.load()
+                                            .localServiceBuilder(new Configuration())
+                                            .withBindAddress(addr.getHostAddress())
+                                            .withBindPort(port)
+                                            .createAndStart();
+                            rpcService.stopService().get();
 
                             log.info("Using address " + addr);
                             return (Inet6Address) addr;


### PR DESCRIPTION
Adds the `RpcSystem` interface which isolates flink-runtime from the AkkaUtils/AkkaRpcServiceUtils etc. . It serves as a factory for rpc services, as well as a crude facade for various static utilities. The interface is heavily inspired by the existing akka-related code; which isn't _that_ nice but fine for the time being because we don't intend to implement other RpcServices at this time.

Implementations of this interface (i.e., the AkkaRpcSystem) are loaded via `RpcSystem#load()` which currently just returns an AkkaRpcSystem, but Later we will load implementations of this interface with a `PluginLoader`.