### PR TITLE
[FLINK-23138][python] Raise an exception if types other than PickledBytesTypeInfo are specified for state descriptor

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -263,7 +263,7 @@ class CountWindowAverage(FlatMapFunction):
     def open(self, runtime_context: RuntimeContext):
         descriptor = ValueStateDescriptor(
             "average",  # the state name
-            Types.TUPLE([Types.LONG(), Types.LONG()])  # type information
+            Types.PICKLED_BYTE_ARRAY()  # type information
         )
         self.sum = runtime_context.get_state(descriptor)
 

--- a/docs/content.zh/docs/dev/datastream/operators/process_function.md
+++ b/docs/content.zh/docs/dev/datastream/operators/process_function.md
@@ -266,7 +266,7 @@ class CountWithTimeoutFunction(KeyedProcessFunction):
 
     def open(self, runtime_context: RuntimeContext):
         self.state = runtime_context.get_state(ValueStateDescriptor(
-            "my_state", Types.ROW([Types.STRING(), Types.LONG(), Types.LONG()])))
+            "my_state", Types.PICKLED_BYTE_ARRAY()))
 
     def process_element(self, value, ctx: 'KeyedProcessFunction.Context'):
         # retrieve the current count

--- a/docs/content.zh/docs/dev/python/datastream/intro_to_datastream_api.md
+++ b/docs/content.zh/docs/dev/python/datastream/intro_to_datastream_api.md
@@ -51,7 +51,7 @@ from pyflink.datastream.state import ValueStateDescriptor
 class MyMapFunction(MapFunction):
 
     def open(self, runtime_context: RuntimeContext):
-        state_desc = ValueStateDescriptor('cnt', Types.LONG())
+        state_desc = ValueStateDescriptor('cnt', Types.PICKLED_BYTE_ARRAY())
         self.cnt_state = runtime_context.get_state(state_desc)
 
     def map(self, value):

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -283,7 +283,7 @@ class CountWindowAverage(FlatMapFunction):
     def open(self, runtime_context: RuntimeContext):
         descriptor = ValueStateDescriptor(
             "average",  # the state name
-            Types.TUPLE([Types.LONG(), Types.LONG()])  # type information
+            Types.PICKLED_BYTE_ARRAY()  # type information
         )
         self.sum = runtime_context.get_state(descriptor)
 

--- a/docs/content/docs/dev/datastream/operators/process_function.md
+++ b/docs/content/docs/dev/datastream/operators/process_function.md
@@ -266,7 +266,7 @@ class CountWithTimeoutFunction(KeyedProcessFunction):
 
     def open(self, runtime_context: RuntimeContext):
         self.state = runtime_context.get_state(ValueStateDescriptor(
-            "my_state", Types.ROW([Types.STRING(), Types.LONG(), Types.LONG()])))
+            "my_state", Types.PICKLED_BYTE_ARRAY()))
 
     def process_element(self, value, ctx: 'KeyedProcessFunction.Context'):
         # retrieve the current count

--- a/docs/content/docs/dev/python/datastream/intro_to_datastream_api.md
+++ b/docs/content/docs/dev/python/datastream/intro_to_datastream_api.md
@@ -51,7 +51,7 @@ from pyflink.datastream.state import ValueStateDescriptor
 class MyMapFunction(MapFunction):
 
     def open(self, runtime_context: RuntimeContext):
-        state_desc = ValueStateDescriptor('cnt', Types.LONG())
+        state_desc = ValueStateDescriptor('cnt', Types.PICKLED_BYTE_ARRAY())
         self.cnt_state = runtime_context.get_state(state_desc)
 
     def map(self, value):

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -932,7 +932,8 @@ class KeyedStream(DataStream):
 
             def open(self, runtime_context: RuntimeContext):
                 self._reduce_value_state = runtime_context.get_state(
-                    ValueStateDescriptor("_reduce_state" + str(uuid.uuid4()), output_type))
+                    ValueStateDescriptor("_reduce_state" + str(uuid.uuid4()),
+                                         Types.PICKLED_BYTE_ARRAY()))
                 self._reduce_function.open(runtime_context)
                 from pyflink.fn_execution.datastream.runtime_context import StreamingRuntimeContext
                 self._in_batch_execution_mode = \
@@ -1200,7 +1201,7 @@ class WindowedStream(object):
                 self.get_execution_environment())
         window_serializer = self._window_assigner.get_window_serializer()
         window_state_descriptor = ListStateDescriptor(
-            "window-contents", self.get_input_type())
+            "window-contents", Types.PICKLED_BYTE_ARRAY())
         window_operation_descriptor = WindowOperationDescriptor(
             self._window_assigner,
             self._window_trigger,

--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 
 from typing import TypeVar, Generic, Iterable, List, Iterator, Dict, Tuple
 
-from pyflink.common.typeinfo import TypeInformation, Types
+from pyflink.common.typeinfo import TypeInformation, Types, PickledBytesTypeInfo
 
 __all__ = [
     'ValueStateDescriptor',
@@ -316,6 +316,10 @@ class ValueStateDescriptor(StateDescriptor):
         :param name: The name of the state.
         :param value_type_info: the type information of the state.
         """
+        if not isinstance(value_type_info, PickledBytesTypeInfo):
+            raise ValueError("The type information of the value could only be PickledBytesTypeInfo "
+                             "(created via Types.PICKLED_BYTE_ARRAY()) currently, got %s."
+                             % type(value_type_info))
         super(ValueStateDescriptor, self).__init__(name, value_type_info)
 
 
@@ -332,6 +336,10 @@ class ListStateDescriptor(StateDescriptor):
         :param name: The name of the state.
         :param elem_type_info: the type information of the state element.
         """
+        if not isinstance(elem_type_info, PickledBytesTypeInfo):
+            raise ValueError("The type information of the element could only be "
+                             "PickledBytesTypeInfo (created via Types.PICKLED_BYTE_ARRAY()) "
+                             "currently, got %s" % type(elem_type_info))
         super(ListStateDescriptor, self).__init__(name, Types.LIST(elem_type_info))
 
 
@@ -349,6 +357,14 @@ class MapStateDescriptor(StateDescriptor):
         :param key_type_info: The type information of the key.
         :param value_type_info: the type information of the value.
         """
+        if not isinstance(key_type_info, PickledBytesTypeInfo):
+            raise ValueError("The type information of the key could only be PickledBytesTypeInfo "
+                             "(created via Types.PICKLED_BYTE_ARRAY()) currently, got %s"
+                             % type(key_type_info))
+        if not isinstance(value_type_info, PickledBytesTypeInfo):
+            raise ValueError("The type information of the value could only be PickledBytesTypeInfo "
+                             "(created via Types.PICKLED_BYTE_ARRAY()) currently, got %s"
+                             % type(value_type_info))
         super(MapStateDescriptor, self).__init__(name, Types.MAP(key_type_info, value_type_info))
 
 
@@ -376,6 +392,10 @@ class ReducingStateDescriptor(StateDescriptor):
                 reduce_function = ReduceFunctionWrapper(reduce_function)  # type: ignore
             else:
                 raise TypeError("The input must be a ReduceFunction or a callable function!")
+        if not isinstance(type_info, PickledBytesTypeInfo):
+            raise ValueError("The type information of the state could only be PickledBytesTypeInfo "
+                             "(created via Types.PICKLED_BYTE_ARRAY()) currently, got %s"
+                             % type(type_info))
         self._reduce_function = reduce_function
 
     def get_reduce_function(self):
@@ -398,6 +418,10 @@ class AggregatingStateDescriptor(StateDescriptor):
         from pyflink.datastream.functions import AggregateFunction
         if not isinstance(agg_function, AggregateFunction):
             raise TypeError("The input must be a pyflink.datastream.functions.AggregateFunction!")
+        if not isinstance(state_type_info, PickledBytesTypeInfo):
+            raise ValueError("The type information of the state could only be PickledBytesTypeInfo "
+                             "(created via Types.PICKLED_BYTE_ARRAY()) currently, got %s"
+                             % type(state_type_info))
         self._agg_function = agg_function
 
     def get_agg_function(self):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -214,9 +214,9 @@ class DataStreamTests(object):
 
             def open(self, runtime_context: RuntimeContext):
                 self.pre1 = runtime_context.get_state(
-                    ValueStateDescriptor("pre1", Types.STRING()))
+                    ValueStateDescriptor("pre1", Types.PICKLED_BYTE_ARRAY()))
                 self.pre2 = runtime_context.get_state(
-                    ValueStateDescriptor("pre2", Types.STRING()))
+                    ValueStateDescriptor("pre2", Types.PICKLED_BYTE_ARRAY()))
 
             def map1(self, value):
                 if value[0] == 'b':
@@ -409,7 +409,7 @@ class DataStreamTests(object):
 
             def open(self, runtime_context: RuntimeContext):
                 self.state = runtime_context.get_state(
-                    ValueStateDescriptor("test_state", Types.INT()))
+                    ValueStateDescriptor("test_state", Types.PICKLED_BYTE_ARRAY()))
 
             def map(self, value):
                 state_value = self.state.value()
@@ -453,7 +453,7 @@ class DataStreamTests(object):
 
             def open(self, runtime_context: RuntimeContext):
                 self.state = runtime_context.get_state(
-                    ValueStateDescriptor("test_state", Types.INT()))
+                    ValueStateDescriptor("test_state", Types.PICKLED_BYTE_ARRAY()))
 
             def flat_map(self, value):
                 state_value = self.state.value()
@@ -497,7 +497,7 @@ class DataStreamTests(object):
 
             def open(self, runtime_context: RuntimeContext):
                 self.state = runtime_context.get_state(
-                    ValueStateDescriptor("test_state", Types.INT()))
+                    ValueStateDescriptor("test_state", Types.PICKLED_BYTE_ARRAY()))
 
             def filter(self, value):
                 state_value = self.state.value()
@@ -694,11 +694,15 @@ class DataStreamTests(object):
                 self.map_state = None
 
             def open(self, runtime_context: RuntimeContext):
-                value_state_descriptor = ValueStateDescriptor('value_state', Types.INT())
+                value_state_descriptor = ValueStateDescriptor('value_state',
+                                                              Types.PICKLED_BYTE_ARRAY())
                 self.value_state = runtime_context.get_state(value_state_descriptor)
-                list_state_descriptor = ListStateDescriptor('list_state', Types.INT())
+                list_state_descriptor = ListStateDescriptor('list_state',
+                                                            Types.PICKLED_BYTE_ARRAY())
                 self.list_state = runtime_context.get_list_state(list_state_descriptor)
-                map_state_descriptor = MapStateDescriptor('map_state', Types.INT(), Types.STRING())
+                map_state_descriptor = MapStateDescriptor('map_state',
+                                                          Types.PICKLED_BYTE_ARRAY(),
+                                                          Types.PICKLED_BYTE_ARRAY())
                 self.map_state = runtime_context.get_map_state(map_state_descriptor)
 
             def process_element(self, value, ctx):
@@ -766,7 +770,7 @@ class DataStreamTests(object):
             def open(self, runtime_context: RuntimeContext):
                 self.reducing_state = runtime_context.get_reducing_state(
                     ReducingStateDescriptor(
-                        'reducing_state', lambda i, i2: i + i2, Types.INT()))
+                        'reducing_state', lambda i, i2: i + i2, Types.PICKLED_BYTE_ARRAY()))
 
             def process_element(self, value, ctx):
                 self.reducing_state.add(value[0])
@@ -810,7 +814,7 @@ class DataStreamTests(object):
             def open(self, runtime_context: RuntimeContext):
                 self.aggregating_state = runtime_context.get_aggregating_state(
                     AggregatingStateDescriptor(
-                        'aggregating_state', MyAggregateFunction(), Types.INT()))
+                        'aggregating_state', MyAggregateFunction(), Types.PICKLED_BYTE_ARRAY()))
 
             def process_element(self, value, ctx):
                 self.aggregating_state.add(value[0])
@@ -1352,7 +1356,7 @@ class MyRichCoFlatMapFunction(CoFlatMapFunction):
 
     def open(self, runtime_context: RuntimeContext):
         self.map_state = runtime_context.get_map_state(
-            MapStateDescriptor("map", Types.STRING(), Types.BOOLEAN()))
+            MapStateDescriptor("map", Types.PICKLED_BYTE_ARRAY(), Types.PICKLED_BYTE_ARRAY()))
 
     def flat_map1(self, value):
         yield str(value[0] + 1)
@@ -1372,7 +1376,8 @@ class MyKeyedCoProcessFunction(KeyedCoProcessFunction):
 
     def open(self, runtime_context: RuntimeContext):
         self.timer_registered = False
-        self.count_state = runtime_context.get_state(ValueStateDescriptor("count", Types.INT()))
+        self.count_state = runtime_context.get_state(ValueStateDescriptor(
+            "count", Types.PICKLED_BYTE_ARRAY()))
 
     def process_element1(self, value, ctx: 'KeyedCoProcessFunction.Context'):
         if not self.timer_registered:
@@ -1406,7 +1411,7 @@ class MyReduceFunction(ReduceFunction):
 
     def open(self, runtime_context: RuntimeContext):
         self.state = runtime_context.get_state(
-            ValueStateDescriptor("test_state", Types.INT()))
+            ValueStateDescriptor("test_state", Types.PICKLED_BYTE_ARRAY()))
 
     def reduce(self, value1, value2):
         state_value = self.state.value()
@@ -1434,7 +1439,7 @@ class SimpleCountWindowTrigger(Trigger[tuple, CountWindow]):
     def __init__(self):
         self._window_size = 3
         self._count_state_descriptor = ReducingStateDescriptor(
-            "trigger_counter", lambda a, b: a + b, Types.BIG_INT())
+            "trigger_counter", lambda a, b: a + b, Types.PICKLED_BYTE_ARRAY())
 
     def on_element(self,
                    element: tuple,
@@ -1474,7 +1479,7 @@ class SimpleCountWindowAssigner(WindowAssigner[tuple, CountWindow]):
         self._window_id = 0
         self._window_size = 3
         self._counter_state_descriptor = ReducingStateDescriptor(
-            "assigner_counter", lambda a, b: a + b, Types.BIG_INT())
+            "assigner_counter", lambda a, b: a + b, Types.PICKLED_BYTE_ARRAY())
 
     def assign_windows(self,
                        element: tuple,

--- a/flink-python/pyflink/fn_execution/table/window_assigner.py
+++ b/flink-python/pyflink/fn_execution/table/window_assigner.py
@@ -144,7 +144,8 @@ class CountTumblingWindowAssigner(WindowAssigner[CountWindow]):
         self._count = None  # type: ValueState
 
     def open(self, ctx: Context[Any, CountWindow]):
-        value_state_descriptor = ValueStateDescriptor('tumble-count-assigner', Types.LONG())
+        value_state_descriptor = ValueStateDescriptor('tumble-count-assigner',
+                                                      Types.PICKLED_BYTE_ARRAY())
         self._count = ctx.get_partitioned_state(value_state_descriptor)
 
     def assign_windows(self, element: List, timestamp: int) -> Iterable[CountWindow]:
@@ -217,7 +218,7 @@ class CountSlidingWindowAssigner(WindowAssigner[CountWindow]):
         self._count = None  # type: ValueState
 
     def open(self, ctx: Context[Any, CountWindow]):
-        count_descriptor = ValueStateDescriptor('slide-count-assigner', Types.LONG())
+        count_descriptor = ValueStateDescriptor('slide-count-assigner', Types.PICKLED_BYTE_ARRAY())
         self._count = ctx.get_partitioned_state(count_descriptor)
 
     def assign_windows(self, element: List, timestamp: int) -> Iterable[W]:

--- a/flink-python/pyflink/fn_execution/table/window_trigger.py
+++ b/flink-python/pyflink/fn_execution/table/window_trigger.py
@@ -180,7 +180,7 @@ class CountTrigger(Trigger[CountWindow]):
     def __init__(self, count_elements: int):
         self._count_elements = count_elements
         self._count_state_desc = ValueStateDescriptor(
-            "trigger-count-%s" % count_elements, Types.LONG())
+            "trigger-count-%s" % count_elements, Types.PICKLED_BYTE_ARRAY())
         self._ctx = None  # type: TriggerContext
 
     def open(self, ctx: TriggerContext):


### PR DESCRIPTION

## What is the purpose of the change

*This pull request improve the codebase to raise an exception if types other than PickledBytesTypeInfo are specified for state descriptor as currently only PickledBytesTypeInfo is actually supported*


## Verifying this change

This change is a trivial rework  without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
