### PR TITLE
[FLINK-23158] Add source transformations to the list when adding sources

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1794,8 +1794,16 @@ public class StreamExecutionEnvironment {
         clean(function);
 
         final StreamSource<OUT, ?> sourceOperator = new StreamSource<>(function);
-        return new DataStreamSource<>(
-                this, resolvedTypeInfo, sourceOperator, isParallel, sourceName, boundedness);
+        DataStreamSource<OUT> dataStreamSource =
+                new DataStreamSource<>(
+                        this,
+                        resolvedTypeInfo,
+                        sourceOperator,
+                        isParallel,
+                        sourceName,
+                        boundedness);
+        addOperator(dataStreamSource.getTransformation());
+        return dataStreamSource;
     }
 
     /**
@@ -1852,12 +1860,15 @@ public class StreamExecutionEnvironment {
         final TypeInformation<OUT> resolvedTypeInfo =
                 getTypeInfo(source, sourceName, Source.class, typeInfo);
 
-        return new DataStreamSource<>(
-                this,
-                checkNotNull(source, "source"),
-                checkNotNull(timestampsAndWatermarks, "timestampsAndWatermarks"),
-                checkNotNull(resolvedTypeInfo),
-                checkNotNull(sourceName));
+        DataStreamSource<OUT> dataStreamSource =
+                new DataStreamSource<>(
+                        this,
+                        checkNotNull(source, "source"),
+                        checkNotNull(timestampsAndWatermarks, "timestampsAndWatermarks"),
+                        checkNotNull(resolvedTypeInfo),
+                        checkNotNull(sourceName));
+        addOperator(dataStreamSource.getTransformation());
+        return dataStreamSource;
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.flink.streaming.api;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
@@ -347,6 +350,21 @@ public class StreamExecutionEnvironmentTest {
         DataStreamSource<Row> source2 = env.addSource(new RowSourceFunction());
         // the source type information should be derived from RowSourceFunction#getProducedType
         assertEquals(new GenericTypeInfo<>(Row.class), source2.getType());
+    }
+
+    @Test
+    public void testTransformationAddedForLegacySource() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.addSource(new RowSourceFunction());
+        assertEquals(1, env.getStreamGraph().getStreamNodes().size());
+    }
+
+    @Test
+    public void testTransformationAddedForNewSource() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.fromSource(
+                new MockSource(Boundedness.BOUNDED, 5), WatermarkStrategy.noWatermarks(), "mock");
+        assertEquals(1, env.getStreamGraph().getStreamNodes().size());
     }
 
     /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What is the purpose of the change

This PR explicitly adds the source transformation to the list of the env to avoid exception thrown for source only jobs.

## Brief change log

- 66ed8fc72a4301a4b23b06e255bfb658fc5d3928 explicitly added the transformation.

## Verifying this change

This PR is verified by the added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**