### PR TITLE
[FLINK-23187][Documentation]Update PubSubSink examples with topicName in documentation

### DIFF
--- a/docs/content/docs/connectors/datastream/pubsub.md
+++ b/docs/content/docs/connectors/datastream/pubsub.md
@@ -90,7 +90,7 @@ SerializationSchema<SomeObject> serializationSchema = (...);
 SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withSerializationSchema(serializationSchema)
                                                 .withProjectName("project")
-                                                .withSubscriptionName("subscription")
+                                                .withTopicName("topic")
                                                 .build()
 
 dataStream.addSink(pubsubSink);
@@ -123,7 +123,7 @@ SerializationSchema<SomeObject> serializationSchema = (...);
 SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withSerializationSchema(serializationSchema)
                                                 .withProjectName("my-fake-project")
-                                                .withSubscriptionName("subscription")
+                                                .withTopicName("topic")
                                                 .withHostAndPortForEmulator(hostAndPort)
                                                 .build();
 


### PR DESCRIPTION
## What is the purpose of the change
There are two PubSubSink code examples in the documentation:

https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/datastream/pubsub/#pubsub-sink

https://ci.apache.org/projects/flink/flink-docs-release-1.13/docs/connectors/datastream/pubsub/#integration-testing

The examples should use "withTopicName" rather than "withSubscriptionName" when building PubSubSink.

Options


## Brief change log
  - *Update documentation*

## Verifying this change

This change is for updating documentation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
