### PR TITLE
[FLINK-23071][table-api-java] Introduce StatementSet#addInsert(TableDescriptor, Table)

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 
 /**
  * A {@link StatementSet} accepts DML statements or {@link Table}s, the planner can optimize all
@@ -37,6 +38,31 @@ public interface StatementSet {
 
     /** add {@link Table} with the given sink table name to the set. */
     StatementSet addInsert(String targetPath, Table table, boolean overwrite);
+
+    /**
+     * Adds a statement that the pipeline defined by the given {@link Table} object should be
+     * written to a table (backed by a {@link DynamicTableSink}) and expressed via the given {@link
+     * TableDescriptor}.
+     *
+     * <p>The given {@link TableDescriptor descriptor} is registered as a temporary table (see
+     * {@link TableEnvironment#createTemporaryTable(String, TableDescriptor)}. Then a statement is
+     * added into the statement set to insert the {@link Table} into that temporary table.
+     *
+     * <p>Examples:
+     *
+     * <pre>{@code
+     * StatementSet stmtSet = tEnv.createStatementSet();
+     * Table sourceTable = tEnv.from("SourceTable");
+     * TableDescriptor sinkDescriptor = TableDescriptor.forConnector("blackhole")
+     *   .schema(Schema.newBuilder()
+     *     // …
+     *     .build())
+     *   .build();
+     *
+     * stmtSet.addInsert(sinkDescriptor, sourceTable);
+     * }</pre>
+     */
+    StatementSet addInsert(TableDescriptor descriptor, Table table);
 
     /**
      * returns the AST and the execution plan to compute the result of the all statements and

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -84,6 +85,13 @@ class StatementSetImpl implements StatementSet {
                         Collections.emptyMap()));
 
         return this;
+    }
+
+    @Override
+    public StatementSet addInsert(TableDescriptor descriptor, Table table) {
+        final String path = TableDescriptorUtil.getUniqueAnonymousPath();
+        tableEnvironment.createTemporaryTable(path, descriptor);
+        return addInsert(path, table);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1494,6 +1494,10 @@ class TestingStatementSet(tEnv: TestingTableEnvironment) extends StatementSet {
     this
   }
 
+  override def addInsert(descriptor: TableDescriptor, table: Table): StatementSet = {
+    throw new TableException("Not implemented")
+  }
+
   override def explain(extraDetails: ExplainDetail*): String = {
     tEnv.explainInternal(operations.map(o => o.asInstanceOf[Operation]), extraDetails: _*)
   }


### PR DESCRIPTION
## What is the purpose of the change

This introduces `StatementSet#addInsert(TableDescriptor, Table)` as part of FLIP-129.

Documentation is currently only in JavaDocs and extensive documentation will be added in FLINK-23116.

## Brief change log

* Add `StatementSet#addInsert(TableDescriptor, Table)`.

## Verifying this change

This change added tests and can be verified as follows:
* `CalcITCase#testStatementSetInsertUsingTableDescriptor`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
