### PR TITLE
[FLINK-23052][ci] Improve stability of maven snapshot deployment

### DIFF
--- a/tools/azure-pipelines/build-nightly-dist.yml
+++ b/tools/azure-pipelines/build-nightly-dist.yml
@@ -65,7 +65,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-20.04'
     container: flink-build-container
-    timeoutInMinutes: 100 # 40 minutes per scala version + 20 buffer
+    timeoutInMinutes: 240
     workspace:
       clean: all
     steps:
@@ -109,7 +109,7 @@ jobs:
             </settings>
             EOF
 
-            export CUSTOM_OPTIONS="-Dgpg.skip -Drat.skip -Dcheckstyle.skip --settings $(pwd)/deploy-settings.xml"
+            export CUSTOM_OPTIONS="-Dgpg.skip -Drat.skip -Dcheckstyle.skip -Dmaven.wagon.http.pool=false --settings $(pwd)/deploy-settings.xml"
             export MVN_RUN_VERBOSE=true
             ./releasing/deploy_staging_jars.sh
         env:


### PR DESCRIPTION
The deployment was timing out or failing a lot recently.