### PR TITLE
[FLINK-23142][table] UpdatableTopNFunction output wrong order in the same unique key

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -132,8 +132,8 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
         expectedOutput.add(insertRecord("book", 2L, 19, 2L));
         // U ("book", 2L, 11)
         expectedOutput.add(updateBeforeRecord("book", 3L, 16, 1L));
-        expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
         expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+        expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
         expectedOutput.add(updateAfterRecord("book", 3L, 16, 2L));
         // U ("book", 3L, 15)
         expectedOutput.add(updateBeforeRecord("book", 3L, 16, 2L));
@@ -145,8 +145,8 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
         expectedOutput.add(updateAfterRecord("book", 2L, 11, 2L));
         // U ("book", 2L, 1)
         expectedOutput.add(updateBeforeRecord("book", 4L, 2, 1L));
-        expectedOutput.add(updateAfterRecord("book", 2L, 1, 1L));
         expectedOutput.add(updateBeforeRecord("book", 2L, 11, 2L));
+        expectedOutput.add(updateAfterRecord("book", 2L, 1, 1L));
         expectedOutput.add(updateAfterRecord("book", 4L, 2, 2L));
 
         assertorWithRowNumber.assertOutputEquals(


### PR DESCRIPTION

## What is the purpose of the change

See UpdatableTopNFunctionTest.testSortKeyChangesWhenOutputRankNumber 
```
expectedOutput.add(updateBeforeRecord("book", 3L, 16, 1L));
expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
expectedOutput.add(updateAfterRecord("book", 3L, 16, 2L));
It should collect the third record and then collect the second record.
```
This wrong order will lead to the wrong implementation of the downstream, because the records expected by the downstream has unique key, but the disorder here will lead to the data being deleted by mistake.

## Brief change log

- Fix `UpdatableTopNFunction`, retract old row before collect new row.

## Verifying this change

`UpdatableTopNFunctionTest.testSortKeyChangesWhenOutputRankNumber `

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no