### PR TITLE
Remove extra commas from the "create" page

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -227,7 +227,7 @@ CREATE TABLE MyTable (
   `name` STRING,
   `record_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'    -- reads and writes a Kafka record's timestamp
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -251,7 +251,7 @@ CREATE TABLE MyTable (
   `name` STRING,
   `timestamp` TIMESTAMP_LTZ(3) METADATA    -- use column name as metadata key
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -265,7 +265,7 @@ CREATE TABLE MyTable (
   `name` STRING,
   `timestamp` BIGINT METADATA    -- cast the timestamp as BIGINT
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -281,7 +281,7 @@ CREATE TABLE MyTable (
   `user_id` BIGINT,
   `name` STRING
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -318,7 +318,7 @@ CREATE TABLE MyTable (
   `quantity` DOUBLE,
   `cost` AS price * quanitity  -- evaluate expression and supply the result to queries
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```

--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -279,7 +279,7 @@ CREATE TABLE MyTable (
   `timestamp` BIGINT METADATA,       -- part of the query-to-sink schema
   `offset` BIGINT METADATA VIRTUAL,  -- not part of the query-to-sink schema
   `user_id` BIGINT,
-  `name` STRING,
+  `name` STRING
 ) WITH (
   'connector' = 'kafka'
   ...
@@ -316,7 +316,7 @@ CREATE TABLE MyTable (
   `user_id` BIGINT,
   `price` DOUBLE,
   `quantity` DOUBLE,
-  `cost` AS price * quanitity,  -- evaluate expression and supply the result to queries
+  `cost` AS price * quanitity  -- evaluate expression and supply the result to queries
 ) WITH (
   'connector' = 'kafka'
   ...

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -278,7 +278,7 @@ CREATE TABLE MyTable (
   `timestamp` BIGINT METADATA,       -- part of the query-to-sink schema
   `offset` BIGINT METADATA VIRTUAL,  -- not part of the query-to-sink schema
   `user_id` BIGINT,
-  `name` STRING,
+  `name` STRING
 ) WITH (
   'connector' = 'kafka'
   ...
@@ -315,7 +315,7 @@ CREATE TABLE MyTable (
   `user_id` BIGINT,
   `price` DOUBLE,
   `quantity` DOUBLE,
-  `cost` AS price * quanitity,  -- evaluate expression and supply the result to queries
+  `cost` AS price * quanitity  -- evaluate expression and supply the result to queries
 ) WITH (
   'connector' = 'kafka'
   ...

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -226,7 +226,7 @@ CREATE TABLE MyTable (
   `name` STRING,
   `record_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'    -- reads and writes a Kafka record's timestamp
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -250,7 +250,7 @@ CREATE TABLE MyTable (
   `name` STRING,
   `timestamp` TIMESTAMP_LTZ(3) METADATA    -- use column name as metadata key
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -264,7 +264,7 @@ CREATE TABLE MyTable (
   `name` STRING,
   `timestamp` BIGINT METADATA    -- cast the timestamp as BIGINT
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -280,7 +280,7 @@ CREATE TABLE MyTable (
   `user_id` BIGINT,
   `name` STRING
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```
@@ -317,7 +317,7 @@ CREATE TABLE MyTable (
   `quantity` DOUBLE,
   `cost` AS price * quanitity  -- evaluate expression and supply the result to queries
 ) WITH (
-  'connector' = 'kafka'
+  'connector' = 'kafka',
   ...
 );
 ```


### PR DESCRIPTION
### What is the purpose of the change
***
Remove extra commas from the "create" page  
Fix missing comma in "create" page WITH statement

### Brief change log
***
alter file:  
/flink/docs/content/docs/dev/table/sql/create.md  
/flink/docs/content.zh/docs/dev/table/sql/create.md

### Verifying this change
***
covered by existing tests


### Does this pull request potentially affect one of the following parts:
***
- Dependencies (does it add or upgrade a dependency): (yes / **no**)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes / **no**)
- The serializers: (yes / **no** / don't know)
- The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
- The S3 file system connector: (yes / **no** / don't know)

### Documentation
***
- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)