### PR TITLE
[FLINK-23017][sql-client] HELP in sql-client still shows the removed SOURCE functionality

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -92,10 +92,6 @@ public final class CliStrings {
                     .append(formatCommand("SHOW TABLES", "Shows all registered tables."))
                     .append(
                             formatCommand(
-                                    "SOURCE",
-                                    "Reads a SQL SELECT query from a file and executes it on the Flink cluster."))
-                    .append(
-                            formatCommand(
                                     "USE CATALOG",
                                     "Sets the current catalog. The current database is set to the catalog's default one. Experimental! Syntax: \"USE CATALOG <name>;\""))
                     .append(

--- a/flink-table/flink-sql-client/src/test/resources/sql-client-help-command.out
+++ b/flink-table/flink-sql-client/src/test/resources/sql-client-help-command.out
@@ -14,7 +14,6 @@ SELECT		Executes a SQL SELECT query on the Flink cluster.
 SET		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
 SHOW FUNCTIONS		Shows all user-defined and built-in functions or only user-defined functions. Syntax: "SHOW [USER] FUNCTIONS;"
 SHOW TABLES		Shows all registered tables.
-SOURCE		Reads a SQL SELECT query from a file and executes it on the Flink cluster.
 USE CATALOG		Sets the current catalog. The current database is set to the catalog's default one. Experimental! Syntax: "USE CATALOG <name>;"
 USE		Sets the current default database. Experimental! Syntax: "USE <name>;"
 LOAD MODULE		Load a module. Syntax: "LOAD MODULE <name> [WITH ('<key1>' = '<value1>' [, '<key2>' = '<value2>', ...])];"

--- a/flink-table/flink-sql-client/src/test/resources/sql/misc.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/misc.q
@@ -35,7 +35,6 @@ SELECT		Executes a SQL SELECT query on the Flink cluster.
 SET		Sets a session configuration property. Syntax: "SET '<key>'='<value>';". Use "SET;" for listing all properties.
 SHOW FUNCTIONS		Shows all user-defined and built-in functions or only user-defined functions. Syntax: "SHOW [USER] FUNCTIONS;"
 SHOW TABLES		Shows all registered tables.
-SOURCE		Reads a SQL SELECT query from a file and executes it on the Flink cluster.
 USE CATALOG		Sets the current catalog. The current database is set to the catalog's default one. Experimental! Syntax: "USE CATALOG <name>;"
 USE		Sets the current default database. Experimental! Syntax: "USE <name>;"
 LOAD MODULE		Load a module. Syntax: "LOAD MODULE <name> [WITH ('<key1>' = '<value1>' [, '<key2>' = '<value2>', ...])];"


### PR DESCRIPTION
## What is the purpose of the change

*SQL client shows the `SOURCE` command in `HELP`, but the `SOURCE` command doesn't exist. The prompting message for `SOURCE` command should be removed from `HELP`.*

## Brief change log

  - *`MESSAGE_HELP` remove the prompting message for `SOURCE` command.*

## Verifying this change

  - *The expected output of `HELP` execution in `misc.q` removes the prompting message for `SOURCE` command.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)