### PR TITLE
[FLINK-23202][rpc] Fail rpc requests for unreachable recipients eagerly 

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -209,7 +209,11 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
         Time futureTimeout = extractRpcTimeout(parameterAnnotations, args, timeout);
 
         final RpcInvocation rpcInvocation =
-                createRpcInvocationMessage(methodName, parameterTypes, args);
+                createRpcInvocationMessage(
+                        method.getDeclaringClass().getSimpleName(),
+                        methodName,
+                        parameterTypes,
+                        args);
 
         Class<?> returnType = method.getReturnType();
 
@@ -262,6 +266,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
     /**
      * Create the RpcInvocation message for the given RPC.
      *
+     * @param declaringClassName of the RPC
      * @param methodName of the RPC
      * @param parameterTypes of the RPC
      * @param args of the RPC
@@ -269,16 +274,21 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
      * @throws IOException if we cannot serialize the RPC invocation parameters
      */
     protected RpcInvocation createRpcInvocationMessage(
-            final String methodName, final Class<?>[] parameterTypes, final Object[] args)
+            final String declaringClassName,
+            final String methodName,
+            final Class<?>[] parameterTypes,
+            final Object[] args)
             throws IOException {
         final RpcInvocation rpcInvocation;
 
         if (isLocal) {
-            rpcInvocation = new LocalRpcInvocation(methodName, parameterTypes, args);
+            rpcInvocation =
+                    new LocalRpcInvocation(declaringClassName, methodName, parameterTypes, args);
         } else {
             try {
                 RemoteRpcInvocation remoteRpcInvocation =
-                        new RemoteRpcInvocation(methodName, parameterTypes, args);
+                        new RemoteRpcInvocation(
+                                declaringClassName, methodName, parameterTypes, args);
 
                 if (remoteRpcInvocation.getSize() > maximumFramesize) {
                     throw new IOException(

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.StartStoppable;
+import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
 import org.apache.flink.runtime.rpc.exceptions.RpcException;
 import org.apache.flink.runtime.rpc.messages.CallAsync;
 import org.apache.flink.runtime.rpc.messages.LocalRpcInvocation;
@@ -196,7 +197,9 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
      *
      * @param method to call
      * @param args of the method call
-     * @return result of the RPC
+     * @return result of the RPC; the result future is completed with a {@link TimeoutException} if
+     *     the requests times out; if the recipient is not reachable, then the result future is
+     *     completed with a {@link RecipientUnreachableException}.
      * @throws Exception if the RPC invocation fails
      */
     private Object invokeRpc(Method method, Object[] args) throws Exception {

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -46,6 +46,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSelection;
 import akka.actor.ActorSystem;
 import akka.actor.Address;
+import akka.actor.DeadLetter;
 import akka.actor.Props;
 import akka.dispatch.Futures;
 import akka.pattern.Patterns;
@@ -144,6 +145,13 @@ public class AkkaRpcService implements RpcService {
         stopped = false;
 
         supervisor = startSupervisorActor();
+        startDeadLettersActor();
+    }
+
+    private void startDeadLettersActor() {
+        final ActorRef deadLettersActor =
+                actorSystem.actorOf(DeadLettersActor.getProps(), "deadLettersActor");
+        actorSystem.eventStream().subscribe(deadLettersActor, DeadLetter.class);
     }
 
     private Supervisor startSupervisorActor() {

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -176,6 +176,10 @@ public class AkkaRpcServiceUtils {
         return internalRpcUrl(endpointName, Optional.empty());
     }
 
+    public static boolean isRecipientTerminatedException(Throwable exception) {
+        return exception.getMessage().contains("had already been terminated.");
+    }
+
     private static final class RemoteAddressInformation {
         private final String hostnameAndPort;
         private final AkkaProtocol akkaProtocol;

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/DeadLettersActor.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/DeadLettersActor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
+import org.apache.flink.runtime.rpc.messages.Message;
+
+import akka.actor.AbstractActor;
+import akka.actor.DeadLetter;
+import akka.actor.Props;
+import akka.actor.Status;
+import akka.japi.pf.ReceiveBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Actor which listens to {@link akka.actor.DeadLetter} and responds with a failure if the message
+ * was a RPC.
+ */
+public class DeadLettersActor extends AbstractActor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeadLettersActor.class);
+
+    @Override
+    public Receive createReceive() {
+        return new ReceiveBuilder().match(DeadLetter.class, this::handleDeadLetter).build();
+    }
+
+    private void handleDeadLetter(DeadLetter deadLetter) {
+        if (deadLetter.message() instanceof Message) {
+            if (deadLetter.sender().equals(getContext().getSystem().deadLetters())) {
+                LOG.debug(
+                        "Could not deliver message {} with no sender to recipient {}. "
+                                + "This indicates that the actor terminated unexpectedly.",
+                        deadLetter.message(),
+                        deadLetter.recipient());
+            } else {
+                deadLetter
+                        .sender()
+                        .tell(
+                                new Status.Failure(
+                                        new RecipientUnreachableException(
+                                                deadLetter.sender().toString(),
+                                                deadLetter.recipient().toString(),
+                                                deadLetter.message().toString())),
+                                getSelf());
+            }
+        }
+    }
+
+    public static Props getProps() {
+        return Props.create(DeadLettersActor.class);
+    }
+}

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -19,10 +19,12 @@
 package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -359,6 +361,30 @@ public class AkkaRpcServiceTest extends TestLogger {
         }
 
         assertThat(akkaRpcService.getActorSystem().whenTerminated().isCompleted(), is(true));
+    }
+
+    @Test
+    public void failsRpcResultImmediatelyIfEndpointIsStopped() throws Exception {
+        try (final AkkaRpcActorTest.SerializedValueRespondingEndpoint endpoint =
+                new AkkaRpcActorTest.SerializedValueRespondingEndpoint(akkaRpcService)) {
+            endpoint.start();
+
+            final AkkaRpcActorTest.SerializedValueRespondingGateway gateway =
+                    akkaRpcService
+                            .connect(
+                                    endpoint.getAddress(),
+                                    AkkaRpcActorTest.SerializedValueRespondingGateway.class)
+                            .join();
+
+            endpoint.close();
+
+            try {
+                gateway.getSerializedValue().join();
+                fail("The endpoint should have been stopped.");
+            } catch (Exception e) {
+                assertThat(e, FlinkMatchers.containsCause(RecipientUnreachableException.class));
+            }
+        }
     }
 
     private Collection<CompletableFuture<Void>> startStopNCountingAsynchronousOnStopEndpoints(

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -50,10 +50,10 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
@@ -35,10 +35,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /** Tests for remote AkkaRpcActors. */

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/RemoteAkkaRpcActorTest.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
@@ -37,6 +39,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 /** Tests for remote AkkaRpcActors. */
 public class RemoteAkkaRpcActorTest extends TestLogger {
@@ -44,9 +47,10 @@ public class RemoteAkkaRpcActorTest extends TestLogger {
     private static AkkaRpcService rpcService;
     private static AkkaRpcService otherRpcService;
 
+    private static final Configuration configuration = new Configuration();
+
     @BeforeClass
     public static void setupClass() throws Exception {
-        final Configuration configuration = new Configuration();
         rpcService =
                 AkkaRpcServiceUtils.createRemoteRpcService(
                         configuration, "localhost", "0", null, Optional.empty());
@@ -123,6 +127,63 @@ public class RemoteAkkaRpcActorTest extends TestLogger {
             assertThat(
                     responseFuture.get(),
                     equalTo(AkkaRpcActorTest.SerializedValueRespondingEndpoint.SERIALIZED_VALUE));
+        }
+    }
+
+    @Test
+    public void failsRpcResultImmediatelyIfEndpointIsStopped() throws Exception {
+        try (final AkkaRpcActorTest.SerializedValueRespondingEndpoint endpoint =
+                new AkkaRpcActorTest.SerializedValueRespondingEndpoint(rpcService)) {
+            endpoint.start();
+
+            final AkkaRpcActorTest.SerializedValueRespondingGateway gateway =
+                    otherRpcService
+                            .connect(
+                                    endpoint.getAddress(),
+                                    AkkaRpcActorTest.SerializedValueRespondingGateway.class)
+                            .join();
+
+            endpoint.close();
+
+            try {
+                gateway.getSerializedValue().join();
+                fail("The endpoint should have been stopped.");
+            } catch (Exception e) {
+                // the rpc result should not fail because of a TimeoutException
+                assertThat(e, FlinkMatchers.containsCause(RecipientUnreachableException.class));
+            }
+        }
+    }
+
+    @Test
+    public void failsRpcResultImmediatelyIfRemoteRpcServiceIsNotAvailable() throws Exception {
+        final AkkaRpcService toBeClosedRpcService =
+                AkkaRpcServiceUtils.createRemoteRpcService(
+                        configuration, "localhost", "0", null, Optional.empty());
+        try (final AkkaRpcActorTest.SerializedValueRespondingEndpoint endpoint =
+                new AkkaRpcActorTest.SerializedValueRespondingEndpoint(toBeClosedRpcService)) {
+            endpoint.start();
+
+            final AkkaRpcActorTest.SerializedValueRespondingGateway gateway =
+                    otherRpcService
+                            .connect(
+                                    endpoint.getAddress(),
+                                    AkkaRpcActorTest.SerializedValueRespondingGateway.class)
+                            .join();
+
+            toBeClosedRpcService.stopService().join();
+
+            Thread.sleep(100L);
+
+            try {
+                gateway.getSerializedValue().join();
+                fail("The endpoint should have been stopped.");
+            } catch (Exception e) {
+                // the rpc result should not fail because of a TimeoutException
+                assertThat(e, FlinkMatchers.containsCause(RecipientUnreachableException.class));
+            }
+        } finally {
+            RpcUtils.terminateRpcService(toBeClosedRpcService, Time.seconds(10L));
         }
     }
 }

--- a/flink-rpc/flink-rpc-akka/src/test/resources/log4j2-test.properties
+++ b/flink-rpc/flink-rpc-akka/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/exceptions/RecipientUnreachableException.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/exceptions/RecipientUnreachableException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.exceptions;
+
+/**
+ * Exception which indicates that the specified recipient is unreachable. This can either mean that
+ * the recipient has been terminated or that the remote RpcService is currently not reachable.
+ */
+public class RecipientUnreachableException extends RpcException {
+    public RecipientUnreachableException(String sender, String recipient, String message) {
+        super(
+                String.format(
+                        "Could not send message [%s] from sender [%s] to recipient [%s], because "
+                                + "the recipient is unreachable. This can either mean that the "
+                                + "recipient has been terminated or that the remote RpcService "
+                                + "is currently not reachable.",
+                        message, sender, recipient));
+    }
+}

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/CallAsync.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/CallAsync.java
@@ -23,7 +23,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.concurrent.Callable;
 
 /** Message for asynchronous callable invocations. */
-public final class CallAsync {
+public final class CallAsync implements Message {
 
     private final Callable<?> callable;
 

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/FencedMessage.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/FencedMessage.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  * @param <F> type of the fencing token
  * @param <P> type of the payload
  */
-public interface FencedMessage<F extends Serializable, P> {
+public interface FencedMessage<F extends Serializable, P> extends Message {
 
     F getFencingToken();
 

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/LocalRpcInvocation.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/LocalRpcInvocation.java
@@ -27,13 +27,16 @@ import org.apache.flink.util.Preconditions;
  */
 public final class LocalRpcInvocation implements RpcInvocation {
 
+    private final String declaringClass;
     private final String methodName;
     private final Class<?>[] parameterTypes;
     private final Object[] args;
 
     private transient String toString;
 
-    public LocalRpcInvocation(String methodName, Class<?>[] parameterTypes, Object[] args) {
+    public LocalRpcInvocation(
+            String declaringClass, String methodName, Class<?>[] parameterTypes, Object[] args) {
+        this.declaringClass = declaringClass;
         this.methodName = Preconditions.checkNotNull(methodName);
         this.parameterTypes = Preconditions.checkNotNull(parameterTypes);
         this.args = args;
@@ -59,17 +62,11 @@ public final class LocalRpcInvocation implements RpcInvocation {
     @Override
     public String toString() {
         if (toString == null) {
-            StringBuilder paramTypeStringBuilder = new StringBuilder(parameterTypes.length * 5);
-
-            if (parameterTypes.length > 0) {
-                paramTypeStringBuilder.append(parameterTypes[0].getSimpleName());
-
-                for (int i = 1; i < parameterTypes.length; i++) {
-                    paramTypeStringBuilder.append(", ").append(parameterTypes[i].getSimpleName());
-                }
-            }
-
-            toString = "LocalRpcInvocation(" + methodName + '(' + paramTypeStringBuilder + "))";
+            toString =
+                    "LocalRpcInvocation("
+                            + RpcInvocation.convertRpcToString(
+                                    declaringClass, methodName, parameterTypes)
+                            + ")";
         }
 
         return toString;

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/Message.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/Message.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,5 @@
 
 package org.apache.flink.runtime.rpc.messages;
 
-/** Handshake success response. */
-public enum HandshakeSuccessMessage implements Message {
-    INSTANCE
-}
+/** Marker interface for all Flink RPC related messages. */
+public interface Message {}

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteHandshakeMessage.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteHandshakeMessage.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  * Handshake message between rpc endpoints. This message can be used to verify compatibility between
  * different endpoints.
  */
-public class RemoteHandshakeMessage implements Serializable {
+public class RemoteHandshakeMessage implements Message, Serializable {
 
     private static final long serialVersionUID = -7150082246232019027L;
 

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RpcInvocation.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RpcInvocation.java
@@ -58,4 +58,27 @@ public interface RpcInvocation extends Message {
      *     serialized classes which cannot be found on the receiving side
      */
     Object[] getArgs() throws IOException, ClassNotFoundException;
+
+    /**
+     * Converts a rpc call into its string representation.
+     *
+     * @param declaringClassName declaringClassName declares the specified rpc
+     * @param methodName methodName of the rpc
+     * @param parameterTypes parameterTypes of the rpc
+     * @return string representation of the rpc
+     */
+    static String convertRpcToString(
+            String declaringClassName, String methodName, Class<?>[] parameterTypes) {
+        final StringBuilder paramTypeStringBuilder = new StringBuilder(parameterTypes.length * 5);
+
+        if (parameterTypes.length > 0) {
+            paramTypeStringBuilder.append(parameterTypes[0].getSimpleName());
+
+            for (int i = 1; i < parameterTypes.length; i++) {
+                paramTypeStringBuilder.append(", ").append(parameterTypes[i].getSimpleName());
+            }
+        }
+
+        return declaringClassName + '.' + methodName + '(' + paramTypeStringBuilder + ')';
+    }
 }

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RpcInvocation.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RpcInvocation.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  * Interface for rpc invocation messages. The interface allows to request all necessary information
  * to lookup a method and call it with the corresponding arguments.
  */
-public interface RpcInvocation {
+public interface RpcInvocation extends Message {
 
     /**
      * Returns the method's name.

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RunAsync.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/RunAsync.java
@@ -22,7 +22,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Message for asynchronous runnable invocations. */
-public final class RunAsync {
+public final class RunAsync implements Message {
 
     private final Runnable runnable;
 

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/UnfencedMessage.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/messages/UnfencedMessage.java
@@ -31,7 +31,7 @@ import org.apache.flink.util.Preconditions;
  *
  * @param <P> type of the payload
  */
-public class UnfencedMessage<P> {
+public class UnfencedMessage<P> implements Message {
     private final P payload;
 
     public UnfencedMessage(P payload) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
@@ -68,6 +68,7 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 
         RemoteRpcInvocation method =
                 new RemoteRpcInvocation(
+                        className,
                         "test",
                         new Class<?>[] {
                             int.class, Class.forName(className, false, userClassLoader)

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.test.recovery;
 
 import org.apache.flink.api.java.utils.ParameterTool;
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -91,7 +90,6 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
         File coordinateTempDir = null;
 
         Configuration config = new Configuration();
-        config.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(100));
         config.setString(JobManagerOptions.ADDRESS, "localhost");
         config.setString(RestOptions.BIND_PORT, "0");
         config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 500L);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -67,7 +67,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase
         ExecutionEnvironment env =
                 ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, configuration);
         env.setParallelism(PARALLELISM);
-        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(2, 0L));
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000L));
         env.getConfig().setExecutionMode(executionMode);
 
         final long numElements = 100000L;


### PR DESCRIPTION
This PR adds support for failing RPC result futures eagerly if the recipient turns out to be unreachable (e.g. terminated or remote ActorSystem is unreachable). This allows to react to failure situations earlier.

The PR contains the following main commits:

#### 74dc9a1: Introduce marker interface to filter out Flink related RPC messages

The marker interface rpc.messages.Message identifies all Flink related RPC messages. This can
be used to filter for these messages and to trigger specific actions.

#### da79d62: Fail rpc requests for unreachable recipients eagerly

This commit adds the DeadLettersActor that monitor Akka's dead letter mailbox. Whenever a
Flink Message is received if sends a failure to the sender to notify the sender about the
unreachability of the recipient. That way it is possible to eagerly fail the result futures,
and not having to wait on the rpc timeout.

#### fe6bdb0: Fail with AkkaRecipientUnreachableException if local actor has terminated

This commit replaces the AskTimeoutException with an AkkaRecipientUnreachableException if the local actor
has already terminated. This works by looking at the exception message. This ensures that we respond with
the right exception if the local actor is unreachable.