### PR TITLE
[FLINK-23078][benchmark] Add SchedulerBenchmarkBase#teardown

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkBase.java
@@ -16,26 +16,23 @@
  * limitations under the License
  */
 
-package org.apache.flink.runtime.scheduler.benchmark.deploying;
+package org.apache.flink.runtime.scheduler.benchmark;
 
-import org.apache.flink.runtime.executiongraph.Execution;
-import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.runtime.testutils.TestingUtils;
 
-import org.junit.Test;
+import java.util.concurrent.ScheduledExecutorService;
 
-/**
- * The benchmark of deploying downstream tasks in a BATCH job. The related method is {@link
- * Execution#deploy}.
- */
-public class DeployingDownstreamTasksInBatchJobBenchmarkTest extends TestLogger {
+/** Base class of all scheduler benchmarks. */
+public class SchedulerBenchmarkBase {
+    public ScheduledExecutorService scheduledExecutorService;
 
-    @Test
-    public void deployDownstreamTasks() throws Exception {
-        DeployingDownstreamTasksInBatchJobBenchmark benchmark =
-                new DeployingDownstreamTasksInBatchJobBenchmark();
-        benchmark.setup(JobConfiguration.BATCH_TEST);
-        benchmark.deployDownstreamTasks();
-        benchmark.teardown();
+    public void setup() {
+        scheduledExecutorService = TestingUtils.defaultExecutor();
+    }
+
+    public void teardown() {
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmark.java
@@ -31,8 +31,9 @@ public class DeployingDownstreamTasksInBatchJobBenchmark extends DeployingTasksB
 
     private ExecutionVertex[] vertices;
 
+    @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
-        createAndSetupExecutionGraph(jobConfiguration);
+        super.setup(jobConfiguration);
 
         final JobVertex source = jobVertices.get(0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksBenchmarkBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 
 import java.util.List;
 
@@ -33,16 +34,19 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
 
 /** The base class of benchmarks related to deploying tasks. */
-public class DeployingTasksBenchmarkBase {
+public class DeployingTasksBenchmarkBase extends SchedulerBenchmarkBase {
 
     List<JobVertex> jobVertices;
     ExecutionGraph executionGraph;
 
-    public void createAndSetupExecutionGraph(JobConfiguration jobConfiguration) throws Exception {
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        super.setup();
 
         jobVertices = createDefaultJobVertices(jobConfiguration);
 
-        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+        executionGraph =
+                createAndInitExecutionGraph(
+                        jobVertices, jobConfiguration, scheduledExecutorService);
 
         final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmark.java
@@ -29,8 +29,9 @@ import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
  */
 public class DeployingTasksInStreamingJobBenchmark extends DeployingTasksBenchmarkBase {
 
+    @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
-        createAndSetupExecutionGraph(jobConfiguration);
+        super.setup(jobConfiguration);
     }
 
     public void deployAllTasks() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkTest.java
@@ -36,5 +36,6 @@ public class DeployingTasksInStreamingJobBenchmarkTest extends TestLogger {
                 new DeployingTasksInStreamingJobBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.deployAllTasks();
+        benchmark.teardown();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmark.java
@@ -21,9 +21,10 @@ package org.apache.flink.runtime.scheduler.benchmark.e2e;
 import org.apache.flink.runtime.scheduler.DefaultScheduler;
 
 /** The benchmark of creating the scheduler in a STREAMING/BATCH job. */
-public class CreateSchedulerBenchmark extends SchedulerBenchmarkBase {
+public class CreateSchedulerBenchmark extends SchedulerEndToEndBenchmarkBase {
 
     public DefaultScheduler createScheduler() throws Exception {
-        return createScheduler(jobGraph, physicalSlotProvider, mainThreadExecutor);
+        return createScheduler(
+                jobGraph, physicalSlotProvider, mainThreadExecutor, scheduledExecutorService);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmark.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
  * The benchmark of scheduling and deploying tasks in a STREAMING/BATCH job. The related method is
  * {@link DefaultScheduler#startScheduling}.
  */
-public class SchedulingAndDeployingBenchmark extends SchedulerBenchmarkBase {
+public class SchedulingAndDeployingBenchmark extends SchedulerEndToEndBenchmarkBase {
 
     private DefaultScheduler scheduler;
 
@@ -36,7 +36,12 @@ public class SchedulingAndDeployingBenchmark extends SchedulerBenchmarkBase {
 
         super.setup(jobConfiguration);
 
-        scheduler = createScheduler(jobGraph, physicalSlotProvider, mainThreadExecutor);
+        scheduler =
+                createScheduler(
+                        jobGraph,
+                        physicalSlotProvider,
+                        mainThreadExecutor,
+                        scheduledExecutorService);
     }
 
     public void startScheduling() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/FailoverBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/FailoverBenchmarkBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 
 import java.util.List;
@@ -30,7 +31,7 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
 
 /** The base class of benchmarks related to failover. */
-public class FailoverBenchmarkBase {
+public class FailoverBenchmarkBase extends SchedulerBenchmarkBase {
 
     JobVertex source;
     List<JobVertex> jobVertices;
@@ -39,11 +40,14 @@ public class FailoverBenchmarkBase {
     SchedulingTopology schedulingTopology;
     RestartPipelinedRegionFailoverStrategy strategy;
 
-    public void createRestartPipelinedRegionFailoverStrategy(JobConfiguration jobConfiguration)
-            throws Exception {
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        super.setup();
+
         jobVertices = createDefaultJobVertices(jobConfiguration);
         source = jobVertices.get(0);
-        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+        executionGraph =
+                createAndInitExecutionGraph(
+                        jobVertices, jobConfiguration, scheduledExecutorService);
         schedulingTopology = executionGraph.getSchedulingTopology();
         strategy = new RestartPipelinedRegionFailoverStrategy(schedulingTopology);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmark.java
@@ -36,8 +36,9 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
  */
 public class RegionToRestartInBatchJobBenchmark extends FailoverBenchmarkBase {
 
+    @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
-        createRestartPipelinedRegionFailoverStrategy(jobConfiguration);
+        super.setup(jobConfiguration);
 
         final JobVertex source = jobVertices.get(0);
         final JobVertex sink = jobVertices.get(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkTest.java
@@ -35,5 +35,6 @@ public class RegionToRestartInBatchJobBenchmarkTest extends TestLogger {
         RegionToRestartInBatchJobBenchmark benchmark = new RegionToRestartInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.calculateRegionToRestart();
+        benchmark.teardown();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmark.java
@@ -34,8 +34,9 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
  */
 public class RegionToRestartInStreamingJobBenchmark extends FailoverBenchmarkBase {
 
+    @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
-        createRestartPipelinedRegionFailoverStrategy(jobConfiguration);
+        super.setup(jobConfiguration);
 
         TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkTest.java
@@ -36,5 +36,6 @@ public class RegionToRestartInStreamingJobBenchmarkTest extends TestLogger {
                 new RegionToRestartInStreamingJobBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.calculateRegionToRestart();
+        benchmark.teardown();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmark.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.R
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 
 import java.util.List;
 
@@ -36,15 +37,19 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
  * The benchmark of releasing partitions in a BATCH job. The related method is {@link
  * RegionPartitionReleaseStrategy#vertexFinished}.
  */
-public class PartitionReleaseInBatchJobBenchmark {
+public class PartitionReleaseInBatchJobBenchmark extends SchedulerBenchmarkBase {
 
     private ExecutionGraph executionGraph;
     private JobVertex sink;
 
     public void setup(JobConfiguration jobConfiguration) throws Exception {
+        super.setup();
+
         final List<JobVertex> jobVertices = createDefaultJobVertices(jobConfiguration);
 
-        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+        executionGraph =
+                createAndInitExecutionGraph(
+                        jobVertices, jobConfiguration, scheduledExecutorService);
 
         final JobVertex source = jobVertices.get(0);
         sink = jobVertices.get(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkTest.java
@@ -35,5 +35,6 @@ public class PartitionReleaseInBatchJobBenchmarkTest extends TestLogger {
         PartitionReleaseInBatchJobBenchmark benchmark = new PartitionReleaseInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.partitionRelease();
+        benchmark.teardown();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmark.java
@@ -28,8 +28,9 @@ public class InitSchedulingStrategyBenchmark extends SchedulingBenchmarkBase {
 
     public InitSchedulingStrategyBenchmark() {}
 
+    @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
-        initSchedulingTopology(jobConfiguration);
+        super.setup(jobConfiguration);
     }
 
     public PipelinedRegionSchedulingStrategy initSchedulingStrategy() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkTest.java
@@ -34,6 +34,7 @@ public class InitSchedulingStrategyBenchmarkTest extends TestLogger {
         InitSchedulingStrategyBenchmark benchmark = new InitSchedulingStrategyBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.initSchedulingStrategy();
+        benchmark.teardown();
     }
 
     @Test
@@ -41,5 +42,6 @@ public class InitSchedulingStrategyBenchmarkTest extends TestLogger {
         InitSchedulingStrategyBenchmark benchmark = new InitSchedulingStrategyBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.initSchedulingStrategy();
+        benchmark.teardown();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.scheduler.strategy.TestingSchedulerOperations;
 
@@ -30,17 +31,21 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
 
 /** The base class of benchmarks related to scheduling tasks. */
-public class SchedulingBenchmarkBase {
+public class SchedulingBenchmarkBase extends SchedulerBenchmarkBase {
 
     TestingSchedulerOperations schedulerOperations;
     List<JobVertex> jobVertices;
     ExecutionGraph executionGraph;
     SchedulingTopology schedulingTopology;
 
-    public void initSchedulingTopology(JobConfiguration jobConfiguration) throws Exception {
+    public void setup(JobConfiguration jobConfiguration) throws Exception {
+        super.setup();
+
         schedulerOperations = new TestingSchedulerOperations();
         jobVertices = createDefaultJobVertices(jobConfiguration);
-        executionGraph = createAndInitExecutionGraph(jobVertices, jobConfiguration);
+        executionGraph =
+                createAndInitExecutionGraph(
+                        jobVertices, jobConfiguration, scheduledExecutorService);
         schedulingTopology = executionGraph.getSchedulingTopology();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
@@ -36,8 +36,9 @@ public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenc
     private ExecutionVertexID executionVertexID;
     private PipelinedRegionSchedulingStrategy schedulingStrategy;
 
+    @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
-        initSchedulingTopology(jobConfiguration);
+        super.setup(jobConfiguration);
 
         schedulingStrategy =
                 new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -36,5 +36,6 @@ public class SchedulingDownstreamTasksInBatchJobBenchmarkTest extends TestLogger
                 new SchedulingDownstreamTasksInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.schedulingDownstreamTasks();
+        benchmark.teardown();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
+import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 
 import java.util.List;
 
@@ -35,7 +36,7 @@ import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUti
  * The benchmark of building the topology of {@link ExecutionGraph} in a STREAMING/BATCH job. The
  * related method is {@link ExecutionGraph#attachJobGraph},
  */
-public class BuildExecutionGraphBenchmark {
+public class BuildExecutionGraphBenchmark extends SchedulerBenchmarkBase {
 
     private List<JobVertex> jobVertices;
     private ExecutionGraph executionGraph;
@@ -43,6 +44,8 @@ public class BuildExecutionGraphBenchmark {
     public BuildExecutionGraphBenchmark() {}
 
     public void setup(JobConfiguration jobConfiguration) throws Exception {
+        super.setup();
+
         jobVertices = createDefaultJobVertices(jobConfiguration);
         final JobGraph jobGraph = createJobGraph(jobConfiguration);
         final VertexParallelismStore parallelismStore =
@@ -51,6 +54,8 @@ public class BuildExecutionGraphBenchmark {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .setVertexParallelismStore(parallelismStore)
                         .setJobGraph(jobGraph)
+                        .setFutureExecutor(scheduledExecutorService)
+                        .setIoExecutor(scheduledExecutorService)
                         .build();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkTest.java
@@ -35,6 +35,7 @@ public class BuildExecutionGraphBenchmarkTest extends TestLogger {
         BuildExecutionGraphBenchmark benchmark = new BuildExecutionGraphBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.buildTopology();
+        benchmark.teardown();
     }
 
     @Test
@@ -42,5 +43,6 @@ public class BuildExecutionGraphBenchmarkTest extends TestLogger {
         BuildExecutionGraphBenchmark benchmark = new BuildExecutionGraphBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.buildTopology();
+        benchmark.teardown();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*In FLINK-22988, TestUtils are ported from Scala to Java. However, SchedulerBenchmarkBase in flink-benchmark calls this method when each benchmark teardowns. This make SchedulerBenchmarks not compiling, as FLINK-23078 says. In #16250, we proposed to wrap `TestingUtils.defaultExecutor().shutdownNow()` into SchedulerBenchmarkUtil. In the discussion at https://github.com/apache/flink-benchmarks/pull/17, we decide to add a method called `teardown()` for each scheduler benchmark, and shutdown the executor in the `teardown()` method.*


## Brief change log

  - *Make all scheduler benchmarks inherit a base class called `SchedulerBenchmarkBase`*
  - *Add `setup` method to `SchedulerBenchmarkBase` to setup the default executor*
  - *Add `teardown` method to `SchedulerBenchmarkBase` to shutdown the default executor*
  - *Add the call of `teardown` for the test cases related to each scheduler benchmark*
  - *Rename `org.apache.flink.runtime.scheduler.benchmark.e2e.SchedulerBenchmarkBase` to `org.apache.flink.runtime.scheduler.benchmark.e2e.SchedulerEndToEndBenchmarkBase`* for clarity


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
