### PR TITLE
[FLINK-23149][table-code-splitter] Introduce the new Java code splitter module

### DIFF
--- a/flink-table/flink-table-code-splitter/NOTICE
+++ b/flink-table/flink-table-code-splitter/NOTICE
@@ -1,0 +1,16 @@
+flink-table-code-splitter
+Copyright 2014-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the BSD 3-clause license.
+See bundled license files for details.
+
+- antlr:4.7
+
+This project bundles the following files under the BSD license.
+See bundled license files for details.
+
+- Antlr Java grammar files (https://github.com/antlr/grammars-v4/tree/master/java/java)
+  -> in src/main/antlr4

--- a/flink-table/flink-table-code-splitter/pom.xml
+++ b/flink-table/flink-table-code-splitter/pom.xml
@@ -33,8 +33,6 @@ under the License.
 	<description>
 		This module contains a tool to split generated Java code
 		so that each method does not exceed the limit of 64KB.
-		Antlr grammar files are copied from the official antlr repository
-		https://github.com/antlr/grammars-v4/tree/master/java/java
 	</description>
 
 	<packaging>jar</packaging>

--- a/flink-table/flink-table-code-splitter/pom.xml
+++ b/flink-table/flink-table-code-splitter/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-table</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.14-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-table-code-splitter</artifactId>
+	<name>Flink : Table : Code Splitter </name>
+	<description>
+		This module contains a tool to split generated Java code
+		so that each method does not exceed the limit of 64KB.
+		Antlr grammar files are copied from the official antlr repository
+		https://github.com/antlr/grammars-v4/tree/master/java/java
+	</description>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<antlr4.version>4.7</antlr4.version>
+		<!-- override parent pom -->
+		<test.excludedGroups/>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4-runtime</artifactId>
+			<version>${antlr4.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>${antlr4.version}</version>
+				<executions>
+					<execution>
+						<id>antlr</id>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/generated-sources/antlr4/org/apache/flink/table/codesplit</outputDirectory>
+							<visitor>true</visitor>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
@@ -1,0 +1,184 @@
+/**
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+lexer grammar JavaLexer;
+
+@header {
+    package org.apache.flink.table.codesplit;
+}
+
+// Keywords
+
+ABSTRACT:           'abstract';
+ASSERT:             'assert';
+BOOLEAN:            'boolean';
+BREAK:              'break';
+BYTE:               'byte';
+CASE:               'case';
+CATCH:              'catch';
+CHAR:               'char';
+CLASS:              'class';
+CONST:              'const';
+CONTINUE:           'continue';
+DEFAULT:            'default';
+DO:                 'do';
+DOUBLE:             'double';
+ELSE:               'else';
+ENUM:               'enum';
+EXTENDS:            'extends';
+FINAL:              'final';
+FINALLY:            'finally';
+FLOAT:              'float';
+FOR:                'for';
+IF:                 'if';
+GOTO:               'goto';
+IMPLEMENTS:         'implements';
+IMPORT:             'import';
+INSTANCEOF:         'instanceof';
+INT:                'int';
+INTERFACE:          'interface';
+LONG:               'long';
+NATIVE:             'native';
+NEW:                'new';
+PACKAGE:            'package';
+PRIVATE:            'private';
+PROTECTED:          'protected';
+PUBLIC:             'public';
+RETURN:             'return';
+SHORT:              'short';
+STATIC:             'static';
+STRICTFP:           'strictfp';
+SUPER:              'super';
+SWITCH:             'switch';
+SYNCHRONIZED:       'synchronized';
+THIS:               'this';
+THROW:              'throw';
+THROWS:             'throws';
+TRANSIENT:          'transient';
+TRY:                'try';
+VOID:               'void';
+VOLATILE:           'volatile';
+WHILE:              'while';
+
+// Literals
+
+DECIMAL_LITERAL:    ('0' | [1-9] (Digits? | '_'+ Digits)) [lL]?;
+HEX_LITERAL:        '0' [xX] [0-9a-fA-F] ([0-9a-fA-F_]* [0-9a-fA-F])? [lL]?;
+OCT_LITERAL:        '0' '_'* [0-7] ([0-7_]* [0-7])? [lL]?;
+BINARY_LITERAL:     '0' [bB] [01] ([01_]* [01])? [lL]?;
+
+FLOAT_LITERAL:      (Digits '.' Digits? | '.' Digits) ExponentPart? [fFdD]?
+             |       Digits (ExponentPart [fFdD]? | [fFdD])
+             ;
+
+HEX_FLOAT_LITERAL:  '0' [xX] (HexDigits '.'? | HexDigits? '.' HexDigits) [pP] [+-]? Digits [fFdD]?;
+
+BOOL_LITERAL:       'true'
+            |       'false'
+            ;
+
+CHAR_LITERAL:       '\'' (~['\\\r\n] | EscapeSequence) '\'';
+
+STRING_LITERAL:     '"' (~["\\\r\n] | EscapeSequence)* '"';
+NULL_LITERAL:       'null';
+// Separators
+LPAREN:             '(';
+RPAREN:             ')';
+LBRACE:             '{';
+RBRACE:             '}';
+LBRACK:             '[';
+RBRACK:             ']';
+SEMI:               ';';
+COMMA:              ',';
+DOT:                '.';
+// Operators
+ASSIGN:             '=';
+GT:                 '>';
+LT:                 '<';
+BANG:               '!';
+TILDE:              '~';
+QUESTION:           '?';
+COLON:              ':';
+EQUAL:              '==';
+LE:                 '<=';
+GE:                 '>=';
+NOTEQUAL:           '!=';
+AND:                '&&';
+OR:                 '||';
+INC:                '++';
+DEC:                '--';
+ADD:                '+';
+SUB:                '-';
+MUL:                '*';
+DIV:                '/';
+BITAND:             '&';
+BITOR:              '|';
+CARET:              '^';
+MOD:                '%';
+ADD_ASSIGN:         '+=';
+SUB_ASSIGN:         '-=';
+MUL_ASSIGN:         '*=';
+DIV_ASSIGN:         '/=';
+AND_ASSIGN:         '&=';
+OR_ASSIGN:          '|=';
+XOR_ASSIGN:         '^=';
+MOD_ASSIGN:         '%=';
+LSHIFT_ASSIGN:      '<<=';
+RSHIFT_ASSIGN:      '>>=';
+URSHIFT_ASSIGN:     '>>>=';
+// Java 8 tokens
+ARROW:              '->';
+COLONCOLON:         '::';
+// Additional symbols not defined in the lexical specification
+AT:                 '@';
+ELLIPSIS:           '...';
+// Whitespace and comments
+WS:                 [ \t\r\n\u000C]+ -> channel(HIDDEN);
+COMMENT:            '/*' .*? '*/'    -> channel(HIDDEN);
+LINE_COMMENT:       '//' ~[\r\n]*    -> channel(HIDDEN);
+
+// Identifiers
+
+IDENTIFIER:         Letter LetterOrDigit*;
+
+// Fragment rules
+
+fragment ExponentPart
+    : [eE] [+-]? Digits
+    ;
+
+fragment EscapeSequence
+    : '\\' [btnfr"'\\]
+    | '\\' ([0-3]? [0-7])? [0-7]
+    | '\\' 'u'+ HexDigit HexDigit HexDigit HexDigit
+    ;
+fragment HexDigits
+    : HexDigit ((HexDigit | '_')* HexDigit)?
+    ;
+fragment HexDigit
+    : [0-9a-fA-F]
+    ;
+fragment Digits
+    : [0-9] ([0-9_]* [0-9])?
+    ;
+fragment LetterOrDigit
+    : Letter
+    | [0-9]
+    ;
+fragment Letter
+    : [a-zA-Z$_] // these are the "java letters" below 0x7F
+    | ~[\u0000-\u007F\uD800-\uDBFF] // covers all characters above 0x7F which are not a surrogate
+    | [\uD800-\uDBFF] [\uDC00-\uDFFF] // covers UTF-16 surrogate pairs encodings for U+10000 to U+10FFFF
+    ;

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
@@ -3,6 +3,7 @@
  Copyright (c) 2013 Terence Parr, Sam Harwell
  Copyright (c) 2017 Ivan Kochurkin (upgrade to Java 8)
  All rights reserved.
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -13,6 +14,7 @@
     documentation and/or other materials provided with the distribution.
  3. The name of the author may not be used to endorse or promote products
     derived from this software without specific prior written permission.
+
  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
@@ -1,16 +1,28 @@
-/**
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-       http://www.apache.org/licenses/LICENSE-2.0
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+/*
+ [The "BSD licence"]
+ Copyright (c) 2013 Terence Parr, Sam Harwell
+ Copyright (c) 2017 Ivan Kochurkin (upgrade to Java 8)
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 lexer grammar JavaLexer;

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
@@ -27,6 +27,15 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// ----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+//
+//  This Java grammar file is copied from the official Antlr repository
+//  https://github.com/antlr/grammars-v4/tree/master/java/java
+//
+// ----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+
 lexer grammar JavaLexer;
 
 @header {

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
@@ -27,6 +27,15 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// ----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+//
+//  This Java grammar file is copied from the official Antlr repository
+//  https://github.com/antlr/grammars-v4/tree/master/java/java
+//
+// ----------------------------------------------------------------------------
+// ----------------------------------------------------------------------------
+
 parser grammar JavaParser;
 
 @header {

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
@@ -3,6 +3,7 @@
  Copyright (c) 2013 Terence Parr, Sam Harwell
  Copyright (c) 2017 Ivan Kochurkin (upgrade to Java 8)
  All rights reserved.
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -13,6 +14,7 @@
     documentation and/or other materials provided with the distribution.
  3. The name of the author may not be used to endorse or promote products
     derived from this software without specific prior written permission.
+
  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
@@ -1,0 +1,603 @@
+/**
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+parser grammar JavaParser;
+
+@header {
+    package org.apache.flink.table.codesplit;
+}
+
+options { tokenVocab=JavaLexer; }
+
+compilationUnit
+    : packageDeclaration? importDeclaration* typeDeclaration* EOF
+    ;
+
+packageDeclaration
+    : annotation* PACKAGE qualifiedName ';'
+    ;
+
+importDeclaration
+    : IMPORT STATIC? qualifiedName ('.' '*')? ';'
+    ;
+
+typeDeclaration
+    : classOrInterfaceModifier*
+      (classDeclaration | enumDeclaration | interfaceDeclaration | annotationTypeDeclaration)
+    | ';'
+    ;
+
+modifier
+    : classOrInterfaceModifier
+    | NATIVE
+    | SYNCHRONIZED
+    | TRANSIENT
+    | VOLATILE
+    ;
+
+classOrInterfaceModifier
+    : annotation
+    | PUBLIC
+    | PROTECTED
+    | PRIVATE
+    | STATIC
+    | ABSTRACT
+    | FINAL    // FINAL for class only -- does not apply to interfaces
+    | STRICTFP
+    ;
+
+variableModifier
+    : FINAL
+    | annotation
+    ;
+
+classDeclaration
+    : CLASS IDENTIFIER typeParameters?
+      (EXTENDS typeType)?
+      (IMPLEMENTS typeList)?
+      classBody
+    ;
+
+typeParameters
+    : '<' typeParameter (',' typeParameter)* '>'
+    ;
+
+typeParameter
+    : annotation* IDENTIFIER (EXTENDS typeBound)?
+    ;
+
+typeBound
+    : typeType ('&' typeType)*
+    ;
+
+enumDeclaration
+    : ENUM IDENTIFIER (IMPLEMENTS typeList)? '{' enumConstants? ','? enumBodyDeclarations? '}'
+    ;
+
+enumConstants
+    : enumConstant (',' enumConstant)*
+    ;
+
+enumConstant
+    : annotation* IDENTIFIER arguments? classBody?
+    ;
+
+enumBodyDeclarations
+    : ';' classBodyDeclaration*
+    ;
+
+interfaceDeclaration
+    : INTERFACE IDENTIFIER typeParameters? (EXTENDS typeList)? interfaceBody
+    ;
+
+classBody
+    : '{' classBodyDeclaration* '}'
+    ;
+
+interfaceBody
+    : '{' interfaceBodyDeclaration* '}'
+    ;
+
+classBodyDeclaration
+    : ';'
+    | STATIC? block
+    | modifier* memberDeclaration
+    ;
+
+memberDeclaration
+    : methodDeclaration
+    | genericMethodDeclaration
+    | fieldDeclaration
+    | constructorDeclaration
+    | genericConstructorDeclaration
+    | interfaceDeclaration
+    | annotationTypeDeclaration
+    | classDeclaration
+    | enumDeclaration
+    ;
+
+/* We use rule this even for void methods which cannot have [] after parameters.
+   This simplifies grammar and we can consider void to be a type, which
+   renders the [] matching as a context-sensitive issue or a semantic check
+   for invalid return type after parsing.
+ */
+methodDeclaration
+    : typeTypeOrVoid IDENTIFIER formalParameters ('[' ']')*
+      (THROWS qualifiedNameList)?
+      methodBody
+    ;
+
+methodBody
+    : block
+    | ';'
+    ;
+
+typeTypeOrVoid
+    : typeType
+    | VOID
+    ;
+
+genericMethodDeclaration
+    : typeParameters methodDeclaration
+    ;
+
+genericConstructorDeclaration
+    : typeParameters constructorDeclaration
+    ;
+
+constructorDeclaration
+    : IDENTIFIER formalParameters (THROWS qualifiedNameList)? constructorBody=block
+    ;
+
+fieldDeclaration
+    : typeType variableDeclarators ';'
+    ;
+
+interfaceBodyDeclaration
+    : modifier* interfaceMemberDeclaration
+    | ';'
+    ;
+
+interfaceMemberDeclaration
+    : constDeclaration
+    | interfaceMethodDeclaration
+    | genericInterfaceMethodDeclaration
+    | interfaceDeclaration
+    | annotationTypeDeclaration
+    | classDeclaration
+    | enumDeclaration
+    ;
+
+constDeclaration
+    : typeType constantDeclarator (',' constantDeclarator)* ';'
+    ;
+
+constantDeclarator
+    : IDENTIFIER ('[' ']')* '=' variableInitializer
+    ;
+
+// see matching of [] comment in methodDeclaratorRest
+// methodBody from Java8
+interfaceMethodDeclaration
+    : interfaceMethodModifier* (typeTypeOrVoid | typeParameters annotation* typeTypeOrVoid)
+      IDENTIFIER formalParameters ('[' ']')* (THROWS qualifiedNameList)? methodBody
+    ;
+
+// Java8
+interfaceMethodModifier
+    : annotation
+    | PUBLIC
+    | ABSTRACT
+    | DEFAULT
+    | STATIC
+    | STRICTFP
+    ;
+
+genericInterfaceMethodDeclaration
+    : typeParameters interfaceMethodDeclaration
+    ;
+
+variableDeclarators
+    : variableDeclarator (',' variableDeclarator)*
+    ;
+
+variableDeclarator
+    : variableDeclaratorId ('=' variableInitializer)?
+    ;
+
+variableDeclaratorId
+    : IDENTIFIER ('[' ']')*
+    ;
+
+variableInitializer
+    : arrayInitializer
+    | expression
+    ;
+
+arrayInitializer
+    : '{' (variableInitializer (',' variableInitializer)* (',')? )? '}'
+    ;
+
+classOrInterfaceType
+    : IDENTIFIER typeArguments? ('.' IDENTIFIER typeArguments?)*
+    ;
+
+typeArgument
+    : typeType
+    | '?' ((EXTENDS | SUPER) typeType)?
+    ;
+
+qualifiedNameList
+    : qualifiedName (',' qualifiedName)*
+    ;
+
+formalParameters
+    : '(' formalParameterList? ')'
+    ;
+
+formalParameterList
+    : formalParameter (',' formalParameter)* (',' lastFormalParameter)?
+    | lastFormalParameter
+    ;
+
+formalParameter
+    : variableModifier* typeType variableDeclaratorId
+    ;
+
+lastFormalParameter
+    : variableModifier* typeType '...' variableDeclaratorId
+    ;
+
+qualifiedName
+    : IDENTIFIER ('.' IDENTIFIER)*
+    ;
+
+literal
+    : integerLiteral
+    | floatLiteral
+    | CHAR_LITERAL
+    | STRING_LITERAL
+    | BOOL_LITERAL
+    | NULL_LITERAL
+    ;
+
+integerLiteral
+    : DECIMAL_LITERAL
+    | HEX_LITERAL
+    | OCT_LITERAL
+    | BINARY_LITERAL
+    ;
+
+floatLiteral
+    : FLOAT_LITERAL
+    | HEX_FLOAT_LITERAL
+    ;
+
+// ANNOTATIONS
+
+annotation
+    : '@' qualifiedName ('(' ( elementValuePairs | elementValue )? ')')?
+    ;
+
+elementValuePairs
+    : elementValuePair (',' elementValuePair)*
+    ;
+
+elementValuePair
+    : IDENTIFIER '=' elementValue
+    ;
+
+elementValue
+    : expression
+    | annotation
+    | elementValueArrayInitializer
+    ;
+
+elementValueArrayInitializer
+    : '{' (elementValue (',' elementValue)*)? (',')? '}'
+    ;
+
+annotationTypeDeclaration
+    : '@' INTERFACE IDENTIFIER annotationTypeBody
+    ;
+
+annotationTypeBody
+    : '{' (annotationTypeElementDeclaration)* '}'
+    ;
+
+annotationTypeElementDeclaration
+    : modifier* annotationTypeElementRest
+    | ';' // this is not allowed by the grammar, but apparently allowed by the actual compiler
+    ;
+
+annotationTypeElementRest
+    : typeType annotationMethodOrConstantRest ';'
+    | classDeclaration ';'?
+    | interfaceDeclaration ';'?
+    | enumDeclaration ';'?
+    | annotationTypeDeclaration ';'?
+    ;
+
+annotationMethodOrConstantRest
+    : annotationMethodRest
+    | annotationConstantRest
+    ;
+
+annotationMethodRest
+    : IDENTIFIER '(' ')' defaultValue?
+    ;
+
+annotationConstantRest
+    : variableDeclarators
+    ;
+
+defaultValue
+    : DEFAULT elementValue
+    ;
+
+// STATEMENTS / BLOCKS
+
+block
+    : '{' blockStatement* '}'
+    ;
+
+blockStatement
+    : localVariableDeclaration ';'
+    | statement
+    | localTypeDeclaration
+    ;
+
+localVariableDeclaration
+    : variableModifier* typeType variableDeclarators
+    ;
+
+localTypeDeclaration
+    : classOrInterfaceModifier*
+      (classDeclaration | interfaceDeclaration)
+    | ';'
+    ;
+
+statement
+    : blockLabel=block
+    | ASSERT expression (':' expression)? ';'
+    | IF parExpression statement (ELSE statement)?
+    | FOR '(' forControl ')' statement
+    | WHILE parExpression statement
+    | DO statement WHILE parExpression ';'
+    | TRY block (catchClause+ finallyBlock? | finallyBlock)
+    | TRY resourceSpecification block catchClause* finallyBlock?
+    | SWITCH parExpression '{' switchBlockStatementGroup* switchLabel* '}'
+    | SYNCHRONIZED parExpression block
+    | RETURN expression? ';'
+    | THROW expression ';'
+    | BREAK IDENTIFIER? ';'
+    | CONTINUE IDENTIFIER? ';'
+    | SEMI
+    | statementExpression=expression ';'
+    | identifierLabel=IDENTIFIER ':' statement
+    ;
+
+catchClause
+    : CATCH '(' variableModifier* catchType IDENTIFIER ')' block
+    ;
+
+catchType
+    : qualifiedName ('|' qualifiedName)*
+    ;
+
+finallyBlock
+    : FINALLY block
+    ;
+
+resourceSpecification
+    : '(' resources ';'? ')'
+    ;
+
+resources
+    : resource (';' resource)*
+    ;
+
+resource
+    : variableModifier* classOrInterfaceType variableDeclaratorId '=' expression
+    ;
+
+/** Matches cases then statements, both of which are mandatory.
+ *  To handle empty cases at the end, we add switchLabel* to statement.
+ */
+switchBlockStatementGroup
+    : switchLabel+ blockStatement+
+    ;
+
+switchLabel
+    : CASE (constantExpression=expression | enumConstantName=IDENTIFIER) ':'
+    | DEFAULT ':'
+    ;
+
+forControl
+    : enhancedForControl
+    | forInit? ';' expression? ';' forUpdate=expressionList?
+    ;
+
+forInit
+    : localVariableDeclaration
+    | expressionList
+    ;
+
+enhancedForControl
+    : variableModifier* typeType variableDeclaratorId ':' expression
+    ;
+
+// EXPRESSIONS
+
+parExpression
+    : '(' expression ')'
+    ;
+
+expressionList
+    : expression (',' expression)*
+    ;
+
+methodCall
+    : IDENTIFIER '(' expressionList? ')'
+    ;
+
+expression
+    : primary
+    | expression bop='.'
+      ( IDENTIFIER
+      | methodCall
+      | THIS
+      | NEW nonWildcardTypeArguments? innerCreator
+      | SUPER superSuffix
+      | explicitGenericInvocation
+      )
+    | expression '[' expression ']'
+    | methodCall
+    | NEW creator
+    | '(' typeType ')' expression
+    | expression postfix=('++' | '--')
+    | prefix=('+'|'-'|'++'|'--') expression
+    | prefix=('~'|'!') expression
+    | expression bop=('*'|'/'|'%') expression
+    | expression bop=('+'|'-') expression
+    | expression ('<' '<' | '>' '>' '>' | '>' '>') expression
+    | expression bop=('<=' | '>=' | '>' | '<') expression
+    | expression bop=INSTANCEOF typeType
+    | expression bop=('==' | '!=') expression
+    | expression bop='&' expression
+    | expression bop='^' expression
+    | expression bop='|' expression
+    | expression bop='&&' expression
+    | expression bop='||' expression
+    | expression bop='?' expression ':' expression
+    | <assoc=right> expression
+      bop=('=' | '+=' | '-=' | '*=' | '/=' | '&=' | '|=' | '^=' | '>>=' | '>>>=' | '<<=' | '%=')
+      expression
+    | lambdaExpression // Java8
+
+    // Java 8 methodReference
+    | expression '::' typeArguments? IDENTIFIER
+    | typeType '::' (typeArguments? IDENTIFIER | NEW)
+    | classType '::' typeArguments? NEW
+    ;
+
+// Java8
+lambdaExpression
+    : lambdaParameters '->' lambdaBody
+    ;
+
+// Java8
+lambdaParameters
+    : IDENTIFIER
+    | '(' formalParameterList? ')'
+    | '(' IDENTIFIER (',' IDENTIFIER)* ')'
+    ;
+
+// Java8
+lambdaBody
+    : expression
+    | block
+    ;
+
+primary
+    : '(' expression ')'
+    | THIS
+    | SUPER
+    | literal
+    | IDENTIFIER
+    | typeTypeOrVoid '.' CLASS
+    | nonWildcardTypeArguments (explicitGenericInvocationSuffix | THIS arguments)
+    ;
+
+classType
+    : (classOrInterfaceType '.')? annotation* IDENTIFIER typeArguments?
+    ;
+
+creator
+    : nonWildcardTypeArguments createdName classCreatorRest
+    | createdName (arrayCreatorRest | classCreatorRest)
+    ;
+
+createdName
+    : IDENTIFIER typeArgumentsOrDiamond? ('.' IDENTIFIER typeArgumentsOrDiamond?)*
+    | primitiveType
+    ;
+
+innerCreator
+    : IDENTIFIER nonWildcardTypeArgumentsOrDiamond? classCreatorRest
+    ;
+
+arrayCreatorRest
+    : '[' (']' ('[' ']')* arrayInitializer | expression ']' ('[' expression ']')* ('[' ']')*)
+    ;
+
+classCreatorRest
+    : arguments classBody?
+    ;
+
+explicitGenericInvocation
+    : nonWildcardTypeArguments explicitGenericInvocationSuffix
+    ;
+
+typeArgumentsOrDiamond
+    : '<' '>'
+    | typeArguments
+    ;
+
+nonWildcardTypeArgumentsOrDiamond
+    : '<' '>'
+    | nonWildcardTypeArguments
+    ;
+
+nonWildcardTypeArguments
+    : '<' typeList '>'
+    ;
+
+typeList
+    : typeType (',' typeType)*
+    ;
+
+typeType
+    : annotation? (classOrInterfaceType | primitiveType) ('[' ']')*
+    ;
+
+primitiveType
+    : BOOLEAN
+    | CHAR
+    | BYTE
+    | SHORT
+    | INT
+    | LONG
+    | FLOAT
+    | DOUBLE
+    ;
+
+typeArguments
+    : '<' typeArgument (',' typeArgument)* '>'
+    ;
+
+superSuffix
+    : arguments
+    | '.' IDENTIFIER arguments?
+    ;
+
+explicitGenericInvocationSuffix
+    : SUPER superSuffix
+    | IDENTIFIER arguments
+    ;
+
+arguments
+    : '(' expressionList? ')'
+    ;

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
@@ -1,16 +1,28 @@
-/**
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-       http://www.apache.org/licenses/LICENSE-2.0
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+/*
+ [The "BSD licence"]
+ Copyright (c) 2013 Terence Parr, Sam Harwell
+ Copyright (c) 2017 Ivan Kochurkin (upgrade to Java 8)
+ All rights reserved.
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 parser grammar JavaParser;

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/CodeSplitUtil.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/CodeSplitUtil.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.codesplit;
 
+import org.apache.flink.annotation.Internal;
+
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
@@ -24,6 +26,7 @@ import org.antlr.v4.runtime.misc.Interval;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Utils for rewriters. */
+@Internal
 public class CodeSplitUtil {
 
     private static final AtomicLong COUNTER = new AtomicLong(0L);

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/CodeSplitUtil.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/CodeSplitUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.misc.Interval;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Utils for rewriters. */
+public class CodeSplitUtil {
+
+    private static final AtomicLong COUNTER = new AtomicLong(0L);
+
+    public static AtomicLong getCounter() {
+        return COUNTER;
+    }
+
+    public static String newName(String name) {
+        return name + "$" + COUNTER.getAndIncrement();
+    }
+
+    public static String getContextString(ParserRuleContext ctx) {
+        if (ctx == null) {
+            return "";
+        }
+
+        CharStream cs = ctx.start.getInputStream();
+        return cs.getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+    }
+
+    public static int getContextTextLength(ParserRuleContext ctx) {
+        return getContextString(ctx).length();
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
@@ -34,7 +34,9 @@ import java.util.Set;
 import java.util.Stack;
 
 /**
- * Extract and rename local variables into member variables. For example,
+ * Extract and rename local variables into member variables.
+ *
+ * <p><i>Before</i>
  *
  * <pre><code>
  * public class Example {
@@ -50,7 +52,7 @@ import java.util.Stack;
  * }
  * </code></pre>
  *
- * will be changed into
+ * <p><i>After</i>
  *
  * <pre><code>
  * public class Example {

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.table.codesplit;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
 import org.antlr.v4.runtime.CharStreams;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.Stack;
 
 /** Extract and rename local variables to member variables. */
+@Internal
 public class DeclarationRewriter {
 
     private final String code;

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.util.Preconditions;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStreamRewriter;
+import org.antlr.v4.runtime.atn.PredictionMode;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
+
+/** Extract and rename local variables to member variables. */
+public class DeclarationRewriter {
+
+    private final String code;
+    private final int maxMethodLength;
+
+    private final CommonTokenStream tokenStream;
+    private final TokenStreamRewriter rewriter;
+
+    private boolean hasRewrite = false;
+
+    public DeclarationRewriter(String code, int maxMethodLength) {
+        this.code = code;
+        this.maxMethodLength = maxMethodLength;
+
+        this.tokenStream = new CommonTokenStream(new JavaLexer(CharStreams.fromString(code)));
+        this.rewriter = new TokenStreamRewriter(tokenStream);
+    }
+
+    public Optional<String> rewrite() {
+        JavaParser javaParser = new JavaParser(tokenStream);
+        javaParser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+        new OuterBlockStatementExtractor().visit(javaParser.compilationUnit());
+        String text = rewriter.getText();
+        return hasRewrite ? Optional.of(text) : Optional.empty();
+    }
+
+    private class OuterBlockStatementExtractor extends JavaParserBaseVisitor<Void> {
+
+        private final Stack<StringBuilder> newFields;
+        private final Set<String> allVarNames;
+
+        OuterBlockStatementExtractor() {
+            this.newFields = new Stack<>();
+            this.allVarNames = new HashSet<>();
+        }
+
+        @Override
+        public Void visitClassBody(JavaParser.ClassBodyContext ctx) {
+            newFields.push(new StringBuilder());
+            Void ret = visitChildren(ctx);
+            rewriter.insertAfter(ctx.start, "\n" + newFields.pop().toString());
+            return ret;
+        }
+
+        @Override
+        public Void visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx) {
+            if ("void".equals(ctx.typeTypeOrVoid().getText())) {
+                visitMethodBody(ctx.methodBody());
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitMethodBody(JavaParser.MethodBodyContext ctx) {
+            // this condition must be the same with the condition in
+            // FunctionSplitter::visitMethodDeclaration
+            if (CodeSplitUtil.getContextTextLength(ctx.block()) <= maxMethodLength) {
+                return null;
+            }
+
+            hasRewrite = true;
+            InnerBlockStatementExtractor extractor = new InnerBlockStatementExtractor();
+            if (ctx.block() != null && ctx.block().blockStatement() != null) {
+                for (JavaParser.BlockStatementContext blockStatementContext :
+                        ctx.block().blockStatement()) {
+                    extractor.visitBlockStatement(blockStatementContext);
+                }
+                newFields.peek().append(extractor.getNewLocalVariables());
+            }
+            return null;
+        }
+
+        private class InnerBlockStatementExtractor extends JavaParserBaseVisitor<Void> {
+
+            private final StringBuilder newLocalVariables;
+            private final Map<String, String> replaceMap;
+
+            InnerBlockStatementExtractor() {
+                this.newLocalVariables = new StringBuilder();
+                this.replaceMap = new HashMap<>();
+            }
+
+            @Override
+            public Void visitLocalVariableDeclaration(
+                    JavaParser.LocalVariableDeclarationContext ctx) {
+                Preconditions.checkArgument(
+                        ctx.variableDeclarators().variableDeclarator().size() == 1,
+                        "%s\nCodegen rewrite failed. You can only declare one local variable in one statement.",
+                        code);
+
+                JavaParser.VariableDeclaratorContext dec =
+                        ctx.variableDeclarators().variableDeclarator(0);
+                JavaParser.VariableDeclaratorIdContext decId = dec.variableDeclaratorId();
+
+                extractLocalVariable(decId, ctx.typeType(), false);
+
+                if (dec.variableInitializer() == null) {
+                    rewriter.delete(ctx.start, ctx.getParent().stop);
+                    return null;
+                } else {
+                    if (ctx.variableModifier() != null) {
+                        for (JavaParser.VariableModifierContext modifier : ctx.variableModifier()) {
+                            rewriter.delete(modifier.start, modifier.stop);
+                        }
+                    }
+                    rewriter.delete(ctx.typeType().start, ctx.typeType().stop);
+                    replaceLocalVar(decId.getText(), decId.IDENTIFIER().getSymbol());
+                    return visitChildren(ctx);
+                }
+            }
+
+            @Override
+            public Void visitEnhancedForControl(JavaParser.EnhancedForControlContext ctx) {
+                JavaParser.VariableDeclaratorIdContext decId = ctx.variableDeclaratorId();
+                String newName = extractLocalVariable(decId, ctx.typeType(), true);
+
+                JavaParser.StatementContext stmt =
+                        (JavaParser.StatementContext) ctx.getParent().getParent();
+                Preconditions.checkState(
+                        stmt.statement(0) != null && stmt.statement(0).block() != null,
+                        "%s\nCodegen rewrite failed. For statements must be placed inside a block.\n",
+                        code);
+                rewriter.insertAfter(
+                        stmt.statement(0).block().start, newName + " = " + decId.getText() + ";");
+
+                return visitChildren(ctx);
+            }
+
+            /** @return new name. */
+            private String extractLocalVariable(
+                    JavaParser.VariableDeclaratorIdContext decId,
+                    JavaParser.TypeTypeContext typeType,
+                    boolean forceNewName) {
+                String name = decId.getText();
+                if (forceNewName || allVarNames.contains(name)) {
+                    // here we assume that the original code can be successfully compiled.
+                    // that is to say, the scope of two variables with the same name will not
+                    // overlap.
+                    String newName = CodeSplitUtil.newName("local");
+                    replaceMap.put(name, newName);
+                    newLocalVariables
+                            .append(typeType.getText())
+                            .append(" ")
+                            .append(newName)
+                            .append(";\n");
+                    return newName;
+                } else {
+                    newLocalVariables
+                            .append(typeType.getText())
+                            .append(" ")
+                            .append(name)
+                            .append(";\n");
+                    allVarNames.add(name);
+                    return name;
+                }
+            }
+
+            @Override
+            public Void visitPrimary(JavaParser.PrimaryContext ctx) {
+                if (ctx.IDENTIFIER() != null) {
+                    replaceLocalVar(ctx.IDENTIFIER().getText(), ctx.IDENTIFIER().getSymbol());
+                    return null;
+                } else {
+                    return visitChildren(ctx);
+                }
+            }
+
+            private void replaceLocalVar(String name, Token token) {
+                String rep = replaceMap.get(name);
+                if (rep != null) {
+                    rewriter.replace(token, rep);
+                }
+            }
+
+            String getNewLocalVariables() {
+                return newLocalVariables.toString();
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
@@ -33,7 +33,43 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 
-/** Extract and rename local variables to member variables. */
+/**
+ * Extract and rename local variables into member variables. For example,
+ *
+ * <pre><code>
+ * public class Example {
+ *     public void myFun1(int[] arr) {
+ *         int a = 1;
+ *         for (int b : arr) {
+ *             System.out.println(b);
+ *         }
+ *     }
+ *     public void myFun2() {
+ *         int a = 2;
+ *     }
+ * }
+ * </code></pre>
+ *
+ * will be changed into
+ *
+ * <pre><code>
+ * public class Example {
+ *     int a;
+ *     int local$0;
+ *     int local$1;
+ *     public void myFun1(int[] arr) {
+ *         a = 1;
+ *         for (int b : arr) {
+ *             local$0 = b;
+ *             System.out.println(local$0);
+ *         }
+ *     }
+ *     public void myFun2() {
+ *         local$1 = 2;
+ *     }
+ * }
+ * </code></pre>
+ */
 @Internal
 public class DeclarationRewriter {
 

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
@@ -29,7 +29,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
- * Split long functions into several smaller functions. For example,
+ * Split long functions into several smaller functions.
+ *
+ * <p><i>Before</i>
  *
  * <pre><code>
  * public class Example {
@@ -44,7 +46,7 @@ import java.util.List;
  * }
  * </code></pre>
  *
- * will be changed into
+ * <p><i>After</i>
  *
  * <pre><code>
  * public class Example {

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.codesplit;
 
+import org.apache.flink.annotation.Internal;
+
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.TokenStreamRewriter;
@@ -27,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 /** Try to split function whose length exceeds the limit. */
+@Internal
 public class FunctionSplitter {
 
     private final String code;

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.TokenStreamRewriter;
+import org.antlr.v4.runtime.atn.PredictionMode;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/** Try to split function whose length exceeds the limit. */
+public class FunctionSplitter {
+
+    private final String code;
+    private final int maxMethodLength;
+
+    public FunctionSplitter(String code, int maxMethodLength) {
+        this.code = code;
+        this.maxMethodLength = maxMethodLength;
+    }
+
+    public String rewrite() {
+        FunctionSplitVisitor visitor = new FunctionSplitVisitor();
+        JavaParser javaParser = new JavaParser(visitor.tokenStream);
+        javaParser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+        visitor.visit(javaParser.compilationUnit());
+        return visitor.rewriter.getText();
+    }
+
+    private class FunctionSplitVisitor extends JavaParserBaseVisitor<Void> {
+
+        private final CommonTokenStream tokenStream;
+
+        private final TokenStreamRewriter rewriter;
+
+        private FunctionSplitVisitor() {
+            this.tokenStream = new CommonTokenStream(new JavaLexer(CharStreams.fromString(code)));
+            this.rewriter = new TokenStreamRewriter(tokenStream);
+        }
+
+        @Override
+        public Void visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx) {
+
+            if (!"void".equals(ctx.typeTypeOrVoid().getText())) {
+                return null;
+            }
+
+            long methodBodyLength = CodeSplitUtil.getContextTextLength(ctx.methodBody().block());
+
+            if (methodBodyLength < maxMethodLength) {
+                return null;
+            }
+
+            if (ctx.methodBody().block().blockStatement() == null
+                    || ctx.methodBody().block().blockStatement().size() <= 1) {
+                return null;
+            }
+
+            List<String> splitFuncBodies = new ArrayList<>();
+            List<JavaParser.BlockStatementContext> blockStatementContexts = new ArrayList<>();
+
+            // function real parameters
+            LinkedHashSet<String> declarations = new LinkedHashSet<>();
+            new JavaParserBaseVisitor<Void>() {
+                @Override
+                public Void visitFormalParameter(JavaParser.FormalParameterContext ctx) {
+                    declarations.add(ctx.variableDeclaratorId().getText());
+                    return null;
+                }
+            }.visit(ctx);
+
+            // function definition
+            String type = CodeSplitUtil.getContextString(ctx.typeTypeOrVoid());
+            String functionName = ctx.IDENTIFIER().getText();
+            String parameters = CodeSplitUtil.getContextString(ctx.formalParameters());
+
+            for (JavaParser.BlockStatementContext blockStatementContext :
+                    ctx.methodBody().block().blockStatement()) {
+                blockStatementContexts.add(blockStatementContext);
+                splitFuncBodies.add(CodeSplitUtil.getContextString(blockStatementContext));
+            }
+
+            List<String> mergedCodeBlocks = getMergedCodeBlocks(splitFuncBodies);
+            List<String> newSplitMethods = new ArrayList<>();
+            List<String> newSplitMethodCalls = new ArrayList<>();
+
+            String methodQualifier = "";
+            if (ctx.THROWS() != null) {
+                methodQualifier =
+                        " throws " + CodeSplitUtil.getContextString(ctx.qualifiedNameList());
+            }
+
+            for (String methodBody : mergedCodeBlocks) {
+                long counter = CodeSplitUtil.getCounter().getAndIncrement();
+
+                // void f_splitXX(int x, String y)
+                String splitMethodDef =
+                        type
+                                + " "
+                                + functionName
+                                + "_split"
+                                + counter
+                                + parameters
+                                + methodQualifier;
+
+                String newSplitMethod = splitMethodDef + " {\n" + methodBody + "\n}\n";
+
+                String newSplitMethodCall =
+                        functionName
+                                + "_split"
+                                + counter
+                                + "("
+                                + String.join(", ", declarations)
+                                + ");\n";
+
+                newSplitMethods.add(newSplitMethod);
+                newSplitMethodCalls.add(newSplitMethodCall);
+            }
+
+            for (int i = 0; i < blockStatementContexts.size(); i++) {
+                if (i < newSplitMethods.size()) {
+                    rewriter.replace(
+                            blockStatementContexts.get(i).start,
+                            blockStatementContexts.get(i).stop,
+                            newSplitMethodCalls.get(i));
+                    rewriter.insertAfter(ctx.getParent().stop, "\n" + newSplitMethods.get(i));
+                } else {
+                    rewriter.delete(
+                            blockStatementContexts.get(i).start,
+                            blockStatementContexts.get(i).stop);
+                }
+            }
+            return null;
+        }
+
+        private List<String> getMergedCodeBlocks(List<String> codeBlock) {
+            List<String> mergedCodeBlocks = new ArrayList<>();
+            StringBuilder sb = new StringBuilder();
+            codeBlock.forEach(
+                    code -> {
+                        if (sb.length() + code.length() + 1 <= maxMethodLength) {
+                            sb.append("\n").append(code);
+                        } else {
+                            if (sb.length() > 0) {
+                                mergedCodeBlocks.add(sb.toString());
+                                sb.delete(0, sb.length());
+                            }
+                            sb.append(code);
+                        }
+                    });
+            if (sb.length() > 0) {
+                mergedCodeBlocks.add(sb.toString());
+            }
+            return mergedCodeBlocks;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/FunctionSplitter.java
@@ -28,7 +28,42 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 
-/** Try to split function whose length exceeds the limit. */
+/**
+ * Split long functions into several smaller functions. For example,
+ *
+ * <pre><code>
+ * public class Example {
+ *     public void myFun(int a, int b) {
+ *         a += b;
+ *         b += a;
+ *         a *= 2;
+ *         b *= 2;
+ *         System.out.println(a);
+ *         System.out.println(b);
+ *     }
+ * }
+ * </code></pre>
+ *
+ * will be changed into
+ *
+ * <pre><code>
+ * public class Example {
+ *     public void myFun(int a, int b) {
+ *         myFun_split0(a, b);
+ *         myFun_split1(a, b);
+ *     }
+ *     void myFun_split0(int a, int b) {
+ *         a += b;
+ *         b += a;
+ *         a *= 2;
+ *     }
+ *     void myFun_split1(int a, int b) {
+ *         b *= 2;
+ *         System.out.println(a + b);
+ *     }
+ * }
+ * </code></pre>
+ */
 @Internal
 public class FunctionSplitter {
 

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
@@ -26,7 +26,48 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 
 import java.util.LinkedHashSet;
 
-/** If rewriter. Rewrite method to two part: 1.if true method. 2.if false method. */
+/**
+ * Extract true and false branch of IFs and ELSEs in long methods into two smaller methods. For
+ * example,
+ *
+ * <pre><code>
+ * public class Example {
+ *     int b;
+ *     public void myFun(int a) {
+ *         if (a > 0) {
+ *             b = a * 2;
+ *             System.out.println(b);
+ *         } else {
+ *             b = a * 3;
+ *             System.out.println(b);
+ *         }
+ *     }
+ * }
+ * </code></pre>
+ *
+ * will be changed into
+ *
+ * <pre><code>
+ * public class Example {
+ *     int b;
+ *     public void myFun(int a) {
+ *         if (a > 0) {
+ *             myFun_trueFilter1(a);
+ *         } else {
+ *             myFun_falseFilter2(a);
+ *         }
+ *     }
+ *     void myFun_trueFilter1(int a) {
+ *         b = a * 2;
+ *         System.out.println(b);
+ *     }
+ *     void myFun_falseFilter2(int a) {
+ *         b = a * 3;
+ *         System.out.println(b);
+ *     }
+ * }
+ * </code></pre>
+ */
 @Internal
 public class IfStatementRewriter {
 

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.codesplit;
 
+import org.apache.flink.annotation.Internal;
+
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.TokenStreamRewriter;
@@ -25,6 +27,7 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 import java.util.LinkedHashSet;
 
 /** If rewriter. Rewrite method to two part: 1.if true method. 2.if false method. */
+@Internal
 public class IfStatementRewriter {
 
     private final long maxMethodLength;
@@ -93,18 +96,18 @@ public class IfStatementRewriter {
                     if (blockStatementContext.statement().statement(0) != null
                             && blockStatementContext.statement().statement(0).block() != null
                             && blockStatementContext
-                                            .statement()
-                                            .statement(0)
-                                            .block()
-                                            .blockStatement()
-                                    != null
+                            .statement()
+                            .statement(0)
+                            .block()
+                            .blockStatement()
+                            != null
                             && blockStatementContext
-                                            .statement()
-                                            .statement(0)
-                                            .block()
-                                            .blockStatement()
-                                            .size()
-                                    > 1) {
+                            .statement()
+                            .statement(0)
+                            .block()
+                            .blockStatement()
+                            .size()
+                            > 1) {
 
                         long counter = CodeSplitUtil.getCounter().incrementAndGet();
 
@@ -120,10 +123,10 @@ public class IfStatementRewriter {
                         String newMethod =
                                 methodDef
                                         + CodeSplitUtil.getContextString(
-                                                blockStatementContext
-                                                        .statement()
-                                                        .statement(0)
-                                                        .block())
+                                        blockStatementContext
+                                                .statement()
+                                                .statement(0)
+                                                .block())
                                         + "\n";
 
                         String newMethodCall =
@@ -144,18 +147,18 @@ public class IfStatementRewriter {
                     if (blockStatementContext.statement().statement(1) != null
                             && blockStatementContext.statement().statement(1).block() != null
                             && blockStatementContext
-                                            .statement()
-                                            .statement(1)
-                                            .block()
-                                            .blockStatement()
-                                    != null
+                            .statement()
+                            .statement(1)
+                            .block()
+                            .blockStatement()
+                            != null
                             && blockStatementContext
-                                            .statement()
-                                            .statement(1)
-                                            .block()
-                                            .blockStatement()
-                                            .size()
-                                    > 1) {
+                            .statement()
+                            .statement(1)
+                            .block()
+                            .blockStatement()
+                            .size()
+                            > 1) {
                         long counter = CodeSplitUtil.getCounter().incrementAndGet();
 
                         String methodDef =
@@ -170,10 +173,10 @@ public class IfStatementRewriter {
                         String newMethod =
                                 methodDef
                                         + CodeSplitUtil.getContextString(
-                                                blockStatementContext
-                                                        .statement()
-                                                        .statement(1)
-                                                        .block())
+                                        blockStatementContext
+                                                .statement()
+                                                .statement(1)
+                                                .block())
                                         + "\n";
 
                         String newMethodCall =

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
@@ -27,8 +27,9 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 import java.util.LinkedHashSet;
 
 /**
- * Extract true and false branch of IFs and ELSEs in long methods into two smaller methods. For
- * example,
+ * Extract true and false branch of IFs and ELSEs in long methods into two smaller methods.
+ *
+ * <p><i>Before</i>
  *
  * <pre><code>
  * public class Example {
@@ -45,7 +46,7 @@ import java.util.LinkedHashSet;
  * }
  * </code></pre>
  *
- * will be changed into
+ * <p><i>After</i>
  *
  * <pre><code>
  * public class Example {

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
@@ -96,18 +96,18 @@ public class IfStatementRewriter {
                     if (blockStatementContext.statement().statement(0) != null
                             && blockStatementContext.statement().statement(0).block() != null
                             && blockStatementContext
-                            .statement()
-                            .statement(0)
-                            .block()
-                            .blockStatement()
-                            != null
+                                            .statement()
+                                            .statement(0)
+                                            .block()
+                                            .blockStatement()
+                                    != null
                             && blockStatementContext
-                            .statement()
-                            .statement(0)
-                            .block()
-                            .blockStatement()
-                            .size()
-                            > 1) {
+                                            .statement()
+                                            .statement(0)
+                                            .block()
+                                            .blockStatement()
+                                            .size()
+                                    > 1) {
 
                         long counter = CodeSplitUtil.getCounter().incrementAndGet();
 
@@ -123,10 +123,10 @@ public class IfStatementRewriter {
                         String newMethod =
                                 methodDef
                                         + CodeSplitUtil.getContextString(
-                                        blockStatementContext
-                                                .statement()
-                                                .statement(0)
-                                                .block())
+                                                blockStatementContext
+                                                        .statement()
+                                                        .statement(0)
+                                                        .block())
                                         + "\n";
 
                         String newMethodCall =
@@ -147,18 +147,18 @@ public class IfStatementRewriter {
                     if (blockStatementContext.statement().statement(1) != null
                             && blockStatementContext.statement().statement(1).block() != null
                             && blockStatementContext
-                            .statement()
-                            .statement(1)
-                            .block()
-                            .blockStatement()
-                            != null
+                                            .statement()
+                                            .statement(1)
+                                            .block()
+                                            .blockStatement()
+                                    != null
                             && blockStatementContext
-                            .statement()
-                            .statement(1)
-                            .block()
-                            .blockStatement()
-                            .size()
-                            > 1) {
+                                            .statement()
+                                            .statement(1)
+                                            .block()
+                                            .blockStatement()
+                                            .size()
+                                    > 1) {
                         long counter = CodeSplitUtil.getCounter().incrementAndGet();
 
                         String methodDef =
@@ -173,10 +173,10 @@ public class IfStatementRewriter {
                         String newMethod =
                                 methodDef
                                         + CodeSplitUtil.getContextString(
-                                        blockStatementContext
-                                                .statement()
-                                                .statement(1)
-                                                .block())
+                                                blockStatementContext
+                                                        .statement()
+                                                        .statement(1)
+                                                        .block())
                                         + "\n";
 
                         String newMethodCall =

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/IfStatementRewriter.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.TokenStreamRewriter;
+import org.antlr.v4.runtime.atn.PredictionMode;
+
+import java.util.LinkedHashSet;
+
+/** If rewriter. Rewrite method to two part: 1.if true method. 2.if false method. */
+public class IfStatementRewriter {
+
+    private final long maxMethodLength;
+    private IfStatementVisitor visitor;
+
+    public IfStatementRewriter(String code, long maxMethodLength) {
+        this.maxMethodLength = maxMethodLength;
+        this.visitor = new IfStatementVisitor(code);
+    }
+
+    public String rewrite() {
+        String rewriterCode = visitor.rewriteAndGetCode();
+        while (visitor.hasRewrite()) {
+            visitor = new IfStatementVisitor(rewriterCode);
+            rewriterCode = visitor.rewriteAndGetCode();
+        }
+        return rewriterCode;
+    }
+
+    private class IfStatementVisitor extends JavaParserBaseVisitor<Void> {
+
+        private final CommonTokenStream tokenStream;
+
+        private final TokenStreamRewriter rewriter;
+
+        private long rewriteCount;
+
+        private IfStatementVisitor(String code) {
+            this.tokenStream = new CommonTokenStream(new JavaLexer(CharStreams.fromString(code)));
+            this.rewriter = new TokenStreamRewriter(tokenStream);
+        }
+
+        @Override
+        public Void visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx) {
+
+            if (!"void".equals(ctx.typeTypeOrVoid().getText())) {
+                return null;
+            }
+
+            // function real parameters
+            LinkedHashSet<String> declarationContext = new LinkedHashSet<>();
+            new JavaParserBaseVisitor<Void>() {
+                @Override
+                public Void visitFormalParameter(JavaParser.FormalParameterContext ctx) {
+                    declarationContext.add(ctx.variableDeclaratorId().getText());
+                    return null;
+                }
+            }.visit(ctx);
+
+            String type = CodeSplitUtil.getContextString(ctx.typeTypeOrVoid());
+            String functionName = ctx.IDENTIFIER().getText();
+            String parameters = CodeSplitUtil.getContextString(ctx.formalParameters());
+
+            String methodQualifier = "";
+            if (ctx.THROWS() != null) {
+                methodQualifier =
+                        " throws " + CodeSplitUtil.getContextString(ctx.qualifiedNameList());
+            }
+
+            for (JavaParser.BlockStatementContext blockStatementContext :
+                    ctx.methodBody().block().blockStatement()) {
+
+                if (blockStatementContext.statement() != null
+                        && blockStatementContext.statement().IF() != null
+                        && blockStatementContext.statement().getText().length() > maxMethodLength) {
+                    if (blockStatementContext.statement().statement(0) != null
+                            && blockStatementContext.statement().statement(0).block() != null
+                            && blockStatementContext
+                                            .statement()
+                                            .statement(0)
+                                            .block()
+                                            .blockStatement()
+                                    != null
+                            && blockStatementContext
+                                            .statement()
+                                            .statement(0)
+                                            .block()
+                                            .blockStatement()
+                                            .size()
+                                    > 1) {
+
+                        long counter = CodeSplitUtil.getCounter().incrementAndGet();
+
+                        String methodDef =
+                                type
+                                        + " "
+                                        + functionName
+                                        + "_trueFilter"
+                                        + counter
+                                        + parameters
+                                        + methodQualifier;
+
+                        String newMethod =
+                                methodDef
+                                        + CodeSplitUtil.getContextString(
+                                                blockStatementContext
+                                                        .statement()
+                                                        .statement(0)
+                                                        .block())
+                                        + "\n";
+
+                        String newMethodCall =
+                                functionName
+                                        + "_trueFilter"
+                                        + counter
+                                        + "("
+                                        + String.join(", ", declarationContext)
+                                        + ");\n";
+                        rewriter.replace(
+                                blockStatementContext.statement().statement(0).block().start,
+                                blockStatementContext.statement().statement(0).block().stop,
+                                "{\n" + newMethodCall + "\n}\n");
+                        rewriter.insertAfter(ctx.getParent().stop, "\n" + newMethod + "\n");
+                        rewriteCount++;
+                    }
+
+                    if (blockStatementContext.statement().statement(1) != null
+                            && blockStatementContext.statement().statement(1).block() != null
+                            && blockStatementContext
+                                            .statement()
+                                            .statement(1)
+                                            .block()
+                                            .blockStatement()
+                                    != null
+                            && blockStatementContext
+                                            .statement()
+                                            .statement(1)
+                                            .block()
+                                            .blockStatement()
+                                            .size()
+                                    > 1) {
+                        long counter = CodeSplitUtil.getCounter().incrementAndGet();
+
+                        String methodDef =
+                                type
+                                        + " "
+                                        + functionName
+                                        + "_falseFilter"
+                                        + counter
+                                        + parameters
+                                        + methodQualifier;
+
+                        String newMethod =
+                                methodDef
+                                        + CodeSplitUtil.getContextString(
+                                                blockStatementContext
+                                                        .statement()
+                                                        .statement(1)
+                                                        .block())
+                                        + "\n";
+
+                        String newMethodCall =
+                                functionName
+                                        + "_falseFilter"
+                                        + counter
+                                        + "("
+                                        + String.join(", ", declarationContext)
+                                        + ");\n";
+                        rewriter.replace(
+                                blockStatementContext.statement().statement(1).block().start,
+                                blockStatementContext.statement().statement(1).block().stop,
+                                "{\n" + newMethodCall + "\n}\n");
+                        rewriter.insertAfter(ctx.getParent().stop, "\n" + newMethod + "\n");
+                        rewriteCount++;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private String rewriteAndGetCode() {
+            JavaParser javaParser = new JavaParser(tokenStream);
+            javaParser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+            visit(javaParser.compilationUnit());
+            return rewriter.getText();
+        }
+
+        private boolean hasRewrite() {
+            return rewriteCount > 0L;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.codesplit;
 
+import org.apache.flink.annotation.Internal;
+
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -25,6 +27,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * Rewrite generated java code so that the length of each method becomes smaller and can be
  * compiled.
  */
+@Internal
 public class JavaCodeSplitter {
 
     public static String split(String code, int maxMethodLength, int maxClassMemberCount) {

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/JavaCodeSplitter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Rewrite generated java code so that the length of each method becomes smaller and can be
+ * compiled.
+ */
+public class JavaCodeSplitter {
+
+    public static String split(String code, int maxMethodLength, int maxClassMemberCount) {
+        try {
+            return splitImpl(code, maxMethodLength, maxClassMemberCount);
+        } catch (Throwable t) {
+            System.out.println(code);
+            throw new RuntimeException(
+                    "JavaCodeSplitter failed. This is a bug. Please file an issue.", t);
+        }
+    }
+
+    private static String splitImpl(String code, int maxMethodLength, int maxClassMemberCount) {
+        checkArgument(code != null && !code.isEmpty(), "code cannot be empty");
+        checkArgument(maxMethodLength > 0);
+        checkArgument(maxClassMemberCount > 0);
+
+        Optional<String> declarationCode = new DeclarationRewriter(code, maxMethodLength).rewrite();
+        if (declarationCode.isPresent()) {
+            String ifSplitCode =
+                    new IfStatementRewriter(declarationCode.get(), maxMethodLength).rewrite();
+            String functionSplitCode = new FunctionSplitter(ifSplitCode, maxMethodLength).rewrite();
+            return new MemberFieldRewriter(functionSplitCode, maxClassMemberCount).rewrite();
+        } else {
+            return code;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
@@ -166,7 +166,7 @@ public class MemberFieldRewriter {
                         type.indexOf('<') == -1
                                 ? type
                                 : type.substring(0, type.indexOf('<'))
-                                + type.substring(type.lastIndexOf('>') + 1);
+                                        + type.substring(type.lastIndexOf('>') + 1);
                 int count = typeCount.getValue();
                 String fieldName = CodeSplitUtil.newName("rewrite");
                 typeFieldNames.put(type, fieldName);

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.table.codesplit;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
 import org.antlr.v4.runtime.CharStreams;
@@ -34,6 +35,7 @@ import java.util.Set;
 import java.util.Stack;
 
 /** Put member variables into arrays so that the number of member variables can be reduced. */
+@Internal
 public class MemberFieldRewriter {
 
     private String code;
@@ -164,7 +166,7 @@ public class MemberFieldRewriter {
                         type.indexOf('<') == -1
                                 ? type
                                 : type.substring(0, type.indexOf('<'))
-                                        + type.substring(type.lastIndexOf('>') + 1);
+                                + type.substring(type.lastIndexOf('>') + 1);
                 int count = typeCount.getValue();
                 String fieldName = CodeSplitUtil.newName("rewrite");
                 typeFieldNames.put(type, fieldName);

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
@@ -35,8 +35,9 @@ import java.util.Set;
 import java.util.Stack;
 
 /**
- * Group member variables with the same type into arrays to reduce the number of members. For
- * example,
+ * Group member variables with the same type into arrays to reduce the number of members.
+ *
+ * <p><i>Before</i>
  *
  * <pre><code>
  * public class Example {
@@ -50,7 +51,7 @@ import java.util.Stack;
  * }
  * </code></pre>
  *
- * will be changed into
+ * <p><i>After</i>
  *
  * <pre><code>
  * public class Example {

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.util.Preconditions;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.TokenStreamRewriter;
+import org.antlr.v4.runtime.atn.PredictionMode;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+/** Put member variables into arrays so that the number of member variables can be reduced. */
+public class MemberFieldRewriter {
+
+    private String code;
+    private int maxFieldCount;
+    private TokenStreamRewriter rewriter;
+
+    public MemberFieldRewriter(String code, int maxFieldCount) {
+        this.code = code;
+        this.maxFieldCount = maxFieldCount;
+    }
+
+    public String rewrite() {
+        MemberFieldVisitor fieldVisitor = new MemberFieldVisitor();
+        fieldVisitor.visit(prepareRewrite().compilationUnit());
+        if (fieldVisitor.fieldCount >= maxFieldCount) {
+            code = rewriter.getText();
+            new MemberFieldReplaceVisitor(fieldVisitor.replaceMap)
+                    .visit(prepareRewrite().compilationUnit());
+            return rewriter.getText();
+        } else {
+            return code;
+        }
+    }
+
+    private JavaParser prepareRewrite() {
+        CommonTokenStream tokenStream =
+                new CommonTokenStream(new JavaLexer(CharStreams.fromString(code)));
+        this.rewriter = new TokenStreamRewriter(tokenStream);
+        JavaParser javaParser = new JavaParser(tokenStream);
+        javaParser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+        return javaParser;
+    }
+
+    private class MemberField {
+        String oldName;
+        String type;
+        int id;
+        String init;
+
+        MemberField(String oldName, String type, int id, String init) {
+            this.oldName = oldName;
+            this.type = type;
+            this.id = id;
+            this.init = init;
+        }
+    }
+
+    private class StackElement {
+        List<MemberField> fields;
+        Map<String, Integer> typeCounts;
+
+        StackElement() {
+            fields = new ArrayList<>();
+            typeCounts = new HashMap<>();
+        }
+    }
+
+    private class MemberFieldVisitor extends JavaParserBaseVisitor<Void> {
+
+        private final Stack<StackElement> classStack;
+        private final Map<String, String> replaceMap;
+        private final Set<String> varNames;
+        private int fieldCount = 0;
+
+        MemberFieldVisitor() {
+            classStack = new Stack<>();
+            replaceMap = new HashMap<>();
+            varNames = new HashSet<>();
+        }
+
+        @Override
+        public Void visitClassDeclaration(JavaParser.ClassDeclarationContext ctx) {
+            classStack.push(new StackElement());
+            Void ret = visitChildren(ctx);
+            rewriteClassDeclaration(ctx);
+            classStack.pop();
+            return ret;
+        }
+
+        @Override
+        public Void visitMemberDeclaration(JavaParser.MemberDeclarationContext ctx) {
+            if (ctx.fieldDeclaration() == null) {
+                return null;
+            }
+
+            checkMemberDeclaration(ctx);
+
+            for (JavaParser.ModifierContext modifier :
+                    ((JavaParser.ClassBodyDeclarationContext) ctx.getParent()).modifier()) {
+                if ("static".equals(modifier.getText())) {
+                    // we will not modify static fields
+                    return null;
+                }
+            }
+
+            String fieldName =
+                    ctx.fieldDeclaration()
+                            .variableDeclarators()
+                            .variableDeclarator(0)
+                            .variableDeclaratorId()
+                            .getText();
+            String type = ctx.fieldDeclaration().typeType().getText();
+            String init =
+                    CodeSplitUtil.getContextString(
+                            ctx.fieldDeclaration()
+                                    .variableDeclarators()
+                                    .variableDeclarator(0)
+                                    .variableInitializer());
+
+            StackElement classInfo = classStack.peek();
+            Integer typeCount = classInfo.typeCounts.get(type);
+            int id = typeCount == null ? 0 : typeCount;
+            classInfo.typeCounts.put(type, id + 1);
+            classInfo.fields.add(new MemberField(fieldName, type, id, init));
+
+            rewriter.delete(ctx.getParent().start, ctx.getParent().stop);
+            fieldCount++;
+            return null;
+        }
+
+        private void rewriteClassDeclaration(JavaParser.ClassDeclarationContext ctx) {
+            Map<String, String> typeFieldNames = new HashMap<>();
+            StringBuilder newDeclaration = new StringBuilder("\n");
+
+            for (Map.Entry<String, Integer> typeCount : classStack.peek().typeCounts.entrySet()) {
+                String type = typeCount.getKey();
+                String typeWithoutArgs =
+                        type.indexOf('<') == -1
+                                ? type
+                                : type.substring(0, type.indexOf('<'))
+                                        + type.substring(type.lastIndexOf('>') + 1);
+                int count = typeCount.getValue();
+                String fieldName = CodeSplitUtil.newName("rewrite");
+                typeFieldNames.put(type, fieldName);
+
+                StringBuilder newField = new StringBuilder();
+                newField.append(type).append("[] ").append(fieldName).append(" = new ");
+                int pos = typeWithoutArgs.indexOf("[");
+                if (pos == -1) {
+                    newField.append(typeWithoutArgs).append("[").append(count).append("]");
+                } else {
+                    newField.append(typeWithoutArgs, 0, pos)
+                            .append("[")
+                            .append(count)
+                            .append("]")
+                            .append(typeWithoutArgs, pos, typeWithoutArgs.length());
+                }
+                newField.append(";\n");
+
+                newDeclaration.append(newField);
+            }
+
+            boolean hasInit = false;
+            for (MemberField field : classStack.peek().fields) {
+                String newName = typeFieldNames.get(field.type) + "[" + field.id + "]";
+                replaceMap.put(field.oldName, newName);
+                if (field.init.length() == 0) {
+                    continue;
+                }
+
+                if (!hasInit) {
+                    newDeclaration.append("\n{\n");
+                    hasInit = true;
+                }
+                newDeclaration.append(newName).append(" = ").append(field.init).append(";\n");
+            }
+            if (hasInit) {
+                newDeclaration.append("}\n");
+            }
+
+            rewriter.insertAfter(ctx.classBody().start, newDeclaration.toString());
+        }
+
+        private void checkMemberDeclaration(JavaParser.MemberDeclarationContext ctx) {
+            if (ctx.fieldDeclaration() == null) {
+                return;
+            }
+
+            Preconditions.checkArgument(
+                    ctx.fieldDeclaration().variableDeclarators().variableDeclarator().size() == 1,
+                    "%s\nCodegen rewrite failed. You can only declare one field in one statement.",
+                    code);
+            for (JavaParser.VariableDeclaratorContext v :
+                    ctx.fieldDeclaration().variableDeclarators().variableDeclarator()) {
+                String identifier = v.variableDeclaratorId().getText();
+                Preconditions.checkArgument(
+                        !varNames.contains(identifier),
+                        "%s\nCodegen rewrite failed. Field names should not be the same. Name: %s",
+                        code,
+                        identifier);
+                varNames.add(identifier);
+            }
+        }
+    }
+
+    private class MemberFieldReplaceVisitor extends JavaParserBaseVisitor<Void> {
+
+        private final Map<String, String> replaceMap;
+        // this set is to prevent us from mistakenly replacing method parameters
+        private final Set<String> excludedNames;
+
+        MemberFieldReplaceVisitor(Map<String, String> replaceMap) {
+            this.replaceMap = replaceMap;
+            excludedNames = new HashSet<>();
+        }
+
+        @Override
+        public Void visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx) {
+            if (ctx.formalParameters().formalParameterList() != null) {
+                for (JavaParser.FormalParameterContext formalParameter :
+                        ctx.formalParameters().formalParameterList().formalParameter()) {
+                    excludedNames.add(formalParameter.variableDeclaratorId().getText());
+                }
+            }
+            visitChildren(ctx);
+            excludedNames.clear();
+            return null;
+        }
+
+        @Override
+        public Void visitConstructorDeclaration(JavaParser.ConstructorDeclarationContext ctx) {
+            if (ctx.formalParameters().formalParameterList() != null) {
+                for (JavaParser.FormalParameterContext formalParameter :
+                        ctx.formalParameters().formalParameterList().formalParameter()) {
+                    excludedNames.add(formalParameter.variableDeclaratorId().getText());
+                }
+            }
+            visitChildren(ctx);
+            excludedNames.clear();
+            return null;
+        }
+
+        @Override
+        public Void visitLocalVariableDeclaration(JavaParser.LocalVariableDeclarationContext ctx) {
+            for (JavaParser.VariableDeclaratorContext dec :
+                    ctx.variableDeclarators().variableDeclarator()) {
+                excludedNames.add(dec.variableDeclaratorId().getText());
+            }
+            return visitChildren(ctx);
+        }
+
+        @Override
+        public Void visitPrimary(JavaParser.PrimaryContext ctx) {
+            if (ctx.THIS() != null) {
+                ParserRuleContext parent = getThisParentContext(ctx);
+                if (parent instanceof JavaParser.ExpressionContext) {
+                    JavaParser.ExpressionContext expressionContext =
+                            (JavaParser.ExpressionContext) parent;
+                    if (expressionContext.bop != null && expressionContext.IDENTIFIER() != null) {
+                        String rep = replaceMap.get(expressionContext.IDENTIFIER().getText());
+                        if (rep != null) {
+                            rewriter.replace(expressionContext.IDENTIFIER().getSymbol(), rep);
+                        }
+                    }
+                }
+            } else if (ctx.IDENTIFIER() != null) {
+                String identifier = ctx.IDENTIFIER().getText();
+                if (excludedNames.contains(identifier)) {
+                    return null;
+                }
+                String rep = replaceMap.get(identifier);
+                if (rep != null) {
+                    rewriter.replace(ctx.IDENTIFIER().getSymbol(), rep);
+                }
+            } else {
+                visitChildren(ctx);
+            }
+            return null;
+        }
+
+        private ParserRuleContext getThisParentContext(JavaParser.PrimaryContext ctx) {
+            return ctx.getParent().getParent();
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/MemberFieldRewriter.java
@@ -34,12 +34,44 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-/** Put member variables into arrays so that the number of member variables can be reduced. */
+/**
+ * Group member variables with the same type into arrays to reduce the number of members. For
+ * example,
+ *
+ * <pre><code>
+ * public class Example {
+ *     int a;
+ *     long b;
+ *     int c = 1;
+ *     long d = 2;
+ *     public void myFun() {
+ *         System.out.println(a + b + c + d);
+ *     }
+ * }
+ * </code></pre>
+ *
+ * will be changed into
+ *
+ * <pre><code>
+ * public class Example {
+ *     int[] rewrite$0 = new int[2];
+ *     long[] rewrite$1 = new long[2];
+ *     {
+ *         rewrite$0[1] = 1;
+ *         rewrite$1[1] = 2;
+ *     }
+ *     public void myFun() {
+ *         System.out.println(rewrite$0[0] + rewrite$1[0] + rewrite$0[1] + rewrite$1[1]);
+ *     }
+ * }
+ * </code></pre>
+ */
 @Internal
 public class MemberFieldRewriter {
 
+    private final int maxFieldCount;
+
     private String code;
-    private int maxFieldCount;
     private TokenStreamRewriter rewriter;
 
     public MemberFieldRewriter(String code, int maxFieldCount) {
@@ -69,7 +101,7 @@ public class MemberFieldRewriter {
         return javaParser;
     }
 
-    private class MemberField {
+    private static class MemberField {
         String oldName;
         String type;
         int id;
@@ -83,7 +115,7 @@ public class MemberFieldRewriter {
         }
     }
 
-    private class StackElement {
+    private static class StackElement {
         List<MemberField> fields;
         Map<String, Integer> typeCounts;
 

--- a/flink-table/flink-table-code-splitter/src/main/resources/META-INF/licenses/LICENSE.antlr
+++ b/flink-table/flink-table-code-splitter/src/main/resources/META-INF/licenses/LICENSE.antlr
@@ -1,0 +1,26 @@
+[The "BSD 3-clause license"]
+Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-table/flink-table-code-splitter/src/main/resources/META-INF/licenses/LICENSE.antlr-java-grammar-files
+++ b/flink-table/flink-table-code-splitter/src/main/resources/META-INF/licenses/LICENSE.antlr-java-grammar-files
@@ -1,0 +1,26 @@
+[The "BSD licence"]
+Copyright (c) 2013 Terence Parr, Sam Harwell
+Copyright (c) 2017 Ivan Kochurkin (upgrade to Java 8)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ 3. The name of the author may not be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/DeclarationRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/DeclarationRewriterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.util.FileUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/** Tests for {@link DeclarationRewriter}. */
+public class DeclarationRewriterTest {
+
+    @Test
+    public void testRewriteLocalVariable() {
+        runTest("TestRewriteLocalVariable");
+    }
+
+    @Test
+    public void testNotRewriteLocalVariableInFunctionWithReturnValue() {
+        runTest("TestNotRewriteLocalVariableInFunctionWithReturnValue");
+    }
+
+    @Test
+    public void testRewriteLocalVariableInForLoop() {
+        runTest("TestRewriteLocalVariableInForLoop1");
+        runTest("TestRewriteLocalVariableInForLoop2");
+    }
+
+    @Test
+    public void testLocalVariableWithSameName() {
+        runTest("TestLocalVariableWithSameName");
+    }
+
+    @Test
+    public void testRewriteInnerClass() {
+        runTest("TestRewriteInnerClass");
+    }
+
+    private void runTest(String filename) {
+        try {
+            String code =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    DeclarationRewriter.class
+                                            .getClassLoader()
+                                            .getResource("declaration/code/" + filename + ".java")
+                                            .toURI()));
+            String expected =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    DeclarationRewriter.class
+                                            .getClassLoader()
+                                            .getResource(
+                                                    "declaration/expected/" + filename + ".java")
+                                            .toURI()));
+            DeclarationRewriter rewriter = new DeclarationRewriter(code, 20);
+            Assert.assertEquals(expected, rewriter.rewrite().orElse(""));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            // we reset the counter to ensure the variable names after rewrite are as expected
+            CodeSplitUtil.getCounter().set(0L);
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/FunctionSplitterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/FunctionSplitterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.util.FileUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/** Tests for {@link FunctionSplitter}. */
+public class FunctionSplitterTest {
+
+    @Test
+    public void testSplitFunction() {
+        runTest("TestSplitFunction");
+    }
+
+    @Test
+    public void testNotSplitFunctionWithReturnValue() {
+        runTest("TestNotSplitFunctionWithReturnValue");
+    }
+
+    @Test
+    public void testNotSplitFunctionWithOnlyOneStatement() {
+        runTest("TestNotSplitFunctionWithOnlyOneStatement");
+    }
+
+    @Test
+    public void testRewriteInnerClass() {
+        runTest("TestRewriteInnerClass");
+    }
+
+    private void runTest(String filename) {
+        try {
+            String code =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    FunctionSplitterTest.class
+                                            .getClassLoader()
+                                            .getResource("function/code/" + filename + ".java")
+                                            .toURI()));
+            String expected =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    FunctionSplitterTest.class
+                                            .getClassLoader()
+                                            .getResource("function/expected/" + filename + ".java")
+                                            .toURI()));
+            FunctionSplitter splitter = new FunctionSplitter(code, 30);
+            Assert.assertEquals(expected, splitter.rewrite());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            // we reset the counter to ensure the variable names after rewrite are as expected
+            CodeSplitUtil.getCounter().set(0L);
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/IfStatementRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/IfStatementRewriterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.util.FileUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/** Tests for {@link IfStatementRewriter}. */
+public class IfStatementRewriterTest {
+
+    @Test
+    public void testIfStatementRewrite() {
+        runTest("TestIfStatementRewrite");
+    }
+
+    @Test
+    public void testNotRewriteIfStatementInFunctionWithReturnValue() {
+        runTest("TestNotRewriteIfStatementInFunctionWithReturnValue");
+    }
+
+    @Test
+    public void testRewriteInnerClass() {
+        runTest("TestRewriteInnerClass");
+    }
+
+    private void runTest(String filename) {
+        try {
+            String code =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    IfStatementRewriterTest.class
+                                            .getClassLoader()
+                                            .getResource("if/code/" + filename + ".java")
+                                            .toURI()));
+            String expected =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    IfStatementRewriterTest.class
+                                            .getClassLoader()
+                                            .getResource("if/expected/" + filename + ".java")
+                                            .toURI()));
+            IfStatementRewriter rewriter = new IfStatementRewriter(code, 20);
+            Assert.assertEquals(expected, rewriter.rewrite());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            // we reset the counter to ensure the variable names after rewrite are as expected
+            CodeSplitUtil.getCounter().set(0L);
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaCodeSplitterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.core.testutils.FlinkMatchers;
+import org.apache.flink.util.FileUtils;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/** Tests for {@link JavaCodeSplitter}. */
+public class JavaCodeSplitterTest {
+
+    @Test
+    public void testSplitJavaCode() {
+        runTest("TestSplitJavaCode", 100, 3);
+    }
+
+    @Test
+    public void testNotSplitJavaCode() {
+        runTest("TestNotSplitJavaCode", 4000, 10000);
+    }
+
+    @Test
+    public void testInvalidJavaCode() {
+        try {
+            JavaCodeSplitter.split("public class InvalidClass { return 1; }", 4000, 10000);
+        } catch (Exception e) {
+            MatcherAssert.assertThat(
+                    e,
+                    FlinkMatchers.containsMessage(
+                            "JavaCodeSplitter failed. This is a bug. Please file an issue."));
+        }
+    }
+
+    private void runTest(String filename, int maxLength, int maxMembers) {
+        try {
+            String code =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    JavaCodeSplitterTest.class
+                                            .getClassLoader()
+                                            .getResource("splitter/code/" + filename + ".java")
+                                            .toURI()));
+            String expected =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    JavaCodeSplitterTest.class
+                                            .getClassLoader()
+                                            .getResource("splitter/expected/" + filename + ".java")
+                                            .toURI()));
+            Assert.assertEquals(expected, JavaCodeSplitter.split(code, maxLength, maxMembers));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            // we reset the counter to ensure the variable names after rewrite are as expected
+            CodeSplitUtil.getCounter().set(0L);
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/MemberFieldRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/MemberFieldRewriterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.apache.flink.util.FileUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+/** Tests for {@link MemberFieldRewriter}. */
+public class MemberFieldRewriterTest {
+
+    @Test
+    public void testRewriteMemberField() {
+        runTest("TestRewriteMemberField");
+    }
+
+    @Test
+    public void testRewriteGenericType() {
+        runTest("TestRewriteGenericType");
+    }
+
+    @Test
+    public void testNotRewriteFunctionParameter() {
+        runTest("TestNotRewriteFunctionParameter");
+    }
+
+    @Test
+    public void testNotRewriteLocalVariable() {
+        runTest("TestNotRewriteLocalVariable");
+    }
+
+    @Test
+    public void testNotRewriteStaticMember() {
+        runTest("TestNotRewriteStaticMember");
+    }
+
+    @Test
+    public void testRewriteInnerClass() {
+        runTest("TestRewriteInnerClass");
+    }
+
+    private void runTest(String filename) {
+        try {
+            String code =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    MemberFieldRewriterTest.class
+                                            .getClassLoader()
+                                            .getResource("member/code/" + filename + ".java")
+                                            .toURI()));
+            String expected =
+                    FileUtils.readFileUtf8(
+                            new File(
+                                    MemberFieldRewriterTest.class
+                                            .getClassLoader()
+                                            .getResource("member/expected/" + filename + ".java")
+                                            .toURI()));
+            MemberFieldRewriter rewriter = new MemberFieldRewriter(code, 3);
+            Assert.assertEquals(expected, rewriter.rewrite());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            // we reset the counter to ensure the variable names after rewrite are as expected
+            CodeSplitUtil.getCounter().set(0L);
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestLocalVariableWithSameName.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestLocalVariableWithSameName.java
@@ -1,0 +1,15 @@
+public class TestLocalVariableWithSameName {
+    public void myFun1() {
+        int local1;
+        String local2 = "AAAAA";
+        final long local3;
+        local3 = 100;
+    }
+
+    public void myFun2() {
+        int local1;
+        local1 = 5;
+        long local2;
+        final String local3 = "BBBBB";
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestNotRewriteLocalVariableInFunctionWithReturnValue.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestNotRewriteLocalVariableInFunctionWithReturnValue.java
@@ -1,0 +1,8 @@
+public class TestNotRewriteLocalVariableInFunctionWithReturnValue {
+    public int myFun() {
+        int local1;
+        String local2 = "local2";
+        final long local3;
+        local3 = 100L;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteInnerClass.java
@@ -1,0 +1,17 @@
+public class TestRewriteInnerClass {
+    public void myFun() {
+        int local1;
+        String local2 = "AAAAA";
+        final long local3;
+        local3 = 100;
+    }
+
+    public class InnerClass {
+        public void myFun() {
+            int local1;
+            local1 = 5;
+            long local2;
+            final String local3 = "BBBBB";
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteLocalVariable.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteLocalVariable.java
@@ -1,0 +1,8 @@
+public class TestRewriteLocalVariable {
+    public void myFun() {
+        int local1;
+        String local2 = "local2";
+        final long local3;
+        local3 = 100L;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteLocalVariableInForLoop1.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteLocalVariableInForLoop1.java
@@ -1,0 +1,9 @@
+public class TestRewriteLocalVariableInForLoop1 {
+    public void myFun() {
+        int sum = 0;
+        for (int i = 0; i < 100; i++) {
+            sum += i;
+        }
+        System.out.println(sum);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteLocalVariableInForLoop2.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/code/TestRewriteLocalVariableInForLoop2.java
@@ -1,0 +1,9 @@
+public class TestRewriteLocalVariableInForLoop2 {
+    public void myFun(int[] arr) {
+        int sum = 0;
+        for (int item : arr) {
+            sum += item;
+        }
+        System.out.println(sum);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestLocalVariableWithSameName.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestLocalVariableWithSameName.java
@@ -1,0 +1,22 @@
+public class TestLocalVariableWithSameName {
+int local1;
+String local2;
+long local3;
+int local$0;
+long local$1;
+String local$2;
+
+    public void myFun1() {
+        
+         local2 = "AAAAA";
+        
+        local3 = 100;
+    }
+
+    public void myFun2() {
+        
+        local$0 = 5;
+        
+          local$2 = "BBBBB";
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteInnerClass.java
@@ -1,0 +1,25 @@
+public class TestRewriteInnerClass {
+int local1;
+String local2;
+long local3;
+
+    public void myFun() {
+        
+         local2 = "AAAAA";
+        
+        local3 = 100;
+    }
+
+    public class InnerClass {
+int local$0;
+long local$1;
+String local$2;
+
+        public void myFun() {
+            
+            local$0 = 5;
+            
+              local$2 = "BBBBB";
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteLocalVariable.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteLocalVariable.java
@@ -1,0 +1,12 @@
+public class TestRewriteLocalVariable {
+int local1;
+String local2;
+long local3;
+
+    public void myFun() {
+        
+         local2 = "local2";
+        
+        local3 = 100L;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteLocalVariableInForLoop1.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteLocalVariableInForLoop1.java
@@ -1,0 +1,12 @@
+public class TestRewriteLocalVariableInForLoop1 {
+int sum;
+int i;
+
+    public void myFun() {
+         sum = 0;
+        for ( i = 0; i < 100; i++) {
+            sum += i;
+        }
+        System.out.println(sum);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteLocalVariableInForLoop2.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/declaration/expected/TestRewriteLocalVariableInForLoop2.java
@@ -1,0 +1,12 @@
+public class TestRewriteLocalVariableInForLoop2 {
+int sum;
+int local$0;
+
+    public void myFun(int[] arr) {
+         sum = 0;
+        for (int item : arr) {local$0 = item;
+            sum += local$0;
+        }
+        System.out.println(sum);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestNotSplitFunctionWithOnlyOneStatement.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestNotSplitFunctionWithOnlyOneStatement.java
@@ -1,0 +1,5 @@
+public class TestNotSplitFunctionWithOnlyOneStatement {
+    public void myFun(int argumentWithALongName) throws RuntimeException {
+        System.out.println(argumentWithALongName);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestNotSplitFunctionWithReturnValue.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestNotSplitFunctionWithReturnValue.java
@@ -1,0 +1,17 @@
+public class TestNotSplitFunctionWithReturnValue {
+    public int myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] != 0) {
+            a[0] += b[0];
+            b[0] += a[1];
+        }
+        a[1] += b[1];
+        b[1] += a[2];
+        if (a[2] != 0) {
+            a[2] += b[2];
+            b[2] += a[3];
+        }
+        a[3] += b[3];
+        b[3] += a[4];
+        return a[0] + a[1] + a[2] + a[3];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestRewriteInnerClass.java
@@ -1,0 +1,33 @@
+public class TestRewriteInnerClass {
+    public void myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] != 0) {
+            a[0] += b[0];
+            b[0] += a[1];
+        }
+        a[1] += b[1];
+        b[1] += a[2];
+        if (a[2] != 0) {
+            a[2] += b[2];
+            b[2] += a[3];
+        }
+        a[3] += b[3];
+        b[3] += a[4];
+    }
+
+    public class InnerClass {
+        public void myFun(int[] a, int[] b) throws RuntimeException {
+            if (a[0] != 0) {
+                a[0] += b[0];
+                b[0] += a[1];
+            }
+            a[1] += b[1];
+            b[1] += a[2];
+            if (a[2] != 0) {
+                a[2] += b[2];
+                b[2] += a[3];
+            }
+            a[3] += b[3];
+            b[3] += a[4];
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestSplitFunction.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/code/TestSplitFunction.java
@@ -1,0 +1,16 @@
+public class TestSplitFunction {
+    public void myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] != 0) {
+            a[0] += b[0];
+            b[0] += a[1];
+        }
+        a[1] += b[1];
+        b[1] += a[2];
+        if (a[2] != 0) {
+            a[2] += b[2];
+            b[2] += a[3];
+        }
+        a[3] += b[3];
+        b[3] += a[4];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestNotSplitFunctionWithOnlyOneStatement.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestNotSplitFunctionWithOnlyOneStatement.java
@@ -1,0 +1,5 @@
+public class TestNotSplitFunctionWithOnlyOneStatement {
+    public void myFun(int argumentWithALongName) throws RuntimeException {
+        System.out.println(argumentWithALongName);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestNotSplitFunctionWithReturnValue.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestNotSplitFunctionWithReturnValue.java
@@ -1,0 +1,17 @@
+public class TestNotSplitFunctionWithReturnValue {
+    public int myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] != 0) {
+            a[0] += b[0];
+            b[0] += a[1];
+        }
+        a[1] += b[1];
+        b[1] += a[2];
+        if (a[2] != 0) {
+            a[2] += b[2];
+            b[2] += a[3];
+        }
+        a[3] += b[3];
+        b[3] += a[4];
+        return a[0] + a[1] + a[2] + a[3];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestRewriteInnerClass.java
@@ -1,0 +1,77 @@
+public class TestRewriteInnerClass {
+    public void myFun(int[] a, int[] b) throws RuntimeException {
+        myFun_split0(a, b);
+
+        myFun_split1(a, b);
+
+        myFun_split2(a, b);
+
+        myFun_split3(a, b);
+
+        
+        
+    }
+void myFun_split0(int[] a, int[] b) throws RuntimeException {
+if (a[0] != 0) {
+            a[0] += b[0];
+            b[0] += a[1];
+        }
+}
+
+void myFun_split1(int[] a, int[] b) throws RuntimeException {
+a[1] += b[1];
+b[1] += a[2];
+}
+
+void myFun_split2(int[] a, int[] b) throws RuntimeException {
+if (a[2] != 0) {
+            a[2] += b[2];
+            b[2] += a[3];
+        }
+}
+
+void myFun_split3(int[] a, int[] b) throws RuntimeException {
+a[3] += b[3];
+b[3] += a[4];
+}
+
+
+    public class InnerClass {
+        public void myFun(int[] a, int[] b) throws RuntimeException {
+            myFun_split4(a, b);
+
+            myFun_split5(a, b);
+
+            myFun_split6(a, b);
+
+            myFun_split7(a, b);
+
+            
+            
+        }
+void myFun_split4(int[] a, int[] b) throws RuntimeException {
+if (a[0] != 0) {
+                a[0] += b[0];
+                b[0] += a[1];
+            }
+}
+
+void myFun_split5(int[] a, int[] b) throws RuntimeException {
+a[1] += b[1];
+b[1] += a[2];
+}
+
+void myFun_split6(int[] a, int[] b) throws RuntimeException {
+if (a[2] != 0) {
+                a[2] += b[2];
+                b[2] += a[3];
+            }
+}
+
+void myFun_split7(int[] a, int[] b) throws RuntimeException {
+a[3] += b[3];
+b[3] += a[4];
+}
+
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestSplitFunction.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/function/expected/TestSplitFunction.java
@@ -1,0 +1,38 @@
+public class TestSplitFunction {
+    public void myFun(int[] a, int[] b) throws RuntimeException {
+        myFun_split0(a, b);
+
+        myFun_split1(a, b);
+
+        myFun_split2(a, b);
+
+        myFun_split3(a, b);
+
+        
+        
+    }
+void myFun_split0(int[] a, int[] b) throws RuntimeException {
+if (a[0] != 0) {
+            a[0] += b[0];
+            b[0] += a[1];
+        }
+}
+
+void myFun_split1(int[] a, int[] b) throws RuntimeException {
+a[1] += b[1];
+b[1] += a[2];
+}
+
+void myFun_split2(int[] a, int[] b) throws RuntimeException {
+if (a[2] != 0) {
+            a[2] += b[2];
+            b[2] += a[3];
+        }
+}
+
+void myFun_split3(int[] a, int[] b) throws RuntimeException {
+a[3] += b[3];
+b[3] += a[4];
+}
+
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/if/code/TestIfStatementRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/if/code/TestIfStatementRewrite.java
@@ -1,0 +1,22 @@
+public class TestIfStatementRewrite {
+    public void myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] == 0) {
+            a[0] = 1;
+            if (a[1] == 0) {
+                a[1] = 1;
+                if (a[2] == 0) {
+                    a[2] = 1;
+                } else {
+                    a[2] = b[2];
+                }
+            } else {
+                a[1] = b[1];
+                a[2] = b[2];
+            }
+        } else {
+            a[0] = b[0];
+            a[1] = b[1];
+            a[2] = b[2];
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/if/code/TestNotRewriteIfStatementInFunctionWithReturnValue.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/if/code/TestNotRewriteIfStatementInFunctionWithReturnValue.java
@@ -1,0 +1,23 @@
+public class TestNotRewriteIfStatementInFunctionWithReturnValue {
+    public int myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] == 0) {
+            a[0] = 1;
+            if (a[1] == 0) {
+                a[1] = 1;
+                if (a[2] == 0) {
+                    a[2] = 1;
+                } else {
+                    a[2] = b[2];
+                }
+            } else {
+                a[1] = b[1];
+                a[2] = b[2];
+            }
+        } else {
+            a[0] = b[0];
+            a[1] = b[1];
+            a[2] = b[2];
+        }
+        return a[0] + a[1] + a[2];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/if/code/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/if/code/TestRewriteInnerClass.java
@@ -1,0 +1,23 @@
+public class TestRewriteInnerClass {
+    public void myFun(int[] a, int[] b) {
+        if (a[0] == 0) {
+            a[0] += b[0];
+            a[1] += b[1];
+        } else {
+            a[0] += b[1];
+            a[1] += b[0];
+        }
+    }
+
+    public class InnerClass {
+        public void myFun(int[] a, int[] b) {
+            if (a[0] == 0) {
+                a[0] += b[0];
+                a[1] += b[1];
+            } else {
+                a[0] += b[1];
+                a[1] += b[0];
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/if/expected/TestIfStatementRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/if/expected/TestIfStatementRewrite.java
@@ -1,0 +1,50 @@
+public class TestIfStatementRewrite {
+    public void myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] == 0) {
+myFun_trueFilter1(a, b);
+
+}
+ else {
+myFun_falseFilter2(a, b);
+
+}
+
+    }
+void myFun_trueFilter1(int[] a, int[] b) throws RuntimeException{
+            a[0] = 1;
+            if (a[1] == 0) {
+myFun_trueFilter1_trueFilter3(a, b);
+
+}
+ else {
+myFun_trueFilter1_falseFilter4(a, b);
+
+}
+
+        }
+void myFun_trueFilter1_trueFilter3(int[] a, int[] b) throws RuntimeException{
+                a[1] = 1;
+                if (a[2] == 0) {
+                    a[2] = 1;
+                } else {
+                    a[2] = b[2];
+                }
+            }
+
+
+void myFun_trueFilter1_falseFilter4(int[] a, int[] b) throws RuntimeException{
+                a[1] = b[1];
+                a[2] = b[2];
+            }
+
+
+
+
+void myFun_falseFilter2(int[] a, int[] b) throws RuntimeException{
+            a[0] = b[0];
+            a[1] = b[1];
+            a[2] = b[2];
+        }
+
+
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/if/expected/TestNotRewriteIfStatementInFunctionWithReturnValue.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/if/expected/TestNotRewriteIfStatementInFunctionWithReturnValue.java
@@ -1,0 +1,23 @@
+public class TestNotRewriteIfStatementInFunctionWithReturnValue {
+    public int myFun(int[] a, int[] b) throws RuntimeException {
+        if (a[0] == 0) {
+            a[0] = 1;
+            if (a[1] == 0) {
+                a[1] = 1;
+                if (a[2] == 0) {
+                    a[2] = 1;
+                } else {
+                    a[2] = b[2];
+                }
+            } else {
+                a[1] = b[1];
+                a[2] = b[2];
+            }
+        } else {
+            a[0] = b[0];
+            a[1] = b[1];
+            a[2] = b[2];
+        }
+        return a[0] + a[1] + a[2];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/if/expected/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/if/expected/TestRewriteInnerClass.java
@@ -1,0 +1,51 @@
+public class TestRewriteInnerClass {
+    public void myFun(int[] a, int[] b) {
+        if (a[0] == 0) {
+myFun_trueFilter1(a, b);
+
+}
+ else {
+myFun_falseFilter2(a, b);
+
+}
+
+    }
+void myFun_trueFilter1(int[] a, int[] b){
+            a[0] += b[0];
+            a[1] += b[1];
+        }
+
+
+void myFun_falseFilter2(int[] a, int[] b){
+            a[0] += b[1];
+            a[1] += b[0];
+        }
+
+
+
+    public class InnerClass {
+        public void myFun(int[] a, int[] b) {
+            if (a[0] == 0) {
+myFun_trueFilter3(a, b);
+
+}
+ else {
+myFun_falseFilter4(a, b);
+
+}
+
+        }
+void myFun_trueFilter3(int[] a, int[] b){
+                a[0] += b[0];
+                a[1] += b[1];
+            }
+
+
+void myFun_falseFilter4(int[] a, int[] b){
+                a[0] += b[1];
+                a[1] += b[0];
+            }
+
+
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestNotRewriteFunctionParameter.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestNotRewriteFunctionParameter.java
@@ -1,0 +1,16 @@
+public class TestNotRewriteFunctionParameter {
+    int a = 1;
+    int b;
+    int c;
+
+    public TestNotRewriteFunctionParameter(int b, int c) {
+        this.b = b;
+        this.c = c;
+        System.out.println(this.c + b + c + this.b);
+    }
+
+    public int myFun(int a) {
+        this.a = a;
+        return this.a + a + this.b + c;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestNotRewriteLocalVariable.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestNotRewriteLocalVariable.java
@@ -1,0 +1,16 @@
+public class TestNotRewriteLocalVariable {
+    int a = 1;
+    int b = 2;
+    int c = 3;
+
+    public TestNotRewriteFunctionParameter() {
+        int b = this.b;
+        int c = this.c;
+        System.out.println(this.c + b + c + this.b);
+    }
+
+    public int myFun() {
+        int a = this.a;
+        return this.a + a + this.b + c;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestNotRewriteStaticMember.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestNotRewriteStaticMember.java
@@ -1,0 +1,11 @@
+public class TestNotRewriteStaticMember {
+    int a;
+    private static int b;
+    public final int c = 1;
+    public static final int d = 2;
+    private int e;
+
+    public int myFun() {
+        return a + b + this.c + TestNotRewriteStaticMember.d + e;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestRewriteGenericType.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestRewriteGenericType.java
@@ -1,0 +1,12 @@
+public class TestRewriteGenericType {
+    java.util.List<String> a = new java.util.ArrayList<>();
+    java.util.List<Integer> b = new java.util.ArrayList<>();
+    java.util.List<String> c = new java.util.ArrayList<>();
+
+    public String myFun() {
+        String aa = a.get(0);
+        long bb = b.get(1);
+        String cc = c.get(2);
+        return cc + bb + aa;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestRewriteInnerClass.java
@@ -1,0 +1,29 @@
+public class TestRewriteInnerClass {
+    public int a;
+    protected int b = 1;
+    final int c;
+
+    public TestRewriteInnerClass(int arg) {
+        c = arg;
+    }
+
+    public int myFun(int d) {
+        int aa = a;
+        return a + aa + this.b + c + d;
+    }
+
+    public class InnerClass {
+        public int innerA;
+        protected int innerB = 1;
+        final int innerC;
+
+        public TestRewriteInnerClass(int arg) {
+            this.innerC = arg;
+        }
+
+        public int myFun(int d) {
+            int aa = innerA;
+            return innerA + aa + this.innerB + innerC + d + a + this.b + c;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestRewriteMemberField.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/code/TestRewriteMemberField.java
@@ -1,0 +1,19 @@
+public class TestRewriteMemberField {
+    public int a;
+    private long b;
+    protected int c = 1;
+    long d;
+    final int e;
+    public final String f;
+    private final String g = "GGGGG";
+    String h;
+
+    public TestRewriteMemberField(String s) {
+        this.f = s;
+    }
+
+    public String myFun(String h) {
+        int aa = a;
+        return f + aa + this.h + a + String.valueOf(c);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteFunctionParameter.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteFunctionParameter.java
@@ -1,0 +1,22 @@
+public class TestNotRewriteFunctionParameter {
+int[] rewrite$0 = new int[3];
+
+{
+rewrite$0[0] = 1;
+}
+
+    
+    
+    
+
+    public TestNotRewriteFunctionParameter(int b, int c) {
+        this.rewrite$0[1] = b;
+        this.rewrite$0[2] = c;
+        System.out.println(this.rewrite$0[2] + b + c + this.rewrite$0[1]);
+    }
+
+    public int myFun(int a) {
+        this.rewrite$0[0] = a;
+        return this.rewrite$0[0] + a + this.rewrite$0[1] + rewrite$0[2];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteLocalVariable.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteLocalVariable.java
@@ -1,0 +1,24 @@
+public class TestNotRewriteLocalVariable {
+int[] rewrite$0 = new int[3];
+
+{
+rewrite$0[0] = 1;
+rewrite$0[1] = 2;
+rewrite$0[2] = 3;
+}
+
+    
+    
+    
+
+    public TestNotRewriteFunctionParameter() {
+        int b = this.rewrite$0[1];
+        int c = this.rewrite$0[2];
+        System.out.println(this.rewrite$0[2] + b + c + this.rewrite$0[1]);
+    }
+
+    public int myFun() {
+        int a = this.rewrite$0[0];
+        return this.rewrite$0[0] + a + this.rewrite$0[1] + rewrite$0[2];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteStaticMember.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestNotRewriteStaticMember.java
@@ -1,0 +1,17 @@
+public class TestNotRewriteStaticMember {
+int[] rewrite$0 = new int[3];
+
+{
+rewrite$0[1] = 1;
+}
+
+    
+    private static int b;
+    
+    public static final int d = 2;
+    
+
+    public int myFun() {
+        return rewrite$0[0] + b + this.rewrite$0[1] + TestNotRewriteStaticMember.d + rewrite$0[2];
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteGenericType.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteGenericType.java
@@ -1,0 +1,21 @@
+public class TestRewriteGenericType {
+java.util.List<Integer>[] rewrite$0 = new java.util.List[1];
+java.util.List<String>[] rewrite$1 = new java.util.List[2];
+
+{
+rewrite$1[0] = new java.util.ArrayList<>();
+rewrite$0[0] = new java.util.ArrayList<>();
+rewrite$1[1] = new java.util.ArrayList<>();
+}
+
+    
+    
+    
+
+    public String myFun() {
+        String aa = rewrite$1[0].get(0);
+        long bb = rewrite$0[0].get(1);
+        String cc = rewrite$1[1].get(2);
+        return cc + bb + aa;
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteInnerClass.java
@@ -1,0 +1,35 @@
+public class TestRewriteInnerClass {
+int[] rewrite$0 = new int[3];
+
+{
+rewrite$0[1] = 1;
+}
+
+    
+    
+    
+
+    public TestRewriteInnerClass(int arg) {
+        rewrite$0[2] = arg;
+    }
+
+    public int myFun(int d) {
+        int aa = rewrite$0[0];
+        return rewrite$0[0] + aa + this.rewrite$0[1] + rewrite$0[2] + d;
+    }
+
+    public class InnerClass {
+        public int innerA;
+        protected int innerB = 1;
+        final int innerC;
+
+        public TestRewriteInnerClass(int arg) {
+            this.innerC = arg;
+        }
+
+        public int myFun(int d) {
+            int aa = innerA;
+            return innerA + aa + this.innerB + innerC + d + rewrite$0[0] + this.rewrite$0[1] + rewrite$0[2];
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteMemberField.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/member/expected/TestRewriteMemberField.java
@@ -1,0 +1,28 @@
+public class TestRewriteMemberField {
+String[] rewrite$0 = new String[3];
+int[] rewrite$1 = new int[3];
+long[] rewrite$2 = new long[2];
+
+{
+rewrite$1[1] = 1;
+rewrite$0[1] = "GGGGG";
+}
+
+    
+    
+    
+    
+    
+    
+    
+    
+
+    public TestRewriteMemberField(String s) {
+        this.rewrite$0[0] = s;
+    }
+
+    public String myFun(String h) {
+        int aa = rewrite$1[0];
+        return rewrite$0[0] + aa + this.rewrite$0[2] + rewrite$1[0] + String.valueOf(rewrite$1[1]);
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/code/TestNotSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/code/TestNotSplitJavaCode.java
@@ -1,0 +1,37 @@
+public class TestNotSplitJavaCode {
+    private int a = 1;
+    public final int[] b;
+
+    public TestSplitJavaCode(int[] b) {
+        this.b = b;
+    }
+
+    public void myFun(int a) {
+        this.a = a;
+        b[0] += b[1];
+        b[1] += b[2];
+        b[2] += b[3];
+        int b1 = b[0] + b[1];
+        int b2 = b[1] + b[2];
+        int b3 = b[2] + b[0];
+        for (int x : b) {
+            System.out.println(x + b1 + b2 + b3);
+        }
+
+        if (b1 > 0) {
+            b[0] += 100;
+            if (b2 > 0) {
+                b[1] += 100;
+                if (b3 > 0) {
+                    b[2] += 100;
+                } else {
+                    b[2] += 50;
+                }
+            } else {
+                b[1] += 50;
+            }
+        } else {
+            b[0] += 50;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/code/TestSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/code/TestSplitJavaCode.java
@@ -1,0 +1,37 @@
+public class TestSplitJavaCode {
+    private int a = 1;
+    public final int[] b;
+
+    public TestSplitJavaCode(int[] b) {
+        this.b = b;
+    }
+
+    public void myFun(int a) {
+        this.a = a;
+        b[0] += b[1];
+        b[1] += b[2];
+        b[2] += b[3];
+        int b1 = b[0] + b[1];
+        int b2 = b[1] + b[2];
+        int b3 = b[2] + b[0];
+        for (int x : b) {
+            System.out.println(x + b1 + b2 + b3);
+        }
+
+        if (b1 > 0) {
+            b[0] += 100;
+            if (b2 > 0) {
+                b[1] += 100;
+                if (b3 > 0) {
+                    b[2] += 100;
+                } else {
+                    b[2] += 50;
+                }
+            } else {
+                b[1] += 50;
+            }
+        } else {
+            b[0] += 50;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestNotSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestNotSplitJavaCode.java
@@ -1,0 +1,37 @@
+public class TestNotSplitJavaCode {
+    private int a = 1;
+    public final int[] b;
+
+    public TestSplitJavaCode(int[] b) {
+        this.b = b;
+    }
+
+    public void myFun(int a) {
+        this.a = a;
+        b[0] += b[1];
+        b[1] += b[2];
+        b[2] += b[3];
+        int b1 = b[0] + b[1];
+        int b2 = b[1] + b[2];
+        int b3 = b[2] + b[0];
+        for (int x : b) {
+            System.out.println(x + b1 + b2 + b3);
+        }
+
+        if (b1 > 0) {
+            b[0] += 100;
+            if (b2 > 0) {
+                b[1] += 100;
+                if (b3 > 0) {
+                    b[2] += 100;
+                } else {
+                    b[2] += 50;
+                }
+            } else {
+                b[1] += 50;
+            }
+        } else {
+            b[0] += 50;
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
@@ -1,0 +1,93 @@
+public class TestSplitJavaCode {
+int[][] rewrite$8 = new int[1][];
+int[] rewrite$9 = new int[5];
+
+{
+rewrite$9[4] = 1;
+}
+
+
+
+
+
+
+    
+    
+
+    public TestSplitJavaCode(int[] b) {
+        this.rewrite$8[0] = b;
+    }
+
+    public void myFun(int a) {
+        myFun_split2(a);
+
+        myFun_split3(a);
+
+        myFun_split4(a);
+
+        myFun_split5(a);
+
+         
+         
+         
+        
+
+        
+    }
+void myFun_split2(int a) {
+
+this.rewrite$9[4] = a;
+rewrite$8[0][0] += rewrite$8[0][1];
+rewrite$8[0][1] += rewrite$8[0][2];
+rewrite$8[0][2] += rewrite$8[0][3];
+rewrite$9[0] = rewrite$8[0][0] + rewrite$8[0][1];
+rewrite$9[1] = rewrite$8[0][1] + rewrite$8[0][2];
+}
+
+void myFun_split3(int a) {
+rewrite$9[2] = rewrite$8[0][2] + rewrite$8[0][0];
+}
+
+void myFun_split4(int a) {
+for (int x : rewrite$8[0]) {rewrite$9[3] = x;
+            System.out.println(rewrite$9[3] + rewrite$9[0] + rewrite$9[1] + rewrite$9[2]);
+        }
+}
+
+void myFun_split5(int a) {
+if (rewrite$9[0] > 0) {
+myFun_trueFilter2(a);
+
+}
+ else {
+            rewrite$8[0][0] += 50;
+        }
+}
+
+void myFun_trueFilter2(int a){
+            myFun_trueFilter2_split6(a);
+
+            myFun_trueFilter2_split7(a);
+
+        }
+void myFun_trueFilter2_split6(int a) {
+
+rewrite$8[0][0] += 100;
+}
+
+void myFun_trueFilter2_split7(int a) {
+if (rewrite$9[1] > 0) {
+                rewrite$8[0][1] += 100;
+                if (rewrite$9[2] > 0) {
+                    rewrite$8[0][2] += 100;
+                } else {
+                    rewrite$8[0][2] += 50;
+                }
+            } else {
+                rewrite$8[0][1] += 50;
+            }
+}
+
+
+
+}

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -44,6 +44,7 @@ under the License.
 		<module>flink-sql-client</module>
 		<module>flink-sql-parser</module>
 		<module>flink-sql-parser-hive</module>
+		<module>flink-table-code-splitter</module>
 	</modules>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1471,6 +1471,9 @@ under the License.
 						<exclude>flink-runtime-web/web-dashboard/node_modules/**</exclude>
 						<exclude>flink-runtime-web/web-dashboard/node/**</exclude>
 
+						<!-- antlr grammar files -->
+						<exclude>flink-table/flink-table-code-splitter/src/main/antlr4/**</exclude>
+
 						<!-- Test Data. -->
 						<exclude>**/src/test/resources/*-data</exclude>
 						<exclude>flink-tests/src/test/resources/testdata/terainput.txt</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1489,6 +1489,7 @@ under the License.
 						<exclude>flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/answer_set/*</exclude>
 						<exclude>flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/query/*</exclude>
 						<exclude>flink-connectors/flink-connector-kinesis/src/test/resources/profile</exclude>
+						<exclude>flink-table/flink-table-code-splitter/src/test/resources/**</exclude>
 
 						<!-- snapshots -->
 						<exclude>**/src/test/resources/serializer-snapshot-*</exclude>


### PR DESCRIPTION
## What is the purpose of the change

This is the first step of FLINK-23007. This parent issue aims to solve the issue in one shot, that some methods of the generated Java code may grow beyond 64KB and reaches the limit of JVM.

In this first step we introduce a Java code splitter for the generated Java code. This splitter will come into effect after the original Java code is generated, hoping to solve the 64KB problem in one shot. Currently this splitter is not used and we'll activate it in the second step of the parent issue.

In this new module we use antlr to parse Java code. The Java antlr grammar files are copied from the official antlr repository https://github.com/antlr/grammars-v4/tree/master/java/java . 

## Brief change log

 - Introduce the new Java code splitter module

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
