### PR TITLE
[FLINK-23067][table-api-java] Introduce Table#executeInsert(TableDescriptor)

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1356,6 +1356,65 @@ public interface Table {
     TableResult executeInsert(String tablePath, boolean overwrite);
 
     /**
+     * Declares that the pipeline defined by the given {@link Table} object should be written to a
+     * table defined by a {@link TableDescriptor}. It executes the insert operation.
+     *
+     * <p>The {@link TableDescriptor descriptor} is registered as an inline (i.e. anonymous)
+     * temporary table (see {@link TableEnvironment#createTemporaryTable(String, TableDescriptor)})
+     * using a unique identifier. Note that calling this method multiple times, even with the same
+     * descriptor, results in multiple sinks being registered.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * Schema schema = Schema.newBuilder()
+     *   .column("f0", DataTypes.STRING())
+     *   .build();
+     *
+     * Table table = tableEnv.from(TableDescriptor.forConnector("datagen")
+     *   .schema(schema)
+     *   .build());
+     *
+     * table.executeInsert(TableDescriptor.forConnector("blackhole")
+     *   .schema(schema)
+     *   .build());
+     * }</pre>
+     *
+     * @param descriptor Descriptor describing the sink into which data should be inserted.
+     */
+    TableResult executeInsert(TableDescriptor descriptor);
+
+    /**
+     * Declares that the pipeline defined by the given {@link Table} object should be written to a
+     * table defined by a {@link TableDescriptor}. It executes the insert operation.
+     *
+     * <p>The {@link TableDescriptor descriptor} is registered as an inline (i.e. anonymous)
+     * temporary table (see {@link TableEnvironment#createTemporaryTable(String, TableDescriptor)})
+     * using a unique identifier. Note that calling this method multiple times, even with the same
+     * descriptor, results in multiple sinks being registered.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * Schema schema = Schema.newBuilder()
+     *   .column("f0", DataTypes.STRING())
+     *   .build();
+     *
+     * Table table = tableEnv.from(TableDescriptor.forConnector("datagen")
+     *   .schema(schema)
+     *   .build());
+     *
+     * table.executeInsert(TableDescriptor.forConnector("blackhole")
+     *   .schema(schema)
+     *   .build(), true);
+     * }</pre>
+     *
+     * @param descriptor Descriptor describing the sink into which data should be inserted.
+     * @param overwrite Indicates whether existing data should be overwritten.
+     */
+    TableResult executeInsert(TableDescriptor descriptor, boolean overwrite);
+
+    /**
      * Collects the contents of the current table local client.
      *
      * <pre>{@code

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.GroupedTable;
 import org.apache.flink.table.api.OverWindow;
 import org.apache.flink.table.api.OverWindowedTable;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
@@ -570,6 +571,18 @@ public class TableImpl implements Table {
                         Collections.emptyMap());
 
         return tableEnvironment.executeInternal(Collections.singletonList(operation));
+    }
+
+    @Override
+    public TableResult executeInsert(TableDescriptor descriptor) {
+        return executeInsert(descriptor, false);
+    }
+
+    @Override
+    public TableResult executeInsert(TableDescriptor descriptor, boolean overwrite) {
+        final String path = TableDescriptorUtil.getUniqueAnonymousPath();
+        tableEnvironment.createTemporaryTable(path, descriptor);
+        return executeInsert(path, overwrite);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -88,10 +88,25 @@ final class TestValuesRuntimeFunctions {
 
     static List<String> getRawResults(String tableName) {
         List<String> result = new ArrayList<>();
-        synchronized (TestValuesTableFactory.class) {
+        synchronized (LOCK) {
             if (globalRawResult.containsKey(tableName)) {
                 globalRawResult.get(tableName).values().forEach(result::addAll);
             }
+        }
+        return result;
+    }
+
+    /** Returns raw results if there was only one table with results, throws otherwise. */
+    static List<String> getOnlyRawResults() {
+        List<String> result = new ArrayList<>();
+        synchronized (LOCK) {
+            if (globalRawResult.size() != 1) {
+                throw new IllegalStateException(
+                        "Expected results for only one table to be present, but found "
+                                + globalRawResult.size());
+            }
+
+            globalRawResult.values().iterator().next().values().forEach(result::addAll);
         }
         return result;
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -176,6 +176,16 @@ public final class TestValuesTableFactory
     }
 
     /**
+     * Returns received row results if there has been exactly one sink, and throws an error
+     * otherwise.
+     *
+     * <p>The raw results are encoded with {@link RowKind}.
+     */
+    public static List<String> getOnlyRawResults() {
+        return TestValuesRuntimeFunctions.getOnlyRawResults();
+    }
+
+    /**
      * Returns materialized (final) results of the registered table sink.
      *
      * @param tableName the table name of the registered table sink.


### PR DESCRIPTION
## What is the purpose of the change

This introduces `Table#executeInsert(TableDescriptor)` as part of FLIP-129. It is essentially a quality-of-life shortcut for registering the descriptor as an unnamed temporary table and then deffering to `executeInsert(String)`.

Documentation for now is using JavaDocs, more extensive documentation will be added in FLINK-23116.

This PR duplicates `TableDescriptorUtil` from https://github.com/apache/flink/pull/16287. I'll rebase as needed.

## Brief change log

* Added `Table#executeInsert(TableDescriptor)`.

## Verifying this change

This change added tests and can be verified as follows:
* `CalcITCase#testExecuteInsertToTableDescriptor`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
