### PR TITLE
[FLINK-23182][connectors/rabbitmq] Fix connection leak in RMQSource

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -28,6 +28,8 @@ import org.apache.flink.streaming.api.functions.source.MessageAcknowledgingSourc
 import org.apache.flink.streaming.api.functions.source.MultipleIdsMessageAcknowledgingSourceBase;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
 import com.rabbitmq.client.AMQP;
@@ -257,6 +259,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
             channel.basicConsume(queueName, autoAck, consumer);
 
         } catch (IOException e) {
+            IOUtils.closeAllQuietly(channel, connection);
             throw new RuntimeException(
                     "Cannot create RMQ connection with "
                             + queueName
@@ -273,44 +276,38 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
     @Override
     public void close() throws Exception {
         super.close();
+        Exception exception = null;
 
         try {
             if (consumer != null && channel != null) {
                 channel.basicCancel(consumer.getConsumerTag());
             }
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while cancelling RMQ consumer on "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+            exception =
+                    new RuntimeException(
+                            "Error while cancelling RMQ consumer on "
+                                    + queueName
+                                    + " at "
+                                    + rmqConnectionConfig.getHost(),
+                            e);
         }
 
         try {
-            if (channel != null) {
-                channel.close();
-            }
+            IOUtils.closeAll(channel, connection);
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while closing RMQ channel with "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+            exception =
+                    ExceptionUtils.firstOrSuppressed(
+                            new RuntimeException(
+                                    "Error while closing RMQ source with "
+                                            + queueName
+                                            + " at "
+                                            + rmqConnectionConfig.getHost(),
+                                    e),
+                            exception);
         }
 
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while closing RMQ connection with "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+        if (exception != null) {
+            throw exception;
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a potential connection leak in RMQSource (issue FLINK-23182). Currently the RabbitMQ connection is not closed properly in the RMQSource connector in case of failures. This leads to a connection leak (we loose handles to still opened connections) that will last until the Flink TaskManager is either stopped or crashes.

## Brief change log

  - `Connection#close` is called in `RMQSource#open` in case of a failure
  - All resources are closed properly in `RMQSource#close`, and in case there are multiple exceptions caught they are suppressed accordingly

## Verifying this change

This change added tests and can be verified as follows:
  - `RMQSourceTest#testResourceCleanupOnOpenFailure`, which tests whether the allocated resources all closed properly in case of a failure during initialization (in `RMQSource#open`)
  - `RMQSourceTest#testResourceCleanupOnClose`, which tests whether all resources (consumer, channel, and connection) all closed properly even in case of failure and all exception information is forwarded

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
