### PR TITLE
[FLINK-23066] Introduce TableEnvironment#from(TableDescriptor)

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -738,6 +738,28 @@ public interface TableEnvironment {
     Table from(String path);
 
     /**
+     * Returns a {@link Table} backed by the given {@link TableDescriptor descriptor}.
+     *
+     * <p>The {@link TableDescriptor descriptor} is registered as an inline (i.e. anonymous)
+     * temporary table (see {@link #createTemporaryTable(String, TableDescriptor)}) using a unique
+     * identifier and then read. Note that calling this method multiple times, even with the same
+     * descriptor, results in multiple temporary tables. In such cases, it is recommended to
+     * register it under a name using #createTemporaryTable(String, TableDescriptor) and reference
+     * it via {@link #from(String)}.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * Table table = tEnv.from(TableDescriptor.forConnector("datagen")
+     *   .schema(Schema.newBuilder()
+     *     .column("f0", DataTypes.STRING())
+     *     .build())
+     *   .build());
+     * }</pre>
+     */
+    Table from(TableDescriptor descriptor);
+
+    /**
      * Writes the {@link Table} to a {@link TableSink} that was registered under the specified name.
      *
      * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or {@link

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableDescriptorUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableDescriptorUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TableEnvironment;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Utilities for working with {@link TableDescriptor}. */
+@Internal
+class TableDescriptorUtil {
+
+    private static final AtomicInteger uniqueId = new AtomicInteger(0);
+
+    /**
+     * Returns an unique name for registering unnamed {@link TableDescriptor descriptors}.
+     *
+     * <p>IDs cannot be associated with the {@link TableDescriptor} directly as the same descriptor
+     * might be registered multiple times (e.g. through {@link
+     * TableEnvironment#from(TableDescriptor)}.
+     */
+    static String getUniqueAnonymousPath() {
+        return "Unnamed_TableDescriptor$" + uniqueId.incrementAndGet();
+    }
+
+    @VisibleForTesting
+    static AtomicInteger getCounter() {
+        return uniqueId;
+    }
+
+    private TableDescriptorUtil() {}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -486,8 +486,12 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         Preconditions.checkNotNull(path, "Path must not be null.");
         Preconditions.checkNotNull(descriptor, "Table descriptor must not be null.");
 
-        final ObjectIdentifier tableIdentifier =
-                catalogManager.qualifyIdentifier(getParser().parseIdentifier(path));
+        createTemporaryTableInternal(getParser().parseIdentifier(path), descriptor);
+    }
+
+    private void createTemporaryTableInternal(
+            UnresolvedIdentifier path, TableDescriptor descriptor) {
+        final ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(path);
 
         final CatalogTable catalogTable =
                 CatalogTable.of(
@@ -567,6 +571,15 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                                 new ValidationException(
                                         String.format(
                                                 "Table %s was not found.", unresolvedIdentifier)));
+    }
+
+    @Override
+    public Table from(TableDescriptor descriptor) {
+        Preconditions.checkNotNull(descriptor, "Table descriptor must not be null.");
+
+        final String path = TableDescriptorUtil.getUniqueAnonymousPath();
+        createTemporaryTableInternal(UnresolvedIdentifier.of(path), descriptor);
+        return from(path);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.operations.CatalogQueryOperation;
 import org.apache.flink.table.utils.ConnectorDescriptorMock;
 import org.apache.flink.table.utils.FormatDescriptorMock;
 import org.apache.flink.table.utils.TableEnvironmentMock;
@@ -129,6 +130,29 @@ public class TableEnvironmentTest {
         assertEquals(schema, catalogTable.getUnresolvedSchema());
         assertEquals("fake", catalogTable.getOptions().get("connector"));
         assertEquals("Test", catalogTable.getOptions().get("a"));
+    }
+
+    public void testTableFromDescriptor() {
+        final TableEnvironmentMock tEnv = TableEnvironmentMock.getStreamingInstance();
+
+        final Schema schema = Schema.newBuilder().column("f0", DataTypes.INT()).build();
+        final TableDescriptor descriptor =
+                TableDescriptor.forConnector("fake").schema(schema).build();
+
+        Table table = tEnv.from(descriptor);
+
+        assertEquals(
+                schema, Schema.newBuilder().fromResolvedSchema(table.getResolvedSchema()).build());
+
+        assertTrue(table.getQueryOperation() instanceof CatalogQueryOperation);
+        final ObjectIdentifier tableIdentifier =
+                ((CatalogQueryOperation) table.getQueryOperation()).getTableIdentifier();
+
+        final Optional<CatalogManager.TableLookupResult> lookupResult =
+                tEnv.getCatalogManager().getTable(tableIdentifier);
+        assertTrue(lookupResult.isPresent());
+
+        assertEquals("fake", lookupResult.get().getTable().getOptions().get("connector"));
     }
 
     private static void assertCatalogTable(CatalogTable table) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -547,5 +547,4 @@ class CalcITCase extends StreamingTestBase {
     val result = tEnv.sqlQuery("SELECT * FROM T").execute().collect().toList
     TestBaseUtils.compareResultAsText(result, "42")
   }
-
 }


### PR DESCRIPTION
## What is the purpose of the change

This introduces `TableEnvironment#from(TableDescriptor)` as part of FLIP-129.

Under the hood it is essentially a shortcut of registering a temporary table using the previously introduced `TableEnvironment#createTemporaryTable(String, TableDescriptor)` and then deferring to the existing `from(String)` method. For this we need to choose some unique name. Note that this name must not just be unique per descriptor but per registration, as the same descriptor may be used multiple times.

This PR relies on JavaDoc for documentation. More extensive documentation will be added as part of FLINK-23116.

## Brief change log

* Added `TableEnvironment#from(TableDescriptor)`.

## Verifying this change

This change added tests and can be verified as follows:
* `CalcITCase#testTableFromDescriptor`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
