### PR TITLE
[FLINK-21804][state/changelog] Create and wire changelog storage with state backend

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -15,6 +15,12 @@
             <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not be enabled.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.changelog.storage</h5></td>
+            <td style="word-wrap: break-word;">"memory"</td>
+            <td>String</td>
+            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' only.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -39,6 +39,12 @@
             <td>Whether to enable state backend to write state changes to StateChangelog. If this config is not set explicitly, it means no preference for enabling the change log, and the value in lower config level will take effect. The default value 'false' here means if no value set (job or cluster), the change log will not be enabled.</td>
         </tr>
         <tr>
+            <td><h5>state.backend.changelog.storage</h5></td>
+            <td style="word-wrap: break-word;">"memory"</td>
+            <td>String</td>
+            <td>The storage to be used to store state changelog.<br />The implementation can be specified via their shortcut name.<br />The list of recognized shortcut names currently includes 'memory' only.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -114,6 +114,30 @@ public class CheckpointingOptions {
                                     + "if no value set (job or cluster), the change log will not be "
                                     + "enabled.");
 
+    /**
+     * Which storage to use to store state changelog.
+     *
+     * <p>Recognized shortcut name is 'memory' from {@code
+     * InMemoryStateChangelogStorageFactory.getIdentifier()}, which is also the default value.
+     */
+    @Documentation.Section(value = Documentation.Sections.COMMON_STATE_BACKENDS)
+    public static final ConfigOption<String> STATE_CHANGE_LOG_STORAGE =
+            ConfigOptions.key("state.backend.changelog.storage")
+                    .stringType()
+                    .defaultValue("memory")
+                    .withDescription(
+                            Description.builder()
+                                    .text("The storage to be used to store state changelog.")
+                                    .linebreak()
+                                    .text(
+                                            "The implementation can be specified via their"
+                                                    + " shortcut name.")
+                                    .linebreak()
+                                    .text(
+                                            "The list of recognized shortcut names currently includes"
+                                                    + " 'memory' only.")
+                                    .build());
+
     /** The maximum number of completed checkpoints to retain. */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS =

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
@@ -88,6 +88,7 @@ final class SavepointTaskStateManager implements TaskStateManager {
         return InflightDataRescalingDescriptor.NO_RESCALE;
     }
 
+    @Nullable
     @Override
     public StateChangelogStorage<?> getStateChangelogStorage() {
         throw new UnsupportedOperationException(MSG);

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.LocalRecoveryDirectoryProvider;
 import org.apache.flink.runtime.state.TaskStateManager;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -85,6 +86,11 @@ final class SavepointTaskStateManager implements TaskStateManager {
     @Override
     public InflightDataRescalingDescriptor getOutputRescalingDescriptor() {
         return InflightDataRescalingDescriptor.NO_RESCALE;
+    }
+
+    @Override
+    public StateChangelogStorage<?> getStateChangelogStorage() {
+        throw new UnsupportedOperationException(MSG);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManager.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
+import org.apache.flink.util.ShutdownHookUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** This class holds the all {@link StateChangelogStorage} objects for a task executor (manager). */
+public class TaskExecutorStateChangelogStoragesManager {
+
+    /** Logger for this class. */
+    private static final Logger LOG =
+            LoggerFactory.getLogger(TaskExecutorStateChangelogStoragesManager.class);
+
+    /**
+     * This map holds all state changelog storages for tasks running on the task manager / executor
+     * that own the instance of this. Maps from job id to all the subtask's state changelog
+     * storages.
+     */
+    @GuardedBy("lock")
+    private final Map<JobID, StateChangelogStorage<?>> changelogStoragesByJobId;
+
+    /** Guarding lock for changelogStoragesByJobId and closed-flag. */
+    private final Object lock;
+
+    @GuardedBy("lock")
+    private boolean closed;
+
+    /** shutdown hook for this manager. */
+    private final Thread shutdownHook;
+
+    public TaskExecutorStateChangelogStoragesManager() {
+        this.changelogStoragesByJobId = new HashMap<>();
+        this.lock = new Object();
+        this.closed = false;
+
+        // register a shutdown hook
+        this.shutdownHook =
+                ShutdownHookUtil.addShutdownHook(this::shutdown, getClass().getSimpleName(), LOG);
+    }
+
+    public StateChangelogStorage<?> stateChangelogStorageForJob(
+            @Nonnull JobID jobId, Configuration configuration) {
+        synchronized (lock) {
+            if (closed) {
+                throw new IllegalStateException(
+                        "TaskExecutorStateChangelogStoragesManager is already closed and cannot "
+                                + "register a new StateChangelogStorage.");
+            }
+
+            StateChangelogStorage<?> stateChangelogStorage = changelogStoragesByJobId.get(jobId);
+
+            if (stateChangelogStorage == null) {
+                stateChangelogStorage = StateChangelogStorageLoader.load(configuration);
+
+                changelogStoragesByJobId.put(jobId, stateChangelogStorage);
+
+                if (stateChangelogStorage != null) {
+                    LOG.debug(
+                            "Registered new state changelog storage for job {} : {}.",
+                            jobId,
+                            stateChangelogStorage);
+                } else {
+                    LOG.info(
+                            "Try to registered new state changelog storage for job {},"
+                                    + "but result is null.",
+                            jobId);
+                }
+            } else {
+                LOG.debug(
+                        "Found existing state changelog storage for job {}: {}.",
+                        jobId,
+                        stateChangelogStorage);
+            }
+
+            return stateChangelogStorage;
+        }
+    }
+
+    public void releaseStateChangelogStorageForJob(@Nonnull JobID jobId) {
+        LOG.debug("Releasing state changelog storage under job id {}.", jobId);
+
+        StateChangelogStorage<?> cleanupChangelogStorage;
+
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+            cleanupChangelogStorage = changelogStoragesByJobId.remove(jobId);
+        }
+
+        if (cleanupChangelogStorage != null) {
+            doRelease(cleanupChangelogStorage);
+        }
+    }
+
+    public void shutdown() {
+        HashMap<JobID, StateChangelogStorage<?>> toRelease;
+
+        synchronized (lock) {
+            if (closed) {
+                return;
+            }
+
+            closed = true;
+            toRelease = new HashMap<>(changelogStoragesByJobId);
+            changelogStoragesByJobId.clear();
+        }
+
+        ShutdownHookUtil.removeShutdownHook(shutdownHook, getClass().getSimpleName(), LOG);
+
+        LOG.info("Shutting down TaskExecutorStateChangelogStoragesManager.");
+
+        for (Map.Entry<JobID, StateChangelogStorage<?>> entry : toRelease.entrySet()) {
+
+            doRelease(entry.getValue());
+        }
+    }
+
+    private void doRelease(StateChangelogStorage<?> storage) {
+        if (storage != null) {
+            try {
+                storage.close();
+            } catch (Exception e) {
+                LOG.warn("Exception while disposing state changelog storage {}.", storage, e);
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
@@ -91,5 +91,6 @@ public interface TaskStateManager extends CheckpointListener, AutoCloseable {
     SequentialChannelStateReader getSequentialChannelStateReader();
 
     /** Returns the configured state changelog storage for this task. */
+    @Nullable
     StateChangelogStorage<?> getStateChangelogStorage();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManager.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.checkpoint.channel.SequentialChannelStateReader;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,4 +89,7 @@ public interface TaskStateManager extends CheckpointListener, AutoCloseable {
     LocalRecoveryConfig createLocalRecoveryConfig();
 
     SequentialChannelStateReader getSequentialChannelStateReader();
+
+    /** Returns the configured state changelog storage for this task. */
+    StateChangelogStorage<?> getStateChangelogStorage();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -72,7 +72,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
     private final TaskLocalStateStore localStateStore;
 
     /** The changelog storage where the manager reads and writes the changelog */
-    private final StateChangelogStorage<?> stateChangelogStorage;
+    @Nullable private final StateChangelogStorage<?> stateChangelogStorage;
 
     /** The checkpoint responder through which this manager can report to the job manager. */
     private final CheckpointResponder checkpointResponder;
@@ -83,7 +83,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
             @Nonnull JobID jobId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             @Nonnull TaskLocalStateStore localStateStore,
-            @Nonnull StateChangelogStorage<?> stateChangelogStorage,
+            @Nullable StateChangelogStorage<?> stateChangelogStorage,
             @Nullable JobManagerTaskRestore jobManagerTaskRestore,
             @Nonnull CheckpointResponder checkpointResponder) {
         this(
@@ -103,7 +103,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
             @Nonnull JobID jobId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             @Nonnull TaskLocalStateStore localStateStore,
-            @Nonnull StateChangelogStorage<?> stateChangelogStorage,
+            @Nullable StateChangelogStorage<?> stateChangelogStorage,
             @Nullable JobManagerTaskRestore jobManagerTaskRestore,
             @Nonnull CheckpointResponder checkpointResponder,
             @Nonnull SequentialChannelStateReaderImpl sequentialChannelStateReader) {
@@ -216,6 +216,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
         return sequentialChannelStateReader;
     }
 
+    @Nullable
     @Override
     public StateChangelogStorage<?> getStateChangelogStorage() {
         return stateChangelogStorage;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.checkpoint.channel.SequentialChannelStateReader;
 import org.apache.flink.runtime.checkpoint.channel.SequentialChannelStateReaderImpl;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 
 import org.slf4j.Logger;
@@ -70,6 +71,9 @@ public class TaskStateManagerImpl implements TaskStateManager {
     /** The local state store to which this manager reports local state snapshots. */
     private final TaskLocalStateStore localStateStore;
 
+    /** The changelog storage where the manager reads and writes the changelog */
+    private final StateChangelogStorage<?> stateChangelogStorage;
+
     /** The checkpoint responder through which this manager can report to the job manager. */
     private final CheckpointResponder checkpointResponder;
 
@@ -79,12 +83,14 @@ public class TaskStateManagerImpl implements TaskStateManager {
             @Nonnull JobID jobId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             @Nonnull TaskLocalStateStore localStateStore,
+            @Nonnull StateChangelogStorage<?> stateChangelogStorage,
             @Nullable JobManagerTaskRestore jobManagerTaskRestore,
             @Nonnull CheckpointResponder checkpointResponder) {
         this(
                 jobId,
                 executionAttemptID,
                 localStateStore,
+                stateChangelogStorage,
                 jobManagerTaskRestore,
                 checkpointResponder,
                 new SequentialChannelStateReaderImpl(
@@ -97,11 +103,13 @@ public class TaskStateManagerImpl implements TaskStateManager {
             @Nonnull JobID jobId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             @Nonnull TaskLocalStateStore localStateStore,
+            @Nonnull StateChangelogStorage<?> stateChangelogStorage,
             @Nullable JobManagerTaskRestore jobManagerTaskRestore,
             @Nonnull CheckpointResponder checkpointResponder,
             @Nonnull SequentialChannelStateReaderImpl sequentialChannelStateReader) {
         this.jobId = jobId;
         this.localStateStore = localStateStore;
+        this.stateChangelogStorage = stateChangelogStorage;
         this.jobManagerTaskRestore = jobManagerTaskRestore;
         this.executionAttemptID = executionAttemptID;
         this.checkpointResponder = checkpointResponder;
@@ -206,6 +214,11 @@ public class TaskStateManagerImpl implements TaskStateManager {
     @Override
     public SequentialChannelStateReader getSequentialChannelStateReader() {
         return sequentialChannelStateReader;
+    }
+
+    @Override
+    public StateChangelogStorage<?> getStateChangelogStorage() {
+        return stateChangelogStorage;
     }
 
     /** Tracking when local state can be confirmed and disposed. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -19,20 +19,17 @@
 package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.configuration.Configuration;
 
 /**
- * A storage for changelog. Could produce {@link StateChangelogHandleReader} and {@link
- * StateChangelogWriter} for read and write. Please use {@link StateChangelogStorageLoader} to
- * obtain an instance.
+ * A factory for {@link StateChangelogStorage}. Please use {@link StateChangelogStorageLoader} to
+ * create {@link StateChangelogStorage}.
  */
 @Internal
-public interface StateChangelogStorage<Handle extends ChangelogStateHandle> extends AutoCloseable {
+public interface StateChangelogStorageFactory {
+    /** Get the identifier for user to use this changelog storage factory. */
+    String getIdentifier();
 
-    StateChangelogWriter<Handle> createWriter(String operatorID, KeyGroupRange keyGroupRange);
-
-    StateChangelogHandleReader<Handle> createReader();
-
-    @Override
-    default void close() throws Exception {}
+    /** Create the storage based on a configuration. */
+    StateChangelogStorage<?> createStorage(Configuration configuration);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -25,6 +25,8 @@ import org.apache.flink.core.plugin.PluginManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ServiceLoader;
@@ -78,6 +80,7 @@ public class StateChangelogStorageLoader {
                 String.join(",", STATE_CHANGELOG_STORAGE_FACTORIES.keySet()));
     }
 
+    @Nullable
     public static StateChangelogStorage<?> load(Configuration configuration) {
         final String identifier =
                 configuration

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -58,9 +58,21 @@ public class StateChangelogStorageLoader {
                                 pluginManager.load(StateChangelogStorageFactory.class),
                                 ServiceLoader.load(StateChangelogStorageFactory.class).iterator());
         iterator.forEachRemaining(
-                factory ->
-                        STATE_CHANGELOG_STORAGE_FACTORIES.putIfAbsent(
-                                factory.getIdentifier().toLowerCase(), factory));
+                factory -> {
+                    String identifier = factory.getIdentifier().toLowerCase();
+                    StateChangelogStorageFactory prev =
+                            STATE_CHANGELOG_STORAGE_FACTORIES.get(identifier);
+                    if (prev == null) {
+                        STATE_CHANGELOG_STORAGE_FACTORIES.put(identifier, factory);
+                    } else {
+                        LOG.warn(
+                                "StateChangelogStorageLoader found duplicated factory,"
+                                        + " using {} instead of {} for name {}.",
+                                prev.getClass().getName(),
+                                factory.getClass().getName(),
+                                identifier);
+                    }
+                });
         LOG.info(
                 "StateChangelogStorageLoader initialized with shortcut names {{}}.",
                 String.join(",", STATE_CHANGELOG_STORAGE_FACTORIES.keySet()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -18,8 +18,14 @@
 package org.apache.flink.runtime.state.changelog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.plugin.PluginManager;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
@@ -28,16 +34,51 @@ import static org.apache.flink.shaded.guava18.com.google.common.collect.Iterator
 /** A thin wrapper around {@link PluginManager} to load {@link StateChangelogStorage}. */
 @Internal
 public class StateChangelogStorageLoader {
-    private final PluginManager pluginManager;
 
-    public StateChangelogStorageLoader(PluginManager pluginManager) {
-        this.pluginManager = pluginManager;
+    private static final Logger LOG = LoggerFactory.getLogger(StateChangelogStorageLoader.class);
+
+    /**
+     * Mapping of state changelog storage identifier to the corresponding storage factories,
+     * populated in {@link StateChangelogStorageLoader#initialize(PluginManager)}.
+     */
+    private static final HashMap<String, StateChangelogStorageFactory>
+            STATE_CHANGELOG_STORAGE_FACTORIES = new HashMap<>();
+
+    static {
+        // Guarantee to trigger once.
+        initialize(null);
     }
 
-    @SuppressWarnings({"rawtypes"})
-    public Iterator<StateChangelogStorage> load() {
-        return concat(
-                pluginManager.load(StateChangelogStorage.class),
-                ServiceLoader.load(StateChangelogStorage.class).iterator());
+    public static void initialize(PluginManager pluginManager) {
+        STATE_CHANGELOG_STORAGE_FACTORIES.clear();
+        Iterator<StateChangelogStorageFactory> iterator =
+                pluginManager == null
+                        ? ServiceLoader.load(StateChangelogStorageFactory.class).iterator()
+                        : concat(
+                                pluginManager.load(StateChangelogStorageFactory.class),
+                                ServiceLoader.load(StateChangelogStorageFactory.class).iterator());
+        iterator.forEachRemaining(
+                factory ->
+                        STATE_CHANGELOG_STORAGE_FACTORIES.putIfAbsent(
+                                factory.getIdentifier().toLowerCase(), factory));
+        LOG.info(
+                "StateChangelogStorageLoader initialized with shortcut names {{}}.",
+                String.join(",", STATE_CHANGELOG_STORAGE_FACTORIES.keySet()));
+    }
+
+    public static StateChangelogStorage<?> load(Configuration configuration) {
+        final String identifier =
+                configuration
+                        .getString(CheckpointingOptions.STATE_CHANGE_LOG_STORAGE)
+                        .toLowerCase();
+
+        StateChangelogStorageFactory factory = STATE_CHANGELOG_STORAGE_FACTORIES.get(identifier);
+        if (factory == null) {
+            LOG.warn("Cannot find a factory for changelog storage with name '{}'.", identifier);
+            return null;
+        } else {
+            LOG.info("Creating a changelog storage with name '{}'.", identifier);
+            return factory.createStorage(configuration);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogStorageFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.changelog.inmemory;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
+
+/** An {@link StateChangelogStorageFactory} for creating {@link InMemoryStateChangelogStorage}. */
+public class InMemoryStateChangelogStorageFactory implements StateChangelogStorageFactory {
+
+    public static String identifier = "memory";
+
+    @Override
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public StateChangelogStorage<?> createStorage(Configuration configuration) {
+        return new InMemoryStateChangelogStorage();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -97,9 +97,11 @@ import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
 import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.taskexecutor.exceptions.RegistrationTimeoutException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
@@ -210,6 +212,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     /** The state manager for this task, providing state managers per slot. */
     private final TaskExecutorLocalStateStoresManager localStateStoresManager;
 
+    /** The changelog manager for this task, providing changelog storage per job. */
+    private final TaskExecutorStateChangelogStoragesManager changelogStoragesManager;
+
     /** Information provider for external resources. */
     private final ExternalResourceInfoProvider externalResourceInfoProvider;
 
@@ -302,6 +307,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         this.unresolvedTaskManagerLocation =
                 taskExecutorServices.getUnresolvedTaskManagerLocation();
         this.localStateStoresManager = taskExecutorServices.getTaskManagerStateStore();
+        this.changelogStoragesManager = taskExecutorServices.getTaskManagerChangelogManager();
         this.shuffleEnvironment = taskExecutorServices.getShuffleEnvironment();
         this.kvStateService = taskExecutorServices.getKvStateService();
         this.ioExecutor = taskExecutorServices.getIOExecutor();
@@ -447,6 +453,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                         ExceptionUtils.firstOrSuppressed(t, jobManagerDisconnectThrowable);
             }
         }
+
+        changelogStoragesManager.shutdown();
 
         Preconditions.checkState(jobTable.isEmpty());
 
@@ -669,6 +677,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             taskInformation.getJobVertexId(),
                             tdd.getSubtaskIndex());
 
+            final StateChangelogStorage<?> changelogStorage =
+                    changelogStoragesManager.stateChangelogStorageForJob(
+                            jobId, jobInformation.getJobConfiguration());
+
             final JobManagerTaskRestore taskRestore = tdd.getTaskRestore();
 
             final TaskStateManager taskStateManager =
@@ -676,6 +688,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             jobId,
                             tdd.getExecutionAttemptId(),
                             localStateStore,
+                            changelogStorage,
                             taskRestore,
                             checkpointResponder);
 
@@ -1789,6 +1802,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                         job -> {
                             closeJob(job, cause);
                         });
+        changelogStoragesManager.releaseStateChangelogStorageForJob(jobId);
         currentSlotOfferPerJob.remove(jobId);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -677,9 +677,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             taskInformation.getJobVertexId(),
                             tdd.getSubtaskIndex());
 
+            // TODO: Pass config value from user program and do overriding here.
             final StateChangelogStorage<?> changelogStorage =
                     changelogStoragesManager.stateChangelogStorageForJob(
-                            jobId, jobInformation.getJobConfiguration());
+                            jobId, taskManagerConfiguration.getConfiguration());
 
             final JobManagerTaskRestore taskRestore = tdd.getTaskRestore();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -56,6 +56,7 @@ import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -410,6 +411,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
         final PluginManager pluginManager =
                 PluginUtils.createPluginManagerFromRootFolder(configuration);
         FileSystem.initialize(configuration, pluginManager);
+
+        StateChangelogStorageLoader.initialize(pluginManager);
 
         int exitCode;
         Throwable throwable = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceLoader;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
@@ -75,6 +76,7 @@ public class TaskManagerServices {
     private final JobTable jobTable;
     private final JobLeaderService jobLeaderService;
     private final TaskExecutorLocalStateStoresManager taskManagerStateStore;
+    private final TaskExecutorStateChangelogStoragesManager taskManagerChangelogManager;
     private final TaskEventDispatcher taskEventDispatcher;
     private final ExecutorService ioExecutor;
     private final LibraryCacheManager libraryCacheManager;
@@ -90,6 +92,7 @@ public class TaskManagerServices {
             JobTable jobTable,
             JobLeaderService jobLeaderService,
             TaskExecutorLocalStateStoresManager taskManagerStateStore,
+            TaskExecutorStateChangelogStoragesManager taskManagerChangelogManager,
             TaskEventDispatcher taskEventDispatcher,
             ExecutorService ioExecutor,
             LibraryCacheManager libraryCacheManager) {
@@ -105,6 +108,7 @@ public class TaskManagerServices {
         this.jobTable = Preconditions.checkNotNull(jobTable);
         this.jobLeaderService = Preconditions.checkNotNull(jobLeaderService);
         this.taskManagerStateStore = Preconditions.checkNotNull(taskManagerStateStore);
+        this.taskManagerChangelogManager = Preconditions.checkNotNull(taskManagerChangelogManager);
         this.taskEventDispatcher = Preconditions.checkNotNull(taskEventDispatcher);
         this.ioExecutor = Preconditions.checkNotNull(ioExecutor);
         this.libraryCacheManager = Preconditions.checkNotNull(libraryCacheManager);
@@ -152,6 +156,10 @@ public class TaskManagerServices {
 
     public TaskExecutorLocalStateStoresManager getTaskManagerStateStore() {
         return taskManagerStateStore;
+    }
+
+    public TaskExecutorStateChangelogStoragesManager getTaskManagerChangelogManager() {
+        return taskManagerChangelogManager;
     }
 
     public TaskEventDispatcher getTaskEventDispatcher() {
@@ -324,6 +332,9 @@ public class TaskManagerServices {
                         stateRootDirectoryFiles,
                         ioExecutor);
 
+        final TaskExecutorStateChangelogStoragesManager changelogStoragesManager =
+                new TaskExecutorStateChangelogStoragesManager();
+
         final boolean failOnJvmMetaspaceOomError =
                 taskManagerServicesConfiguration
                         .getConfiguration()
@@ -353,6 +364,7 @@ public class TaskManagerServices {
                 jobTable,
                 jobLeaderService,
                 taskStateManager,
+                changelogStoragesManager,
                 taskEventDispatcher,
                 ioExecutor,
                 libraryCacheManager);

--- a/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory
+++ b/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage
+org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorageFactory

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorStateChangelogStoragesManagerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.runtime.state.changelog.ChangelogStateHandle;
+import org.apache.flink.runtime.state.changelog.StateChangelogHandleReader;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageFactory;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
+import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Tests for {@link TaskExecutorStateChangelogStoragesManager}. */
+public class TaskExecutorStateChangelogStoragesManagerTest {
+
+    @Test
+    public void testDuplicatedAllocation() {
+        TaskExecutorStateChangelogStoragesManager manager =
+                new TaskExecutorStateChangelogStoragesManager();
+        Configuration configuration = new Configuration();
+        JobID jobId1 = new JobID(1L, 1L);
+        StateChangelogStorage<?> storage1 =
+                manager.stateChangelogStorageForJob(jobId1, configuration);
+        StateChangelogStorage<?> storage2 =
+                manager.stateChangelogStorageForJob(jobId1, configuration);
+        Assert.assertEquals(storage1, storage2);
+
+        JobID jobId2 = new JobID(1L, 2L);
+        StateChangelogStorage<?> storage3 =
+                manager.stateChangelogStorageForJob(jobId2, configuration);
+        Assert.assertNotEquals(storage1, storage3);
+        manager.shutdown();
+    }
+
+    @Test
+    public void testReleaseForJob() {
+        StateChangelogStorageLoader.initialize(TestStateChangelogStorageFactory.pluginManager);
+        TaskExecutorStateChangelogStoragesManager manager =
+                new TaskExecutorStateChangelogStoragesManager();
+        Configuration configuration = new Configuration();
+        configuration.set(
+                CheckpointingOptions.STATE_CHANGE_LOG_STORAGE,
+                TestStateChangelogStorageFactory.identifier);
+        JobID jobId1 = new JobID(1L, 1L);
+        StateChangelogStorage<?> storage1 =
+                manager.stateChangelogStorageForJob(jobId1, configuration);
+        Assert.assertTrue(storage1 instanceof TestStateChangelogStorage);
+        Assert.assertFalse(((TestStateChangelogStorage) storage1).closed);
+        manager.releaseStateChangelogStorageForJob(jobId1);
+        Assert.assertTrue(((TestStateChangelogStorage) storage1).closed);
+
+        StateChangelogStorage<?> storage2 =
+                manager.stateChangelogStorageForJob(jobId1, configuration);
+        Assert.assertNotEquals(storage1, storage2);
+
+        manager.shutdown();
+        StateChangelogStorageLoader.initialize(null);
+    }
+
+    @Test
+    public void testShutdown() {
+        StateChangelogStorageLoader.initialize(TestStateChangelogStorageFactory.pluginManager);
+        TaskExecutorStateChangelogStoragesManager manager =
+                new TaskExecutorStateChangelogStoragesManager();
+        Configuration configuration = new Configuration();
+        configuration.set(
+                CheckpointingOptions.STATE_CHANGE_LOG_STORAGE,
+                TestStateChangelogStorageFactory.identifier);
+        JobID jobId1 = new JobID(1L, 1L);
+        StateChangelogStorage<?> storage1 =
+                manager.stateChangelogStorageForJob(jobId1, configuration);
+        Assert.assertTrue(storage1 instanceof TestStateChangelogStorage);
+        Assert.assertFalse(((TestStateChangelogStorage) storage1).closed);
+
+        JobID jobId2 = new JobID(1L, 2L);
+        StateChangelogStorage<?> storage2 =
+                manager.stateChangelogStorageForJob(jobId1, configuration);
+        Assert.assertTrue(storage2 instanceof TestStateChangelogStorage);
+        Assert.assertFalse(((TestStateChangelogStorage) storage2).closed);
+
+        manager.shutdown();
+        Assert.assertTrue(((TestStateChangelogStorage) storage1).closed);
+        Assert.assertTrue(((TestStateChangelogStorage) storage2).closed);
+
+        StateChangelogStorageLoader.initialize(null);
+    }
+
+    private static class TestStateChangelogStorage
+            implements StateChangelogStorage<ChangelogStateHandle> {
+        public boolean closed = false;
+
+        @Override
+        public StateChangelogWriter<ChangelogStateHandle> createWriter(
+                String operatorID, KeyGroupRange keyGroupRange) {
+            return null;
+        }
+
+        @Override
+        public StateChangelogHandleReader<ChangelogStateHandle> createReader() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private static class TestStateChangelogStorageFactory implements StateChangelogStorageFactory {
+
+        public static String identifier = "test-factory";
+
+        /** PluginManager that can load this factory. */
+        public static PluginManager pluginManager =
+                new PluginManager() {
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    public <P> Iterator<P> load(Class<P> service) {
+                        checkArgument(service.equals(StateChangelogStorageFactory.class));
+                        return (Iterator<P>)
+                                singletonList(new TestStateChangelogStorageFactory()).iterator();
+                    }
+                };
+
+        @Override
+        public String getIdentifier() {
+            // same identifier for overlapping test.
+            return identifier;
+        }
+
+        @Override
+        public StateChangelogStorage<?> createStorage(Configuration configuration) {
+            return new TestStateChangelogStorage();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -31,6 +31,8 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.util.TestLogger;
@@ -56,6 +58,7 @@ public class TaskStateManagerImplTest extends TestLogger {
 
         TestCheckpointResponder testCheckpointResponder = new TestCheckpointResponder();
         TestTaskLocalStateStore testTaskLocalStateStore = new TestTaskLocalStateStore();
+        InMemoryStateChangelogStorage changelogStorage = new InMemoryStateChangelogStorage();
 
         TaskStateManager taskStateManager =
                 taskStateManager(
@@ -63,7 +66,8 @@ public class TaskStateManagerImplTest extends TestLogger {
                         executionAttemptID,
                         testCheckpointResponder,
                         null,
-                        testTaskLocalStateStore);
+                        testTaskLocalStateStore,
+                        changelogStorage);
 
         // ---------------------------------------- test reporting
         // -----------------------------------------
@@ -139,7 +143,8 @@ public class TaskStateManagerImplTest extends TestLogger {
                         executionAttemptID,
                         testCheckpointResponder,
                         taskRestore,
-                        testTaskLocalStateStore);
+                        testTaskLocalStateStore,
+                        changelogStorage);
 
         // this has remote AND local managed keyed state.
         PrioritizedOperatorSubtaskState prioritized_1 =
@@ -225,13 +230,16 @@ public class TaskStateManagerImplTest extends TestLogger {
                             localRecoveryConfig,
                             directExecutor);
 
+            InMemoryStateChangelogStorage changelogStorage = new InMemoryStateChangelogStorage();
+
             TaskStateManager taskStateManager =
                     taskStateManager(
                             jobID,
                             executionAttemptID,
                             checkpointResponderMock,
                             null,
-                            taskLocalStateStore);
+                            taskLocalStateStore,
+                            changelogStorage);
 
             LocalRecoveryConfig localRecoveryConfFromTaskLocalStateStore =
                     taskLocalStateStore.getLocalRecoveryConfig();
@@ -265,12 +273,14 @@ public class TaskStateManagerImplTest extends TestLogger {
             ExecutionAttemptID executionAttemptID,
             CheckpointResponder checkpointResponderMock,
             JobManagerTaskRestore jobManagerTaskRestore,
-            TaskLocalStateStore localStateStore) {
+            TaskLocalStateStore localStateStore,
+            StateChangelogStorage<?> stateChangelogStorage) {
 
         return new TaskStateManagerImpl(
                 jobID,
                 executionAttemptID,
                 localStateStore,
+                stateChangelogStorage,
                 jobManagerTaskRestore,
                 checkpointResponderMock);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.checkpoint.channel.SequentialChannelStateReader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.util.Preconditions;
@@ -176,6 +178,11 @@ public class TestTaskStateManager implements TaskStateManager {
     @Override
     public SequentialChannelStateReader getSequentialChannelStateReader() {
         return SequentialChannelStateReader.NO_OP;
+    }
+
+    @Override
+    public StateChangelogStorage<?> getStateChangelogStorage() {
+        return new InMemoryStateChangelogStorage();
     }
 
     public void setLocalRecoveryConfig(LocalRecoveryConfig recoveryDirectoryProvider) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -180,6 +180,7 @@ public class TestTaskStateManager implements TaskStateManager {
         return SequentialChannelStateReader.NO_OP;
     }
 
+    @Nullable
     @Override
     public StateChangelogStorage<?> getStateChangelogStorage() {
         return new InMemoryStateChangelogStorage();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.state.TaskExecutorStateChangelogStoragesManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
 import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
@@ -54,6 +55,7 @@ public class TaskManagerServicesBuilder {
     private JobTable jobTable;
     private JobLeaderService jobLeaderService;
     private TaskExecutorLocalStateStoresManager taskStateManager;
+    private TaskExecutorStateChangelogStoragesManager taskChangelogStoragesManager;
     private TaskEventDispatcher taskEventDispatcher;
     private ExecutorService ioExecutor;
     private LibraryCacheManager libraryCacheManager;
@@ -76,6 +78,7 @@ public class TaskManagerServicesBuilder {
                         unresolvedTaskManagerLocation,
                         RetryingRegistrationConfiguration.defaultConfiguration());
         taskStateManager = mock(TaskExecutorLocalStateStoresManager.class);
+        taskChangelogStoragesManager = mock(TaskExecutorStateChangelogStoragesManager.class);
         ioExecutor = TestingUtils.defaultExecutor();
         libraryCacheManager = TestingLibraryCacheManager.newBuilder().build();
         managedMemorySize = MemoryManager.MIN_PAGE_SIZE;
@@ -130,6 +133,12 @@ public class TaskManagerServicesBuilder {
         return this;
     }
 
+    public TaskManagerServicesBuilder setTaskChangelogStoragesManager(
+            TaskExecutorStateChangelogStoragesManager taskChangelogStoragesManager) {
+        this.taskChangelogStoragesManager = taskChangelogStoragesManager;
+        return this;
+    }
+
     public TaskManagerServicesBuilder setIOExecutorService(ExecutorService ioExecutor) {
         this.ioExecutor = ioExecutor;
         return this;
@@ -158,6 +167,7 @@ public class TaskManagerServicesBuilder {
                 jobTable,
                 jobLeaderService,
                 taskStateManager,
+                taskChangelogStoragesManager,
                 taskEventDispatcher,
                 ioExecutor,
                 libraryCacheManager);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -54,6 +54,8 @@ import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
 import org.apache.flink.runtime.taskexecutor.NoOpPartitionProducerStateChecker;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
@@ -199,11 +201,15 @@ public class JvmExitOnFatalErrorTest extends TestLogger {
                                 TestLocalRecoveryConfig.disabled(),
                                 executor);
 
+                final StateChangelogStorage<?> changelogStorage =
+                        new InMemoryStateChangelogStorage();
+
                 final TaskStateManager slotStateManager =
                         new TaskStateManagerImpl(
                                 jid,
                                 executionAttemptID,
                                 localStateStore,
+                                changelogStorage,
                                 null,
                                 mock(CheckpointResponder.class));
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.changelog.ChangelogStateBackendHandle;
-import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.delegate.DelegatingStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.changelog.restore.ChangelogBackendRestoreOperation;
@@ -200,8 +200,11 @@ public class ChangelogStateBackend implements DelegatingStateBackend, Configurab
             Collection<KeyedStateHandle> stateHandles,
             BaseBackendBuilder<K> baseBackendBuilder)
             throws Exception {
-        // todo: FLINK-21804 get from Environment.getTaskStateManager
-        InMemoryStateChangelogStorage changelogStorage = new InMemoryStateChangelogStorage();
+        StateChangelogStorage<?> changelogStorage =
+                Preconditions.checkNotNull(
+                        env.getTaskStateManager().getStateChangelogStorage(),
+                        "Changelog storage is null when creating and restoring"
+                                + " the ChangelogKeyedStateBackend.");
         return ChangelogBackendRestoreOperation.restore(
                 changelogStorage.createReader(),
                 env.getUserCodeClassLoader().asClassLoader(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestTaskLocalStateStore;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
@@ -166,6 +167,7 @@ public class StateInitializationContextImplTest {
                         new JobID(),
                         new ExecutionAttemptID(),
                         new TestTaskLocalStateStore(),
+                        new InMemoryStateChangelogStorage(),
                         jobManagerTaskRestore,
                         mock(CheckpointResponder.class));
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImplTest;
 import org.apache.flink.runtime.state.TestTaskLocalStateStore;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
@@ -281,6 +282,7 @@ public class StreamTaskStateInitializerImplTest {
         TestCheckpointResponder checkpointResponderMock = new TestCheckpointResponder();
 
         TaskLocalStateStore taskLocalStateStore = new TestTaskLocalStateStore();
+        InMemoryStateChangelogStorage changelogStorage = new InMemoryStateChangelogStorage();
 
         TaskStateManager taskStateManager =
                 TaskStateManagerImplTest.taskStateManager(
@@ -288,7 +290,8 @@ public class StreamTaskStateInitializerImplTest {
                         executionAttemptID,
                         checkpointResponderMock,
                         jobManagerTaskRestore,
-                        taskLocalStateStore);
+                        taskLocalStateStore,
+                        changelogStorage);
 
         DummyEnvironment dummyEnvironment = new DummyEnvironment("test-task", 1, 0);
         dummyEnvironment.setTaskStateManager(taskStateManager);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -45,6 +45,8 @@ import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
+import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.util.TestLogger;
@@ -238,9 +240,16 @@ public class LocalStateForwardingTest extends TestLogger {
                     }
                 };
 
+        StateChangelogStorage<?> stateChangelogStorage = new InMemoryStateChangelogStorage();
+
         TaskStateManagerImpl taskStateManager =
                 new TaskStateManagerImpl(
-                        jobID, executionAttemptID, taskLocalStateStore, null, checkpointResponder);
+                        jobID,
+                        executionAttemptID,
+                        taskLocalStateStore,
+                        stateChangelogStorage,
+                        null,
+                        checkpointResponder);
 
         taskStateManager.reportTaskStateSnapshots(
                 checkpointMetaData, checkpointMetrics, jmSnapshot, tmSnapshot);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -84,6 +84,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskLocalStateStoreImpl;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.NoOpTaskManagerActions;
@@ -911,6 +912,7 @@ public class StreamTaskTest extends TestLogger {
                         new JobID(1L, 2L),
                         new ExecutionAttemptID(),
                         mock(TaskLocalStateStoreImpl.class),
+                        mock(StateChangelogStorage.class),
                         null,
                         checkpointResponder);
 
@@ -1103,6 +1105,7 @@ public class StreamTaskTest extends TestLogger {
                         new JobID(1L, 2L),
                         new ExecutionAttemptID(),
                         mock(TaskLocalStateStoreImpl.class),
+                        mock(StateChangelogStorage.class),
                         null,
                         checkpointResponder);
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request creates the storage for changelog state backend during task initialization. The changelog state backend will use the storage to create changelog reader and writer.
For more details, check [the doc](https://docs.google.com/document/d/10c6hZsOVxzUjeCLPSDpKGyZOYHi73yd92lCqRs1CyUE/edit?disco=AAAAMNoM4Cc)

## Brief change log
 - Add ```StateChangelogStorageFactory```, use ```PluginManager``` and ```ServiceLoader``` to load it.
 - Add ```StateChangelogStorageLoader```. It loads all ```StateChangelogStorageFactory``` and create ```StateChangelogStorage``` based on configuration.
  - Add ```StateChangelogStorage``` instance in ```JobTable.JobServices```

## Verifying this change

This change added tests and can be verified as follows:

  - Added tests in ```StateChangelogStorageLoaderTest``` for ```StateChangelogStorageFactory``` and ```StateChangelogStorageLoader```
  
The taskmanager creation and running procedure are covered by the existing IT cases.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs and JavaDocs
