### PR TITLE
[FLINK-23119][python] Throw exceptions when compiling the job at places where Python UDAF is not supported

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonWindowAggregateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonWindowAggregateRule.java
@@ -82,13 +82,13 @@ public class BatchExecPythonWindowAggregateRule extends RelOptRule {
         boolean existJavaFunction =
                 aggCalls.stream().anyMatch(x -> !PythonUtil.isPythonAggregate(x, null));
         if (existPandasFunction || existGeneralPythonFunction) {
+            if (existGeneralPythonFunction) {
+                throw new TableException(
+                        "non-Pandas UDAFs are not supported in batch mode currently.");
+            }
             if (existJavaFunction) {
                 throw new TableException(
                         "Python UDAF and Java/Scala UDAF cannot be used together.");
-            }
-            if (existPandasFunction && existGeneralPythonFunction) {
-                throw new TableException(
-                        "Pandas UDAF and non-Pandas UDAF cannot be used together.");
             }
             return true;
         } else {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecOverAggregateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecOverAggregateRule.scala
@@ -114,11 +114,11 @@ class BatchExecOverAggregateRule
         .map(_._2)
         .exists(_.map(_._1).exists(!isPythonAggregate(_)))
       if (existPandasFunction || existGeneralPythonFunction) {
+        if (existGeneralPythonFunction) {
+          throw new TableException("non-Pandas UDAFs are not supported in batch mode currently.")
+        }
         if (existJavaFunction) {
           throw new TableException("Python UDAF and Java/Scala UDAF cannot be used together.")
-        }
-        if (existPandasFunction && existGeneralPythonFunction) {
-          throw new TableException("Pandas UDAF and non-Pandas UDAF cannot be used together.")
         }
       }
       overWindowAgg = if (existJavaFunction) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/PythonOverWindowAggregateTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.batch.table
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
-import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.PandasAggregateFunction
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.{PandasAggregateFunction, TestPythonAggregateFunction}
 import org.apache.flink.table.planner.utils.TableTestBase
 import org.junit.Test
 
@@ -60,6 +60,21 @@ class PythonOverWindowAggregateTest extends TableTestBase {
           preceding 10.rows
           as 'w)
       .select('b, func('a, 'c) over 'w)
+
+    util.verifyPlan(resultTable)
+  }
+
+  @Test(expected = classOf[TableException])
+  def testGeneralEventTimeTumblingGroupWindowOverTime(): Unit = {
+    val util = batchTestUtil()
+    val sourceTable = util.addTableSource[(Int, Long, Int, Long)](
+      "MyTable", 'a, 'b, 'c, 'rowtime.rowtime)
+    val func = new TestPythonAggregateFunction
+
+    val resultTable = sourceTable
+      .window(Tumble over 5.millis on 'rowtime as 'w)
+      .groupBy('w, 'b)
+      .select('b, 'w.start,'w.end, func('a, 'c))
 
     util.verifyPlan(resultTable)
   }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will throw exceptions when compiling the job at places where Python UDAF is not supported*

## Brief change log

  - *Throws the unsupported exception in physical rule*

## Verifying this change

This change added tests and can be verified as follows:

  - *UT in `PythonOverWindowAggregateTest` and `PythonGroupWindowAggregateTest`*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
