### PR TITLE
[hotfix][streaming] Fix the boundary condition when collect limited records from streaming job

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1317,7 +1317,7 @@ public class DataStream<T> {
         try (ClientAndIterator<T> clientAndIterator =
                 executeAndCollectWithClient(jobExecutionName)) {
             List<T> results = new ArrayList<>(limit);
-            while (clientAndIterator.iterator.hasNext() && limit > 0) {
+            while (limit > 0 && clientAndIterator.iterator.hasNext()) {
                 results.add(clientAndIterator.iterator.next());
                 limit--;
             }


### PR DESCRIPTION
## What is the purpose of the change

* This pull request to fix the boundary condition when fetch limited records from streaming job

## Brief change log
 -  Imagine this case, you sent 5 records to a unbounded Source like Kafka and want to call `DataStream#executeAndCollect(5)` to fetch 5 records and verify them, but for now, the job will hang because `clientAndIterator.iterator.hasNext()` will hang until the 6th record arrived Kafka.


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
