### PR TITLE
[FLINK-18783] Load AkkaRpcSystem through separate classloader

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -310,7 +310,7 @@ data:
     appender.rolling.strategy.max = 10
 
     # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-    logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+    logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
     logger.netty.level = OFF
 ```
 
@@ -380,7 +380,7 @@ data:
     appender.rolling.strategy.max = 10
 
     # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-    logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+    logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
     logger.netty.level = OFF
 ```
 

--- a/docs/content/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -310,7 +310,7 @@ data:
     appender.rolling.strategy.max = 10
 
     # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-    logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+    logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
     logger.netty.level = OFF
 ```
 
@@ -380,7 +380,7 @@ data:
     appender.rolling.strategy.max = 10
 
     # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-    logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+    logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
     logger.netty.level = OFF
 ```
 

--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -30,7 +30,7 @@ This check should only be disabled if such a leak prevents further jobs from run
         </tr>
         <tr>
             <td><h5>classloader.parent-first-patterns.default</h5></td>
-            <td style="word-wrap: break-word;">"java.;<wbr>scala.;<wbr>org.apache.flink.;<wbr>com.esotericsoftware.kryo;<wbr>org.apache.hadoop.;<wbr>javax.annotation.;<wbr>org.slf4j;<wbr>org.apache.log4j;<wbr>org.apache.logging;<wbr>org.apache.commons.logging;<wbr>ch.qos.logback;<wbr>org.xml;<wbr>javax.xml;<wbr>org.apache.xerces;<wbr>org.w3c"</td>
+            <td style="word-wrap: break-word;">"java.;<wbr>scala.;<wbr>org.apache.flink.;<wbr>com.esotericsoftware.kryo;<wbr>org.apache.hadoop.;<wbr>javax.annotation.;<wbr>org.xml;<wbr>javax.xml;<wbr>org.apache.xerces;<wbr>org.w3c;<wbr>org.slf4j;<wbr>org.apache.log4j;<wbr>org.apache.logging;<wbr>org.apache.commons.logging;<wbr>ch.qos.logback"</td>
             <td>String</td>
             <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against the fully qualified class name. This setting should generally not be modified. To add another pattern we recommend to use "classloader.parent-first-patterns.additional" instead.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/expert_class_loading_section.html
+++ b/docs/layouts/shortcodes/generated/expert_class_loading_section.html
@@ -30,7 +30,7 @@ This check should only be disabled if such a leak prevents further jobs from run
         </tr>
         <tr>
             <td><h5>classloader.parent-first-patterns.default</h5></td>
-            <td style="word-wrap: break-word;">"java.;<wbr>scala.;<wbr>org.apache.flink.;<wbr>com.esotericsoftware.kryo;<wbr>org.apache.hadoop.;<wbr>javax.annotation.;<wbr>org.slf4j;<wbr>org.apache.log4j;<wbr>org.apache.logging;<wbr>org.apache.commons.logging;<wbr>ch.qos.logback;<wbr>org.xml;<wbr>javax.xml;<wbr>org.apache.xerces;<wbr>org.w3c"</td>
+            <td style="word-wrap: break-word;">"java.;<wbr>scala.;<wbr>org.apache.flink.;<wbr>com.esotericsoftware.kryo;<wbr>org.apache.hadoop.;<wbr>javax.annotation.;<wbr>org.xml;<wbr>javax.xml;<wbr>org.apache.xerces;<wbr>org.w3c;<wbr>org.slf4j;<wbr>org.apache.log4j;<wbr>org.apache.logging;<wbr>org.apache.commons.logging;<wbr>ch.qos.logback"</td>
             <td>String</td>
             <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against the fully qualified class name. This setting should generally not be modified. To add another pattern we recommend to use "classloader.parent-first-patterns.additional" instead.</td>
         </tr>

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/Internal.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/Internal.java
@@ -29,6 +29,6 @@ import java.lang.annotation.Target;
  * <p>Developer APIs are stable but internal to Flink and might change across releases.
  */
 @Documented
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
 @Public
 public @interface Internal {}

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -47,13 +47,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
+			<artifactId>flink-optimizer</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -77,7 +77,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -68,7 +68,7 @@
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -183,7 +183,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -94,7 +94,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -135,7 +135,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -112,7 +112,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -110,7 +110,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -107,7 +107,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -88,7 +88,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-connectors/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-connector-hbase-1.4/pom.xml
@@ -348,7 +348,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -867,7 +867,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -72,7 +72,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -99,7 +99,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -149,7 +149,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -157,7 +157,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-jmx</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -180,14 +180,14 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -65,14 +65,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -39,7 +39,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.configuration;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
@@ -33,6 +34,10 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @PublicEvolving
 @ConfigGroups(groups = {@ConfigGroup(name = "Environment", keyPrefix = "env")})
 public class CoreOptions {
+
+    @Internal
+    public static final String PARENT_FIRST_LOGGING_PATTERNS =
+            "org.slf4j;org.apache.log4j;org.apache.logging;org.apache.commons.logging;ch.qos.logback";
 
     // ------------------------------------------------------------------------
     //  Classloading Parameters
@@ -92,7 +97,8 @@ public class CoreOptions {
     public static final ConfigOption<String> ALWAYS_PARENT_FIRST_LOADER_PATTERNS =
             ConfigOptions.key("classloader.parent-first-patterns.default")
                     .defaultValue(
-                            "java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging;org.apache.commons.logging;ch.qos.logback;org.xml;javax.xml;org.apache.xerces;org.w3c")
+                            "java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.xml;javax.xml;org.apache.xerces;org.w3c;"
+                                    + PARENT_FIRST_LOGGING_PATTERNS)
                     .withDeprecatedKeys("classloader.parent-first-patterns")
                     .withDescription(
                             "A (semicolon-separated) list of patterns that specifies which classes should always be"
@@ -149,8 +155,8 @@ public class CoreOptions {
             ConfigOptions.key("plugin.classloader.parent-first-patterns.default")
                     .stringType()
                     .defaultValue(
-                            "java.;org.apache.flink.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache"
-                                    + ".logging;org.apache.commons.logging;ch.qos.logback")
+                            "java.;org.apache.flink.;javax.annotation.;"
+                                    + PARENT_FIRST_LOGGING_PATTERNS)
                     .withDescription(
                             "A (semicolon-separated) list of patterns that specifies which classes should always be"
                                     + " resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked "

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -183,7 +183,8 @@ public class CoreOptions {
         return parseParentFirstLoaderPatterns(base, append);
     }
 
-    private static String[] parseParentFirstLoaderPatterns(String base, String append) {
+    @Internal
+    public static String[] parseParentFirstLoaderPatterns(String base, String append) {
         Splitter splitter = Splitter.on(';').omitEmptyStrings();
         return Iterables.toArray(
                 Iterables.concat(splitter.split(base), splitter.split(append)), String.class);

--- a/flink-core/src/main/java/org/apache/flink/core/classloading/ComponentClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/classloading/ComponentClassLoader.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.classloading;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Iterator;
+
+/**
+ * A {@link URLClassLoader} that restricts which classes can be loaded to those contained within the
+ * given classpath, except classes from a given set of packages that are either loaded owner or
+ * component-first.
+ *
+ * <p>Depiction of the class loader hierarchy:
+ *
+ * <pre>
+ *       Owner     Bootstrap
+ *           ^         ^
+ *           |---------|
+ *                |
+ *            Component
+ * </pre>
+ *
+ * <p>For loading classes/resources, class loaders are accessed in one of the following orders:
+ *
+ * <ul>
+ *   <li>component-only: component -> bootstrap; default.
+ *   <li>component-first: component -> bootstrap -> owner; opt-in.
+ *   <li>owner-first: owner -> component -> bootstrap; opt-in.
+ * </ul>
+ */
+public class ComponentClassLoader extends URLClassLoader {
+    private static final ClassLoader PLATFORM_OR_BOOTSTRAP_LOADER;
+
+    private final ClassLoader ownerClassLoader;
+
+    private final String[] ownerFirstPackages;
+    private final String[] componentFirstPackages;
+    private final String[] ownerFirstResourcePrefixes;
+    private final String[] componentFirstResourcePrefixes;
+
+    public ComponentClassLoader(
+            URL[] classpath,
+            ClassLoader ownerClassLoader,
+            String[] ownerFirstPackages,
+            String[] componentFirstPackages) {
+        super(classpath, PLATFORM_OR_BOOTSTRAP_LOADER);
+        this.ownerClassLoader = ownerClassLoader;
+
+        this.ownerFirstPackages = ownerFirstPackages;
+        this.componentFirstPackages = componentFirstPackages;
+
+        ownerFirstResourcePrefixes = convertPackagePrefixesToPathPrefixes(ownerFirstPackages);
+        componentFirstResourcePrefixes =
+                convertPackagePrefixesToPathPrefixes(componentFirstPackages);
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Class loading
+    // ----------------------------------------------------------------------------------------------
+
+    @Override
+    protected Class<?> loadClass(final String name, final boolean resolve)
+            throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            final Class<?> loadedClass = findLoadedClass(name);
+            if (loadedClass != null) {
+                return resolveIfNeeded(resolve, loadedClass);
+            }
+
+            if (isComponentFirstClass(name)) {
+                return loadClassFromComponentFirst(name, resolve);
+            }
+            if (isOwnerFirstClass(name)) {
+                return loadClassFromOwnerFirst(name, resolve);
+            }
+
+            // making this behavior configurable (component-only/component-first/owner-first) would
+            // allow this class to subsume the FlinkUserCodeClassLoader (with an added exception
+            // handler)
+            return loadClassFromComponentOnly(name, resolve);
+        }
+    }
+
+    private Class<?> resolveIfNeeded(final boolean resolve, final Class<?> loadedClass) {
+        if (resolve) {
+            resolveClass(loadedClass);
+        }
+        return loadedClass;
+    }
+
+    private boolean isOwnerFirstClass(final String name) {
+        return Arrays.stream(ownerFirstPackages).anyMatch(name::startsWith);
+    }
+
+    private boolean isComponentFirstClass(final String name) {
+        return Arrays.stream(componentFirstPackages).anyMatch(name::startsWith);
+    }
+
+    private Class<?> loadClassFromComponentOnly(final String name, final boolean resolve)
+            throws ClassNotFoundException {
+        return super.loadClass(name, resolve);
+    }
+
+    private Class<?> loadClassFromComponentFirst(final String name, final boolean resolve)
+            throws ClassNotFoundException {
+        try {
+            return loadClassFromComponentOnly(name, resolve);
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            return loadClassFromOwnerOnly(name, resolve);
+        }
+    }
+
+    private Class<?> loadClassFromOwnerOnly(final String name, final boolean resolve)
+            throws ClassNotFoundException {
+        return resolveIfNeeded(resolve, ownerClassLoader.loadClass(name));
+    }
+
+    private Class<?> loadClassFromOwnerFirst(final String name, final boolean resolve)
+            throws ClassNotFoundException {
+        try {
+            return loadClassFromOwnerOnly(name, resolve);
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            return loadClassFromComponentOnly(name, resolve);
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Resource loading
+    // ----------------------------------------------------------------------------------------------
+
+    @Override
+    public URL getResource(final String name) {
+        try {
+            final Enumeration<URL> resources = getResources(name);
+            if (resources.hasMoreElements()) {
+                return resources.nextElement();
+            }
+        } catch (IOException ignored) {
+            // mimics the behavior of the JDK
+        }
+        return null;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(final String name) throws IOException {
+        if (isComponentFirstResource(name)) {
+            return loadResourceFromComponentFirst(name);
+        }
+        if (isOwnerFirstResource(name)) {
+            return loadResourceFromOwnerFirst(name);
+        }
+
+        return loadResourceFromComponentOnly(name);
+    }
+
+    private boolean isOwnerFirstResource(final String name) {
+        return Arrays.stream(ownerFirstResourcePrefixes).anyMatch(name::startsWith);
+    }
+
+    private boolean isComponentFirstResource(final String name) {
+        return Arrays.stream(componentFirstResourcePrefixes).anyMatch(name::startsWith);
+    }
+
+    private Enumeration<URL> loadResourceFromComponentOnly(final String name) throws IOException {
+        return super.getResources(name);
+    }
+
+    private Enumeration<URL> loadResourceFromComponentFirst(final String name) throws IOException {
+        return loadResourcesInOrder(
+                name, this::loadResourceFromComponentOnly, this::loadResourceFromOwnerOnly);
+    }
+
+    private Enumeration<URL> loadResourceFromOwnerOnly(final String name) throws IOException {
+        return ownerClassLoader.getResources(name);
+    }
+
+    private Enumeration<URL> loadResourceFromOwnerFirst(final String name) throws IOException {
+        return loadResourcesInOrder(
+                name, this::loadResourceFromOwnerOnly, this::loadResourceFromComponentOnly);
+    }
+
+    private interface ResourceLoadingFunction
+            extends FunctionWithException<String, Enumeration<URL>, IOException> {}
+
+    private Enumeration<URL> loadResourcesInOrder(
+            String name,
+            ResourceLoadingFunction firstClassLoader,
+            ResourceLoadingFunction secondClassLoader)
+            throws IOException {
+        final Iterator<URL> iterator =
+                Iterators.concat(
+                        Iterators.forEnumeration(firstClassLoader.apply(name)),
+                        Iterators.forEnumeration(secondClassLoader.apply(name)));
+
+        return new IteratorBackedEnumeration<>(iterator);
+    }
+
+    @VisibleForTesting
+    static class IteratorBackedEnumeration<T> implements Enumeration<T> {
+        private final Iterator<T> backingIterator;
+
+        public IteratorBackedEnumeration(Iterator<T> backingIterator) {
+            this.backingIterator = backingIterator;
+        }
+
+        @Override
+        public boolean hasMoreElements() {
+            return backingIterator.hasNext();
+        }
+
+        @Override
+        public T nextElement() {
+            return backingIterator.next();
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Utils
+    // ----------------------------------------------------------------------------------------------
+
+    private static String[] convertPackagePrefixesToPathPrefixes(String[] packagePrefixes) {
+        return Arrays.stream(packagePrefixes)
+                .map(packageName -> packageName.replace('.', '/'))
+                .toArray(String[]::new);
+    }
+
+    static {
+        ClassLoader platformLoader = null;
+        try {
+            platformLoader =
+                    (ClassLoader)
+                            ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
+        } catch (NoSuchMethodException e) {
+            // on Java 8 this method does not exist, but using null indicates the bootstrap
+            // loader that we want to have
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot retrieve platform classloader on Java 9+", e);
+        }
+        PLATFORM_OR_BOOTSTRAP_LOADER = platformLoader;
+        ClassLoader.registerAsParallelCapable();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/classloading/SubmoduleClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/classloading/SubmoduleClassLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.classloading;
+
+import org.apache.flink.configuration.CoreOptions;
+
+import java.net.URL;
+
+/**
+ * Loads all classes from the submodule jar, except for explicitly white-listed packages.
+ *
+ * <p>To ensure that classes from the submodule are always loaded through the submodule classloader
+ * (and thus from the submodule jar), even if the classes are also on the classpath (e.g., during
+ * tests), all classes from the "org.apache.flink" package are loaded child-first.
+ *
+ * <p>Classes related to logging (e.g., log4j) are loaded parent-first.
+ *
+ * <p>All other classes can only be loaded if they are either available in the submodule jar or the
+ * bootstrap/app classloader (i.e., provided by the JDK).
+ */
+public class SubmoduleClassLoader extends ComponentClassLoader {
+    public SubmoduleClassLoader(URL[] classpath, ClassLoader parentClassLoader) {
+        super(
+                classpath,
+                parentClassLoader,
+                CoreOptions.parseParentFirstLoaderPatterns(
+                        CoreOptions.PARENT_FIRST_LOGGING_PATTERNS, ""),
+                new String[] {"org.apache.flink"});
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
@@ -19,6 +19,7 @@
 package org.apache.flink.core.plugin;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.classloading.ComponentClassLoader;
 import org.apache.flink.util.ArrayUtils;
 import org.apache.flink.util.TemporaryClassLoaderContext;
 
@@ -30,8 +31,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
@@ -146,102 +145,13 @@ public class PluginLoader implements AutoCloseable {
      * <p>No class/resource in the system class loader (everything in lib/) can be seen in the
      * plugin except those starting with a whitelist prefix.
      */
-    private static final class PluginClassLoader extends URLClassLoader {
-        private static final ClassLoader PLATFORM_OR_BOOTSTRAP_LOADER;
-
-        private final ClassLoader flinkClassLoader;
-
-        private final String[] allowedFlinkPackages;
-
-        private final String[] allowedResourcePrefixes;
+    private static final class PluginClassLoader extends ComponentClassLoader {
 
         PluginClassLoader(
                 URL[] pluginResourceURLs,
                 ClassLoader flinkClassLoader,
                 String[] allowedFlinkPackages) {
-            super(pluginResourceURLs, PLATFORM_OR_BOOTSTRAP_LOADER);
-            this.flinkClassLoader = flinkClassLoader;
-            this.allowedFlinkPackages = allowedFlinkPackages;
-            allowedResourcePrefixes =
-                    Arrays.stream(allowedFlinkPackages)
-                            .map(packageName -> packageName.replace('.', '/'))
-                            .toArray(String[]::new);
-        }
-
-        @Override
-        protected Class<?> loadClass(final String name, final boolean resolve)
-                throws ClassNotFoundException {
-            synchronized (getClassLoadingLock(name)) {
-                final Class<?> loadedClass = findLoadedClass(name);
-                if (loadedClass != null) {
-                    return resolveIfNeeded(resolve, loadedClass);
-                }
-
-                if (isAllowedFlinkClass(name)) {
-                    try {
-                        return resolveIfNeeded(resolve, flinkClassLoader.loadClass(name));
-                    } catch (ClassNotFoundException e) {
-                        // fallback to resolving it in this classloader
-                        // for cases where the plugin uses org.apache.flink namespace
-                    }
-                }
-
-                return super.loadClass(name, resolve);
-            }
-        }
-
-        private Class<?> resolveIfNeeded(final boolean resolve, final Class<?> loadedClass) {
-            if (resolve) {
-                resolveClass(loadedClass);
-            }
-
-            return loadedClass;
-        }
-
-        @Override
-        public URL getResource(final String name) {
-            if (isAllowedFlinkResource(name)) {
-                return flinkClassLoader.getResource(name);
-            }
-
-            return super.getResource(name);
-        }
-
-        @Override
-        public Enumeration<URL> getResources(final String name) throws IOException {
-            // ChildFirstClassLoader merges child and parent resources
-            if (isAllowedFlinkResource(name)) {
-                return flinkClassLoader.getResources(name);
-            }
-
-            return super.getResources(name);
-        }
-
-        private boolean isAllowedFlinkClass(final String name) {
-            return Arrays.stream(allowedFlinkPackages).anyMatch(name::startsWith);
-        }
-
-        private boolean isAllowedFlinkResource(final String name) {
-            return Arrays.stream(allowedResourcePrefixes).anyMatch(name::startsWith);
-        }
-
-        static {
-            ClassLoader platformLoader = null;
-            try {
-                platformLoader =
-                        (ClassLoader)
-                                ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
-            } catch (NoSuchMethodException e) {
-                // on Java 8 this method does not exist, but using null indicates the bootstrap
-                // loader that we want
-                // to have
-            } catch (Exception e) {
-                throw new IllegalStateException(
-                        "Cannot retrieve platform classloader on Java 9+", e);
-            }
-            PLATFORM_OR_BOOTSTRAP_LOADER = platformLoader;
-
-            ClassLoader.registerAsParallelCapable();
+            super(pluginResourceURLs, flinkClassLoader, allowedFlinkPackages, new String[0]);
         }
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -1319,13 +1319,25 @@ public class FutureUtils {
     }
 
     private static <T> BiConsumer<T, Throwable> forwardTo(CompletableFuture<T> target) {
-        return (value, throwable) -> {
-            if (throwable != null) {
-                target.completeExceptionally(throwable);
-            } else {
-                target.complete(value);
-            }
-        };
+        return (value, throwable) -> doForward(value, throwable, target);
+    }
+
+    /**
+     * Completes the given future with either the given value or throwable, depending on which
+     * parameter is not null.
+     *
+     * @param value value with which the future should be completed
+     * @param throwable throwable with which the future should be completed exceptionally
+     * @param target future to complete
+     * @param <T> completed future
+     */
+    public static <T> void doForward(
+            @Nullable T value, @Nullable Throwable throwable, CompletableFuture<T> target) {
+        if (throwable != null) {
+            target.completeExceptionally(throwable);
+        } else {
+            target.complete(value);
+        }
     }
 
     /**

--- a/flink-core/src/test/java/org/apache/flink/core/classloading/ComponentClassLoaderTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/classloading/ComponentClassLoaderTest.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.classloading;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/** Tests for the {@link ComponentClassLoader}. */
+public class ComponentClassLoaderTest extends TestLogger {
+
+    private static final String NON_EXISTENT_CLASS_NAME = "foo.Bar";
+    private static final Class<?> CLASS_TO_LOAD = Class.class;
+    private static final Class<?> CLASS_RETURNED_BY_OWNER = ComponentClassLoaderTest.class;
+
+    private static final String NON_EXISTENT_RESOURCE_NAME = "foo/Bar";
+    private static String resourceToLoad;
+    private static final URL RESOURCE_RETURNED_BY_OWNER = createURL();
+
+    @ClassRule public static final TemporaryFolder TMP = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        resourceToLoad = TMP.newFile("tmpfile").getName();
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Class loading
+    // ----------------------------------------------------------------------------------------------
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testComponentOnlyIsDefaultForClasses() throws Exception {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(NON_EXISTENT_CLASS_NAME, CLASS_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(new URL[0], owner, new String[0], new String[0]);
+
+        componentClassLoader.loadClass(NON_EXISTENT_CLASS_NAME);
+    }
+
+    @Test
+    public void testOwnerFirstClassFoundIgnoresComponent() throws Exception {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(CLASS_TO_LOAD.getName(), CLASS_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[0], owner, new String[] {CLASS_TO_LOAD.getName()}, new String[0]);
+
+        final Class<?> loadedClass = componentClassLoader.loadClass(CLASS_TO_LOAD.getName());
+        assertThat(loadedClass, sameInstance(CLASS_RETURNED_BY_OWNER));
+    }
+
+    @Test
+    public void testOwnerFirstClassNotFoundFallsBackToComponent() throws Exception {
+        TestUrlClassLoader owner = new TestUrlClassLoader();
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[0], owner, new String[] {CLASS_TO_LOAD.getName()}, new String[0]);
+
+        final Class<?> loadedClass = componentClassLoader.loadClass(CLASS_TO_LOAD.getName());
+        assertThat(loadedClass, sameInstance(CLASS_TO_LOAD));
+    }
+
+    @Test
+    public void testComponentFirstClassFoundIgnoresOwner() throws Exception {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(CLASS_TO_LOAD.getName(), CLASS_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[0], owner, new String[0], new String[] {CLASS_TO_LOAD.getName()});
+
+        final Class<?> loadedClass = componentClassLoader.loadClass(CLASS_TO_LOAD.getName());
+        assertThat(loadedClass, sameInstance(CLASS_TO_LOAD));
+    }
+
+    @Test
+    public void testComponentFirstClassNotFoundFallsBackToOwner() throws Exception {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(NON_EXISTENT_CLASS_NAME, CLASS_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[0], owner, new String[0], new String[] {NON_EXISTENT_CLASS_NAME});
+
+        final Class<?> loadedClass = componentClassLoader.loadClass(NON_EXISTENT_CLASS_NAME);
+        assertThat(loadedClass, sameInstance(CLASS_RETURNED_BY_OWNER));
+    }
+
+    // ----------------------------------------------------------------------------------------------
+    // Resource loading
+    // ----------------------------------------------------------------------------------------------
+
+    @Test
+    public void testComponentOnlyIsDefaultForResources() throws IOException {
+        TestUrlClassLoader owner = new TestUrlClassLoader();
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(new URL[0], owner, new String[0], new String[0]);
+
+        assertThat(componentClassLoader.getResource(NON_EXISTENT_RESOURCE_NAME), nullValue());
+        assertThat(
+                componentClassLoader.getResources(NON_EXISTENT_RESOURCE_NAME).hasMoreElements(),
+                is(false));
+    }
+
+    @Test
+    public void testOwnerFirstResourceFoundIgnoresComponent() {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(resourceToLoad, RESOURCE_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[] {}, owner, new String[] {resourceToLoad}, new String[0]);
+
+        final URL loadedResource = componentClassLoader.getResource(resourceToLoad);
+        assertThat(loadedResource, sameInstance(RESOURCE_RETURNED_BY_OWNER));
+    }
+
+    @Test
+    public void testOwnerFirstResourceNotFoundFallsBackToComponent() throws Exception {
+        TestUrlClassLoader owner = new TestUrlClassLoader();
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[] {TMP.getRoot().toURI().toURL()},
+                        owner,
+                        new String[] {resourceToLoad},
+                        new String[0]);
+
+        final URL loadedResource = componentClassLoader.getResource(resourceToLoad);
+        assertThat(loadedResource.toString(), containsString(resourceToLoad));
+    }
+
+    @Test
+    public void testComponentFirstResourceFoundIgnoresOwner() throws Exception {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(resourceToLoad, RESOURCE_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[] {TMP.getRoot().toURI().toURL()},
+                        owner,
+                        new String[0],
+                        new String[] {resourceToLoad});
+
+        final URL loadedResource = componentClassLoader.getResource(resourceToLoad);
+        assertThat(loadedResource.toString(), containsString(resourceToLoad));
+    }
+
+    @Test
+    public void testComponentFirstResourceNotFoundFallsBackToOwner() {
+        TestUrlClassLoader owner =
+                new TestUrlClassLoader(NON_EXISTENT_RESOURCE_NAME, RESOURCE_RETURNED_BY_OWNER);
+
+        final ComponentClassLoader componentClassLoader =
+                new ComponentClassLoader(
+                        new URL[0],
+                        owner,
+                        new String[0],
+                        new String[] {NON_EXISTENT_RESOURCE_NAME});
+
+        final URL loadedResource = componentClassLoader.getResource(NON_EXISTENT_RESOURCE_NAME);
+        assertThat(loadedResource, sameInstance(RESOURCE_RETURNED_BY_OWNER));
+    }
+
+    private static class TestUrlClassLoader extends URLClassLoader {
+
+        private final String nameToCheck;
+        private final Class<?> classToReturn;
+        private final URL resourceToReturn;
+
+        public TestUrlClassLoader() {
+            this(null, null, null);
+        }
+
+        public TestUrlClassLoader(String resourceNameToCheck, URL resourceToReturn) {
+            this(checkNotNull(resourceNameToCheck), null, checkNotNull(resourceToReturn));
+        }
+
+        public TestUrlClassLoader(String classNameToCheck, Class<?> classToReturn) {
+            this(checkNotNull(classNameToCheck), checkNotNull(classToReturn), null);
+        }
+
+        public TestUrlClassLoader(
+                String classNameToCheck, Class<?> classToReturn, URL resourceToReturn) {
+            super(new URL[0], null);
+            this.nameToCheck = classNameToCheck;
+            this.classToReturn = classToReturn;
+            this.resourceToReturn = resourceToReturn;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (nameToCheck == null) {
+                throw new ClassNotFoundException();
+            }
+            if (nameToCheck.equals(name)) {
+                return classToReturn;
+            }
+            return super.loadClass(name);
+        }
+
+        @Override
+        public URL getResource(String name) {
+            if (nameToCheck == null) {
+                return null;
+            }
+            if (nameToCheck.equals(name)) {
+                return resourceToReturn;
+            }
+            return super.getResource(name);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            if (nameToCheck != null && nameToCheck.equals(name)) {
+                return new ComponentClassLoader.IteratorBackedEnumeration<>(
+                        Collections.singleton(resourceToReturn).iterator());
+            }
+            return super.getResources(name);
+        }
+    }
+
+    private static URL createURL() {
+        try {
+            return Paths.get("").toUri().toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -61,7 +61,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -73,7 +73,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
+			<artifactId>flink-optimizer</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -254,21 +254,21 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-influxdb_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-influxdb</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-prometheus_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-prometheus</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-jmx</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -376,7 +376,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-queryable-state-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-queryable-state-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -688,11 +688,6 @@ under the License.
 									<exclude>org.apache.flink:flink-shaded-zookeeper-3</exclude>
 								</excludes>
 							</artifactSet>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>reference.conf</resource>
-								</transformer>
-							</transformers>
 						</configuration>
 					</execution>
 					<execution>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -105,9 +105,9 @@
 
 		<!-- Queryable State -->
 		<file>
-			<source>../flink-queryable-state/flink-queryable-state-runtime/target/flink-queryable-state-runtime_${scala.binary.version}-${project.version}.jar</source>
+			<source>../flink-queryable-state/flink-queryable-state-runtime/target/flink-queryable-state-runtime-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
-			<destName>flink-queryable-state-runtime_${scala.binary.version}-${project.version}.jar</destName>
+			<destName>flink-queryable-state-runtime-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 

--- a/flink-dist/src/main/assemblies/plugins.xml
+++ b/flink-dist/src/main/assemblies/plugins.xml
@@ -32,7 +32,7 @@
 		<!-- Metrics -->
 
 		<file>
-			<source>../flink-metrics/flink-metrics-jmx/target/flink-metrics-jmx_${scala.binary.version}-${project.version}.jar</source>
+			<source>../flink-metrics/flink-metrics-jmx/target/flink-metrics-jmx-${project.version}.jar</source>
 			<outputDirectory>plugins/metrics-jmx/</outputDirectory>
 			<destName>flink-metrics-jmx-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -46,14 +46,14 @@
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-influxdb/target/flink-metrics-influxdb_${scala.binary.version}-${project.version}.jar</source>
+			<source>../flink-metrics/flink-metrics-influxdb/target/flink-metrics-influxdb-${project.version}.jar</source>
 			<outputDirectory>plugins/metrics-influx/</outputDirectory>
 			<destName>flink-metrics-influxdb-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-prometheus/target/flink-metrics-prometheus_${scala.binary.version}-${project.version}.jar</source>
+			<source>../flink-metrics/flink-metrics-prometheus/target/flink-metrics-prometheus-${project.version}.jar</source>
 			<outputDirectory>plugins/metrics-prometheus/</outputDirectory>
 			<destName>flink-metrics-prometheus-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>

--- a/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
@@ -63,5 +63,5 @@ logger.hadoopnative.name = org.apache.hadoop.util.NativeCodeLoader
 logger.hadoopnative.level = OFF
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF

--- a/flink-dist/src/main/flink-bin/conf/log4j-console.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-console.properties
@@ -64,5 +64,5 @@ appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF

--- a/flink-dist/src/main/flink-bin/conf/log4j-session.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-session.properties
@@ -28,7 +28,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF
 logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = WARN

--- a/flink-dist/src/main/flink-bin/conf/log4j.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j.properties
@@ -57,5 +57,5 @@ appender.main.strategy.type = DefaultRolloverStrategy
 appender.main.strategy.max = ${env:MAX_LOG_FILE_NUMBER:-10}
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
-logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF

--- a/flink-dist/src/main/flink-bin/conf/logback-console.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback-console.xml
@@ -60,5 +60,5 @@
     <logger name="org.apache.zookeeper" level="INFO"/>
 
     <!-- Suppress the irrelevant (wrong) warnings from the Netty channel handler -->
-    <logger name="org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR"/>
+    <logger name="org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR"/>
 </configuration>

--- a/flink-dist/src/main/flink-bin/conf/logback.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback.xml
@@ -52,7 +52,7 @@
     </logger>
 
     <!-- Suppress the irrelevant (wrong) warnings from the Netty channel handler -->
-    <logger name="org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR">
+    <logger name="org.jboss.netty.channel.DefaultChannelPipeline" level="ERROR">
         <appender-ref ref="file"/>
     </logger>
 </configuration>

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -10,12 +10,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.twitter:chill_2.11:0.7.6
-- com.typesafe:config:1.3.0
-- com.typesafe:ssl-config-core_2.11:0.3.7
-- com.typesafe.akka:akka-actor_2.11:2.5.21
-- com.typesafe.akka:akka-protobuf_2.11:2.5.21
-- com.typesafe.akka:akka-slf4j_2.11:2.5.21
-- com.typesafe.akka:akka-stream_2.11:2.5.21
 - commons-cli:commons-cli:1.3.1
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.8.0
@@ -32,7 +26,6 @@ See bundled license files for details.
 
 - com.esotericsoftware.kryo:kryo:2.24.0
 - com.esotericsoftware.minlog:minlog:1.2
-- org.clapper:grizzled-slf4j_2.11:1.3.2
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
@@ -46,7 +39,6 @@ The following dependencies all share the same BSD license which you find under l
 This project bundles the following dependencies under the MIT/X11 license.
 See bundled license files for details.
 
-- com.github.scopt:scopt_2.11:3.5.0
 - org.slf4j:slf4j-api:1.7.15
 
 This project bundles the following dependencies under the CDDL 1.1 license.
@@ -54,7 +46,3 @@ See bundled license files for details.
 
 - javax.activation:javax.activation-api:1.2.0
 - javax.xml.bind:jaxb-api:2.3.1
-
-This project bundles the following dependencies under the Creative Commons CC0 "No Rights Reserved".
-
-- org.reactivestreams:reactive-streams:1.0.2

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -55,12 +55,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 		</dependency>
@@ -76,12 +76,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-prometheus_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-prometheus</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-influxdb_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-influxdb</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -77,7 +77,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -58,7 +58,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>

--- a/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
@@ -40,7 +40,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -40,7 +40,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-metrics-prometheus_${scala.binary.version}</artifactId>
+			<artifactId>flink-metrics-prometheus</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -354,7 +354,7 @@ function check_logs_for_errors {
       | grep -v "AskTimeoutException" \
       | grep -v "Error while loading kafka-version.properties" \
       | grep -v "WARN  akka.remote.transport.netty.NettyTransport" \
-      | grep -v "WARN  org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" \
+      | grep -v "WARN  org.jboss.netty.channel.DefaultChannelPipeline" \
       | grep -v "jvm-exit-on-fatal-error" \
       | grep -v 'INFO.*AWSErrorCode' \
       | grep -v "RejectedExecutionException" \
@@ -389,7 +389,7 @@ function check_logs_for_exceptions {
    | grep -v "Cannot connect to ResourceManager right now" \
    | grep -v "AskTimeoutException" \
    | grep -v "WARN  akka.remote.transport.netty.NettyTransport" \
-   | grep -v  "WARN  org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline" \
+   | grep -v  "WARN  org.jboss.netty.channel.DefaultChannelPipeline" \
    | grep -v 'INFO.*AWSErrorCode' \
    | grep -v "RejectedExecutionException" \
    | grep -v "CancellationException" \

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -95,7 +95,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -80,7 +80,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -141,7 +141,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-compress/pom.xml
+++ b/flink-formats/flink-compress/pom.xml
@@ -66,7 +66,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -77,7 +77,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-hadoop-bulk/pom.xml
+++ b/flink-formats/flink-hadoop-bulk/pom.xml
@@ -83,7 +83,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -66,7 +66,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -118,7 +118,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -174,7 +174,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -80,7 +80,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -58,7 +58,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -91,7 +91,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -59,14 +59,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -93,7 +93,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -92,7 +92,7 @@ under the License.
 
        <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime_${scala.binary.version}</artifactId>
+            <artifactId>flink-runtime</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
@@ -107,7 +107,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -77,7 +77,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
+			<artifactId>flink-optimizer</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -63,7 +63,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -85,7 +85,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -73,14 +73,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-metrics-influxdb_${scala.binary.version}</artifactId>
+	<artifactId>flink-metrics-influxdb</artifactId>
 	<name>Flink : Metrics : InfluxDB</name>
 
 	<dependencies>
@@ -42,7 +42,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -72,7 +72,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
+	<artifactId>flink-metrics-jmx</artifactId>
 	<name>Flink : Metrics : JMX</name>
 
 	<dependencies>
@@ -49,7 +49,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -73,7 +73,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
@@ -92,7 +92,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-metrics-prometheus_${scala.binary.version}</artifactId>
+	<artifactId>flink-metrics-prometheus</artifactId>
 	<name>Flink : Metrics : Prometheus</name>
 
 	<dependencies>
@@ -49,7 +49,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -91,7 +91,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-metrics/flink-metrics-slf4j/pom.xml
+++ b/flink-metrics/flink-metrics-slf4j/pom.xml
@@ -66,14 +66,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -66,14 +66,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
+	<artifactId>flink-optimizer</artifactId>
 	<name>Flink : Optimizer</name>
 
 	<packaging>jar</packaging>
@@ -46,7 +46,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -75,7 +75,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -174,7 +174,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-queryable-state-runtime_${scala.binary.version}</artifactId>
+	<artifactId>flink-queryable-state-runtime</artifactId>
 	<name>Flink : Queryable state : Runtime</name>
 	<packaging>jar</packaging>
 
@@ -47,7 +47,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -88,7 +88,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -114,7 +114,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-rpc/flink-rpc-akka-loader/pom.xml
+++ b/flink-rpc/flink-rpc-akka-loader/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-rpc</artifactId>
+		<version>1.14-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-rpc-akka-loader</artifactId>
+	<name>Flink : RPC : Akka-Loader</name>
+	<packaging>jar</packaging>
+	<description>This module contains the mechanism for loading flink-rpc-akka through a separate classloader.</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-rpc-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<!-- Ensures that flink-rpc-akka is built beforehand, in order to bundle the jar -->
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-rpc-akka</artifactId>
+			<version>${project.version}</version>
+			<!-- We don't want any production code from flink-rpc-akka-loader to reference flink-rpc-akka directly -->
+			<scope>runtime</scope>
+			<!-- Prevent dependency from being accessible to modules depending on flink-akka-loader-->
+			<optional>true</optional>
+			<exclusions>
+				<!-- Prevent akka and scala from being visible to other modules depending on flink-rpc-akka-loader -->
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-rpc-akka-jars</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.apache.flink</groupId>
+									<artifactId>flink-rpc-akka</artifactId>
+									<version>${project.version}</version>
+									<type>jar</type>
+									<overWrite>true</overWrite>
+									<destFileName>flink-rpc-akka.jar</destFileName>
+								</artifactItem>
+							</artifactItems>
+							<outputDirectory>${project.build.directory}/classes</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+				<execution>
+					<id>shade-flink</id>
+					<phase>package</phase>
+					<goals>
+						<goal>shade</goal>
+					</goals>
+					<configuration>
+						<artifactSet>
+							<includes>
+								<include>org.apache.flink:flink-rpc-akka</include>
+							</includes>
+						</artifactSet>
+						<filters>
+							<filter>
+								<artifact>org.apache.flink:flink-rpc-akka</artifact>
+								<includes>
+									<include>META-INF/NOTICE</include>
+									<include>META-INF/licenses/**</include>
+								</includes>
+							</filter>
+						</filters>
+					</configuration>
+				</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoader.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcSystemLoader.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.core.classloading.SubmoduleClassLoader;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcSystemLoader;
+import org.apache.flink.util.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ServiceLoader;
+import java.util.UUID;
+
+/**
+ * Loader for the {@link AkkaRpcSystemLoader}.
+ *
+ * <p>This loader expects the flink-rpc-akka jar to be accessible via {@link
+ * ClassLoader#getResource(String)}. It will extract the jar into a temporary directory and create a
+ * new {@link SubmoduleClassLoader} to load the rpc system from that jar.
+ */
+public class AkkaRpcSystemLoader implements RpcSystemLoader {
+
+    @Override
+    public RpcSystem loadRpcSystem(Configuration config) {
+        try {
+            final ClassLoader flinkClassLoader = RpcSystem.class.getClassLoader();
+
+            final String tmpDirectory = ConfigurationUtils.parseTempDirectories(config)[0];
+            final Path tempFile =
+                    Files.createFile(
+                            Paths.get(
+                                    tmpDirectory, "_flink-rpc-akka_" + UUID.randomUUID() + ".jar"));
+
+            final InputStream resourceStream =
+                    flinkClassLoader.getResourceAsStream("flink-rpc-akka.jar");
+            if (resourceStream == null) {
+                throw new RuntimeException(
+                        "Akka RPC system could not be found. If this happened while running a test in the IDE,"
+                                + "run the process-resources phase on flink-rpc/flink-rpc-akka-loader via maven.");
+            }
+
+            IOUtils.copyBytes(resourceStream, Files.newOutputStream(tempFile));
+
+            final SubmoduleClassLoader submoduleClassLoader =
+                    new SubmoduleClassLoader(
+                            new URL[] {tempFile.toUri().toURL()}, flinkClassLoader);
+
+            return new CleanupOnCloseRpcSystem(
+                    ServiceLoader.load(RpcSystem.class, submoduleClassLoader).iterator().next(),
+                    submoduleClassLoader,
+                    tempFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not initialize RPC system.", e);
+        }
+    }
+}

--- a/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/CleanupOnCloseRpcSystem.java
+++ b/flink-rpc/flink-rpc-akka-loader/src/main/java/org/apache/flink/runtime/rpc/akka/CleanupOnCloseRpcSystem.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.classloading.SubmoduleClassLoader;
+import org.apache.flink.runtime.rpc.AddressResolution;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** An {@link RpcSystem} wrapper that cleans up resources after the RPC system has been closed. */
+class CleanupOnCloseRpcSystem implements RpcSystem {
+    private static final Logger LOG = LoggerFactory.getLogger(CleanupOnCloseRpcSystem.class);
+
+    private final RpcSystem rpcSystem;
+    private final SubmoduleClassLoader pluginLoader;
+    private final Path tempFile;
+
+    public CleanupOnCloseRpcSystem(
+            RpcSystem rpcSystem, SubmoduleClassLoader pluginLoader, Path tempFile) {
+        this.rpcSystem = Preconditions.checkNotNull(rpcSystem);
+        this.pluginLoader = Preconditions.checkNotNull(pluginLoader);
+        this.tempFile = Preconditions.checkNotNull(tempFile);
+    }
+
+    @Override
+    public void close() {
+        rpcSystem.close();
+
+        try {
+            pluginLoader.close();
+        } catch (Exception e) {
+            LOG.warn("Could not close RpcSystem classloader.", e);
+        }
+        try {
+            Files.delete(tempFile);
+        } catch (Exception e) {
+            LOG.warn("Could not delete temporary rpc system file {}.", tempFile, e);
+        }
+    }
+
+    @Override
+    public RpcServiceBuilder localServiceBuilder(Configuration config) {
+        return rpcSystem.localServiceBuilder(config);
+    }
+
+    @Override
+    public RpcServiceBuilder remoteServiceBuilder(
+            Configuration configuration,
+            @Nullable String externalAddress,
+            String externalPortRange) {
+        return rpcSystem.remoteServiceBuilder(configuration, externalAddress, externalPortRange);
+    }
+
+    @Override
+    public String getRpcUrl(
+            String hostname,
+            int port,
+            String endpointName,
+            AddressResolution addressResolution,
+            Configuration config)
+            throws UnknownHostException {
+        return rpcSystem.getRpcUrl(hostname, port, endpointName, addressResolution, config);
+    }
+
+    @Override
+    public InetSocketAddress getInetSocketAddressFromRpcUrl(String url) throws Exception {
+        return rpcSystem.getInetSocketAddressFromRpcUrl(url);
+    }
+
+    @Override
+    public long getMaximumMessageSizeInBytes(Configuration config) {
+        return rpcSystem.getMaximumMessageSizeInBytes(config);
+    }
+}

--- a/flink-rpc/flink-rpc-akka-loader/src/main/resources/META-INF/services/org.apache.flink.runtime.rpc.RpcSystemLoader
+++ b/flink-rpc/flink-rpc-akka-loader/src/main/resources/META-INF/services/org.apache.flink.runtime.rpc.RpcSystemLoader
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.runtime.rpc.akka.AkkaRpcSystemLoader

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -29,9 +29,15 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-rpc-akka_${scala.binary.version}</artifactId>
+	<artifactId>flink-rpc-akka</artifactId>
 	<name>Flink : RPC : Akka</name>
 	<packaging>jar</packaging>
+
+	<properties>
+		<akka.version>2.6.15</akka.version>
+		<akka.scala.binary.version>2.12</akka.scala.binary.version>
+		<akka.scala.version>2.12.7</akka.scala.version>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -55,100 +61,89 @@ under the License.
 
 		<dependency>
 			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-reflect</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-compiler</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-actor_${scala.binary.version}</artifactId>
-			<!-- exclusions for dependency conversion -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
+			<artifactId>akka-actor_${akka.scala.binary.version}</artifactId>
+			<version>${akka.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-remote_${scala.binary.version}</artifactId>
-			<!-- exclusions for dependency conversion -->
+			<artifactId>akka-remote_${akka.scala.binary.version}</artifactId>
+			<version>${akka.version}</version>
 			<exclusions>
 				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
+					<!-- optional dependency for UDP transport which we don't need -->
+					<groupId>io.aeron</groupId>
+					<artifactId>aeron-driver</artifactId>
+				</exclusion>
+				<exclusion>
+					<!-- optional dependency for UDP transport which we don't need -->
+					<groupId>io.aeron</groupId>
+					<artifactId>aeron-client</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
-
-		<!-- Transitive dependency of akka-remote that we explicitly define to pin
-		 	its version (our Hadoop dependency has overridden the netty version in the past) -->
+		<dependency>
+			<groupId>com.typesafe.akka</groupId>
+			<artifactId>akka-slf4j_${akka.scala.binary.version}</artifactId>
+			<version>${akka.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty</artifactId>
 			<version>3.10.6.Final</version>
 		</dependency>
 
-		<!-- Transitive dependency of akka-remote that we explicitly define to keep it
-			visible after the shading (without relocation!) of akka-remote -->
-		<dependency>
-			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-stream_${scala.binary.version}</artifactId>
-			<!-- exclusions for dependency conversion -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.typesafe</groupId>
-					<artifactId>config</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<!-- Transitive dependency of akka-remote that we explicitly define to keep it
-			visible after the shading (without relocation!) of akka-remote -->
-		<dependency>
-			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-protobuf_${scala.binary.version}</artifactId>
-			<!-- exclusions for dependency conversion -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-slf4j_${scala.binary.version}</artifactId>
-			<!-- exclusions for dependency conversion -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
 		<dependency>
 			<groupId>org.clapper</groupId>
-			<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
-			<!-- exclusions for dependency conversion -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.scala-lang</groupId>
-					<artifactId>scala-library</artifactId>
-				</exclusion>
-			</exclusions>
+			<artifactId>grizzled-slf4j_${akka.scala.binary.version}</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_${akka.scala.binary.version}</artifactId>
+			<version>3.0.0</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -168,9 +163,29 @@ under the License.
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.scala-lang</groupId>
+				<artifactId>scala-compiler</artifactId>
+				<version>${akka.scala.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.scala-lang</groupId>
+				<artifactId>scala-library</artifactId>
+				<version>${akka.scala.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.scala-lang</groupId>
+				<artifactId>scala-reflect</artifactId>
+				<version>${akka.scala.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.scala-lang.modules</groupId>
+				<artifactId>scala-xml_${akka.scala.binary.version}</artifactId>
+				<version>1.0.6</version>
+			</dependency>
+			<dependency>
 				<groupId>com.typesafe</groupId>
 				<artifactId>config</artifactId>
-				<version>1.3.0</version>
+				<version>1.4.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -201,20 +216,10 @@ under the License.
 						</goals>
 						<configuration>
 							<artifactSet>
-								<includes combine.children="append">
-									<!-- add akka, akka's netty -->
-									<!-- we can do this only because our own netty dependency is
-										already externally shaded (flink-shaded-netty) -->
-									<include>com.typesafe.akka:akka-remote_*</include>
-									<include>io.netty:netty</include>
+								<includes>
+									<include>*</include>
 								</includes>
 							</artifactSet>
-							<relocations combine.children="append">
-								<relocation>
-									<pattern>org.jboss.netty</pattern>
-									<shadedPattern>org.apache.flink.shaded.akka.org.jboss.netty</shadedPattern>
-								</relocation>
-							</relocations>
 							<filters>
 								<filter>
 									<artifact>io.netty:netty</artifact>
@@ -228,7 +233,27 @@ under the License.
 									</excludes>
 								</filter>
 							</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>reference.conf</resource>
+								</transformer>
+							</transformers>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<!-- disable check for 2.12 dependencies -->
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<phase>none</phase>
 					</execution>
 				</executions>
 			</plugin>
@@ -259,6 +284,7 @@ under the License.
 					</execution>
 				</executions>
 				<configuration>
+					<scalaVersion>${akka.scala.version}</scalaVersion>
 					<jvmArgs>
 						<jvmArg>-Xms128m</jvmArg>
 						<jvmArg>-Xmx512m</jvmArg>

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/concurrent/akka/ClassLoadingUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/concurrent/akka/ClassLoadingUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent.akka;
+
+import org.apache.flink.util.TemporaryClassLoaderContext;
+import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.SupplierWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/** Classloading utilities. */
+public class ClassLoadingUtils {
+
+    /**
+     * Wraps the given runnable in a {@link TemporaryClassLoaderContext} to prevent the plugin class
+     * loader from leaking into Flink.
+     *
+     * @param runnable runnable to wrap
+     * @param contextClassLoader class loader that should be set as the context class loader
+     * @return wrapped runnable
+     */
+    public static Runnable withContextClassLoader(
+            Runnable runnable, ClassLoader contextClassLoader) {
+        return () -> runWithContextClassLoader(runnable::run, contextClassLoader);
+    }
+
+    /**
+     * Wraps the given executor such that all submitted are runnables are run in a {@link
+     * TemporaryClassLoaderContext} based on the given classloader.
+     *
+     * @param executor executor to wrap
+     * @param contextClassLoader class loader that should be set as the context class loader
+     * @return wrapped executor
+     */
+    public static Executor withContextClassLoader(
+            Executor executor, ClassLoader contextClassLoader) {
+        return new ContextClassLoaderSettingExecutor(executor, contextClassLoader);
+    }
+
+    /**
+     * Runs the given runnable in a {@link TemporaryClassLoaderContext} to prevent the plugin class
+     * loader from leaking into Flink.
+     *
+     * @param runnable runnable to run
+     * @param contextClassLoader class loader that should be set as the context class loader
+     */
+    public static <T extends Throwable> void runWithContextClassLoader(
+            ThrowingRunnable<T> runnable, ClassLoader contextClassLoader) throws T {
+        try (TemporaryClassLoaderContext ignored =
+                TemporaryClassLoaderContext.of(contextClassLoader)) {
+            runnable.run();
+        }
+    }
+
+    /**
+     * Runs the given supplier in a {@link TemporaryClassLoaderContext} based on the given
+     * classloader.
+     *
+     * @param supplier supplier to run
+     * @param contextClassLoader class loader that should be set as the context class loader
+     */
+    public static <T, E extends Throwable> T runWithContextClassLoader(
+            SupplierWithException<T, E> supplier, ClassLoader contextClassLoader) throws E {
+        try (TemporaryClassLoaderContext ignored =
+                TemporaryClassLoaderContext.of(contextClassLoader)) {
+            return supplier.get();
+        }
+    }
+
+    public static <T> CompletableFuture<T> guardCompletionWithContextClassLoader(
+            CompletableFuture<T> future, ClassLoader contextClassLoader) {
+        final CompletableFuture<T> guardedFuture = new CompletableFuture<>();
+        future.whenComplete(
+                (value, throwable) ->
+                        runWithContextClassLoader(
+                                () -> FutureUtils.doForward(value, throwable, guardedFuture),
+                                contextClassLoader));
+        return guardedFuture;
+    }
+
+    /**
+     * An {@link Executor} wrapper that temporarily resets the ContextClassLoader to the given
+     * ClassLoader.
+     */
+    private static class ContextClassLoaderSettingExecutor implements Executor {
+
+        private final Executor backingExecutor;
+        private final ClassLoader contextClassLoader;
+
+        public ContextClassLoaderSettingExecutor(
+                Executor backingExecutor, ClassLoader contextClassLoader) {
+            this.backingExecutor = backingExecutor;
+            this.contextClassLoader = contextClassLoader;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            backingExecutor.execute(
+                    ClassLoadingUtils.withContextClassLoader(command, contextClassLoader));
+        }
+    }
+}

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -23,9 +23,12 @@ import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.rpc.AddressResolution;
+import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TemporaryClassLoaderContext;
+import org.apache.flink.util.function.TriFunction;
 
 import akka.actor.ActorSystem;
 import com.typesafe.config.Config;
@@ -38,7 +41,6 @@ import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
 import static org.apache.flink.util.NetUtils.isValidClientPort;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -58,10 +60,10 @@ public class AkkaRpcServiceUtils {
     static final String SUPERVISOR_NAME = "rpc";
 
     private static final String SIMPLE_AKKA_CONFIG_TEMPLATE =
-            "akka {remote {netty.tcp {maximum-frame-size = %s}}}";
+            "akka {remote.classic {netty.tcp {maximum-frame-size = %s}}}";
 
     private static final String MAXIMUM_FRAME_SIZE_PATH =
-            "akka.remote.netty.tcp.maximum-frame-size";
+            "akka.remote.classic.netty.tcp.maximum-frame-size";
 
     // ------------------------------------------------------------------------
     //  RPC instantiation
@@ -326,7 +328,8 @@ public class AkkaRpcServiceUtils {
         }
 
         public AkkaRpcService createAndStart(
-                BiFunction<ActorSystem, AkkaRpcServiceConfiguration, AkkaRpcService> constructor)
+                TriFunction<ActorSystem, AkkaRpcServiceConfiguration, ClassLoader, AkkaRpcService>
+                        constructor)
                 throws Exception {
             if (actorSystemExecutorConfiguration == null) {
                 actorSystemExecutorConfiguration =
@@ -336,32 +339,39 @@ public class AkkaRpcServiceUtils {
 
             final ActorSystem actorSystem;
 
-            if (externalAddress == null) {
-                // create local actor system
-                actorSystem =
-                        AkkaBootstrapTools.startLocalActorSystem(
-                                configuration,
-                                actorSystemName,
-                                logger,
-                                actorSystemExecutorConfiguration,
-                                customConfig);
-            } else {
-                // create remote actor system
-                actorSystem =
-                        AkkaBootstrapTools.startRemoteActorSystem(
-                                configuration,
-                                actorSystemName,
-                                externalAddress,
-                                externalPortRange,
-                                bindAddress,
-                                Optional.ofNullable(bindPort),
-                                logger,
-                                actorSystemExecutorConfiguration,
-                                customConfig);
+            // akka internally caches the context class loader
+            // make sure it uses the plugin class loader
+            try (TemporaryClassLoaderContext ignored =
+                    TemporaryClassLoaderContext.of(getClass().getClassLoader())) {
+                if (externalAddress == null) {
+                    // create local actor system
+                    actorSystem =
+                            AkkaBootstrapTools.startLocalActorSystem(
+                                    configuration,
+                                    actorSystemName,
+                                    logger,
+                                    actorSystemExecutorConfiguration,
+                                    customConfig);
+                } else {
+                    // create remote actor system
+                    actorSystem =
+                            AkkaBootstrapTools.startRemoteActorSystem(
+                                    configuration,
+                                    actorSystemName,
+                                    externalAddress,
+                                    externalPortRange,
+                                    bindAddress,
+                                    Optional.ofNullable(bindPort),
+                                    logger,
+                                    actorSystemExecutorConfiguration,
+                                    customConfig);
+                }
             }
 
             return constructor.apply(
-                    actorSystem, AkkaRpcServiceConfiguration.fromConfiguration(configuration));
+                    actorSystem,
+                    AkkaRpcServiceConfiguration.fromConfiguration(configuration),
+                    RpcService.class.getClassLoader());
         }
     }
 

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -64,7 +64,8 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
             long maximumFramesize,
             @Nullable CompletableFuture<Void> terminationFuture,
             Supplier<F> fencingTokenSupplier,
-            boolean captureAskCallStacks) {
+            boolean captureAskCallStacks,
+            ClassLoader flinkClassLoader) {
         super(
                 address,
                 hostname,
@@ -72,7 +73,8 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
                 timeout,
                 maximumFramesize,
                 terminationFuture,
-                captureAskCallStacks);
+                captureAskCallStacks,
+                flinkClassLoader);
 
         this.fencingTokenSupplier = Preconditions.checkNotNull(fencingTokenSupplier);
     }

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -45,8 +45,9 @@ public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpo
             T rpcEndpoint,
             CompletableFuture<Boolean> terminationFuture,
             int version,
-            final long maximumFramesize) {
-        super(rpcEndpoint, terminationFuture, version, maximumFramesize);
+            final long maximumFramesize,
+            ClassLoader flinkClassLoader) {
+        super(rpcEndpoint, terminationFuture, version, maximumFramesize, flinkClassLoader);
     }
 
     @Override

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,35 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.typesafe.akka:akka-remote_2.11:2.5.21
+- com.hierynomus:asn-one:0.5.0
+- com.typesafe:config:1.4.0
+- com.typesafe:ssl-config-core_2.12:0.4.2
+- com.typesafe.akka:akka-actor_2.12:2.6.15
+- com.typesafe.akka:akka-remote_2.12:2.6.15
+- com.typesafe.akka:akka-pki_2.12:2.6.15
+- com.typesafe.akka:akka-protobuf-v3_2.12:2.6.15
+- com.typesafe.akka:akka-slf4j_2.12:2.6.15
+- com.typesafe.akka:akka-stream_2.12:2.6.15
 - io.netty:netty:3.10.6.Final
+- org.agrona:agrona:1.9.0
+
+This project bundles the following dependencies under the BSD license.
+See bundled license files for details.
+
+- org.clapper:grizzled-slf4j_2.12:1.3.2
+
+The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
+
+- org.scala-lang:scala-compiler:2.12.7
+- org.scala-lang:scala-library:2.12.7
+- org.scala-lang:scala-reflect:2.12.7
+- org.scala-lang.modules:scala-java8-compat_2.12:0.8.0
+- org.scala-lang.modules:scala-parser-combinators_2.12:1.0.4
+- org.scala-lang.modules:scala-xml_2.12:1.0.6
+
+This project bundles the following dependencies under the Creative Commons CC0 "No Rights Reserved".
+
+- org.reactivestreams:reactive-streams:1.0.3
 
 This project bundles io.netty:netty:3.10.6.Final from which it inherits the following notices:
 

--- a/flink-rpc/flink-rpc-akka/src/main/scala/org/apache/flink/runtime/rpc/akka/AkkaUtils.scala
+++ b/flink-rpc/flink-rpc-akka/src/main/scala/org/apache/flink/runtime/rpc/akka/AkkaUtils.scala
@@ -299,6 +299,7 @@ object AkkaUtils {
         |   guardian-supervisor-strategy = $supervisorStrategy
         |
         |   warn-about-java-serializer-usage = off
+        |   allow-java-serialization = on
         |
         |   default-dispatcher {
         |     throughput = $akkaThroughput
@@ -470,15 +471,18 @@ object AkkaUtils {
          |    provider = "akka.remote.RemoteActorRefProvider"
          |  }
          |
-         |  remote {
-         |    startup-timeout = $startupTimeout
+         |  remote.artery.enabled = false
+         |  remote.startup-timeout = $startupTimeout
          |
+         |  remote.classic {
          |    # disable the transport failure detector by setting very high values
          |    transport-failure-detector{
          |      acceptable-heartbeat-pause = 6000 s
          |      heartbeat-interval = 1000 s
          |      threshold = 300
          |    }
+         |
+         |    enabled-transports = ["akka.remote.classic.netty.tcp"]
          |
          |    netty {
          |      tcp {
@@ -522,7 +526,7 @@ object AkkaUtils {
     val hostnameConfigString =
       s"""
          |akka {
-         |  remote {
+         |  remote.classic {
          |    netty {
          |      tcp {
          |        hostname = "$effectiveHostname"
@@ -536,13 +540,13 @@ object AkkaUtils {
     val sslConfigString = if (akkaEnableSSLConfig) {
       s"""
          |akka {
-         |  remote {
+         |  remote.classic {
          |
-         |    enabled-transports = ["akka.remote.netty.ssl"]
+         |    enabled-transports = ["akka.remote.classic.netty.ssl"]
          |
          |    netty {
          |
-         |      ssl = $${akka.remote.netty.tcp}
+         |      ssl = $${akka.remote.classic.netty.tcp}
          |
          |      ssl {
          |

--- a/flink-rpc/flink-rpc-akka/src/main/scala/org/apache/flink/runtime/rpc/akka/CustomSSLEngineProvider.scala
+++ b/flink-rpc/flink-rpc-akka/src/main/scala/org/apache/flink/runtime/rpc/akka/CustomSSLEngineProvider.scala
@@ -26,7 +26,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.util.FingerprintTrust
 class CustomSSLEngineProvider(system : akka.actor.ActorSystem)
                               extends ConfigSSLEngineProvider(system) {
 
-  private val securityConfig = system.settings.config.getConfig("akka.remote.netty.ssl.security")
+  private val securityConfig = system.settings.config.
+    getConfig("akka.remote.classic.netty.ssl.security")
   private val SSLTrustStore = securityConfig.getString("trust-store")
   private val SSLTrustStorePassword = securityConfig.getString("trust-store-password")
   private val SSLCertFingerprints = securityConfig.getStringList("cert-fingerprints")

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/concurrent/akka/ClassLoadingUtilsTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/concurrent/akka/ClassLoadingUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent.akka;
+
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.function.SupplierWithException;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/** Tests for the {@link ClassLoadingUtils}. */
+public class ClassLoadingUtilsTest extends TestLogger {
+
+    private static final ClassLoader TEST_CLASS_LOADER =
+            new URLClassLoader(new URL[0], ClassLoadingUtilsTest.class.getClassLoader());
+
+    @Test
+    public void testRunnableWithContextClassLoader() throws Exception {
+        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
+        Runnable runnable =
+                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader());
+
+        final Runnable wrappedRunnable =
+                ClassLoadingUtils.withContextClassLoader(runnable, TEST_CLASS_LOADER);
+
+        // the runnable should only be wrapped, not run immediately
+        assertThat(contextClassLoader.isDone(), is(false));
+
+        wrappedRunnable.run();
+        assertThat(contextClassLoader.get(), is(TEST_CLASS_LOADER));
+    }
+
+    @Test
+    public void testExecutorWithContextClassLoader() throws Exception {
+        final Executor wrappedExecutor =
+                ClassLoadingUtils.withContextClassLoader(
+                        Executors.newDirectExecutorService(), TEST_CLASS_LOADER);
+
+        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
+        Runnable runnable =
+                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader());
+
+        wrappedExecutor.execute(runnable);
+        assertThat(contextClassLoader.get(), is(TEST_CLASS_LOADER));
+    }
+
+    @Test
+    public void testRunRunnableWithContextClassLoader() throws Exception {
+        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
+        ThrowingRunnable<Exception> runnable =
+                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader());
+
+        ClassLoadingUtils.runWithContextClassLoader(runnable, TEST_CLASS_LOADER);
+        assertThat(contextClassLoader.get(), is(TEST_CLASS_LOADER));
+    }
+
+    @Test
+    public void testRunSupplierWithContextClassLoader() throws Exception {
+        SupplierWithException<ClassLoader, Exception> runnable =
+                () -> Thread.currentThread().getContextClassLoader();
+
+        final ClassLoader contextClassLoader =
+                ClassLoadingUtils.runWithContextClassLoader(runnable, TEST_CLASS_LOADER);
+        assertThat(contextClassLoader, is(TEST_CLASS_LOADER));
+    }
+
+    @Test
+    public void testGuardCompletionWithContextClassLoader() throws Exception {
+        final CompletableFuture<Void> originalFuture = new CompletableFuture<>();
+
+        final CompletableFuture<Void> guardedFuture =
+                ClassLoadingUtils.guardCompletionWithContextClassLoader(
+                        originalFuture, TEST_CLASS_LOADER);
+
+        final CompletableFuture<ClassLoader> contextClassLoader =
+                guardedFuture.thenApply(ignored -> Thread.currentThread().getContextClassLoader());
+
+        originalFuture.complete(null);
+        assertThat(contextClassLoader.get(), is(TEST_CLASS_LOADER));
+    }
+}

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -192,7 +192,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
         assertFalse(terminationFuture.isDone());
 
-        CompletableFuture.runAsync(rpcEndpoint::closeAsync, akkaRpcService.getExecutor());
+        CompletableFuture.runAsync(rpcEndpoint::closeAsync, akkaRpcService.getScheduledExecutor());
 
         // wait until the rpc endpoint has terminated
         terminationFuture.get();

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -1,0 +1,381 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.akka.AkkaFutureUtils;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import akka.actor.ActorSystem;
+import akka.actor.Terminated;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader;
+import static org.hamcrest.CoreMatchers.either;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Tests the context class loader handling in various parts of the akka rpc system.
+ *
+ * <p>The tests check cases where we call from the akka rpc system into Flink, in which case the
+ * context class loader must be set to the Flink class loader. This ensures that the Akka class
+ * loader does not get accidentally leaked, e.g., via thread locals or thread pools on the Flink
+ * side.
+ */
+public class ContextClassLoadingSettingTest extends TestLogger {
+
+    private static final Time TIMEOUT = Time.milliseconds(10000L);
+
+    // Many of the contained tests assert that a future is completed with a specific context class
+    // loader by applying a synchronous operation.
+    // If the initial future is completed by the time we apply the synchronous operation the test
+    // thread will execute the operation instead. The tests are thus susceptible to timing issues.
+    // We hence take a probabilistic approach: Assume that this timing is rare, guard these calls in
+    // the test with a temporary class loader context, and assert that the actually used
+    // context class loader is _either_ the one we truly expect or the temporary one.
+    private static final ClassLoader testClassLoader =
+            new URLClassLoader(new URL[0], ContextClassLoadingSettingTest.class.getClassLoader());
+
+    private ClassLoader pretendFlinkClassLoader;
+    private ActorSystem actorSystem;
+    private AkkaRpcService akkaRpcService;
+
+    @Before
+    public void setup() {
+        pretendFlinkClassLoader =
+                new URLClassLoader(
+                        new URL[0], ContextClassLoadingSettingTest.class.getClassLoader());
+        actorSystem = AkkaUtils.createDefaultActorSystem();
+        akkaRpcService =
+                new AkkaRpcService(
+                        actorSystem,
+                        AkkaRpcServiceConfiguration.defaultConfiguration(),
+                        pretendFlinkClassLoader);
+    }
+
+    @After
+    public void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
+        final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
+        final CompletableFuture<Terminated> actorSystemTerminationFuture =
+                AkkaFutureUtils.toJava(actorSystem.terminate());
+
+        FutureUtils.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+                .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+        actorSystem = null;
+        akkaRpcService = null;
+    }
+
+    @Test
+    public void testAkkaRpcService_ExecuteRunnableSetsFlinkContextClassLoader()
+            throws ExecutionException, InterruptedException {
+        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
+        akkaRpcService.execute(
+                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader()));
+        assertIsFlinkClassLoader(contextClassLoader.get());
+    }
+
+    @Test
+    public void testAkkaRpcService_ExecuteCallableSetsFlinkContextClassLoader()
+            throws ExecutionException, InterruptedException {
+        final CompletableFuture<ClassLoader> contextClassLoader =
+                akkaRpcService.execute(() -> Thread.currentThread().getContextClassLoader());
+        assertIsFlinkClassLoader(contextClassLoader.get());
+    }
+
+    @Test
+    public void testAkkaRpcService_ExecuteCallableResultCompletedWithFlinkContextClassLoader()
+            throws ExecutionException, InterruptedException {
+
+        final CompletableFuture<Void> blocker = new CompletableFuture<>();
+
+        final CompletableFuture<ClassLoader> contextClassLoader =
+                runWithContextClassLoader(
+                        () ->
+                                akkaRpcService
+                                        .execute((Callable<Void>) blocker::get)
+                                        .thenApply(
+                                                ignored ->
+                                                        Thread.currentThread()
+                                                                .getContextClassLoader()),
+                        testClassLoader);
+        blocker.complete(null);
+
+        assertIsFlinkClassLoader(contextClassLoader.get());
+    }
+
+    @Test
+    public void testAkkaRpcService_ScheduleSetsFlinkContextClassLoader()
+            throws ExecutionException, InterruptedException {
+        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
+        akkaRpcService.scheduleRunnable(
+                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader()),
+                5,
+                TimeUnit.MILLISECONDS);
+        assertThat(contextClassLoader.get(), is(pretendFlinkClassLoader));
+    }
+
+    @Test
+    public void testAkkaRpcService_ConnectFutureCompletedWithFlinkContextClassLoader()
+            throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+
+            final ClassLoader contextClassLoader =
+                    runWithContextClassLoader(
+                            () ->
+                                    akkaRpcService
+                                            .connect(
+                                                    testEndpoint.getAddress(),
+                                                    TestEndpointGateway.class)
+                                            .thenApply(
+                                                    ignored ->
+                                                            Thread.currentThread()
+                                                                    .getContextClassLoader())
+                                            .get(),
+                            testClassLoader);
+            assertIsFlinkClassLoader(contextClassLoader);
+        }
+    }
+
+    @Test
+    public void testAkkaRpcService_TerminationFutureCompletedWithFlinkContextClassLoader()
+            throws Exception {
+        final ClassLoader contextClassLoader =
+                runWithContextClassLoader(
+                        () ->
+                                akkaRpcService
+                                        .stopService()
+                                        .thenApply(
+                                                ignored ->
+                                                        Thread.currentThread()
+                                                                .getContextClassLoader())
+                                        .get(),
+                        testClassLoader);
+
+        assertIsFlinkClassLoader(contextClassLoader);
+    }
+
+    @Test
+    public void testAkkaRpcActor_OnStartCalledWithFlinkContextClassLoader() throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+            testEndpoint.start();
+            assertIsFlinkClassLoader(testEndpoint.onStartClassLoader.get());
+        }
+    }
+
+    @Test
+    public void testAkkaRpcActor_OnStopCalledWithFlinkContextClassLoader() throws Exception {
+        final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService);
+        testEndpoint.start();
+        testEndpoint.close();
+
+        assertIsFlinkClassLoader(testEndpoint.onStopClassLoader.get());
+    }
+
+    @Test
+    public void testAkkaRpcActor_CallAsyncCalledWithFlinkContextClassLoader() throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+            testEndpoint.start();
+
+            final CompletableFuture<ClassLoader> contextClassLoader = testEndpoint.doCallAsync();
+            assertIsFlinkClassLoader(contextClassLoader.get());
+        }
+    }
+
+    @Test
+    public void testAkkaRpcActor_RunAsyncCalledWithFlinkContextClassLoader() throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+            testEndpoint.start();
+
+            final CompletableFuture<ClassLoader> contextClassLoader = testEndpoint.doRunAsync();
+            assertIsFlinkClassLoader(contextClassLoader.get());
+        }
+    }
+
+    @Test
+    public void testAkkaRpcActor_RPCReturningVoidCalledWithFlinkContextClassLoader()
+            throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+            testEndpoint.start();
+
+            final TestEndpointGateway testEndpointGateway =
+                    akkaRpcService
+                            .connect(testEndpoint.getAddress(), TestEndpointGateway.class)
+                            .get();
+            testEndpointGateway.doSomethingWithoutReturningAnything();
+
+            assertIsFlinkClassLoader(testEndpoint.voidOperationClassLoader.get());
+        }
+    }
+
+    @Test
+    public void testAkkaRpcActor_RPCCalledWithFlinkContextClassLoader() throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+            testEndpoint.start();
+
+            final TestEndpointGateway testEndpointGateway =
+                    akkaRpcService
+                            .connect(testEndpoint.getAddress(), TestEndpointGateway.class)
+                            .get();
+            final ClassLoader contextClassLoader =
+                    testEndpointGateway.getContextClassLoader().get();
+            assertIsFlinkClassLoader(contextClassLoader);
+        }
+    }
+
+    @Test
+    public void testAkkaRpcInvocationHandler_RPCFutureCompletedWithFlinkContextClassLoader()
+            throws Exception {
+        try (final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService)) {
+            testEndpoint.start();
+
+            final TestEndpointGateway testEndpointGateway =
+                    akkaRpcService
+                            .connect(testEndpoint.getAddress(), TestEndpointGateway.class)
+                            .get();
+            final CompletableFuture<ClassLoader> contextClassLoader =
+                    runWithContextClassLoader(
+                            () ->
+                                    testEndpointGateway
+                                            .doSomethingAsync()
+                                            .thenApply(
+                                                    ignored ->
+                                                            Thread.currentThread()
+                                                                    .getContextClassLoader()),
+                            testClassLoader);
+            testEndpoint.completeRPCFuture();
+
+            assertIsFlinkClassLoader(contextClassLoader.get());
+        }
+    }
+
+    @Test
+    public void testSupervisorActor_TerminationFutureCompletedWithFlinkContextClassLoader()
+            throws Exception {
+        final TestEndpoint testEndpoint = new TestEndpoint(akkaRpcService);
+        testEndpoint.start();
+
+        final ClassLoader contextClassLoader =
+                runWithContextClassLoader(
+                        () ->
+                                testEndpoint
+                                        .closeAsync()
+                                        .thenApply(
+                                                ignored ->
+                                                        Thread.currentThread()
+                                                                .getContextClassLoader())
+                                        .get(),
+                        testClassLoader);
+
+        assertIsFlinkClassLoader(contextClassLoader);
+    }
+
+    private void assertIsFlinkClassLoader(ClassLoader classLoader) {
+        assertThat(classLoader, either(is(pretendFlinkClassLoader)).or(is(testClassLoader)));
+    }
+
+    private interface TestEndpointGateway extends RpcGateway {
+        CompletableFuture<ClassLoader> getContextClassLoader();
+
+        CompletableFuture<Void> doSomethingAsync();
+
+        CompletableFuture<ClassLoader> doCallAsync();
+
+        CompletableFuture<ClassLoader> doRunAsync();
+
+        void doSomethingWithoutReturningAnything();
+    }
+
+    private static class TestEndpoint extends RpcEndpoint implements TestEndpointGateway {
+
+        private final CompletableFuture<ClassLoader> onStartClassLoader = new CompletableFuture<>();
+        private final CompletableFuture<ClassLoader> onStopClassLoader = new CompletableFuture<>();
+        private final CompletableFuture<ClassLoader> voidOperationClassLoader =
+                new CompletableFuture<>();
+        private final CompletableFuture<Void> rpcResponseFuture = new CompletableFuture<>();
+
+        protected TestEndpoint(RpcService rpcService) {
+            super(rpcService);
+        }
+
+        @Override
+        protected void onStart() throws Exception {
+            onStartClassLoader.complete(Thread.currentThread().getContextClassLoader());
+            super.onStart();
+        }
+
+        @Override
+        protected CompletableFuture<Void> onStop() {
+            onStopClassLoader.complete(Thread.currentThread().getContextClassLoader());
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Void> doSomethingAsync() {
+            return rpcResponseFuture;
+        }
+
+        @Override
+        public CompletableFuture<ClassLoader> doCallAsync() {
+            return callAsync(
+                    () -> Thread.currentThread().getContextClassLoader(),
+                    Time.of(10, TimeUnit.SECONDS));
+        }
+
+        @Override
+        public CompletableFuture<ClassLoader> doRunAsync() {
+            final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
+            runAsync(
+                    () ->
+                            contextClassLoader.complete(
+                                    Thread.currentThread().getContextClassLoader()));
+            return contextClassLoader;
+        }
+
+        @Override
+        public void doSomethingWithoutReturningAnything() {
+            voidOperationClassLoader.complete(Thread.currentThread().getContextClassLoader());
+        }
+
+        public void completeRPCFuture() {
+            rpcResponseFuture.complete(null);
+        }
+
+        @Override
+        public CompletableFuture<ClassLoader> getContextClassLoader() {
+            return CompletableFuture.completedFuture(
+                    Thread.currentThread().getContextClassLoader());
+        }
+    }
+}

--- a/flink-rpc/flink-rpc-akka/src/test/scala/org/apache/flink/runtime/rpc/akka/AkkaUtilsTest.scala
+++ b/flink-rpc/flink-rpc-akka/src/test/scala/org/apache/flink/runtime/rpc/akka/AkkaUtilsTest.scala
@@ -65,7 +65,7 @@ class AkkaUtilsTest
   }
 
   test("getHostFromAkkaURL should return host after at sign") {
-    val url = "akka://flink@localhost:1234/user/jobmanager"
+    val url = "akka.tcp://flink@localhost:1234/user/jobmanager"
     val expected = new InetSocketAddress("localhost", 1234)
 
     val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
@@ -146,14 +146,14 @@ class AkkaUtilsTest
 
     val akkaConfig = AkkaUtils.getAkkaConfig(configuration, hostname, port)
 
-    akkaConfig.getString("akka.remote.netty.tcp.hostname") should
+    akkaConfig.getString("akka.remote.classic.netty.tcp.hostname") should
       equal(NetUtils.unresolvedHostToNormalizedString(hostname))
   }
 
   test("null hostname should go to localhost") {
     val configure = AkkaUtils.getAkkaConfig(new Configuration(), Some((null, 1772)))
 
-    val hostname = configure.getString("akka.remote.netty.tcp.hostname")
+    val hostname = configure.getString("akka.remote.classic.netty.tcp.hostname")
 
     InetAddress.getByName(hostname).isLoopbackAddress should be(true)
   }
@@ -196,7 +196,7 @@ class AkkaUtilsTest
 
     val akkaConfig = AkkaUtils.getAkkaConfig(configuration, ipv6AddressString, port)
 
-    akkaConfig.getString("akka.remote.netty.tcp.hostname") should
+    akkaConfig.getString("akka.remote.classic.netty.tcp.hostname") should
       equal(NetUtils.unresolvedHostToNormalizedString(ipv6AddressString))
   }
 
@@ -216,7 +216,7 @@ class AkkaUtilsTest
 
     val akkaConfig = AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
 
-    val sslConfig = akkaConfig.getConfig("akka.remote.netty.ssl")
+    val sslConfig = akkaConfig.getConfig("akka.remote.classic.netty.ssl")
 
     sslConfig.getString("ssl-engine-provider") should
       equal("org.apache.flink.runtime.rpc.akka.CustomSSLEngineProvider")
@@ -233,7 +233,7 @@ class AkkaUtilsTest
 
     val akkaConfig = AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
 
-    val sslConfig = akkaConfig.getConfig("akka.remote.netty.ssl")
+    val sslConfig = akkaConfig.getConfig("akka.remote.classic.netty.ssl")
 
     sslConfig.getString("ssl-engine-provider") should
       equal("org.apache.flink.runtime.rpc.akka.CustomSSLEngineProvider")

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -24,7 +24,6 @@ import org.apache.flink.util.concurrent.ScheduledExecutor;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -125,19 +124,6 @@ public interface RpcService {
     CompletableFuture<Void> getTerminationFuture();
 
     /**
-     * Gets the executor, provided by this RPC service. This executor can be used for example for
-     * the {@code handleAsync(...)} or {@code thenAcceptAsync(...)} methods of futures.
-     *
-     * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against any
-     * concurrent invocations and is therefore not suitable to run completion methods of futures
-     * that modify state of an {@link RpcEndpoint}. For such operations, one needs to use the {@link
-     * RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that {@code RpcEndpoint}.
-     *
-     * @return The execution context provided by the RPC service
-     */
-    Executor getExecutor();
-
-    /**
      * Gets a scheduled executor from the RPC service. This executor can be used to schedule tasks
      * to be executed in the future.
      *
@@ -152,7 +138,7 @@ public interface RpcService {
 
     /**
      * Execute the runnable in the execution context of this RPC Service, as returned by {@link
-     * #getExecutor()}, after a scheduled delay.
+     * #getScheduledExecutor()} ()}, after a scheduled delay.
      *
      * @param runnable Runnable to be executed
      * @param delay The delay after which the runnable will be executed

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -78,6 +78,16 @@ public interface RpcSystem extends RpcSystemUtils, AutoCloseable {
      * @return loaded RpcSystem
      */
     static RpcSystem load() {
+        return load(new Configuration());
+    }
+
+    /**
+     * Loads the RpcSystem.
+     *
+     * @param config Flink configuration
+     * @return loaded RpcSystem
+     */
+    static RpcSystem load(Configuration config) {
         final ClassLoader classLoader = RpcSystem.class.getClassLoader();
         return ServiceLoader.load(RpcSystem.class, classLoader).iterator().next();
     }

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -27,7 +27,7 @@ import java.util.ServiceLoader;
  * This interface serves as a factory interface for RPC services, with some additional utilities
  * that are reliant on implementation details of the RPC service.
  */
-public interface RpcSystem extends RpcSystemUtils {
+public interface RpcSystem extends RpcSystemUtils, AutoCloseable {
 
     /**
      * Returns a builder for an {@link RpcService} that is only reachable from the local machine.
@@ -50,6 +50,10 @@ public interface RpcSystem extends RpcSystemUtils {
             Configuration configuration,
             @Nullable String externalAddress,
             String externalPortRange);
+
+    /** Hook to cleanup resources, like common thread pools or classloaders. */
+    @Override
+    default void close() {}
 
     /** Builder for {@link RpcService}. */
     interface RpcServiceBuilder {

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystem.java
@@ -88,8 +88,7 @@ public interface RpcSystem extends RpcSystemUtils, AutoCloseable {
      * @return loaded RpcSystem
      */
     static RpcSystem load(Configuration config) {
-        final ClassLoader classLoader = RpcSystem.class.getClassLoader();
-        return ServiceLoader.load(RpcSystem.class, classLoader).iterator().next();
+        return ServiceLoader.load(RpcSystemLoader.class).iterator().next().loadRpcSystem(config);
     }
 
     /** Descriptor for creating a fork-join thread-pool. */

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystemLoader.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcSystemLoader.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc;
+
+import org.apache.flink.configuration.Configuration;
+
+/** A loader for an {@link RpcSystem}. */
+public interface RpcSystemLoader {
+    RpcSystem loadRpcSystem(Configuration config);
+}

--- a/flink-rpc/pom.xml
+++ b/flink-rpc/pom.xml
@@ -36,5 +36,6 @@ under the License.
 	<modules>
 		<module>flink-rpc-core</module>
 		<module>flink-rpc-akka</module>
+		<module>flink-rpc-akka-loader</module>
 	</modules>
 </project>

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -48,7 +48,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
@@ -94,7 +94,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -114,7 +114,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -29,7 +29,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+	<artifactId>flink-runtime</artifactId>
 	<name>Flink : Runtime</name>
 
 	<packaging>jar</packaging>
@@ -52,7 +52,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-rpc-akka_${scala.binary.version}</artifactId>
+			<artifactId>flink-rpc-akka-loader</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -175,7 +175,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-rpc-akka_${scala.binary.version}</artifactId>
+			<artifactId>flink-rpc-akka</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-rpc-akka</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
@@ -301,6 +308,33 @@ under the License.
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-rpc-akka-jars</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.apache.flink</groupId>
+									<artifactId>flink-rpc-akka</artifactId>
+									<version>${project.version}</version>
+									<type>jar</type>
+									<overWrite>true</overWrite>
+									<destFileName>flink-rpc-akka.jar</destFileName>
+								</artifactItem>
+							</artifactItems>
+							<outputDirectory>${project.build.directory}/classes</outputDirectory>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -294,7 +294,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         LOG.info("Initializing cluster services.");
 
         synchronized (lock) {
-            rpcSystem = RpcSystem.load();
+            rpcSystem = RpcSystem.load(configuration);
 
             commonRpcService =
                     RpcUtils.createRemoteRpcService(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -197,6 +197,9 @@ public class MiniCluster implements AutoCloseableAsync {
     /** Flag marking the mini cluster as started/running. */
     private volatile boolean running;
 
+    @GuardedBy("lock")
+    private RpcSystem rpcSystem;
+
     // ------------------------------------------------------------------------
 
     /**
@@ -273,7 +276,7 @@ public class MiniCluster implements AutoCloseableAsync {
             try {
                 initializeIOFormatClasses(configuration);
 
-                final RpcSystem rpcSystem = RpcSystem.load();
+                rpcSystem = RpcSystem.load();
 
                 LOG.info("Starting Metrics Registry");
                 metricRegistry =
@@ -1062,6 +1065,12 @@ public class MiniCluster implements AutoCloseableAsync {
                     exception = ExceptionUtils.firstOrSuppressed(e, exception);
                 }
                 haServices = null;
+            }
+
+            try {
+                rpcSystem.close();
+            } catch (Exception e) {
+                exception = ExceptionUtils.firstOrSuppressed(e, exception);
             }
 
             if (exception != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -276,7 +276,7 @@ public class MiniCluster implements AutoCloseableAsync {
             try {
                 initializeIOFormatClasses(configuration);
 
-                rpcSystem = RpcSystem.load();
+                rpcSystem = RpcSystem.load(configuration);
 
                 LOG.info("Starting Metrics Registry");
                 metricRegistry =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -166,7 +166,7 @@ public abstract class RetryingRegistration<
                                         retryingRegistrationConfiguration
                                                 .getInitialRegistrationTimeoutMillis());
                             },
-                            rpcService.getExecutor());
+                            rpcService.getScheduledExecutor());
 
             // upon failure, retry, unless this is cancelled
             rpcGatewayAcceptFuture.whenCompleteAsync(
@@ -194,7 +194,7 @@ public abstract class RetryingRegistration<
                                     retryingRegistrationConfiguration.getErrorDelayMillis());
                         }
                     },
-                    rpcService.getExecutor());
+                    rpcService.getScheduledExecutor());
         } catch (Throwable t) {
             completionFuture.completeExceptionally(t);
             cancel();
@@ -272,7 +272,7 @@ public abstract class RetryingRegistration<
                                     }
                                 }
                             },
-                            rpcService.getExecutor());
+                            rpcService.getScheduledExecutor());
 
             // upon failure, retry
             registrationAcceptFuture.whenCompleteAsync(
@@ -320,7 +320,7 @@ public abstract class RetryingRegistration<
                             }
                         }
                     },
-                    rpcService.getExecutor());
+                    rpcService.getScheduledExecutor());
         } catch (Throwable t) {
             completionFuture.completeExceptionally(t);
             cancel();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderService.java
@@ -341,7 +341,7 @@ public class DefaultJobLeaderService implements JobLeaderService {
             currentJobMasterId = jobMasterId;
             rpcConnection =
                     new JobManagerRegisteredRpcConnection(
-                            LOG, leaderAddress, jobMasterId, rpcService.getExecutor());
+                            LOG, leaderAddress, jobMasterId, rpcService.getScheduledExecutor());
 
             LOG.info(
                     "Try to register at job manager {} with leader id {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -729,7 +729,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                             taskMetricGroup,
                             resultPartitionConsumableNotifier,
                             partitionStateChecker,
-                            getRpcService().getExecutor());
+                            getRpcService().getScheduledExecutor());
 
             taskMetricGroup.gauge(MetricNames.IS_BACK_PRESSURED, task::isBackPressured);
 
@@ -870,7 +870,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                                         task.failExternally(e);
                                     }
                                 },
-                                getRpcService().getExecutor()));
+                                getRpcService().getScheduledExecutor()));
             }
             return CompletableFuture.completedFuture(Acknowledge.get());
         } else {
@@ -1723,7 +1723,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         ResultPartitionConsumableNotifier resultPartitionConsumableNotifier =
                 new RpcResultPartitionConsumableNotifier(
                         jobMasterGateway,
-                        getRpcService().getExecutor(),
+                        getRpcService().getScheduledExecutor(),
                         taskManagerConfiguration.getRpcTimeout());
 
         PartitionProducerStateChecker partitionStateChecker =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -139,7 +139,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
             throws Exception {
         this.configuration = checkNotNull(configuration);
 
-        rpcSystem = RpcSystem.load();
+        rpcSystem = RpcSystem.load(configuration);
 
         timeout = Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcSystem;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServicesBuilder;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
@@ -40,7 +39,6 @@ import org.apache.flink.util.function.CheckedSupplier;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
 
-import akka.actor.ActorSystem;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -54,7 +52,6 @@ import java.util.List;
 import static org.apache.flink.runtime.metrics.util.MetricUtils.METRIC_GROUP_FLINK;
 import static org.apache.flink.runtime.metrics.util.MetricUtils.METRIC_GROUP_MANAGED_MEMORY;
 import static org.apache.flink.runtime.metrics.util.MetricUtils.METRIC_GROUP_MEMORY;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -83,17 +80,10 @@ public class MetricUtilsTest extends TestLogger {
         final RpcService rpcService =
                 MetricUtils.startRemoteMetricsRpcService(
                         configuration, "localhost", RpcSystem.load());
-        assertThat(rpcService, instanceOf(AkkaRpcService.class));
-
-        final ActorSystem actorSystem = ((AkkaRpcService) rpcService).getActorSystem();
 
         try {
             final int threadPriority =
-                    actorSystem
-                            .settings()
-                            .config()
-                            .getInt("akka.actor.default-dispatcher.thread-priority");
-
+                    rpcService.execute(() -> Thread.currentThread().getPriority()).get();
             assertThat(threadPriority, is(expectedThreadPriority));
         } finally {
             rpcService.stopService().get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RegisteredRpcConnectionTest.java
@@ -78,7 +78,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
                     new TestRpcConnection(
                             testRpcConnectionEndpointAddress,
                             leaderId,
-                            rpcService.getExecutor(),
+                            rpcService.getScheduledExecutor(),
                             rpcService);
             connection.start();
 
@@ -125,7 +125,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
                 new TestRpcConnection(
                         testRpcConnectionEndpointAddress,
                         leaderId,
-                        rpcService.getExecutor(),
+                        rpcService.getScheduledExecutor(),
                         rpcService);
         connection.start();
 
@@ -162,7 +162,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
                 new TestRpcConnection(
                         testRegistrationGateway.getAddress(),
                         UUID.randomUUID(),
-                        rpcService.getExecutor(),
+                        rpcService.getScheduledExecutor(),
                         rpcService);
         connection.start();
 
@@ -194,7 +194,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
                     new TestRpcConnection(
                             testRpcConnectionEndpointAddress,
                             leaderId,
-                            rpcService.getExecutor(),
+                            rpcService.getScheduledExecutor(),
                             rpcService);
             connection.start();
             // close the connection
@@ -226,7 +226,7 @@ public class RegisteredRpcConnectionTest extends TestLogger {
                 new TestRpcConnection(
                         testRpcConnectionEndpointAddress,
                         leaderId,
-                        rpcService.getExecutor(),
+                        rpcService.getScheduledExecutor(),
                         rpcService);
         connection.start();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
 import org.junit.After;
 import org.junit.Before;
@@ -36,7 +37,7 @@ import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -146,7 +147,7 @@ public class RetryingRegistrationTest extends TestLogger {
         final String testId = "laissez les bon temps roulez";
         final UUID leaderId = UUID.randomUUID();
 
-        ExecutorService executor = TestingUtils.defaultExecutor();
+        ScheduledExecutorService executor = TestingUtils.defaultExecutor();
         ManualResponseTestRegistrationGateway testGateway =
                 new ManualResponseTestRegistrationGateway(new TestRegistrationSuccess(testId));
 
@@ -162,7 +163,8 @@ public class RetryingRegistrationTest extends TestLogger {
                             CompletableFuture.completedFuture(
                                     testGateway) // second connection attempt succeeds
                             );
-            when(rpc.getExecutor()).thenReturn(executor);
+            when(rpc.getScheduledExecutor())
+                    .thenReturn(new ScheduledExecutorServiceAdapter(executor));
             when(rpc.scheduleRunnable(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                     .thenAnswer(
                             (InvocationOnMock invocation) -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -56,7 +56,6 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
 
-import akka.pattern.AskTimeoutException;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -602,7 +601,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
         final BlockingQueue<Supplier<CompletableFuture<Acknowledge>>> responseQueue =
                 new ArrayBlockingQueue<>(2);
         responseQueue.add(
-                () -> FutureUtils.completedExceptionally(new AskTimeoutException("timeout")));
+                () -> FutureUtils.completedExceptionally(new TimeoutException("timeout")));
         responseQueue.add(
                 () -> {
                     secondSlotRequestFuture.complete(null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultSlotStatusSyncerTest.java
@@ -36,11 +36,11 @@ import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import akka.pattern.AskTimeoutException;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -126,7 +126,7 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
                         .setRequestSlotFunction(
                                 ignored ->
                                         FutureUtils.completedExceptionally(
-                                                new AskTimeoutException("timeout")))
+                                                new TimeoutException("timeout")))
                         .createTestingTaskExecutorGateway();
         final TaskExecutorConnection taskExecutorConnection =
                 new TaskExecutorConnection(ResourceID.generate(), taskExecutorGateway);
@@ -151,7 +151,7 @@ public class DefaultSlotStatusSyncerTest extends TestLogger {
         try {
             allocatedFuture.get();
         } catch (Exception e) {
-            assertThat(e.getCause(), instanceOf(AskTimeoutException.class));
+            assertThat(e.getCause(), instanceOf(TimeoutException.class));
         }
         assertThat(resourceTracker.getAcquiredResources(jobId), is(empty()));
         assertThat(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -382,7 +382,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 
                                 return value;
                             },
-                            getRpcService().getExecutor())
+                            getRpcService().getScheduledExecutor())
                     .thenApplyAsync((String v) -> Acknowledge.get(), getMainThreadExecutor());
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -212,7 +212,9 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
                             new TestCheckpointResponder(),
                             new TestGlobalAggregateManager(),
                             new RpcResultPartitionConsumableNotifier(
-                                    jobMasterGateway, testingRpcService.getExecutor(), timeout),
+                                    jobMasterGateway,
+                                    testingRpcService.getScheduledExecutor(),
+                                    timeout),
                             TestingPartitionProducerStateChecker.newBuilder()
                                     .setPartitionProducerStateFunction(
                                             (jobID, intermediateDataSetID, resultPartitionID) ->

--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -31,7 +31,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+	<artifactId>flink-statebackend-changelog</artifactId>
 	<name>Flink : State backends : Changelog</name>
 
 	<packaging>jar</packaging>
@@ -47,7 +47,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -66,7 +66,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
+++ b/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
@@ -31,7 +31,7 @@ under the License.
 		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-statebackend-heap-spillable_${scala.binary.version}</artifactId>
+	<artifactId>flink-statebackend-heap-spillable</artifactId>
 	<name>Flink : State backends : Heap spillable</name>
 
 	<packaging>jar</packaging>
@@ -41,7 +41,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
@@ -55,7 +55,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -76,7 +76,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -52,7 +52,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -97,7 +97,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -85,7 +85,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -116,7 +116,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -128,7 +128,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -136,7 +136,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -78,7 +78,7 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -281,7 +281,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -44,14 +44,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>compile</scope>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -87,14 +87,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
+			<artifactId>flink-optimizer</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -187,7 +187,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-optimizer_${scala.binary.version}</artifactId>
+			<artifactId>flink-optimizer</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -195,7 +195,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
@@ -249,7 +249,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-changelog_${scala.binary.version}</artifactId>
+			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -73,7 +73,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -509,11 +508,6 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
         @Override
         public CompletableFuture<Void> getTerminationFuture() {
             return rpcService.getTerminationFuture();
-        }
-
-        @Override
-        public Executor getExecutor() {
-            return rpcService.getExecutor();
         }
 
         @Override

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -63,7 +63,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -43,7 +43,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -88,7 +88,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@ under the License.
 		<flink.reuseForks>true</flink.reuseForks>
 		<flink.shaded.version>13.0</flink.shaded.version>
 		<guava.version>18.0</guava.version>
-		<akka.version>2.5.21</akka.version>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.15</slf4j.version>
 		<log4j.version>2.14.1</log4j.version>
@@ -508,13 +507,6 @@ under the License.
 
 			<!-- For dependency convergence -->
 			<dependency>
-				<groupId>com.typesafe</groupId>
-				<artifactId>config</artifactId>
-				<version>1.3.0</version>
-			</dependency>
-
-			<!-- For dependency convergence -->
-			<dependency>
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
 				<version>1.1.3</version>
@@ -648,56 +640,6 @@ under the License.
 				<groupId>org.scala-lang</groupId>
 				<artifactId>scala-compiler</artifactId>
 				<version>${scala.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.clapper</groupId>
-				<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
-				<version>1.3.2</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.typesafe.akka</groupId>
-				<artifactId>akka-actor_${scala.binary.version}</artifactId>
-				<version>${akka.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.typesafe.akka</groupId>
-				<artifactId>akka-remote_${scala.binary.version}</artifactId>
-				<version>${akka.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>io.aeron</groupId>
-						<artifactId>aeron-driver</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>io.aeron</groupId>
-						<artifactId>aeron-client</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-
-			<!-- Transitive dependency of akka-remote that we explicitly define to keep it
-                visible after the shading (without relocation!) of akka-remote -->
-			<dependency>
-				<groupId>com.typesafe.akka</groupId>
-				<artifactId>akka-stream_${scala.binary.version}</artifactId>
-				<version>${akka.version}</version>
-			</dependency>
-
-			<!-- Transitive dependency of akka-remote that we explicitly define to keep it
-                visible after the shading (without relocation!) of akka-remote -->
-			<dependency>
-				<groupId>com.typesafe.akka</groupId>
-				<artifactId>akka-protobuf_${scala.binary.version}</artifactId>
-				<version>${akka.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.typesafe.akka</groupId>
-				<artifactId>akka-slf4j_${scala.binary.version}</artifactId>
-				<version>${akka.version}</version>
 			</dependency>
 
 			<dependency>

--- a/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/suffixcheck/ScalaSuffixChecker.java
+++ b/tools/ci/java-ci-tools/src/main/java/org/apache/flink/tools/ci/suffixcheck/ScalaSuffixChecker.java
@@ -52,6 +52,8 @@ public class ScalaSuffixChecker {
     // [INFO] +- org.scala-lang:scala-reflect:jar:2.11.12:test
     private static final Pattern scalaSuffixPattern = Pattern.compile("_2.1[0-9]");
 
+    private static final String AKKA_RPC_MODULE_NAME = "flink-rpc-akka";
+
     public static void main(String[] args) throws IOException {
         if (args.length < 2) {
             System.out.println("Usage: ScalaSuffixChecker <pathMavenBuildOutput> <pathFlinkRoot>");
@@ -93,6 +95,11 @@ public class ScalaSuffixChecker {
                 final Matcher matcher = moduleNamePattern.matcher(line);
                 if (matcher.matches()) {
                     final String moduleName = stripScalaSuffix(matcher.group(1));
+                    // we ignored flink-rpc-akka because it is loaded through a separate class
+                    // loader
+                    if (moduleName.equals(AKKA_RPC_MODULE_NAME)) {
+                        continue;
+                    }
                     LOG.trace("Parsing module '{}'.", moduleName);
 
                     // skip: [INFO] org.apache.flink:flink-annotations:jar:1.14-SNAPSHOT
@@ -103,10 +110,14 @@ public class ScalaSuffixChecker {
                     while (blockPattern.matcher(line).matches()) {
                         final boolean dependsOnScala = dependsOnScala(line);
                         final boolean isTestDependency = line.endsWith(":test");
+                        // we ignored flink-rpc-akka because it is loaded through a separate class
+                        // loader
+                        final boolean isFlinkAkkaRpc = line.contains(AKKA_RPC_MODULE_NAME);
                         LOG.trace("\tline:{}", line);
                         LOG.trace("\t\tdepends-on-scala:{}", dependsOnScala);
                         LOG.trace("\t\tis-test-dependency:{}", isTestDependency);
-                        if (dependsOnScala && !isTestDependency) {
+                        LOG.trace("\t\tis-flink-rpc-akka:{}", isFlinkAkkaRpc);
+                        if (dependsOnScala && !isTestDependency && !isFlinkAkkaRpc) {
                             LOG.trace("\t\tOutbreak detected at {}!", moduleName);
                             infected = true;
                         }


### PR DESCRIPTION
Based on #16339, just to get rid of a test instability that I ran into quite often.

With this PR in a nutshell:
- akka was bumped to 2.6 (FLINK-23091)
- akka+scala+flink-rpc-akka are loaded through a separate classloader (FLINK-18783)
- scala suffix was removed from flink-runtime, cascading into various other modules

The commit structure is _not_ what I intend to eventually be merged; I separate the changes for ease of review, the majority however would not succeed on CI on their own.
For example, bumping Akka is not possible without the plugin work (because it needs scala 2.12), while the plugin work is not possible without bumping Akka (because it leaks the plugin classloader).


I will now describe the changes in each commit:

`Replace AskTimeException usages in tests`:
This is a simple removal of some direct references to Akka.

`Use reflection to access akka in MetricUtils`:
Similar to above; ideally we'd come up with a TestingRpcSystem, but the dependencies are too extencies (RpcSystem needs a Builder, Builder needs an RpcService, RpcService needs even more stuff)

`Add RpcSystem#cleanup`
In order to work with the MiniCluster we need to be able to unload the AkkaRpcSystem when the MiniCluster is shutdown. This hook will eventuallly allow us to do that.

`RpcSystem#load accepts Configuration`
The configuration will primarily be necessary to retrieve the temp directory; more on that later.

`Remove netty relocation`
Now that we load netty through a separate class loader the relocation is technically not necessary. We may still want to keep it, because it is quite likely that some security scanner might now pick it up, and it is unlikely that we can migrate away from Netty for 1.14.

`Remove scala suffixes`
flink-runtime no longer depends on `${scala.binary.version}`. While it still transitively depends on scala via flink-rpc-akka, that module uses a fixed scala version so the suffix is not necessary.
This also results in other modules lossing their scala suffix, like the reporter for example.

`Exclude flink-rpc-akka from scala-suffix check`
The suffix checker is pretty simple in that it mandates a scala suffix if scala shows up in the dependency tree. Since the scala version for flink-rpc-akka is fixed and independent of `${scala.binary.version}` I added crude exclusions for this module such that neither flink-rpc-akka nor modules depending on it require a suffix.

`Bump akka to 2.6, bundle scala, and consolidate maven stuff in flink-rpc`
This commits does a few things. It sets up flink-rpc-akka to assemble a fat jar, taking over bundling concerns from flink-dist.
Everything related to akka dependencies (depMngt entries, properties) are now consolidated in flink-rpc-akka.
The enforcer rule that ensures the same scala version is used for all projects is disabled for flink-rpc-akka, because it uses a separate scala version.

Finally, Akka is bumped to 2.6.15, which did not require any code changes, but we had to modify many netty configurations settings to have a `classic` infix. In 2.6 Artery has become the default network layer, and we explicitly need to buy in to netty. Migrating to Artery is something we should look into in the near future.

The primary reason for the bump is that in 2.5 Akka contained a custom common thread pool, that also contained a thread local, which meant that if any thread from outside Akka touches this executor a reference to this pool would be leaked to the outside. In 2.6 this pool was removed.

`Load AkkaRpcSystem in separate classloader`
The nasty bit.

Primarily consists of 3 changes:

1) flink-runtime has an optional runtime dependency on flink-rpc-akka

- optional ensures that downstream modules don't see it
- runtime scopes ensures that production code cannot reference flink-rpc-akka directly

2) flink-rpc-akka jar is bundled by flink-runtime as is and extracted on the demand when the RpcSystem is being loaded
The AkkaRpcSystem is not loaded like usual plugins; it does not use the PluginManager nor the plugins/ directory of the distribution. The reason for this is simple: It just does not work outside of production.
In order for this feature to work we need to ensure dependency isolation in these cases:
- production
- tests without a MiniCluster in the IDE/maven (e.g., most of the stuff in flink-runtime)
- tests with the MiniCLuster in the IDE/maven (most stuff outside of flink-runtime, currently the MiniCluster does not plugins)

For the latter 2 we ideally want a solution where akka etc. are not on the compile/test classpath.
Without a dependency being declared this means we require the flink-rpc-akka jar to be _somewhere_ on disk in order to point a ClassLoader to it.
To solve this I concocted the following approach:
a) flink-runtime bundles the flink-rpc-akka jar _as is_, that is the _jar_ is contained within the flink-runtime jar
b) RpcSystem#load() extracts this jar from the flink-runtime jar, puts it into some temporary directory (IO_TMPDIR option), and points a PluginLoader at it

This works in maven, the IDE and in production. Overall I think it is actually quite neat, but it has some downsides:
a) A big gotcha that people need to be aware of is that if you change something in flink-rpc-akka, then you first need to rebuild flink-rpc-akka and flink-runtime for it to take effect.
This is super unfortunate, but I just don't see a way to work around that.
b) Having to extract the jar from the flink-runtime jar is a bit unfortunate; it would be neat if we could just point the ClassLoader to the file contained in flink-runtime. Which technically _should_ work, but the standard URLClassLoader just doesn't support it. It is possible though, as shown by the [One-JAR project](http://one-jar.sourceforge.net/).

3) At various points the ContextClassLoader is set to either the Akka or Flink ClassLoader

Akka itself sets the ContextClassLoader of all of it's threads to the one it itself was loaded with. As described in FLINK-23147 this can result in thread pools outside of the AkkaRpcSystem being poisoned such that some threads use a different classloader than others, resulting in classloading issues.
To remedy this I covered most places where we transition from Akka to Flink with a TemporaryClassLoaderContext.
There _are_ still other ocurrences, but from what I can tell they are not problematic at this time, and I already spend days on tracking and debugging.


# Known issues:
- flink-runtime still has a test dependency on flink-rpc-akka; this is primarily to get access to the TestRpcService, which unfortunately relies on Akka. This isn't a _problem_ for the time being, but we should address it at some point.
- running flink-runtime tests that rely on RpcSystem#load can fail in IntelliJ (but work in maven); has got something to do with flink classes being loaded parent-first by the PluginClassLoader and flink-rpc-akka being on the test classpath. It _can_ be fixed by changing the PluginClassLoader to always load child-first, but not sure about the repercussions. I'd also be fine with adding a separate CL with that loading order. @AHeise 