### PR TITLE
[FLINK-22843][docs-zh]Document and code are inconsistent.

### DIFF
--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -169,14 +169,14 @@ ON myTopic.key = hTable.rowkey;
     <tr>
       <td><h5>lookup.cache.max-rows</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">(无)</td>
-      <td>Integer</td>
+      <td style="word-wrap: break-word;">-1</td>
+      <td>Long</td>
       <td>查找缓存的最大行数，超过这个值，最旧的行将过期。注意："lookup.cache.max-rows" 和 "lookup.cache.ttl" 必须同时被设置。默认情况下，查找缓存是禁用的。 </td>
     </tr>
     <tr>
       <td><h5>lookup.cache.ttl</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">(无)</td>
+      <td style="word-wrap: break-word;">0 s</td>
       <td>Duration</td>
       <td>查找缓存中每一行的最大生存时间，在这段时间内，最老的行将过期。注意："lookup.cache.max-rows" 和 "lookup.cache.ttl" 必须同时被设置。默认情况下，查找缓存是禁用的。</td>
     </tr>

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -176,14 +176,14 @@ Connector Options
     <tr>
       <td><h5>lookup.cache.max-rows</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>Integer</td>
+      <td style="word-wrap: break-word;">-1</td>
+      <td>Long</td>
       <td>The max number of rows of lookup cache, over this value, the oldest rows will be expired. Note, "lookup.cache.max-rows" and "lookup.cache.ttl" options must all be specified if any of them is specified. Lookup cache is disabled by default.</td>
     </tr>
     <tr>
       <td><h5>lookup.cache.ttl</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">0 s</td>
       <td>Duration</td>
       <td>The max time to live for each rows in lookup cache, over this time, the oldest rows will be expired. Note, "cache.max-rows" and "cache.ttl" options must all be specified if any of them is specified.Lookup cache is disabled by default.</td>
     </tr>


### PR DESCRIPTION
## What is the purpose of the change

code:flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/options/HBaseOptions.java#L103

docment: https://github.com/apache/flink/blob/master/docs/content/docs/connectors/table/hbase.md#lookupcachemax-rows

The type of configuration `lookup.cache.max-rows` should be Long instead of Integer and the defaule value is wrong also.

## Brief change log

Document and code are inconsistent.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 