### PR TITLE
[FLINK-23157][docs] Versioned View's SQL Script was missing a "," at Line 3 which yields Could not execute SQL statement ERROR

### DIFF
--- a/docs/content/docs/dev/table/concepts/versioned_tables.md
+++ b/docs/content/docs/dev/table/concepts/versioned_tables.md
@@ -103,7 +103,7 @@ and event-time attribute. Imagine an append-only table of currency rates.
 ```sql
 CREATE TABLE currency_rates (
 	currency      STRING,
-	rate          DECIMAL(32, 10)
+	rate          DECIMAL(32, 10),
 	update_time   TIMESTAMP(3),
 	WATERMARK FOR update_time AS update_time
 ) WITH (


### PR DESCRIPTION
## What is the purpose of the change

Fix the  Script of [Creating Versioned View Script](https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/dev/table/concepts/versioned_tables/#versioned-table-views)


## Brief change log

* add "," to Line 3  to correctly pass the semantic check  
rate          DECIMAL(32, 10),

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
