### PR TITLE
[FLINK-23163][Kubernetes]Add debug log to flink kubeclient

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -141,6 +141,12 @@
             <td>The namespace that will be used for running the jobmanager and taskmanager pods.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.okhttp.log-level</h5></td>
+            <td style="word-wrap: break-word;">NONE</td>
+            <td><p>Enum</p>Possible values: [NONE, BASIC, HEADERS, BODY]</td>
+            <td>The log level set for http client used to talk to kubernetes master</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.pod-template-file</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -27,6 +27,8 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import okhttp3.logging.HttpLoggingInterceptor;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -431,6 +433,13 @@ public class KubernetesConfigOptions {
                                     + "Configure the value to greater than 1 to start standby JobManagers. "
                                     + "It will help to achieve faster recovery. "
                                     + "Notice that high availability should be enabled when starting standby JobManagers.");
+
+    public static final ConfigOption<HttpLoggingInterceptor.Level> KUBERNETES_OK_HTTP_LOG_LEVEL =
+            key("kubernetes.okhttp.log-level")
+                    .enumType(HttpLoggingInterceptor.Level.class)
+                    .defaultValue(HttpLoggingInterceptor.Level.NONE)
+                    .withDescription(
+                            "The log level set for http client used to talk to kubernetes master");
 
     private static String getDefaultFlinkImage() {
         // The default container image that ties to the exact needed versions of both Flink and


### PR DESCRIPTION
## What is the purpose of the change

Enable to debug the http request in flink kubeclient.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
