### PR TITLE
[FLINK-23009][kinesis] Upgrade Guava for Flink Connector Kinesis

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -40,6 +40,7 @@ under the License.
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
 		<httpclient.version>4.5.9</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
+		<guava.version>29.0-jre</guava.version>
 	</properties>
 
 	<packaging>jar</packaging>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -71,6 +71,7 @@ under the License.
 									<include>commons-logging:commons-logging</include>
 									<include>org.apache.commons:commons-lang3</include>
 									<include>com.google.guava:guava</include>
+									<include>com.google.guava:failureaccess</include>
 								</includes>
 							</artifactSet>
 							<filters>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -35,17 +35,6 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<!-- Bumped for security purposes to a common version in the Hadoop ecosystem -->
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>27.0-jre</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - commons-codec:commons-codec:1.13
 - org.apache.commons:commons-lang3:3.3.2
-- com.google.guava:guava:27.0-jre
+- com.google.guava:guava:29.0-jre
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -13,6 +13,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.13
 - org.apache.commons:commons-lang3:3.3.2
 - com.google.guava:guava:29.0-jre
+- com.google.guava:failureaccess:1.0.1
 - com.fasterxml.jackson.core:jackson-annotations:2.12.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.core:jackson-core:2.12.1


### PR DESCRIPTION
## What is the purpose of the change

Upgrade Guava dependency for Flink Connector Kinesis. The connector was using Guava 18.0 which is quite old and has been flagged by some security tools as noted in another ticket https://issues.apache.org/jira/browse/FLINK-22774 

This PR also makes the flink-sql-connector-kinesis use the Guava dependency transitively through the flink-connector-kinesis dependency.

## Brief change log

- Bumped Guava for Flink Connector Kinesis from 18.0 (inherited from parent) to 29.0-jre

## Verifying this change

This change is already covered by existing tests, such as `FlinkKinesisProducerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
