### PR TITLE
[FLINK-21925][api] Support configuring fine grained resource requirements via DataStream API

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -332,6 +332,10 @@ public final class ResourceSpec implements Serializable {
         return new Builder(new CPUResource(cpuCores), MemorySize.ofMebiBytes(taskHeapMemoryMB));
     }
 
+    public static Builder newBuilder(double cpuCores, MemorySize taskHeapMemory) {
+        return new Builder(new CPUResource(cpuCores), taskHeapMemory);
+    }
+
     /** Builder for the {@link ResourceSpec}. */
     public static class Builder {
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -359,7 +359,7 @@ public final class ResourceSpec implements Serializable {
             return this;
         }
 
-        public Builder setOffTaskHeapMemoryMB(int taskOffHeapMemoryMB) {
+        public Builder setTaskOffHeapMemoryMB(int taskOffHeapMemoryMB) {
             this.taskOffHeapMemory = MemorySize.ofMebiBytes(taskOffHeapMemoryMB);
             return this;
         }

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.MemorySize;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,7 +71,13 @@ public final class ResourceSpec implements Serializable {
     public static final ResourceSpec DEFAULT = UNKNOWN;
 
     /** A ResourceSpec that indicates zero amount of resources. */
-    public static final ResourceSpec ZERO = ResourceSpec.newBuilder(0.0, 0).build();
+    public static final ResourceSpec ZERO =
+            new ResourceSpec(
+                    new CPUResource(0.0),
+                    MemorySize.ZERO,
+                    MemorySize.ZERO,
+                    MemorySize.ZERO,
+                    Collections.emptyMap());
 
     /** How many cpu cores are needed. Can be null only if it is unknown. */
     @Nullable private final CPUResource cpuCores;
@@ -397,6 +404,8 @@ public final class ResourceSpec implements Serializable {
         }
 
         public ResourceSpec build() {
+            checkArgument(cpuCores.getValue().compareTo(BigDecimal.ZERO) > 0);
+            checkArgument(taskHeapMemory.compareTo(MemorySize.ZERO) > 0);
             return new ResourceSpec(
                     cpuCores, taskHeapMemory, taskOffHeapMemory, managedMemory, extendedResources);
         }

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/SlotSharingGroup.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/SlotSharingGroup.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.MemorySize;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Describe the name and the the different resource components of a slot sharing group. */
+@PublicEvolving
+public class SlotSharingGroup implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+
+    /** How many cpu cores are needed. Can be null only if it is unknown. */
+    @Nullable // can be null only for UNKNOWN
+    private final CPUResource cpuCores;
+
+    /** How much task heap memory is needed. */
+    @Nullable // can be null only for UNKNOWN
+    private final MemorySize taskHeapMemory;
+
+    /** How much task off-heap memory is needed. */
+    @Nullable // can be null only for UNKNOWN
+    private final MemorySize taskOffHeapMemory;
+
+    /** How much managed memory is needed. */
+    @Nullable // can be null only for UNKNOWN
+    private final MemorySize managedMemory;
+
+    /** A extensible field for user specified resources from {@link SlotSharingGroup}. */
+    private final Map<String, Double> externalResources = new HashMap<>();
+
+    private SlotSharingGroup(
+            String name,
+            CPUResource cpuCores,
+            MemorySize taskHeapMemory,
+            MemorySize taskOffHeapMemory,
+            MemorySize managedMemory,
+            Map<String, Double> extendedResources) {
+        this.name = checkNotNull(name);
+        this.cpuCores = checkNotNull(cpuCores);
+        this.taskHeapMemory = checkNotNull(taskHeapMemory);
+        this.taskOffHeapMemory = checkNotNull(taskOffHeapMemory);
+        this.managedMemory = checkNotNull(managedMemory);
+        this.externalResources.putAll(checkNotNull(extendedResources));
+    }
+
+    private SlotSharingGroup(String name) {
+        this.name = checkNotNull(name);
+        this.cpuCores = null;
+        this.taskHeapMemory = null;
+        this.taskOffHeapMemory = null;
+        this.managedMemory = null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Optional<MemorySize> getManagedMemory() {
+        return Optional.ofNullable(managedMemory);
+    }
+
+    public Optional<MemorySize> getTaskHeapMemory() {
+        return Optional.ofNullable(taskHeapMemory);
+    }
+
+    public Optional<MemorySize> getTaskOffHeapMemory() {
+        return Optional.ofNullable(taskOffHeapMemory);
+    }
+
+    public Optional<Double> getCpuCores() {
+        return Optional.ofNullable(cpuCores)
+                .map(cpuResource -> cpuResource.getValue().doubleValue());
+    }
+
+    public Map<String, Double> getExternalResources() {
+        return Collections.unmodifiableMap(externalResources);
+    }
+
+    public static Builder newBuilder(String name) {
+        return new Builder(name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj != null && obj.getClass() == SlotSharingGroup.class) {
+            SlotSharingGroup that = (SlotSharingGroup) obj;
+            return Objects.equals(this.cpuCores, that.cpuCores)
+                    && Objects.equals(taskHeapMemory, that.taskHeapMemory)
+                    && Objects.equals(taskOffHeapMemory, that.taskOffHeapMemory)
+                    && Objects.equals(managedMemory, that.managedMemory)
+                    && Objects.equals(externalResources, that.externalResources);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(cpuCores);
+        result = 31 * result + Objects.hashCode(taskHeapMemory);
+        result = 31 * result + Objects.hashCode(taskOffHeapMemory);
+        result = 31 * result + Objects.hashCode(managedMemory);
+        result = 31 * result + externalResources.hashCode();
+        return result;
+    }
+
+    /** Builder for the {@link SlotSharingGroup}. */
+    public static class Builder {
+
+        private String name;
+        private CPUResource cpuCores;
+        private MemorySize taskHeapMemory;
+        private MemorySize taskOffHeapMemory;
+        private MemorySize managedMemory;
+        private Map<String, Double> externalResources = new HashMap<>();
+
+        private Builder(String name) {
+            this.name = name;
+        }
+
+        /** Set the CPU cores for this SlotSharingGroup. */
+        public Builder setCpuCores(double cpuCores) {
+            checkArgument(cpuCores > 0, "The cpu cores should be positive.");
+            this.cpuCores = new CPUResource(cpuCores);
+            return this;
+        }
+
+        /** Set the task heap memory for this SlotSharingGroup. */
+        public Builder setTaskHeapMemory(MemorySize taskHeapMemory) {
+            checkArgument(
+                    taskHeapMemory.compareTo(MemorySize.ZERO) > 0,
+                    "The task heap memory should be positive.");
+            this.taskHeapMemory = taskHeapMemory;
+            return this;
+        }
+
+        /** Set the task heap memory for this SlotSharingGroup in MB. */
+        public Builder setTaskHeapMemoryMB(int taskHeapMemoryMB) {
+            checkArgument(taskHeapMemoryMB > 0, "The task heap memory should be positive.");
+            this.taskHeapMemory = MemorySize.ofMebiBytes(taskHeapMemoryMB);
+            return this;
+        }
+
+        /** Set the task off-heap memory for this SlotSharingGroup. */
+        public Builder setTaskOffHeapMemory(MemorySize taskOffHeapMemory) {
+            this.taskOffHeapMemory = taskOffHeapMemory;
+            return this;
+        }
+
+        /** Set the task off-heap memory for this SlotSharingGroup in MB. */
+        public Builder setTaskOffHeapMemoryMB(int taskOffHeapMemoryMB) {
+            this.taskOffHeapMemory = MemorySize.ofMebiBytes(taskOffHeapMemoryMB);
+            return this;
+        }
+
+        /** Set the task managed memory for this SlotSharingGroup. */
+        public Builder setManagedMemory(MemorySize managedMemory) {
+            this.managedMemory = managedMemory;
+            return this;
+        }
+
+        /** Set the task managed memory for this SlotSharingGroup in MB. */
+        public Builder setManagedMemoryMB(int managedMemoryMB) {
+            this.managedMemory = MemorySize.ofMebiBytes(managedMemoryMB);
+            return this;
+        }
+
+        /**
+         * Add the given external resource. The old value with the same resource name will be
+         * replaced if present.
+         */
+        public Builder setExternalResource(String name, double value) {
+            this.externalResources.put(name, value);
+            return this;
+        }
+
+        /** Build the SlotSharingGroup. */
+        public SlotSharingGroup build() {
+            if (cpuCores != null && taskHeapMemory != null) {
+                taskOffHeapMemory = Optional.ofNullable(taskOffHeapMemory).orElse(MemorySize.ZERO);
+                managedMemory = Optional.ofNullable(managedMemory).orElse(MemorySize.ZERO);
+                return new SlotSharingGroup(
+                        name,
+                        cpuCores,
+                        taskHeapMemory,
+                        taskOffHeapMemory,
+                        managedMemory,
+                        externalResources);
+            } else if (cpuCores != null
+                    || taskHeapMemory != null
+                    || taskOffHeapMemory != null
+                    || managedMemory != null
+                    || !externalResources.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "The cpu cores and task heap memory are required when specifying the resource of a slot sharing group. "
+                                + "You need to explicitly configure them with positive value.");
+            } else {
+                return new SlotSharingGroup(name);
+            }
+        }
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/SlotSharingGroupUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/SlotSharingGroupUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators.util;
+
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
+import org.apache.flink.api.common.resources.ExternalResource;
+import org.apache.flink.util.Preconditions;
+
+import java.util.stream.Collectors;
+
+/** Utils for {@link SlotSharingGroup}. */
+public class SlotSharingGroupUtils {
+    public static ResourceSpec extractResourceSpec(SlotSharingGroup slotSharingGroup) {
+        if (!slotSharingGroup.getCpuCores().isPresent()) {
+            return ResourceSpec.UNKNOWN;
+        }
+
+        Preconditions.checkState(slotSharingGroup.getCpuCores().isPresent());
+        Preconditions.checkState(slotSharingGroup.getTaskHeapMemory().isPresent());
+        Preconditions.checkState(slotSharingGroup.getTaskOffHeapMemory().isPresent());
+        Preconditions.checkState(slotSharingGroup.getManagedMemory().isPresent());
+
+        return ResourceSpec.newBuilder(
+                        slotSharingGroup.getCpuCores().get(),
+                        slotSharingGroup.getTaskHeapMemory().get())
+                .setTaskOffHeapMemory(slotSharingGroup.getTaskOffHeapMemory().get())
+                .setManagedMemory(slotSharingGroup.getManagedMemory().get())
+                .setExtendedResources(
+                        slotSharingGroup.getExternalResources().entrySet().stream()
+                                .map(
+                                        entry ->
+                                                new ExternalResource(
+                                                        entry.getKey(), entry.getValue()))
+                                .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -123,6 +123,14 @@ public class ClusterOptions {
                     .withDescription(
                             "Defines whether the cluster uses fine-grained resource management.");
 
+    @Documentation.ExcludeFromDocumentation
+    public static final ConfigOption<Boolean> FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING =
+            ConfigOptions.key("fine-grained.shuffle-mode.all-blocking")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to convert all PIPELINE edges to BLOCKING when apply fine-grained resource management in batch jobs.");
+
     public static JobManagerOptions.SchedulerType getSchedulerType(Configuration configuration) {
         if (isAdaptiveSchedulerEnabled(configuration) || isReactiveModeEnabled(configuration)) {
             return JobManagerOptions.SchedulerType.Adaptive;

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/SlotSharingGroupTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators;
+
+import org.apache.flink.configuration.MemorySize;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link SlotSharingGroup}. */
+public class SlotSharingGroupTest {
+    @Test
+    public void testBuildSlotSharingGroupWithSpecificResource() {
+        final String name = "ssg";
+        final MemorySize heap = MemorySize.ofMebiBytes(100);
+        final MemorySize offHeap = MemorySize.ofMebiBytes(200);
+        final MemorySize managed = MemorySize.ofMebiBytes(300);
+        final SlotSharingGroup slotSharingGroup =
+                SlotSharingGroup.newBuilder(name)
+                        .setCpuCores(1)
+                        .setTaskHeapMemory(heap)
+                        .setTaskOffHeapMemory(offHeap)
+                        .setManagedMemory(managed)
+                        .setExternalResource("gpu", 1)
+                        .build();
+
+        assertThat(slotSharingGroup.getName(), is(name));
+        assertThat(slotSharingGroup.getCpuCores().get(), is(1.0));
+        assertThat(slotSharingGroup.getTaskHeapMemory().get(), is(heap));
+        assertThat(slotSharingGroup.getTaskOffHeapMemory().get(), is(offHeap));
+        assertThat(slotSharingGroup.getManagedMemory().get(), is(managed));
+        assertThat(
+                slotSharingGroup.getExternalResources(), is(Collections.singletonMap("gpu", 1.0)));
+    }
+
+    @Test
+    public void testBuildSlotSharingGroupWithUnknownResource() {
+        final String name = "ssg";
+        final SlotSharingGroup slotSharingGroup = SlotSharingGroup.newBuilder(name).build();
+
+        assertThat(slotSharingGroup.getName(), is(name));
+        assertFalse(slotSharingGroup.getCpuCores().isPresent());
+        assertFalse(slotSharingGroup.getTaskHeapMemory().isPresent());
+        assertFalse(slotSharingGroup.getManagedMemory().isPresent());
+        assertFalse(slotSharingGroup.getTaskOffHeapMemory().isPresent());
+        assertTrue(slotSharingGroup.getExternalResources().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildSlotSharingGroupWithIllegalConfig() {
+        SlotSharingGroup.newBuilder("ssg")
+                .setCpuCores(1)
+                .setTaskHeapMemory(MemorySize.ZERO)
+                .setTaskOffHeapMemoryMB(10)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildSlotSharingGroupWithoutAllRequiredConfig() {
+        SlotSharingGroup.newBuilder("ssg").setCpuCores(1).setTaskOffHeapMemoryMB(10).build();
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/util/SlotSharingGroupUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/util/SlotSharingGroupUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators.util;
+
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
+import org.apache.flink.api.common.resources.ExternalResource;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/** Tests for {@link SlotSharingGroupUtils}. */
+public class SlotSharingGroupUtilsTest {
+    @Test
+    public void testCovertToResourceSpec() {
+        final ExternalResource gpu = new ExternalResource("gpu", 1);
+        final ResourceSpec resourceSpec =
+                ResourceSpec.newBuilder(1.0, 100)
+                        .setManagedMemoryMB(200)
+                        .setTaskOffHeapMemoryMB(300)
+                        .setExtendedResource(gpu)
+                        .build();
+        final SlotSharingGroup slotSharingGroup1 =
+                SlotSharingGroup.newBuilder("ssg")
+                        .setCpuCores(resourceSpec.getCpuCores().getValue().doubleValue())
+                        .setTaskHeapMemory(resourceSpec.getTaskHeapMemory())
+                        .setTaskOffHeapMemory(resourceSpec.getTaskOffHeapMemory())
+                        .setManagedMemory(resourceSpec.getManagedMemory())
+                        .setExternalResource(gpu.getName(), gpu.getValue().doubleValue())
+                        .build();
+        final SlotSharingGroup slotSharingGroup2 = SlotSharingGroup.newBuilder("ssg").build();
+
+        assertThat(SlotSharingGroupUtils.extractResourceSpec(slotSharingGroup1), is(resourceSpec));
+        assertThat(
+                SlotSharingGroupUtils.extractResourceSpec(slotSharingGroup2),
+                is(ResourceSpec.UNKNOWN));
+    }
+}

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -39,6 +39,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
         # Currently only the methods for configuration is added.
         # 'isForceCheckpointing', 'getNumberOfExecutionRetries', 'setNumberOfExecutionRetries'
         # is deprecated, exclude them.
+        # TODO the registerSlotSharingGroup should be removed from this list after FLINK-23165.
         return {'getLastJobExecutionResult', 'getId', 'getIdString',
                 'registerCachedFile', 'createCollectionsEnvironment', 'createLocalEnvironment',
                 'createRemoteEnvironment', 'addOperator', 'fromElements',
@@ -48,7 +49,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
-                'clearJobListeners', 'getJobListeners', "fromSequence"}
+                'clearJobListeners', 'getJobListeners', "fromSequence", "registerSlotSharingGroup"}
 
 
 if __name__ == '__main__':

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -215,7 +215,9 @@ public class PythonConfigUtil {
 
     private static void chainTransformation(
             Transformation<?> firstTransformation, Transformation<?> secondTransformation) {
-        firstTransformation.setSlotSharingGroup(secondTransformation.getSlotSharingGroup());
+        secondTransformation
+                .getSlotSharingGroup()
+                .ifPresent(firstTransformation::setSlotSharingGroup);
         firstTransformation.setCoLocationGroupKey(secondTransformation.getCoLocationGroupKey());
         firstTransformation.setParallelism(secondTransformation.getParallelism());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -269,7 +269,7 @@ public class DispatcherTest extends TestLogger {
      */
     @Test
     public void testJobSubmissionWithPartialResourceConfigured() throws Exception {
-        ResourceSpec resourceSpec = ResourceSpec.newBuilder(2.0, 0).build();
+        ResourceSpec resourceSpec = ResourceSpec.newBuilder(2.0, 10).build();
 
         final JobVertex firstVertex = new JobVertex("firstVertex");
         firstVertex.setInvokableClass(NoOpInvokable.class);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.StreamSink;
@@ -202,6 +203,24 @@ public class DataStreamSink<T> {
      */
     @PublicEvolving
     public DataStreamSink<T> slotSharingGroup(String slotSharingGroup) {
+        transformation.setSlotSharingGroup(slotSharingGroup);
+        return this;
+    }
+
+    /**
+     * Sets the slot sharing group of this operation. Parallel instances of operations that are in
+     * the same slot sharing group will be co-located in the same TaskManager slot, if possible.
+     *
+     * <p>Operations inherit the slot sharing group of input operations if all input operations are
+     * in the same slot sharing group and no slot sharing group was explicitly specified.
+     *
+     * <p>Initially an operation is in the default slot sharing group. An operation can be put into
+     * the default group explicitly by setting the slot sharing group with name {@code "default"}.
+     *
+     * @param slotSharingGroup which contains name and its resource spec.
+     */
+    @PublicEvolving
+    public DataStreamSink<T> slotSharingGroup(SlotSharingGroup slotSharingGroup) {
         transformation.setSlotSharingGroup(slotSharingGroup);
         return this;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.common.operators.util.OperatorValidationUtils;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -369,6 +370,24 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
      */
     @PublicEvolving
     public SingleOutputStreamOperator<T> slotSharingGroup(String slotSharingGroup) {
+        transformation.setSlotSharingGroup(slotSharingGroup);
+        return this;
+    }
+
+    /**
+     * Sets the slot sharing group of this operation. Parallel instances of operations that are in
+     * the same slot sharing group will be co-located in the same TaskManager slot, if possible.
+     *
+     * <p>Operations inherit the slot sharing group of input operations if all input operations are
+     * in the same slot sharing group and no slot sharing group was explicitly specified.
+     *
+     * <p>Initially an operation is in the default slot sharing group. An operation can be put into
+     * the default group explicitly by setting the slot sharing group with name {@code "default"}.
+     *
+     * @param slotSharingGroup which contains name and its resource spec.
+     */
+    @PublicEvolving
+    public SingleOutputStreamOperator<T> slotSharingGroup(SlotSharingGroup slotSharingGroup) {
         transformation.setSlotSharingGroup(slotSharingGroup);
         return this;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -52,10 +52,12 @@ import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
@@ -91,6 +93,7 @@ import org.apache.flink.streaming.api.functions.source.SocketTextStreamFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
@@ -2099,6 +2102,24 @@ public class StreamExecutionEnvironment {
     @Internal
     public StreamGraph getStreamGraph(String jobName, boolean clearTransformations) {
         StreamGraph streamGraph = getStreamGraphGenerator().setJobName(jobName).generate();
+
+        // There might be a resource deadlock when applying fine-grained resource management in
+        // batch jobs with PIPELINE edges. Users need to trigger the
+        // fine-grained.shuffle-mode.all-blocking to convert all edges to BLOCKING before we fix
+        // that issue.
+        if (configuration.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.BATCH
+                && streamGraph.hasFineGrainedResource()) {
+            if (configuration.get(ClusterOptions.FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING)) {
+                streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
+            } else {
+                throw new IllegalConfigurationException(
+                        "At the moment, fine-grained resource management requires batch workloads to "
+                                + "be executed with types of all edges being BLOCKING. To do that, you need to configure '"
+                                + ClusterOptions.FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING.key()
+                                + "' to 'true'. Notice that this may affect the performance. See FLINK-20865 for more details.");
+            }
+        }
+
         if (clearTransformations) {
             this.transformations.clear();
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -31,6 +31,9 @@ import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.io.FileInputFormat;
 import org.apache.flink.api.common.io.FilePathFilter;
 import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.operators.ResourceSpec;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
+import org.apache.flink.api.common.operators.util.SlotSharingGroupUtils;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -53,6 +56,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.RestOptions;
@@ -64,6 +68,7 @@ import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
@@ -110,8 +115,10 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -188,6 +195,9 @@ public class StreamExecutionEnvironment {
     private final ClassLoader userClassloader;
 
     private final List<JobListener> jobListeners = new ArrayList<>();
+
+    // Records the slot sharing groups and their corresponding fine-grained ResourceProfile
+    private final Map<String, ResourceProfile> slotSharingGroupResources = new HashMap<>();
 
     // --------------------------------------------------------------------------------------------
     // Constructor and Properties
@@ -333,6 +343,30 @@ public class StreamExecutionEnvironment {
                         + maxParallelism);
 
         config.setMaxParallelism(maxParallelism);
+        return this;
+    }
+
+    /**
+     * Register a slot sharing group with its resource spec.
+     *
+     * <p>Note that a slot sharing group hints the scheduler that the grouped operators CAN be
+     * deployed into a shared slot. There's no guarantee that the scheduler always deploy the
+     * grouped operators together. In cases grouped operators are deployed into separate slots, the
+     * slot resources will be derived from the specified group requirements.
+     *
+     * @param slotSharingGroup which contains name and its resource spec.
+     */
+    @PublicEvolving
+    public StreamExecutionEnvironment registerSlotSharingGroup(SlotSharingGroup slotSharingGroup) {
+        final ResourceSpec resourceSpec =
+                SlotSharingGroupUtils.extractResourceSpec(slotSharingGroup);
+        if (!resourceSpec.equals(ResourceSpec.UNKNOWN)) {
+            this.slotSharingGroupResources.put(
+                    slotSharingGroup.getName(),
+                    ResourceProfile.fromResourceSpec(
+                            SlotSharingGroupUtils.extractResourceSpec(slotSharingGroup),
+                            MemorySize.ZERO));
+        }
         return this;
     }
 
@@ -2087,7 +2121,8 @@ public class StreamExecutionEnvironment {
                 .setChaining(isChainingEnabled)
                 .setUserArtifacts(cacheFile)
                 .setTimeCharacteristic(timeCharacteristic)
-                .setDefaultBufferTimeout(bufferTimeout);
+                .setDefaultBufferTimeout(bufferTimeout)
+                .setSlotSharingGroupResource(slotSharingGroupResources);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -253,6 +253,11 @@ public class StreamGraph implements Pipeline {
         return Optional.ofNullable(slotSharingGroupResources.get(groupId));
     }
 
+    public boolean hasFineGrainedResource() {
+        return slotSharingGroupResources.values().stream()
+                .anyMatch(resourceProfile -> !resourceProfile.equals(ResourceProfile.UNKNOWN));
+    }
+
     /**
      * Set whether to put all vertices into the same slot sharing group by default.
      *

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/StreamExecutionEnvironmentTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -25,6 +26,7 @@ import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -48,7 +50,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -272,6 +277,45 @@ public class StreamExecutionEnvironmentTest {
         // override config
         env.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false).getJobGraph();
         Assert.assertEquals(1 << 15, operator.getTransformation().getMaxParallelism());
+    }
+
+    @Test
+    public void testRegisterSlotSharingGroup() {
+        final SlotSharingGroup ssg1 =
+                SlotSharingGroup.newBuilder("ssg1").setCpuCores(1).setTaskHeapMemoryMB(100).build();
+        final SlotSharingGroup ssg2 =
+                SlotSharingGroup.newBuilder("ssg2").setCpuCores(2).setTaskHeapMemoryMB(200).build();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.registerSlotSharingGroup(ssg1);
+        env.registerSlotSharingGroup(ssg2);
+        env.registerSlotSharingGroup(SlotSharingGroup.newBuilder("ssg3").build());
+
+        final DataStream<Integer> source = env.fromElements(1).slotSharingGroup("ssg1");
+        source.map(value -> value).slotSharingGroup(ssg2).addSink(new DiscardingSink<>());
+
+        final StreamGraph streamGraph = env.getStreamGraph();
+        assertThat(
+                streamGraph.getSlotSharingGroupResource("ssg1").get(),
+                is(ResourceProfile.fromResources(1, 100)));
+        assertThat(
+                streamGraph.getSlotSharingGroupResource("ssg2").get(),
+                is(ResourceProfile.fromResources(2, 200)));
+        assertFalse(streamGraph.getSlotSharingGroupResource("ssg3").isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRegisterSlotSharingGroupConflict() {
+        final SlotSharingGroup ssg =
+                SlotSharingGroup.newBuilder("ssg1").setCpuCores(1).setTaskHeapMemoryMB(100).build();
+        final SlotSharingGroup ssgConflict =
+                SlotSharingGroup.newBuilder("ssg1").setCpuCores(2).setTaskHeapMemoryMB(200).build();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.registerSlotSharingGroup(ssg);
+
+        final DataStream<Integer> source = env.fromElements(1).slotSharingGroup("ssg1");
+        source.map(value -> value).slotSharingGroup(ssgConflict).addSink(new DiscardingSink<>());
+
+        env.getStreamGraph();
     }
 
     @Test

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -24,6 +24,7 @@ import org.apache.flink.annotation.{Experimental, Internal, Public, PublicEvolvi
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
+import org.apache.flink.api.common.operators.SlotSharingGroup
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.connector.source.{Source, SourceSplit}
@@ -104,6 +105,22 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     **/
   def setMaxParallelism(maxParallelism: Int): Unit = {
     javaEnv.setMaxParallelism(maxParallelism)
+  }
+
+  /**
+   * Register a slot sharing group with its resource spec.
+   *
+   * <p>Note that a slot sharing group hints the scheduler that the grouped operators CAN be
+   * deployed into a shared slot. There's no guarantee that the scheduler always deploy the
+   * grouped operators together. In cases grouped operators are deployed into separate slots, the
+   * slot resources will be derived from the specified group requirements.
+   *
+   * @param slotSharingGroup which contains name and its resource spec.
+   */
+  @PublicEvolving
+  def registerSlotSharingGroup(slotSharingGroup: SlotSharingGroup): StreamExecutionEnvironment = {
+    javaEnv.registerSlotSharingGroup(slotSharingGroup)
+    this
   }
 
   /**


### PR DESCRIPTION

## What is the purpose of the change

Support configuring fine grained resource requirements via DataStream API.


## Brief change log

- Introduce `SlotSharingGroup`. Users can use this class to describe the name and the the different resource components of a slot sharing group.
- Add `#slotSharingGroup(SlotSharingGroup)`.
- Add `StreamExecutionEnvironment#registerSlotSharingGroup(SlotSharingGroup)`
- Add internal option `fine-grained.shuffle-mode.all-blocking` to avoid resource deadlock in batch jobs that apply fine-grained resource management.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? will be documented in the following PRs.