### PR TITLE
[FLINK-23121][python] Fix the issue that the InternalRow as arguments in Python UDAF

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -127,32 +127,6 @@ cdef class AggregateFunctionRowCoderImpl(FlattenRowCoderImpl):
         output_stream.write(self._tmp_output_data, self._tmp_output_pos)
         self._tmp_output_pos = 0
 
-    cdef InternalRow _decode_field_row(self, RowCoderImpl field_coder):
-        cdef list row_field_coders
-        cdef size_t row_field_count, leading_complete_bytes_num, remaining_bits_num
-        cdef bint*mask
-        cdef unsigned char row_kind_value
-        cdef libc.stdint.int32_t i
-        cdef InternalRow row
-        cdef FieldCoder row_field_coder
-        row_field_coders = field_coder.field_coders
-        row_field_count = field_coder.field_count
-        mask = <bint*> malloc((row_field_count + ROW_KIND_BIT_SIZE) * sizeof(bint))
-        leading_complete_bytes_num = (row_field_count + ROW_KIND_BIT_SIZE) // 8
-        remaining_bits_num = (row_field_count + ROW_KIND_BIT_SIZE) % 8
-        self._read_mask(mask, leading_complete_bytes_num, remaining_bits_num)
-        row_kind_value = 0
-        for i in range(ROW_KIND_BIT_SIZE):
-            row_kind_value += mask[i] * 2 ** i
-        row = InternalRow([None if mask[i + ROW_KIND_BIT_SIZE] else
-                    self._decode_field(
-                        row_field_coders[i].coder_type(),
-                        row_field_coders[i].type_name(),
-                        row_field_coders[i])
-                    for i in range(row_field_count)], row_kind_value)
-        free(mask)
-        return row
-
 
 cdef class DataStreamFlatMapCoderImpl(BaseCoderImpl):
 

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -375,7 +375,11 @@ class AbstractStreamGroupAggregateOperation(StatefulTableOperation):
         # all the fields are nullable except the "element_type"
         for input_data in input_datas:
             if input_data[0] == NORMAL_RECORD:
-                self.group_agg_function.process_element(input_data[1])
+                if has_cython:
+                    row = InternalRow(input_data[1]._values, input_data[1].get_row_kind().value)
+                else:
+                    row = input_data[1]
+                self.group_agg_function.process_element(row)
             else:
                 self.group_agg_function.on_timer(input_data[3])
         return self.group_agg_function.finish_bundle()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the issue that the InternalRow as arguments in Python UDAF*


## Brief change log

  - *Fix the issue that the InternalRow as arguments in Python UDAF*

## Verifying this change

This change added tests and can be verified as follows:

- *Change the original IT `test_flat_aggregate_list_view` to cover this patch*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
