### PR TITLE
[FLINK-22157][table-planner-blink] Fix join & select a portion of composite primary key will cause ArrayIndexOutOfBoundsException

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -66,23 +66,27 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
         val catalogTable = sourceTable.catalogTable
         catalogTable match {
           case act: CatalogTable =>
+            val builder = ImmutableSet.builder[ImmutableBitSet]()
+
             val schema = act.getSchema
             if (schema.getPrimaryKey.isPresent) {
               // use relOptTable's type which may be projected based on original schema
               val columns = relOptTable.getRowType.getFieldNames
-              val columnIndices = schema.getPrimaryKey.get().getColumns map { c =>
-                columns.indexOf(c)
+              val primaryKeyColumns = schema.getPrimaryKey.get().getColumns
+              // we check this because a portion of a composite primary key is not unique
+              if (columns.containsAll(primaryKeyColumns)) {
+                val columnIndices = primaryKeyColumns.map(c => columns.indexOf(c))
+                builder.add(ImmutableBitSet.of(columnIndices: _*))
               }
-              val builder = ImmutableSet.builder[ImmutableBitSet]()
-              builder.add(ImmutableBitSet.of(columnIndices:_*))
-              val uniqueSet = sourceTable.uniqueKeysSet().orElse(null)
-              if (uniqueSet != null) {
-                builder.addAll(uniqueSet)
-              }
-              builder.build()
-            } else {
-              sourceTable.uniqueKeysSet.orElse(null)
             }
+
+            val uniqueSet = sourceTable.uniqueKeysSet.orElse(null)
+            if (uniqueSet != null) {
+              builder.addAll(uniqueSet)
+            }
+
+            val result = builder.build()
+            if (result.isEmpty) null else result
         }
       case table: FlinkPreparingTableBase => table.uniqueKeysSet.orElse(null)
       case _ => null

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/HashAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/HashAggregateTest.xml
@@ -1071,4 +1071,69 @@ HashAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS EXPR$0, Final_SUM(sum$
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReduceGroupingOnTableWithCompositePrimaryKey[aggStrategy=AUTO]">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(val) FROM tableWithCompositePk GROUP BY grp1, grp2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(grp1=[$3], grp2=[$4], val=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- HashAggregate(isMerge=[true], groupBy=[grp1, grp2], select=[grp1, grp2, Final_SUM(sum$0) AS EXPR$0])
+   +- Exchange(distribution=[hash[grp1, grp2]])
+      +- LocalHashAggregate(groupBy=[grp1, grp2], select=[grp1, grp2, Partial_SUM(val) AS sum$0])
+         +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[grp1, grp2, val]]], fields=[grp1, grp2, val])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReduceGroupingOnTableWithCompositePrimaryKey[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(val) FROM tableWithCompositePk GROUP BY grp1, grp2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(grp1=[$3], grp2=[$4], val=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- HashAggregate(isMerge=[true], groupBy=[grp1, grp2], select=[grp1, grp2, Final_SUM(sum$0) AS EXPR$0])
+   +- Exchange(distribution=[hash[grp1, grp2]])
+      +- LocalHashAggregate(groupBy=[grp1, grp2], select=[grp1, grp2, Partial_SUM(val) AS sum$0])
+         +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[grp1, grp2, val]]], fields=[grp1, grp2, val])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReduceGroupingOnTableWithCompositePrimaryKey[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(val) FROM tableWithCompositePk GROUP BY grp1, grp2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(grp1=[$3], grp2=[$4], val=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- HashAggregate(isMerge=[false], groupBy=[grp1, grp2], select=[grp1, grp2, SUM(val) AS EXPR$0])
+   +- Exchange(distribution=[hash[grp1, grp2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[grp1, grp2, val]]], fields=[grp1, grp2, val])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/SortAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/SortAggregateTest.xml
@@ -1281,4 +1281,74 @@ SortAggregate(isMerge=[true], select=[Final_SUM(sum$0) AS EXPR$0, Final_SUM(sum$
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReduceGroupingOnTableWithCompositePrimaryKey[aggStrategy=AUTO]">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(val) FROM tableWithCompositePk GROUP BY grp1, grp2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(grp1=[$3], grp2=[$4], val=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- SortAggregate(isMerge=[true], groupBy=[grp1, grp2], select=[grp1, grp2, Final_SUM(sum$0) AS EXPR$0])
+   +- Sort(orderBy=[grp1 ASC, grp2 ASC])
+      +- Exchange(distribution=[hash[grp1, grp2]])
+         +- LocalSortAggregate(groupBy=[grp1, grp2], select=[grp1, grp2, Partial_SUM(val) AS sum$0])
+            +- Sort(orderBy=[grp1 ASC, grp2 ASC])
+               +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[grp1, grp2, val]]], fields=[grp1, grp2, val])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReduceGroupingOnTableWithCompositePrimaryKey[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(val) FROM tableWithCompositePk GROUP BY grp1, grp2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(grp1=[$3], grp2=[$4], val=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- SortAggregate(isMerge=[true], groupBy=[grp1, grp2], select=[grp1, grp2, Final_SUM(sum$0) AS EXPR$0])
+   +- Sort(orderBy=[grp1 ASC, grp2 ASC])
+      +- Exchange(distribution=[hash[grp1, grp2]])
+         +- LocalSortAggregate(groupBy=[grp1, grp2], select=[grp1, grp2, Partial_SUM(val) AS sum$0])
+            +- Sort(orderBy=[grp1 ASC, grp2 ASC])
+               +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[grp1, grp2, val]]], fields=[grp1, grp2, val])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReduceGroupingOnTableWithCompositePrimaryKey[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT SUM(val) FROM tableWithCompositePk GROUP BY grp1, grp2]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$0=[SUM($2)])
+   +- LogicalProject(grp1=[$3], grp2=[$4], val=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- SortAggregate(isMerge=[false], groupBy=[grp1, grp2], select=[grp1, grp2, SUM(val) AS EXPR$0])
+   +- Sort(orderBy=[grp1 ASC, grp2 ASC])
+      +- Exchange(distribution=[hash[grp1, grp2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[grp1, grp2, val]]], fields=[grp1, grp2, val])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
@@ -398,6 +398,30 @@ Calc(select=[a1, a2, b1, b2], changelogMode=[I,UB,UA])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinAndSelectOnPartialCompositePrimaryKey">
+    <Resource name="sql">
+      <![CDATA[SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalJoin(condition=[=($0, $3)], joinType=[left])
+   :- LogicalTableScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a1, a2, a3)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, tableWithCompositePk]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a1])
++- Join(joinType=[LeftOuterJoin], where=[=(a1, pk1)], select=[a1, pk1], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1])
+   :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, A, source: [TestTableSource(a1, a2, a3)]]], fields=[a1, a2, a3])
+   +- Exchange(distribution=[hash[pk1]])
+      +- TableSourceScan(table=[[default_catalog, default_database, tableWithCompositePk, project=[pk1]]], fields=[pk1])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinWithSort">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -57,6 +57,20 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUniqueKeysOnProjectedTableScanWithPartialCompositePrimaryKey(): Unit = {
+    val table = relBuilder
+      .getRelOptSchema
+      .asInstanceOf[CalciteCatalogReader]
+      .getTable(Seq("projected_table_source_table_with_partial_pk"))
+      .asInstanceOf[TableSourceTable]
+    val tableSourceScan = new StreamExecTableSourceScan(
+      cluster,
+      streamPhysicalTraits,
+      table)
+    assertNull(mq.getUniqueKeys(tableSourceScan))
+  }
+
+  @Test
   def testGetUniqueKeysOnValues(): Unit = {
     assertNull(mq.getUniqueKeys(logicalValues))
     assertNull(mq.getUniqueKeys(emptyValues))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/MetadataTestUtil.scala
@@ -56,6 +56,9 @@ object MetadataTestUtil {
     rootSchema.add("TemporalTable2", createTemporalTable2())
     rootSchema.add("TemporalTable3", createTemporalTable3())
     rootSchema.add("projected_table_source_table", createProjectedTableSourceTable())
+    rootSchema.add(
+      "projected_table_source_table_with_partial_pk",
+      createProjectedTableSourceTableWithPartialCompositePrimaryKey())
     rootSchema
   }
 
@@ -266,6 +269,36 @@ object MetadataTestUtil {
       true,
       catalogTable,
       Array("project=[a, c, d]"))
+  }
+
+  private def createProjectedTableSourceTableWithPartialCompositePrimaryKey(): Table = {
+    val catalogTable = CatalogTableImpl.fromProperties(
+      Map(
+        "connector" -> "values",
+        "bounded" -> "true",
+        "schema.0.name" -> "a",
+        "schema.0.data-type" -> "BIGINT NOT NULL",
+        "schema.1.name" -> "b",
+        "schema.1.data-type" -> "BIGINT NOT NULL",
+        "schema.primary-key.name" -> "PK_1",
+        "schema.primary-key.columns" -> "a,b")
+    )
+
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem)
+    val rowType = typeFactory.buildRelNodeRowType(
+      Seq("a"),
+      Seq(new BigIntType(false)))
+
+    new MockTableSourceTable(
+      ObjectIdentifier.of(
+        "default_catalog",
+        "default_database",
+        "projected_table_source_table_with_partial_pk"),
+      rowType,
+      new TestTableSource(),
+      true,
+      catalogTable,
+      Array("project=[a]"))
   }
 
   private def getMetadataTable(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.scala
@@ -284,4 +284,19 @@ class JoinTest extends TableTestBase {
   def testRightOuterJoinEquiAndNonEquiPred(): Unit = {
     util.verifyPlan("SELECT b, y FROM t RIGHT OUTER JOIN s ON a = z AND b < x")
   }
+
+  @Test
+  def testJoinAndSelectOnPartialCompositePrimaryKey(): Unit = {
+    util.tableEnv.executeSql(
+      """
+        |CREATE TABLE tableWithCompositePk (
+        |  pk1 INT,
+        |  pk2 BIGINT,
+        |  PRIMARY KEY (pk1, pk2) NOT ENFORCED
+        |) WITH (
+        |  'connector'='values'
+        |)
+        |""".stripMargin)
+    util.verifyPlan("SELECT A.a1 FROM A LEFT JOIN tableWithCompositePk T ON A.a1 = T.pk1")
+  }
 }


### PR DESCRIPTION
(This PR is picked from #15540.)

## What is the purpose of the change

`FlinkRelMdUniqueKeys#getTableUniqueKeys` currently does not consider the case when projections are pushed down and cause only a part of the composite primary key to be selected.

This PR fixes this issue.

## Brief change log

 - Fix join & select a portion of composite primary key will cause ArrayIndexOutOfBoundsException

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable