### PR TITLE
[FLINK-23133][python] Properly handle the dependencies when mixing use of Python Table API and Python DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/python/dependency_management.md
+++ b/docs/content.zh/docs/dev/python/dependency_management.md
@@ -38,6 +38,11 @@ the local Python environment, download the machine learning model to local, etc.
 However, this approach doesn't work well when users want to submit the PyFlink jobs to remote clusters.
 In the following sections, we will introduce the options provided in PyFlink for these requirements.
 
+<span class="label label-info">Note</span> Both Python DataStream API and Python Table API have provided
+APIs for each kind of dependency. If you are mixing use of Python DataStream API and Python Table API
+in a single job, you should specify the dependencies via Python DataStream API to make them work for
+both the Python DataStream API and Python Table API.
+
 ## JAR Dependencies
 
 If third-party JARs are used, you can specify the JARs in the Python Table API as following:

--- a/docs/content/docs/dev/python/dependency_management.md
+++ b/docs/content/docs/dev/python/dependency_management.md
@@ -38,6 +38,11 @@ the local Python environment, download the machine learning model to local, etc.
 However, this approach doesn't work well when users want to submit the PyFlink jobs to remote clusters.
 In the following sections, we will introduce the options provided in PyFlink for these requirements.
 
+<span class="label label-info">Note</span> Both Python DataStream API and Python Table API have provided
+APIs for each kind of dependency. If you are mixing use of Python DataStream API and Python Table API
+in a single job, you should specify the dependencies via Python DataStream API to make them work for
+both the Python DataStream API and Python Table API.
+
 ## JAR Dependencies
 
 If third-party JARs are used, you can specify the JARs in the Python Table API as following:

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1706,10 +1706,7 @@ class StreamTableEnvironment(TableEnvironment):
         """
         j_data_stream = data_stream._j_data_stream
         JPythonConfigUtil = get_gateway().jvm.org.apache.flink.python.util.PythonConfigUtil
-        JPythonConfigUtil.declareManagedMemory(
-            j_data_stream.getTransformation(),
-            self._get_j_env(),
-            self._j_tenv.getConfig())
+        JPythonConfigUtil.configPythonOperator(j_data_stream.getExecutionEnvironment())
         if len(fields) == 0:
             return Table(j_table=self._j_tenv.fromDataStream(j_data_stream), t_env=self)
         elif all(isinstance(f, Expression) for f in fields):

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.python.PythonConfig;
-import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
@@ -95,17 +94,6 @@ public class PythonConfigUtil {
 
         getConfigurationMethod.setAccessible(true);
         return (Configuration) getConfigurationMethod.invoke(env);
-    }
-
-    /** Set Python Operator Use Managed Memory. */
-    public static void declareManagedMemory(
-            Transformation<?> transformation,
-            StreamExecutionEnvironment env,
-            TableConfig tableConfig) {
-        Configuration config = getMergedConfig(env, tableConfig);
-        if (config.getBoolean(PythonOptions.USE_MANAGED_MEMORY)) {
-            declareManagedMemory(transformation);
-        }
     }
 
     /**
@@ -324,16 +312,6 @@ public class PythonConfigUtil {
                                             != Boundedness.BOUNDED);
         }
         return !existsUnboundedSource;
-    }
-
-    private static void declareManagedMemory(Transformation<?> transformation) {
-        if (isPythonOperator(transformation)) {
-            transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.PYTHON);
-        }
-
-        for (Transformation<?> inputTransformation : transformation.getInputs()) {
-            declareManagedMemory(inputTransformation);
-        }
     }
 
     private static void setPartitionCustomOperatorNumPartitions(


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the problem that the dependencies are not handled correctly when mixing use of Python Table API and Python DataStream API. *

## Brief change log

  - *Handle the dependencies when converting DataStream to Table*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_add_python_file_2*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
