### PR TITLE
[FLINK-23219][runtime] Fix the bug of temproary join ttl configruation does not take effect

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
@@ -209,7 +209,6 @@ public class TemporalRowTimeJoinOperator extends BaseTwoInputStreamOperatorWithS
             if (lastUnprocessedTime < Long.MAX_VALUE || !rightState.isEmpty()) {
                 registerProcessingCleanupTimer();
             } else {
-                cleanupLastTimer();
                 nextLeftIndex.clear();
             }
         }


### PR DESCRIPTION
### What is the purpose of the change
- message
   This commit solves the problem that setting ttl does not take effect when running temporary join, which causes the task status to increase continuously.
The main reason is that when the dimension table is not joined to the fact table in the previous code, the ttl registration time trigger is deleted. The current measure is to remove this delete operation.
 
- problem 
   Run the job of table A temproary left join table B, and set the table.exec.state.ttl configuration
 to 3 hour or 2 sencond for test. But the task status keeps growing for more than 7 days.


### Verifying this change
All existing tests pass.


###  Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
* The serializers: (no)
* The runtime per-record code paths (performance sensitive): (no)
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
* The S3 file system connector: (no)
### Documentation
* Does this pull request introduce a new feature? (no)
* If yes, how is the feature documented? (not documented)