### PR TITLE
[hotfix] [docs] Fix the bug that the document address does not match the actual web page

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/custom_serializers.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/custom_serializers.md
@@ -3,8 +3,8 @@ title: 自定义序列化器
 weight: 11
 type: docs
 aliases:
-  - /zh/dev/custom_serializers.
-  - /zh/docs/dev/serialization/types_serialization/
+  - /zh/dev/custom_serializers.html
+  - /zh/docs/dev/datastream/fault-tolerance/serialization/custom_serializers/
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/third_party_serializers.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/third_party_serializers.md
@@ -4,7 +4,7 @@ weight: 11
 type: docs
 aliases:
   - /zh/dev/custom_serializers.html
-  - /zh/docs/dev/datastream/fault-tolerance/serialization/custom_serializers/
+  - /zh/docs/dev/datastream/fault-tolerance/serialization/third_party_serializers/
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md
@@ -259,7 +259,7 @@ The most frequent issues where users need to interact with Flink's data type han
   by itself. Not all types are seamlessly handled by Kryo (and thus by Flink). For example, many Google Guava collection types do not work well
   by default. The solution is to register additional serializers for the types that cause problems.
   Call `.getConfig().addDefaultKryoSerializer(clazz, serializer)` on the `StreamExecutionEnvironment`.
-  Additional Kryo serializers are available in many libraries. See [Custom Serializers]({{< ref "docs/dev/datastream/fault-tolerance/serialization/custom_serializers" >}}) for more details on working with custom serializers.
+  Additional Kryo serializers are available in many libraries. See [3rd party serializer]({{< ref "docs/dev/datastream/fault-tolerance/serialization/third_party_serializers" >}}) for more details on working with external serializers.
 
 * **Adding Type Hints:** Sometimes, when Flink cannot infer the generic types despite all tricks, a user must pass a *type hint*. That is generally
   only necessary in the Java API. The [Type Hints Section](#type-hints-in-the-java-api) describes that in more detail.


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug that the document address does not match the actual web page

the English page is: https://ci.apache.org/projects/flink/flink-docs-master/docs/dev/datastream/fault-tolerance/serialization/third_party_serializers/,but the Chinese page is:https://ci.apache.org/projects/flink/flink-docs-master/zh/docs/dev/datastream/fault-tolerance/serialization/custom_serializers/.if chick the language change button, it does not work.

and I found some links in docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md is different from English version, so I modify it in same sense .

## Brief change log

- Fix the bug from `docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/third_party_serializers.md`
- modify the link form `docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/types_serialization.md`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
