### PR TITLE
[FLINK-22945][runtime] Avoid StackOverflowException when a large scale job is canceling or failing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolImpl.java
@@ -193,7 +193,7 @@ public class SlotPoolImpl implements SlotPool, SlotPoolService {
     }
 
     @VisibleForTesting
-    DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
+    public DualKeyLinkedMap<SlotRequestId, AllocationID, PendingRequest> getPendingRequests() {
         return pendingRequests;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -48,7 +48,9 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.topology.Vertex;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -167,6 +169,13 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
     @Override
     protected long getNumberOfRestarts() {
         return executionFailureHandler.getNumberOfRestarts();
+    }
+
+    @Override
+    protected void cancelAllPendingSlotRequestsInternal() {
+        IterableUtils.toStream(getSchedulingTopology().getVertices())
+                .map(Vertex::getId)
+                .forEach(executionSlotAllocator::cancel);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -498,6 +498,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
     protected void failJob(Throwable cause, long timestamp) {
         incrementVersionsOfAllVertices();
+        cancelAllPendingSlotRequestsInternal();
         executionGraph.failJob(cause, timestamp);
         getJobTerminationFuture().thenRun(() -> archiveGlobalFailure(cause));
     }
@@ -557,6 +558,8 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
                         .collect(Collectors.toSet()));
     }
 
+    protected abstract void cancelAllPendingSlotRequestsInternal();
+
     protected void transitionExecutionGraphState(
             final JobStatus current, final JobStatus newState) {
         executionGraph.transitionState(current, newState);
@@ -604,6 +607,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         final FlinkException cause = new FlinkException("Scheduler is being stopped.");
 
         incrementVersionsOfAllVertices();
+        cancelAllPendingSlotRequestsInternal();
         executionGraph.suspend(cause);
         operatorCoordinatorHandler.disposeAllOperatorCoordinators();
 
@@ -615,6 +619,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         mainThreadExecutor.assertRunningInMainThread();
 
         incrementVersionsOfAllVertices();
+        cancelAllPendingSlotRequestsInternal();
         executionGraph.cancel();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR clear the pending requests in ExecutionSlotAllocator when a job is CANCELING or FAILING to avoid StackOverflowException when a large scale job is canceling or failing.

The pending requests in ExecutionSlotAllocator are not cleared when a job transitions to CANCELING or FAILING, while all vertices will be canceled and assigned slot will be returned. The returned slot is possible to be used to fulfill the pending request of a CANCELED vertex and the assignment will fail immediately and the slot will be returned and used to fulfilled another vertex in a recursive way. StackOverflow can happen in this way when there are many vertices, and fatal error can happen and lead to JM will crash.

We also tried to improve the call stack of slot assignment, but found it too complex to maintain the task or slot status if we make the step notifying new slots or assigning new resource asynchronously, so we give up the plan and only clear all pending requests to avoid entering the recursive loop.

## Brief change log

 - Added SchedulerBase#cancelAllPendingSlotRequestsInternal(), which is called when the execution version is updated due to canceling or failing
- Added DefaultScheduler#cancelAllPendingSlotRequestsInternal() as an implementation

The changes are not applicable for AdaptiveScheduler, which means the issue may still occur when using AdaptiveScheduler.

## Verifying this change

This change added tests and can be verified as follows:
  - Added test that validates the pending requests are all canceled while canceling or failing

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no
 
## Documentation
  - Does this pull request introduce a new feature? no