### PR TITLE
[FLINK-23166][python] Fix ZipUtils to handle properly for softlinks

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -69,7 +69,7 @@ import static org.apache.flink.python.PythonOptions.PYTHON_FILES;
 import static org.apache.flink.python.util.PythonDependencyUtils.FILE_DELIMITER;
 
 /** The util class help to prepare Python env and run the python process. */
-final class PythonEnvUtils {
+public final class PythonEnvUtils {
     private static final Logger LOG = LoggerFactory.getLogger(PythonEnvUtils.class);
 
     static final String PYFLINK_CLIENT_EXECUTABLE = "PYFLINK_CLIENT_EXECUTABLE";
@@ -149,7 +149,7 @@ final class PythonEnvUtils {
      * @param libPath the pyflink lib file path.
      * @param symbolicLinkPath the symbolic link to pyflink lib.
      */
-    private static void createSymbolicLink(
+    public static void createSymbolicLink(
             java.nio.file.Path libPath, java.nio.file.Path symbolicLinkPath) throws IOException {
         try {
             Files.createSymbolicLink(symbolicLinkPath, libPath);

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -69,7 +69,7 @@ import static org.apache.flink.python.PythonOptions.PYTHON_FILES;
 import static org.apache.flink.python.util.PythonDependencyUtils.FILE_DELIMITER;
 
 /** The util class help to prepare Python env and run the python process. */
-public final class PythonEnvUtils {
+final class PythonEnvUtils {
     private static final Logger LOG = LoggerFactory.getLogger(PythonEnvUtils.class);
 
     static final String PYFLINK_CLIENT_EXECUTABLE = "PYFLINK_CLIENT_EXECUTABLE";
@@ -149,7 +149,7 @@ public final class PythonEnvUtils {
      * @param libPath the pyflink lib file path.
      * @param symbolicLinkPath the symbolic link to pyflink lib.
      */
-    public static void createSymbolicLink(
+    private static void createSymbolicLink(
             java.nio.file.Path libPath, java.nio.file.Path symbolicLinkPath) throws IOException {
         try {
             Files.createSymbolicLink(symbolicLinkPath, libPath);

--- a/flink-python/src/test/java/org/apache/flink/python/util/ZipUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/ZipUtilsTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.util;
+
+import org.apache.flink.configuration.ConfigConstants;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link ZipUtils}. */
+public class ZipUtilsTest {
+
+    private static final int S_IFLNK = 40960;
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testSymlink() throws IOException {
+        File zipFile = temporaryFolder.newFile();
+
+        try (ZipArchiveOutputStream zipOut =
+                new ZipArchiveOutputStream(new FileOutputStream(zipFile))) {
+            String file1 = "zipFile1";
+            ZipArchiveEntry entry = new ZipArchiveEntry(file1);
+            entry.setUnixMode(0644);
+            zipOut.putArchiveEntry(entry);
+            zipOut.write(new byte[] {1, 1, 1, 1, 1});
+            zipOut.closeArchiveEntry();
+
+            String file2 = "zipFile2";
+            entry = new ZipArchiveEntry(file2);
+            entry.setUnixMode(0644);
+            zipOut.putArchiveEntry(entry);
+            zipOut.write(new byte[] {2, 2, 2, 2, 2});
+            zipOut.closeArchiveEntry();
+
+            entry = new ZipArchiveEntry("softlink");
+            entry.setUnixMode(S_IFLNK | 0644);
+            zipOut.putArchiveEntry(entry);
+            zipOut.write(file1.getBytes(ConfigConstants.DEFAULT_CHARSET));
+            zipOut.closeArchiveEntry();
+        }
+
+        String targetPath = temporaryFolder.newFolder().getCanonicalPath();
+        ZipUtils.extractZipFileWithPermissions(zipFile.getCanonicalPath(), targetPath);
+        Path softLink = new File(targetPath, "softlink").toPath();
+        assertTrue(Files.isSymbolicLink(softLink));
+        assertTrue(Files.readSymbolicLink(softLink).toString().endsWith("zipFile1"));
+
+        Path file1Path = new File(targetPath, "zipFile1").toPath();
+        assertTrue(Files.isRegularFile(file1Path));
+        assertArrayEquals(Files.readAllBytes(file1Path), new byte[] {1, 1, 1, 1, 1});
+
+        Path file2Path = new File(targetPath, "zipFile2").toPath();
+        assertTrue(Files.isRegularFile(file2Path));
+        assertArrayEquals(Files.readAllBytes(file2Path), new byte[] {2, 2, 2, 2, 2});
+    }
+
+    @Test
+    public void testSymlinkWithoutTargetFile() throws IOException {
+        File zipFile = temporaryFolder.newFile();
+
+        try (ZipArchiveOutputStream zipOut =
+                new ZipArchiveOutputStream(new FileOutputStream(zipFile))) {
+            ZipArchiveEntry entry = new ZipArchiveEntry("softlink");
+            entry.setUnixMode(S_IFLNK | 0644);
+            zipOut.putArchiveEntry(entry);
+            zipOut.write("targetFile".getBytes(ConfigConstants.DEFAULT_CHARSET));
+            zipOut.closeArchiveEntry();
+        }
+
+        String targetPath = temporaryFolder.newFolder().getCanonicalPath();
+        ZipUtils.extractZipFileWithPermissions(zipFile.getCanonicalPath(), targetPath);
+        Path softLink = new File(targetPath, "softlink").toPath();
+        assertTrue(Files.isSymbolicLink(softLink));
+        assertTrue(Files.readSymbolicLink(softLink).toString().endsWith("targetFile"));
+    }
+
+    @Test
+    public void testExpandOutOfTargetDir() throws IOException {
+        File zipFile = temporaryFolder.newFile();
+
+        try (ZipArchiveOutputStream zipOut =
+                new ZipArchiveOutputStream(new FileOutputStream(zipFile))) {
+            String file1 = "../zipFile";
+            ZipArchiveEntry entry = new ZipArchiveEntry(file1);
+            zipOut.putArchiveEntry(entry);
+            zipOut.write(new byte[] {1, 1, 1, 1, 1});
+            zipOut.closeArchiveEntry();
+        }
+
+        String targetPath = temporaryFolder.newFolder().getCanonicalPath();
+        try {
+            ZipUtils.extractZipFileWithPermissions(zipFile.getCanonicalPath(), targetPath);
+            Assert.fail("exception expected");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("Expand ../zipFile would create a file outside of"));
+        }
+    }
+
+    @Test
+    public void testPermissionRestored() throws IOException {
+        File zipFile = temporaryFolder.newFile();
+
+        try (ZipArchiveOutputStream zipOut =
+                new ZipArchiveOutputStream(new FileOutputStream(zipFile))) {
+            String file1 = "zipFile";
+            ZipArchiveEntry entry = new ZipArchiveEntry(file1);
+            entry.setUnixMode(0355);
+            zipOut.putArchiveEntry(entry);
+            zipOut.write(new byte[] {1, 1, 1, 1, 1});
+            zipOut.closeArchiveEntry();
+        }
+
+        String targetPath = temporaryFolder.newFolder().getCanonicalPath();
+        ZipUtils.extractZipFileWithPermissions(zipFile.getCanonicalPath(), targetPath);
+
+        Path path = new File(targetPath, "zipFile").toPath();
+        assertEquals(0355, toUnixMode(Files.getPosixFilePermissions(path)));
+    }
+
+    private int toUnixMode(Set<PosixFilePermission> permission) {
+        int mode = 0;
+        for (PosixFilePermission action : PosixFilePermission.values()) {
+            mode = mode << 1;
+            mode += permission.contains(action) ? 1 : 0;
+        }
+        return mode;
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

* This pull request fixes ZipUtils to handle properly for softlinks*

## Brief change log

  - *Fix ZipUtils*
  - *Added test cases ZipUtilsTest*


## Verifying this change
This change added tests and can be verified as follows:

  - *Added tests ZipUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
