### PR TITLE
[FLINK-22964][connector/common] Exclude flink-core from connector-common dependencies. [1.12]

### DIFF
--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -40,6 +40,7 @@
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- test dependency -->


### PR DESCRIPTION
Unchanged backport of #16322.