### PR TITLE
[FLINK-22492][test] Use order-agnostic check in KinesisTableApiITCase. [1.13]

### DIFF
--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/test/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/test/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -49,7 +50,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /** End-to-end test for Kinesis Table API using Kinesalite. */
 @Category(value = {TravisGroup1.class})
@@ -107,8 +108,9 @@ public class KinesisTableApiITCase extends TestLogger {
 
         executeSqlStatements(readSqlFile("filter-large-orders.sql"));
 
+        // result order is not guaranteed
         List<Order> result = readAllOrdersFromKinesis(kinesisClient);
-        assertEquals(expected, result);
+        assertThat(result, Matchers.containsInAnyOrder(expected.toArray(new Order[0])));
     }
 
     private List<Order> readAllOrdersFromKinesis(final KinesisPubsubClient client)

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/test/java/org/apache/flink/streaming/kinesis/test/model/Order.java
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/test/java/org/apache/flink/streaming/kinesis/test/model/Order.java
@@ -57,4 +57,9 @@ public class Order {
     public int hashCode() {
         return Objects.hash(code, quantity);
     }
+
+    @Override
+    public String toString() {
+        return "Order{" + "code='" + code + '\'' + ", quantity=" + quantity + '}';
+    }
 }


### PR DESCRIPTION
Unchanged backport of #16277.