### PR TITLE
[FLINK-23209] Introduce HeartbeatListener.notifyTargetUnreachable

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -62,5 +62,11 @@
             <td>Long</td>
             <td>The shutdown timeout for cluster services like executors in milliseconds.</td>
         </tr>
+        <tr>
+            <td><h5>cluster.uncaught-exception-handling</h5></td>
+            <td style="word-wrap: break-word;">LOG</td>
+            <td><p>Enum</p>Possible values: [LOG, FAIL]</td>
+            <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/expert_fault_tolerance_section.html
+++ b/docs/layouts/shortcodes/generated/expert_fault_tolerance_section.html
@@ -48,13 +48,19 @@
             <td><h5>heartbeat.interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>
-            <td>Time interval for requesting heartbeat from sender side.</td>
+            <td>Time interval between heartbeat RPC requests from the sender to the receiver side.</td>
+        </tr>
+        <tr>
+            <td><h5>heartbeat.rpc-failure-threshold</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>The number of consecutive failed heartbeat RPCs until a heartbeat target is marked as unreachable. Failed heartbeat RPCs can be used to detect dead targets faster because they no longer receive the RPCs. The detection time is <code class="highlighter-rouge">heartbeat.interval</code> * <code class="highlighter-rouge">heartbeat.rpc-failure-threshold</code>. In environments with a flaky network, setting this value too low can produce false positives. In this case, we recommend to increase this value, but not higher than <code class="highlighter-rouge">heartbeat.timeout</code> / <code class="highlighter-rouge">heartbeat.interval</code>. The mechanism can be disabled by setting this option to <code class="highlighter-rouge">-1</code></td>
         </tr>
         <tr>
             <td><h5>heartbeat.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>Long</td>
-            <td>Timeout for requesting and receiving heartbeat for both sender and receiver sides.</td>
+            <td>Timeout for requesting and receiving heartbeats for both sender and receiver sides.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>

--- a/docs/layouts/shortcodes/generated/heartbeat_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/heartbeat_manager_configuration.html
@@ -12,13 +12,19 @@
             <td><h5>heartbeat.interval</h5></td>
             <td style="word-wrap: break-word;">10000</td>
             <td>Long</td>
-            <td>Time interval for requesting heartbeat from sender side.</td>
+            <td>Time interval between heartbeat RPC requests from the sender to the receiver side.</td>
+        </tr>
+        <tr>
+            <td><h5>heartbeat.rpc-failure-threshold</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>The number of consecutive failed heartbeat RPCs until a heartbeat target is marked as unreachable. Failed heartbeat RPCs can be used to detect dead targets faster because they no longer receive the RPCs. The detection time is <code class="highlighter-rouge">heartbeat.interval</code> * <code class="highlighter-rouge">heartbeat.rpc-failure-threshold</code>. In environments with a flaky network, setting this value too low can produce false positives. In this case, we recommend to increase this value, but not higher than <code class="highlighter-rouge">heartbeat.timeout</code> / <code class="highlighter-rouge">heartbeat.interval</code>. The mechanism can be disabled by setting this option to <code class="highlighter-rouge">-1</code></td>
         </tr>
         <tr>
             <td><h5>heartbeat.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>Long</td>
-            <td>Timeout for requesting and receiving heartbeat for both sender and receiver sides.</td>
+            <td>Timeout for requesting and receiving heartbeats for both sender and receiver sides.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
@@ -20,6 +20,8 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -32,7 +34,8 @@ public class HeartbeatManagerOptions {
     public static final ConfigOption<Long> HEARTBEAT_INTERVAL =
             key("heartbeat.interval")
                     .defaultValue(10000L)
-                    .withDescription("Time interval for requesting heartbeat from sender side.");
+                    .withDescription(
+                            "Time interval between heartbeat RPC requests from the sender to the receiver side.");
 
     /** Timeout for requesting and receiving heartbeat for both sender and receiver sides. */
     @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
@@ -40,7 +43,31 @@ public class HeartbeatManagerOptions {
             key("heartbeat.timeout")
                     .defaultValue(50000L)
                     .withDescription(
-                            "Timeout for requesting and receiving heartbeat for both sender and receiver sides.");
+                            "Timeout for requesting and receiving heartbeats for both sender and receiver sides.");
+
+    private static final String HEARTBEAT_RPC_FAILURE_THRESHOLD_KEY =
+            "heartbeat.rpc-failure-threshold";
+
+    @Documentation.Section(Documentation.Sections.EXPERT_FAULT_TOLERANCE)
+    public static final ConfigOption<Integer> HEARTBEAT_RPC_FAILURE_THRESHOLD =
+            key(HEARTBEAT_RPC_FAILURE_THRESHOLD_KEY)
+                    .intType()
+                    .defaultValue(2)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of consecutive failed heartbeat RPCs until a heartbeat target is marked as unreachable. "
+                                                    + "Failed heartbeat RPCs can be used to detect dead targets faster because they no longer receive the RPCs. "
+                                                    + "The detection time is %s * %s. "
+                                                    + "In environments with a flaky network, setting this value too low can produce false positives. "
+                                                    + "In this case, we recommend to increase this value, but not higher than %s / %s. "
+                                                    + "The mechanism can be disabled by setting this option to %s",
+                                            TextElement.code(HEARTBEAT_INTERVAL.key()),
+                                            TextElement.code(HEARTBEAT_RPC_FAILURE_THRESHOLD_KEY),
+                                            TextElement.code(HEARTBEAT_TIMEOUT.key()),
+                                            TextElement.code(HEARTBEAT_INTERVAL.key()),
+                                            TextElement.code("-1"))
+                                    .build());
 
     // ------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -70,6 +70,20 @@ public class FutureUtils {
         return COMPLETED_VOID_FUTURE;
     }
 
+    private static final CompletableFuture<?> UNSUPPORTED_OPERATION_FUTURE =
+            completedExceptionally(
+                    new UnsupportedOperationException("This method is unsupported."));
+
+    /**
+     * Returns an exceptionally completed future with an {@link UnsupportedOperationException}.
+     *
+     * @param <T> type of the future
+     * @return exceptionally completed future
+     */
+    public static <T> CompletableFuture<T> unsupportedOperationFuture() {
+        return (CompletableFuture<T>) UNSUPPORTED_OPERATION_FUTURE;
+    }
+
     /**
      * Fakes asynchronous execution by immediately executing the operation and completing the
      * supplied future either normally or exceptionally.

--- a/flink-core/src/main/java/org/apache/flink/util/function/TriConsumerWithException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/TriConsumerWithException.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.util.ExceptionUtils;
+
+/**
+ * A checked extension of the {@link TriConsumer} interface.
+ *
+ * @param <S> type of the first argument
+ * @param <T> type of the first argument
+ * @param <U> type of the second argument
+ * @param <E> type of the thrown exception
+ */
+@FunctionalInterface
+public interface TriConsumerWithException<S, T, U, E extends Throwable> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param s the first input argument
+     * @param t the second input argument
+     * @param u the third input argument
+     * @throws E in case of an error
+     */
+    void accept(S s, T t, U u) throws E;
+
+    /**
+     * Convert a {@link TriConsumerWithException} into a {@link TriConsumer}.
+     *
+     * @param triConsumerWithException TriConsumer with exception to convert into a {@link
+     *     TriConsumer}.
+     * @param <A> first input type
+     * @param <B> second input type
+     * @param <C> third input type
+     * @return {@link TriConsumer} which rethrows all checked exceptions as unchecked.
+     */
+    static <A, B, C> TriConsumer<A, B, C> unchecked(
+            TriConsumerWithException<A, B, C, ?> triConsumerWithException) {
+        return (A a, B b, C c) -> {
+            try {
+                triConsumerWithException.accept(a, b, c);
+            } catch (Throwable t) {
+                ExceptionUtils.rethrow(t);
+            }
+        };
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
@@ -44,6 +44,14 @@ public interface HeartbeatListener<I, O> {
     void notifyHeartbeatTimeout(ResourceID resourceID);
 
     /**
+     * Callback which is called if a target specified by the given resource ID is no longer
+     * reachable.
+     *
+     * @param resourceID resourceID identifying the target that is no longer reachable
+     */
+    void notifyTargetUnreachable(ResourceID resourceID);
+
+    /**
      * Callback which is called whenever a heartbeat with an associated payload is received. The
      * carried payload is given to this method.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -90,6 +90,15 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
         O payload = getHeartbeatListener().retrievePayload(heartbeatMonitor.getHeartbeatTargetId());
         final HeartbeatTarget<O> heartbeatTarget = heartbeatMonitor.getHeartbeatTarget();
 
-        heartbeatTarget.requestHeartbeat(getOwnResourceID(), payload);
+        heartbeatTarget
+                .requestHeartbeat(getOwnResourceID(), payload)
+                .whenCompleteAsync(
+                        (unused, failure) -> {
+                            if (failure != null) {
+                                handleHeartbeatRpcFailure(
+                                        heartbeatMonitor.getHeartbeatTargetId(), failure);
+                            }
+                        },
+                        getMainThreadExecutor());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -40,6 +40,7 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
     HeartbeatManagerSenderImpl(
             long heartbeatPeriod,
             long heartbeatTimeout,
+            int failedRpcRequestsUntilUnreachable,
             ResourceID ownResourceID,
             HeartbeatListener<I, O> heartbeatListener,
             ScheduledExecutor mainThreadExecutor,
@@ -47,6 +48,7 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
         this(
                 heartbeatPeriod,
                 heartbeatTimeout,
+                failedRpcRequestsUntilUnreachable,
                 ownResourceID,
                 heartbeatListener,
                 mainThreadExecutor,
@@ -57,6 +59,7 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
     HeartbeatManagerSenderImpl(
             long heartbeatPeriod,
             long heartbeatTimeout,
+            int failedRpcRequestsUntilUnreachable,
             ResourceID ownResourceID,
             HeartbeatListener<I, O> heartbeatListener,
             ScheduledExecutor mainThreadExecutor,
@@ -64,6 +67,7 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
             HeartbeatMonitor.Factory<O> heartbeatMonitorFactory) {
         super(
                 heartbeatTimeout,
+                failedRpcRequestsUntilUnreachable,
                 ownResourceID,
                 heartbeatListener,
                 mainThreadExecutor,
@@ -93,12 +97,7 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
         heartbeatTarget
                 .requestHeartbeat(getOwnResourceID(), payload)
                 .whenCompleteAsync(
-                        (unused, failure) -> {
-                            if (failure != null) {
-                                handleHeartbeatRpcFailure(
-                                        heartbeatMonitor.getHeartbeatTargetId(), failure);
-                            }
-                        },
+                        handleHeartbeatRpc(heartbeatMonitor.getHeartbeatTargetId()),
                         getMainThreadExecutor());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitor.java
@@ -57,6 +57,9 @@ public interface HeartbeatMonitor<O> {
      */
     long getLastHeartbeat();
 
+    /** Reports that the target is unreachable. */
+    void reportTargetUnreachable();
+
     /**
      * This factory provides an indirection way to create {@link HeartbeatMonitor}.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitor.java
@@ -57,8 +57,11 @@ public interface HeartbeatMonitor<O> {
      */
     long getLastHeartbeat();
 
-    /** Reports that the target is unreachable. */
-    void reportTargetUnreachable();
+    /** Reports that the heartbeat rpc could not be sent to the target. */
+    void reportHeartbeatRpcFailure();
+
+    /** Reports that the heartbeat rpc could be sent to the target. */
+    void reportHeartbeatRpcSuccess();
 
     /**
      * This factory provides an indirection way to create {@link HeartbeatMonitor}.
@@ -74,6 +77,8 @@ public interface HeartbeatMonitor<O> {
          * @param mainThreadExecutor the main thread executor
          * @param heartbeatListener the heartbeat listener
          * @param heartbeatTimeoutIntervalMs the heartbeat timeout interval ms
+         * @param failedRpcRequestsUntilUnreachable the number of failed heartbeat RPCs until the
+         *     target is marked as unreachable
          * @return the heartbeat monitor
          */
         HeartbeatMonitor<O> createHeartbeatMonitor(
@@ -81,6 +86,7 @@ public interface HeartbeatMonitor<O> {
                 HeartbeatTarget<O> heartbeatTarget,
                 ScheduledExecutor mainThreadExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs);
+                long heartbeatTimeoutIntervalMs,
+                int failedRpcRequestsUntilUnreachable);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitorImpl.java
@@ -91,6 +91,14 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
     }
 
     @Override
+    public void reportTargetUnreachable() {
+        if (state.compareAndSet(State.RUNNING, State.UNREACHABLE)) {
+            cancelTimeout();
+            heartbeatListener.notifyTargetUnreachable(resourceID);
+        }
+    }
+
+    @Override
     public void reportHeartbeat() {
         lastHeartbeat = System.currentTimeMillis();
         resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
@@ -139,6 +147,7 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
     private enum State {
         RUNNING,
         TIMEOUT,
+        UNREACHABLE,
         CANCELED
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatMonitorImpl.java
@@ -22,8 +22,12 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -32,6 +36,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <O> Type of the payload being sent to the associated heartbeat target
  */
 public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HeartbeatMonitorImpl.class);
 
     /** Resource ID of the monitored heartbeat target. */
     private final ResourceID resourceID;
@@ -47,9 +53,13 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
     /** Maximum heartbeat timeout interval. */
     private final long heartbeatTimeoutIntervalMs;
 
+    private final int failedRpcRequestsUntilUnreachable;
+
     private volatile ScheduledFuture<?> futureTimeout;
 
     private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
+
+    private final AtomicInteger numberFailedRpcRequestsSinceLastSuccess = new AtomicInteger(0);
 
     private volatile long lastHeartbeat;
 
@@ -58,7 +68,8 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
             HeartbeatTarget<O> heartbeatTarget,
             ScheduledExecutor scheduledExecutor,
             HeartbeatListener<?, O> heartbeatListener,
-            long heartbeatTimeoutIntervalMs) {
+            long heartbeatTimeoutIntervalMs,
+            int failedRpcRequestsUntilUnreachable) {
 
         this.resourceID = Preconditions.checkNotNull(resourceID);
         this.heartbeatTarget = Preconditions.checkNotNull(heartbeatTarget);
@@ -69,6 +80,11 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
                 heartbeatTimeoutIntervalMs > 0L,
                 "The heartbeat timeout interval has to be larger than 0.");
         this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
+
+        Preconditions.checkArgument(
+                failedRpcRequestsUntilUnreachable > 0 || failedRpcRequestsUntilUnreachable == -1,
+                "The number of failed heartbeat RPC requests has to be larger than 0 or -1 (deactivated).");
+        this.failedRpcRequestsUntilUnreachable = failedRpcRequestsUntilUnreachable;
 
         lastHeartbeat = 0L;
 
@@ -91,11 +107,31 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
     }
 
     @Override
-    public void reportTargetUnreachable() {
-        if (state.compareAndSet(State.RUNNING, State.UNREACHABLE)) {
-            cancelTimeout();
-            heartbeatListener.notifyTargetUnreachable(resourceID);
+    public void reportHeartbeatRpcFailure() {
+        final int failedRpcRequestsSinceLastSuccess =
+                numberFailedRpcRequestsSinceLastSuccess.incrementAndGet();
+
+        if (isHeartbeatRpcFailureDetectionEnabled()
+                && failedRpcRequestsSinceLastSuccess >= failedRpcRequestsUntilUnreachable) {
+            if (state.compareAndSet(State.RUNNING, State.UNREACHABLE)) {
+                LOG.debug(
+                        "Mark heartbeat target {} as unreachable because {} consecutive heartbeat RPCs have failed.",
+                        resourceID,
+                        failedRpcRequestsSinceLastSuccess);
+
+                cancelTimeout();
+                heartbeatListener.notifyTargetUnreachable(resourceID);
+            }
         }
+    }
+
+    private boolean isHeartbeatRpcFailureDetectionEnabled() {
+        return failedRpcRequestsUntilUnreachable > 0;
+    }
+
+    @Override
+    public void reportHeartbeatRpcSuccess() {
+        numberFailedRpcRequestsSinceLastSuccess.set(0);
     }
 
     @Override
@@ -164,14 +200,16 @@ public class HeartbeatMonitorImpl<O> implements HeartbeatMonitor<O>, Runnable {
                 HeartbeatTarget<O> heartbeatTarget,
                 ScheduledExecutor mainThreadExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs) {
+                long heartbeatTimeoutIntervalMs,
+                int failedRpcRequestsUntilUnreachable) {
 
             return new HeartbeatMonitorImpl<>(
                     resourceID,
                     heartbeatTarget,
                     mainThreadExecutor,
                     heartbeatListener,
-                    heartbeatTimeoutIntervalMs);
+                    heartbeatTimeoutIntervalMs,
+                    failedRpcRequestsUntilUnreachable);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatTarget.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatTarget.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Interface for components which can be sent heartbeats and from which one can request a heartbeat
  * response. Both the heartbeat response as well as the heartbeat request can carry a payload. This
@@ -37,8 +39,10 @@ public interface HeartbeatTarget<I> {
      * @param heartbeatOrigin Resource ID identifying the machine for which a heartbeat shall be
      *     reported.
      * @param heartbeatPayload Payload of the heartbeat. Null indicates an empty payload.
+     * @return Future that is completed exceptionally if the heartbeat response could not be sent to
+     *     the target
      */
-    void receiveHeartbeat(ResourceID heartbeatOrigin, I heartbeatPayload);
+    CompletableFuture<Void> receiveHeartbeat(ResourceID heartbeatOrigin, I heartbeatPayload);
 
     /**
      * Requests a heartbeat from the target. Each heartbeat request can carry a payload which
@@ -46,6 +50,8 @@ public interface HeartbeatTarget<I> {
      *
      * @param requestOrigin Resource ID identifying the machine issuing the heartbeat request.
      * @param heartbeatPayload Payload of the heartbeat request. Null indicates an empty payload.
+     * @return Future that is completed exceptionally if the heartbeat request could not be sent to
+     *     the target
      */
-    void requestHeartbeat(ResourceID requestOrigin, I heartbeatPayload);
+    CompletableFuture<Void> requestHeartbeat(ResourceID requestOrigin, I heartbeatPayload);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/NoOpHeartbeatManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/NoOpHeartbeatManager.java
@@ -19,6 +19,9 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * {@link HeartbeatManager} implementation which does nothing.
@@ -47,10 +50,15 @@ public class NoOpHeartbeatManager<I, O> implements HeartbeatManager<I, O> {
     }
 
     @Override
-    public void receiveHeartbeat(ResourceID heartbeatOrigin, I heartbeatPayload) {}
+    public CompletableFuture<Void> receiveHeartbeat(
+            ResourceID heartbeatOrigin, I heartbeatPayload) {
+        return FutureUtils.completedVoidFuture();
+    }
 
     @Override
-    public void requestHeartbeat(ResourceID requestOrigin, I heartbeatPayload) {}
+    public CompletableFuture<Void> requestHeartbeat(ResourceID requestOrigin, I heartbeatPayload) {
+        return FutureUtils.completedVoidFuture();
+    }
 
     @SuppressWarnings("unchecked")
     public static <A, B> NoOpHeartbeatManager<A, B> getInstance() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -184,16 +184,18 @@ public interface JobMasterGateway
      *
      * @param resourceID unique id of the task manager
      * @param payload report payload
+     * @return future which is completed exceptionally if the operation fails
      */
-    void heartbeatFromTaskManager(
+    CompletableFuture<Void> heartbeatFromTaskManager(
             final ResourceID resourceID, final TaskExecutorToJobManagerHeartbeatPayload payload);
 
     /**
      * Sends heartbeat request from the resource manager.
      *
      * @param resourceID unique id of the resource manager
+     * @return future which is completed exceptionally if the operation fails
      */
-    void heartbeatFromResourceManager(final ResourceID resourceID);
+    CompletableFuture<Void> heartbeatFromResourceManager(final ResourceID resourceID);
 
     /**
      * Request the details of the executed job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -480,14 +480,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     }
 
     @Override
-    public void heartbeatFromTaskManager(
+    public CompletableFuture<Void> heartbeatFromTaskManager(
             final ResourceID resourceID, final TaskExecutorHeartbeatPayload heartbeatPayload) {
-        taskManagerHeartbeatManager.receiveHeartbeat(resourceID, heartbeatPayload);
+        return taskManagerHeartbeatManager.receiveHeartbeat(resourceID, heartbeatPayload);
     }
 
     @Override
-    public void heartbeatFromJobManager(final ResourceID resourceID) {
-        jobManagerHeartbeatManager.receiveHeartbeat(resourceID, null);
+    public CompletableFuture<Void> heartbeatFromJobManager(final ResourceID resourceID) {
+        return jobManagerHeartbeatManager.receiveHeartbeat(resourceID, null);
     }
 
     @Override
@@ -1201,13 +1201,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
 
         @Override
-        public void receiveHeartbeat(ResourceID resourceID, Void payload) {
+        public CompletableFuture<Void> receiveHeartbeat(ResourceID resourceID, Void payload) {
             // the ResourceManager will always send heartbeat requests to the JobManager
+            return FutureUtils.unsupportedOperationFuture();
         }
 
         @Override
-        public void requestHeartbeat(ResourceID resourceID, Void payload) {
-            jobMasterGateway.heartbeatFromResourceManager(resourceID);
+        public CompletableFuture<Void> requestHeartbeat(ResourceID resourceID, Void payload) {
+            return jobMasterGateway.heartbeatFromResourceManager(resourceID);
         }
     }
 
@@ -1219,14 +1220,15 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
 
         @Override
-        public void receiveHeartbeat(ResourceID resourceID, Void payload) {
+        public CompletableFuture<Void> receiveHeartbeat(ResourceID resourceID, Void payload) {
             // the ResourceManager will always send heartbeat requests to the
             // TaskManager
+            return FutureUtils.unsupportedOperationFuture();
         }
 
         @Override
-        public void requestHeartbeat(ResourceID resourceID, Void payload) {
-            taskExecutorGateway.heartbeatFromResourceManager(resourceID);
+        public CompletableFuture<Void> requestHeartbeat(ResourceID resourceID, Void payload) {
+            return taskExecutorGateway.heartbeatFromResourceManager(resourceID);
         }
     }
 
@@ -1312,17 +1314,29 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
         @Override
         public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-            validateRunsInMainThread();
-            log.info(
-                    "The heartbeat of TaskManager with id {} timed out.",
-                    resourceID.getStringWithMetadata());
+            final String message =
+                    String.format(
+                            "The heartbeat of TaskManager with id %s timed out.",
+                            resourceID.getStringWithMetadata());
+            log.info(message);
 
-            closeTaskManagerConnection(
-                    resourceID,
-                    new TimeoutException(
-                            "The heartbeat of TaskManager with id "
-                                    + resourceID.getStringWithMetadata()
-                                    + "  timed out."));
+            handleTaskManagerConnectionLoss(resourceID, new TimeoutException(message));
+        }
+
+        private void handleTaskManagerConnectionLoss(ResourceID resourceID, Exception cause) {
+            validateRunsInMainThread();
+            closeTaskManagerConnection(resourceID, cause);
+        }
+
+        @Override
+        public void notifyTargetUnreachable(ResourceID resourceID) {
+            final String message =
+                    String.format(
+                            "TaskManager with id %s is no longer reachable.",
+                            resourceID.getStringWithMetadata());
+            log.info(message);
+
+            handleTaskManagerConnectionLoss(resourceID, new ResourceManagerException(message));
         }
 
         @Override
@@ -1354,9 +1368,17 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
         @Override
         public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-            validateRunsInMainThread();
-            log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
+            final String message =
+                    String.format(
+                            "The heartbeat of JobManager with id %s timed out.",
+                            resourceID.getStringWithMetadata());
+            log.info(message);
 
+            handleJobManagerConnectionLoss(resourceID, new TimeoutException(message));
+        }
+
+        private void handleJobManagerConnectionLoss(ResourceID resourceID, Exception cause) {
+            validateRunsInMainThread();
             if (jmResourceIdRegistrations.containsKey(resourceID)) {
                 JobManagerRegistration jobManagerRegistration =
                         jmResourceIdRegistrations.get(resourceID);
@@ -1365,12 +1387,20 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                     closeJobManagerConnection(
                             jobManagerRegistration.getJobID(),
                             ResourceRequirementHandling.RETAIN,
-                            new TimeoutException(
-                                    "The heartbeat of JobManager with id "
-                                            + resourceID.getStringWithMetadata()
-                                            + " timed out."));
+                            cause);
                 }
             }
+        }
+
+        @Override
+        public void notifyTargetUnreachable(ResourceID resourceID) {
+            final String message =
+                    String.format(
+                            "JobManager with id %s is no longer reachable.",
+                            resourceID.getStringWithMetadata());
+            log.info(message);
+
+            handleJobManagerConnectionLoss(resourceID, new ResourceManagerException(message));
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -854,18 +854,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
                 jobId);
 
         jobManagerHeartbeatManager.monitorTarget(
-                jobManagerResourceId,
-                new HeartbeatTarget<Void>() {
-                    @Override
-                    public void receiveHeartbeat(ResourceID resourceID, Void payload) {
-                        // the ResourceManager will always send heartbeat requests to the JobManager
-                    }
-
-                    @Override
-                    public void requestHeartbeat(ResourceID resourceID, Void payload) {
-                        jobMasterGateway.heartbeatFromResourceManager(resourceID);
-                    }
-                });
+                jobManagerResourceId, new JobMasterHeartbeatTarget(jobMasterGateway));
 
         return new JobMasterRegistrationSuccess(getFencingToken(), resourceId);
     }
@@ -927,19 +916,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             taskExecutors.put(taskExecutorResourceId, registration);
 
             taskManagerHeartbeatManager.monitorTarget(
-                    taskExecutorResourceId,
-                    new HeartbeatTarget<Void>() {
-                        @Override
-                        public void receiveHeartbeat(ResourceID resourceID, Void payload) {
-                            // the ResourceManager will always send heartbeat requests to the
-                            // TaskManager
-                        }
-
-                        @Override
-                        public void requestHeartbeat(ResourceID resourceID, Void payload) {
-                            taskExecutorGateway.heartbeatFromResourceManager(resourceID);
-                        }
-                    });
+                    taskExecutorResourceId, new TaskExecutorHeartbeatTarget(taskExecutorGateway));
 
             return new TaskExecutorRegistrationSuccess(
                     registration.getInstanceID(), resourceId, clusterInformation);
@@ -1215,6 +1192,43 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     // ------------------------------------------------------------------------
     //  Static utility classes
     // ------------------------------------------------------------------------
+
+    private static final class JobMasterHeartbeatTarget implements HeartbeatTarget<Void> {
+        private final JobMasterGateway jobMasterGateway;
+
+        private JobMasterHeartbeatTarget(JobMasterGateway jobMasterGateway) {
+            this.jobMasterGateway = jobMasterGateway;
+        }
+
+        @Override
+        public void receiveHeartbeat(ResourceID resourceID, Void payload) {
+            // the ResourceManager will always send heartbeat requests to the JobManager
+        }
+
+        @Override
+        public void requestHeartbeat(ResourceID resourceID, Void payload) {
+            jobMasterGateway.heartbeatFromResourceManager(resourceID);
+        }
+    }
+
+    private static final class TaskExecutorHeartbeatTarget implements HeartbeatTarget<Void> {
+        private final TaskExecutorGateway taskExecutorGateway;
+
+        private TaskExecutorHeartbeatTarget(TaskExecutorGateway taskExecutorGateway) {
+            this.taskExecutorGateway = taskExecutorGateway;
+        }
+
+        @Override
+        public void receiveHeartbeat(ResourceID resourceID, Void payload) {
+            // the ResourceManager will always send heartbeat requests to the
+            // TaskManager
+        }
+
+        @Override
+        public void requestHeartbeat(ResourceID resourceID, Void payload) {
+            taskExecutorGateway.heartbeatFromResourceManager(resourceID);
+        }
+    }
 
     private class ResourceActionsImpl implements ResourceActions {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -138,20 +138,22 @@ public interface ResourceManagerGateway
     CompletableFuture<Integer> getNumberOfRegisteredTaskManagers();
 
     /**
-     * Sends the heartbeat to resource manager from task manager
+     * Sends the heartbeat to resource manager from task manager.
      *
      * @param heartbeatOrigin unique id of the task manager
      * @param heartbeatPayload payload from the originating TaskManager
+     * @return future which is completed exceptionally if the operation fails
      */
-    void heartbeatFromTaskManager(
+    CompletableFuture<Void> heartbeatFromTaskManager(
             final ResourceID heartbeatOrigin, final TaskExecutorHeartbeatPayload heartbeatPayload);
 
     /**
-     * Sends the heartbeat to resource manager from job manager
+     * Sends the heartbeat to resource manager from job manager.
      *
      * @param heartbeatOrigin unique id of the job manager
+     * @return future which is completed exceptionally if the operation fails
      */
-    void heartbeatFromJobManager(final ResourceID heartbeatOrigin);
+    CompletableFuture<Void> heartbeatFromJobManager(final ResourceID heartbeatOrigin);
 
     /**
      * Disconnects a TaskManager specified by the given resourceID from the {@link ResourceManager}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -176,16 +176,18 @@ public interface TaskExecutorGateway
      * Heartbeat request from the job manager.
      *
      * @param heartbeatOrigin unique id of the job manager
+     * @return future which is completed exceptionally if the operation fails
      */
-    void heartbeatFromJobManager(
+    CompletableFuture<Void> heartbeatFromJobManager(
             ResourceID heartbeatOrigin, AllocatedSlotReport allocatedSlotReport);
 
     /**
      * Heartbeat request from the resource manager.
      *
      * @param heartbeatOrigin unique id of the resource manager
+     * @return future which is completed exceptionally if the operation fails
      */
-    void heartbeatFromResourceManager(ResourceID heartbeatOrigin);
+    CompletableFuture<Void> heartbeatFromResourceManager(ResourceID heartbeatOrigin);
 
     /**
      * Disconnects the given JobManager from the TaskManager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -150,14 +150,14 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
     }
 
     @Override
-    public void heartbeatFromJobManager(
+    public CompletableFuture<Void> heartbeatFromJobManager(
             ResourceID heartbeatOrigin, AllocatedSlotReport allocatedSlotReport) {
-        originalGateway.heartbeatFromJobManager(heartbeatOrigin, allocatedSlotReport);
+        return originalGateway.heartbeatFromJobManager(heartbeatOrigin, allocatedSlotReport);
     }
 
     @Override
-    public void heartbeatFromResourceManager(ResourceID heartbeatOrigin) {
-        originalGateway.heartbeatFromResourceManager(heartbeatOrigin);
+    public CompletableFuture<Void> heartbeatFromResourceManager(ResourceID heartbeatOrigin) {
+        return originalGateway.heartbeatFromResourceManager(heartbeatOrigin);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -645,7 +645,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
 
             // we have one task scheduled that will cancel after timeout
-            assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             long checkpointId =
                     checkpointCoordinator
@@ -703,7 +703,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             assertTrue(checkpoint.isDisposed());
 
             // the canceler is also removed
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             // validate that we have no new pending checkpoint
             assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
@@ -759,7 +759,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             // trigger the first checkpoint. this should succeed
             final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
@@ -776,7 +776,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             // validate that we have a pending checkpoint
             assertEquals(2, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(2, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(2, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             Iterator<Map.Entry<Long, PendingCheckpoint>> it =
                     checkpointCoordinator.getPendingCheckpoints().entrySet().iterator();
@@ -836,7 +836,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             // validate that we have only one pending checkpoint left
             assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             // validate that it is the same second checkpoint from earlier
             long checkpointIdNew =
@@ -919,7 +919,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             // trigger the first checkpoint. this should succeed
             final CompletableFuture<CompletedCheckpoint> checkpointFuture =
@@ -930,7 +930,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             // validate that we have a pending checkpoint
             assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(1, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             long checkpointId =
                     checkpointCoordinator
@@ -1014,7 +1014,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
             assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
             // the canceler should be removed now
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             // validate that the subtasks states have registered their shared states.
             {
@@ -1060,7 +1060,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
             assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
             assertEquals(1, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-            assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+            assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
             CompletedCheckpoint successNew =
                     checkpointCoordinator.getSuccessfulCheckpoints().get(0);
@@ -2142,7 +2142,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
                     TASK_MANAGER_LOCATION_INFO);
 
             final Collection<ScheduledFuture<?>> periodicScheduledTasks =
-                    manuallyTriggeredScheduledExecutor.getPeriodicScheduledTask();
+                    manuallyTriggeredScheduledExecutor.getActivePeriodicScheduledTask();
             assertEquals(1, periodicScheduledTasks.size());
 
             manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
@@ -3171,7 +3171,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         // Verify initial state.
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
         assertEquals(0, checkpointCoordinator.getNumberOfRetainedSuccessfulCheckpoints());
-        assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
         // trigger the first checkpoint. this should succeed
         final CompletableFuture<CompletedCheckpoint> checkpointFuture =
@@ -3184,7 +3184,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
         assertEquals(0, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
         // the canceler should be removed now
-        assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+        assertEquals(0, manuallyTriggeredScheduledExecutor.getActiveScheduledTasks().size());
 
         // validate that the relevant tasks got a confirmation message
         long checkpointId = checkpointIdRef.get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -338,7 +338,8 @@ public class FutureUtilsTest extends TestLogger {
 
         assertFalse(retryFuture.isDone());
 
-        final Collection<ScheduledFuture<?>> scheduledTasks = scheduledExecutor.getScheduledTasks();
+        final Collection<ScheduledFuture<?>> scheduledTasks =
+                scheduledExecutor.getActiveScheduledTasks();
 
         assertFalse(scheduledTasks.isEmpty());
 
@@ -381,7 +382,7 @@ public class FutureUtilsTest extends TestLogger {
                         noOpRunnable, TestingUtils.infiniteTime(), scheduledExecutor);
 
         final ScheduledFuture<?> scheduledFuture =
-                scheduledExecutor.getScheduledTasks().iterator().next();
+                scheduledExecutor.getActiveScheduledTasks().iterator().next();
 
         completableFuture.cancel(false);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.concurrent.ScheduledExecutor;
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
@@ -83,16 +84,20 @@ public class ManuallyTriggeredScheduledExecutor implements ScheduledExecutor {
         return execService.scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }
 
-    public Collection<ScheduledFuture<?>> getScheduledTasks() {
-        return execService.getScheduledTasks();
+    public Collection<ScheduledFuture<?>> getActiveScheduledTasks() {
+        return execService.getActiveScheduledTasks();
     }
 
-    public Collection<ScheduledFuture<?>> getPeriodicScheduledTask() {
-        return execService.getPeriodicScheduledTask();
+    public Collection<ScheduledFuture<?>> getActivePeriodicScheduledTask() {
+        return execService.getActivePeriodicScheduledTask();
     }
 
-    public Collection<ScheduledFuture<?>> getNonPeriodicScheduledTask() {
-        return execService.getNonPeriodicScheduledTask();
+    public Collection<ScheduledFuture<?>> getActiveNonPeriodicScheduledTask() {
+        return execService.getActiveNonPeriodicScheduledTask();
+    }
+
+    public List<ScheduledFuture<?>> getAllScheduledTasks() {
+        return execService.getAllScheduledTasks();
     }
 
     /** Triggers all registered tasks. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListener.java
@@ -32,18 +32,27 @@ final class TestingHeartbeatListener<I, O> implements HeartbeatListener<I, O> {
 
     private final Function<ResourceID, O> retrievePayloadFunction;
 
+    private final Consumer<ResourceID> notifyTargetUnreachableConsumer;
+
     TestingHeartbeatListener(
             Consumer<ResourceID> notifyHeartbeatTimeoutConsumer,
             BiConsumer<ResourceID, I> reportPayloadConsumer,
-            Function<ResourceID, O> retrievePayloadFunction) {
+            Function<ResourceID, O> retrievePayloadFunction,
+            Consumer<ResourceID> notifyTargetUnreachableConsumer) {
         this.notifyHeartbeatTimeoutConsumer = notifyHeartbeatTimeoutConsumer;
         this.reportPayloadConsumer = reportPayloadConsumer;
         this.retrievePayloadFunction = retrievePayloadFunction;
+        this.notifyTargetUnreachableConsumer = notifyTargetUnreachableConsumer;
     }
 
     @Override
     public void notifyHeartbeatTimeout(ResourceID resourceID) {
         notifyHeartbeatTimeoutConsumer.accept(resourceID);
+    }
+
+    @Override
+    public void notifyTargetUnreachable(ResourceID resourceID) {
+        notifyTargetUnreachableConsumer.accept(resourceID);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListenerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatListenerBuilder.java
@@ -28,6 +28,7 @@ class TestingHeartbeatListenerBuilder<I, O> {
     private Consumer<ResourceID> notifyHeartbeatTimeoutConsumer = ignored -> {};
     private BiConsumer<ResourceID, I> reportPayloadConsumer = (ignoredA, ignoredB) -> {};
     private Function<ResourceID, O> retrievePayloadFunction = ignored -> null;
+    private Consumer<ResourceID> notifyTargetUnreachableConsumer = ignored -> {};
 
     public TestingHeartbeatListenerBuilder<I, O> setNotifyHeartbeatTimeoutConsumer(
             Consumer<ResourceID> notifyHeartbeatTimeoutConsumer) {
@@ -47,8 +48,17 @@ class TestingHeartbeatListenerBuilder<I, O> {
         return this;
     }
 
+    public TestingHeartbeatListenerBuilder<I, O> setNotifyTargetUnreachableConsumer(
+            Consumer<ResourceID> notifyTargetUnreachableConsumer) {
+        this.notifyTargetUnreachableConsumer = notifyTargetUnreachableConsumer;
+        return this;
+    }
+
     public TestingHeartbeatListener<I, O> createNewTestingHeartbeatListener() {
         return new TestingHeartbeatListener<>(
-                notifyHeartbeatTimeoutConsumer, reportPayloadConsumer, retrievePayloadFunction);
+                notifyHeartbeatTimeoutConsumer,
+                reportPayloadConsumer,
+                retrievePayloadFunction,
+                notifyTargetUnreachableConsumer);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
@@ -68,6 +68,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
         HeartbeatManagerImpl<I, O> heartbeatManager =
                 new HeartbeatManagerImpl<>(
                         heartbeatTimeout,
+                        failedRpcRequestsUntilUnreachable,
                         resourceId,
                         heartbeatListener,
                         mainThreadExecutor,
@@ -103,6 +104,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
                 new HeartbeatManagerSenderImpl<>(
                         heartbeatInterval,
                         heartbeatTimeout,
+                        failedRpcRequestsUntilUnreachable,
                         resourceId,
                         heartbeatListener,
                         mainThreadExecutor,
@@ -179,14 +181,16 @@ public class TestingHeartbeatServices extends HeartbeatServices {
                 HeartbeatTarget<O> heartbeatTarget,
                 ScheduledExecutor mainThreadExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs) {
+                long heartbeatTimeoutIntervalMs,
+                int failedRpcRequestsUntilUnreachable) {
 
             return new TestingHeartbeatMonitor<>(
                     resourceID,
                     heartbeatTarget,
                     mainThreadExecutor,
                     heartbeatListener,
-                    heartbeatTimeoutIntervalMs);
+                    heartbeatTimeoutIntervalMs,
+                    failedRpcRequestsUntilUnreachable);
         }
     }
 
@@ -204,14 +208,16 @@ public class TestingHeartbeatServices extends HeartbeatServices {
                 HeartbeatTarget<O> heartbeatTarget,
                 ScheduledExecutor scheduledExecutor,
                 HeartbeatListener<?, O> heartbeatListener,
-                long heartbeatTimeoutIntervalMs) {
+                long heartbeatTimeoutIntervalMs,
+                int failedRpcRequestsUntilUnreachable) {
 
             super(
                     resourceID,
                     heartbeatTarget,
                     scheduledExecutor,
                     heartbeatListener,
-                    heartbeatTimeoutIntervalMs);
+                    heartbeatTimeoutIntervalMs,
+                    failedRpcRequestsUntilUnreachable);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTarget.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTarget.java
@@ -20,27 +20,29 @@ package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 
-import java.util.function.BiConsumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 
 class TestingHeartbeatTarget<T> implements HeartbeatTarget<T> {
-    private final BiConsumer<ResourceID, T> receiveHeartbeatConsumer;
+    private final BiFunction<ResourceID, T, CompletableFuture<Void>> receiveHeartbeatFunction;
 
-    private final BiConsumer<ResourceID, T> requestHeartbeatConsumer;
+    private final BiFunction<ResourceID, T, CompletableFuture<Void>> requestHeartbeatFunction;
 
     TestingHeartbeatTarget(
-            BiConsumer<ResourceID, T> receiveHeartbeatConsumer,
-            BiConsumer<ResourceID, T> requestHeartbeatConsumer) {
-        this.receiveHeartbeatConsumer = receiveHeartbeatConsumer;
-        this.requestHeartbeatConsumer = requestHeartbeatConsumer;
+            BiFunction<ResourceID, T, CompletableFuture<Void>> receiveHeartbeatFunction,
+            BiFunction<ResourceID, T, CompletableFuture<Void>> requestHeartbeatFunction) {
+        this.receiveHeartbeatFunction = receiveHeartbeatFunction;
+        this.requestHeartbeatFunction = requestHeartbeatFunction;
     }
 
     @Override
-    public void receiveHeartbeat(ResourceID heartbeatOrigin, T heartbeatPayload) {
-        receiveHeartbeatConsumer.accept(heartbeatOrigin, heartbeatPayload);
+    public CompletableFuture<Void> receiveHeartbeat(
+            ResourceID heartbeatOrigin, T heartbeatPayload) {
+        return receiveHeartbeatFunction.apply(heartbeatOrigin, heartbeatPayload);
     }
 
     @Override
-    public void requestHeartbeat(ResourceID requestOrigin, T heartbeatPayload) {
-        requestHeartbeatConsumer.accept(requestOrigin, heartbeatPayload);
+    public CompletableFuture<Void> requestHeartbeat(ResourceID requestOrigin, T heartbeatPayload) {
+        return requestHeartbeatFunction.apply(requestOrigin, heartbeatPayload);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTargetBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatTargetBuilder.java
@@ -19,26 +19,30 @@
 package org.apache.flink.runtime.heartbeat;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.concurrent.FutureUtils;
 
-import java.util.function.BiConsumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 
 class TestingHeartbeatTargetBuilder<T> {
-    private BiConsumer<ResourceID, T> receiveHeartbeatConsumer = (ignoredA, ignoredB) -> {};
-    private BiConsumer<ResourceID, T> requestHeartbeatConsumer = (ignoredA, ignoredB) -> {};
+    private BiFunction<ResourceID, T, CompletableFuture<Void>> receiveHeartbeatFunction =
+            (ignoredA, ignoredB) -> FutureUtils.completedVoidFuture();
+    private BiFunction<ResourceID, T, CompletableFuture<Void>> requestHeartbeatFunction =
+            (ignoredA, ignoredB) -> FutureUtils.completedVoidFuture();
 
-    public TestingHeartbeatTargetBuilder<T> setReceiveHeartbeatConsumer(
-            BiConsumer<ResourceID, T> receiveHeartbeatConsumer) {
-        this.receiveHeartbeatConsumer = receiveHeartbeatConsumer;
+    public TestingHeartbeatTargetBuilder<T> setReceiveHeartbeatFunction(
+            BiFunction<ResourceID, T, CompletableFuture<Void>> receiveHeartbeatFunction) {
+        this.receiveHeartbeatFunction = receiveHeartbeatFunction;
         return this;
     }
 
-    public TestingHeartbeatTargetBuilder<T> setRequestHeartbeatConsumer(
-            BiConsumer<ResourceID, T> requestHeartbeatConsumer) {
-        this.requestHeartbeatConsumer = requestHeartbeatConsumer;
+    public TestingHeartbeatTargetBuilder<T> setRequestHeartbeatFunction(
+            BiFunction<ResourceID, T, CompletableFuture<Void>> requestHeartbeatFunction) {
+        this.requestHeartbeatFunction = requestHeartbeatFunction;
         return this;
     }
 
     public TestingHeartbeatTarget<T> createTestingHeartbeatTarget() {
-        return new TestingHeartbeatTarget<>(receiveHeartbeatConsumer, requestHeartbeatConsumer);
+        return new TestingHeartbeatTarget<>(receiveHeartbeatFunction, requestHeartbeatFunction);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolServiceBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolServiceBuilder.java
@@ -84,6 +84,12 @@ public class TestingSlotPoolServiceBuilder implements SlotPoolServiceFactory {
                 createAllocatedSlotReportFunction);
     }
 
+    public TestingSlotPoolServiceBuilder setConnectToResourceManagerConsumer(
+            Consumer<? super ResourceManagerGateway> connectToResourceManagerConsumer) {
+        this.connectToResourceManagerConsumer = connectToResourceManagerConsumer;
+        return this;
+    }
+
     public static TestingSlotPoolServiceBuilder newBuilder() {
         return new TestingSlotPoolServiceBuilder();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -119,10 +119,12 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             registerTaskManagerFunction;
 
     @Nonnull
-    private final BiConsumer<ResourceID, TaskExecutorToJobManagerHeartbeatPayload>
-            taskManagerHeartbeatConsumer;
+    private final BiFunction<
+                    ResourceID, TaskExecutorToJobManagerHeartbeatPayload, CompletableFuture<Void>>
+            taskManagerHeartbeatFunction;
 
-    @Nonnull private final Consumer<ResourceID> resourceManagerHeartbeatConsumer;
+    @Nonnull
+    private final Function<ResourceID, CompletableFuture<Void>> resourceManagerHeartbeatFunction;
 
     @Nonnull private final Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier;
 
@@ -221,9 +223,12 @@ public class TestingJobMasterGateway implements JobMasterGateway {
                                     CompletableFuture<RegistrationResponse>>
                             registerTaskManagerFunction,
             @Nonnull
-                    BiConsumer<ResourceID, TaskExecutorToJobManagerHeartbeatPayload>
-                            taskManagerHeartbeatConsumer,
-            @Nonnull Consumer<ResourceID> resourceManagerHeartbeatConsumer,
+                    BiFunction<
+                                    ResourceID,
+                                    TaskExecutorToJobManagerHeartbeatPayload,
+                                    CompletableFuture<Void>>
+                            taskManagerHeartbeatFunction,
+            @Nonnull Function<ResourceID, CompletableFuture<Void>> resourceManagerHeartbeatFunction,
             @Nonnull Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier,
             @Nonnull Supplier<CompletableFuture<ExecutionGraphInfo>> requestJobSupplier,
             @Nonnull
@@ -291,8 +296,8 @@ public class TestingJobMasterGateway implements JobMasterGateway {
         this.offerSlotsFunction = offerSlotsFunction;
         this.failSlotConsumer = failSlotConsumer;
         this.registerTaskManagerFunction = registerTaskManagerFunction;
-        this.taskManagerHeartbeatConsumer = taskManagerHeartbeatConsumer;
-        this.resourceManagerHeartbeatConsumer = resourceManagerHeartbeatConsumer;
+        this.taskManagerHeartbeatFunction = taskManagerHeartbeatFunction;
+        this.resourceManagerHeartbeatFunction = resourceManagerHeartbeatFunction;
         this.requestJobDetailsSupplier = requestJobDetailsSupplier;
         this.requestJobSupplier = requestJobSupplier;
         this.triggerSavepointFunction = triggerSavepointFunction;
@@ -372,14 +377,14 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     }
 
     @Override
-    public void heartbeatFromTaskManager(
+    public CompletableFuture<Void> heartbeatFromTaskManager(
             ResourceID resourceID, TaskExecutorToJobManagerHeartbeatPayload payload) {
-        taskManagerHeartbeatConsumer.accept(resourceID, payload);
+        return taskManagerHeartbeatFunction.apply(resourceID, payload);
     }
 
     @Override
-    public void heartbeatFromResourceManager(ResourceID resourceID) {
-        resourceManagerHeartbeatConsumer.accept(resourceID);
+    public CompletableFuture<Void> heartbeatFromResourceManager(ResourceID resourceID) {
+        return resourceManagerHeartbeatFunction.apply(resourceID);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -110,9 +110,12 @@ public class TestingJobMasterGatewayBuilder {
                     (ignoredA, ignoredB, ignoredC) ->
                             CompletableFuture.completedFuture(
                                     new JMTMRegistrationSuccess(RESOURCE_MANAGER_ID));
-    private BiConsumer<ResourceID, TaskExecutorToJobManagerHeartbeatPayload>
-            taskManagerHeartbeatConsumer = (ignoredA, ignoredB) -> {};
-    private Consumer<ResourceID> resourceManagerHeartbeatConsumer = ignored -> {};
+    private BiFunction<
+                    ResourceID, TaskExecutorToJobManagerHeartbeatPayload, CompletableFuture<Void>>
+            taskManagerHeartbeatFunction =
+                    (ignoredA, ignoredB) -> FutureUtils.completedVoidFuture();
+    private Function<ResourceID, CompletableFuture<Void>> resourceManagerHeartbeatFunction =
+            ignored -> FutureUtils.completedVoidFuture();
     private Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier =
             () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
     private Supplier<CompletableFuture<ExecutionGraphInfo>> requestJobSupplier =
@@ -248,16 +251,19 @@ public class TestingJobMasterGatewayBuilder {
         return this;
     }
 
-    public TestingJobMasterGatewayBuilder setTaskManagerHeartbeatConsumer(
-            BiConsumer<ResourceID, TaskExecutorToJobManagerHeartbeatPayload>
-                    taskManagerHeartbeatConsumer) {
-        this.taskManagerHeartbeatConsumer = taskManagerHeartbeatConsumer;
+    public TestingJobMasterGatewayBuilder setTaskManagerHeartbeatFunction(
+            BiFunction<
+                            ResourceID,
+                            TaskExecutorToJobManagerHeartbeatPayload,
+                            CompletableFuture<Void>>
+                    taskManagerHeartbeatFunction) {
+        this.taskManagerHeartbeatFunction = taskManagerHeartbeatFunction;
         return this;
     }
 
-    public TestingJobMasterGatewayBuilder setResourceManagerHeartbeatConsumer(
-            Consumer<ResourceID> resourceManagerHeartbeatConsumer) {
-        this.resourceManagerHeartbeatConsumer = resourceManagerHeartbeatConsumer;
+    public TestingJobMasterGatewayBuilder setResourceManagerHeartbeatFunction(
+            Function<ResourceID, CompletableFuture<Void>> resourceManagerHeartbeatFunction) {
+        this.resourceManagerHeartbeatFunction = resourceManagerHeartbeatFunction;
         return this;
     }
 
@@ -389,8 +395,8 @@ public class TestingJobMasterGatewayBuilder {
                 offerSlotsFunction,
                 failSlotConsumer,
                 registerTaskManagerFunction,
-                taskManagerHeartbeatConsumer,
-                resourceManagerHeartbeatConsumer,
+                taskManagerHeartbeatFunction,
+                resourceManagerHeartbeatFunction,
                 requestJobDetailsSupplier,
                 requestJobSupplier,
                 triggerSavepointFunction,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -193,7 +193,7 @@ public class MetricRegistryImplTest extends TestLogger {
                         manuallyTriggeredScheduledExecutorService);
         try {
             Collection<ScheduledFuture<?>> scheduledTasks =
-                    manuallyTriggeredScheduledExecutorService.getScheduledTasks();
+                    manuallyTriggeredScheduledExecutorService.getActiveScheduledTasks();
             ScheduledFuture<?> reportTask = Iterators.getOnlyElement(scheduledTasks.iterator());
             Assert.assertEquals(
                     MetricOptions.REPORTER_INTERVAL.defaultValue().getSeconds(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -87,6 +87,9 @@ public class ResourceManagerTest extends TestLogger {
 
     private static final HeartbeatServices fastHeartbeatServices = new HeartbeatServices(1L, 1L);
 
+    private static final HeartbeatServices failedRpcEnabledHeartbeatServices =
+            new HeartbeatServices(1L, 10000000L, 1);
+
     private static final HardwareDescription hardwareDescription =
             new HardwareDescription(42, 1337L, 1337L, 0L);
 
@@ -525,7 +528,7 @@ public class ResourceManagerTest extends TestLogger {
             ThrowingConsumer<ResourceManagerGateway, Exception> registerComponentAtResourceManager,
             ThrowingConsumer<ResourceID, Exception> verifyHeartbeatTimeout)
             throws Exception {
-        resourceManager = createAndStartResourceManager(new HeartbeatServices(5L, 10000L));
+        resourceManager = createAndStartResourceManager(failedRpcEnabledHeartbeatServices);
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -35,12 +35,14 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.DeclarativeSlotManagerBuilder;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.TestingSlotManagerBuilder;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -51,6 +53,7 @@ import org.apache.flink.runtime.testutils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.After;
@@ -288,7 +291,11 @@ public class ResourceManagerTest extends TestLogger {
         final CompletableFuture<ResourceManagerId> disconnectFuture = new CompletableFuture<>();
         final TestingJobMasterGateway jobMasterGateway =
                 new TestingJobMasterGatewayBuilder()
-                        .setResourceManagerHeartbeatConsumer(heartbeatRequestFuture::complete)
+                        .setResourceManagerHeartbeatFunction(
+                                resourceId -> {
+                                    heartbeatRequestFuture.complete(resourceId);
+                                    return FutureUtils.completedVoidFuture();
+                                })
                         .setDisconnectResourceManagerConsumer(disconnectFuture::complete)
                         .build();
         rpcService.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
@@ -331,6 +338,53 @@ public class ResourceManagerTest extends TestLogger {
     }
 
     @Test
+    public void testJobMasterBecomesUnreachableTriggersDisconnect() throws Exception {
+        final JobID jobId = new JobID();
+        final ResourceID jobMasterResourceId = ResourceID.generate();
+        final CompletableFuture<ResourceManagerId> disconnectFuture = new CompletableFuture<>();
+        final TestingJobMasterGateway jobMasterGateway =
+                new TestingJobMasterGatewayBuilder()
+                        .setAddress(UUID.randomUUID().toString())
+                        .setResourceManagerHeartbeatFunction(
+                                resourceId ->
+                                        FutureUtils.completedExceptionally(
+                                                new RecipientUnreachableException(
+                                                        "sender",
+                                                        "recipient",
+                                                        "task executor is unreachable")))
+                        .setDisconnectResourceManagerConsumer(disconnectFuture::complete)
+                        .build();
+        rpcService.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
+
+        final LeaderRetrievalService jobMasterLeaderRetrievalService =
+                new SettableLeaderRetrievalService(
+                        jobMasterGateway.getAddress(), jobMasterGateway.getFencingToken().toUUID());
+
+        highAvailabilityServices.setJobMasterLeaderRetrieverFunction(
+                requestedJobId -> {
+                    assertThat(requestedJobId, is(equalTo(jobId)));
+                    return jobMasterLeaderRetrievalService;
+                });
+
+        runHeartbeatTargetBecomesUnreachableTest(
+                resourceManagerGateway -> {
+                    final CompletableFuture<RegistrationResponse> registrationFuture =
+                            resourceManagerGateway.registerJobManager(
+                                    jobMasterGateway.getFencingToken(),
+                                    jobMasterResourceId,
+                                    jobMasterGateway.getAddress(),
+                                    jobId,
+                                    TIMEOUT);
+
+                    assertThat(
+                            registrationFuture.get(),
+                            instanceOf(RegistrationResponse.Success.class));
+                },
+                resourceManagerResourceId ->
+                        assertThat(disconnectFuture.get(), is(equalTo(resourceManagerId))));
+    }
+
+    @Test
     public void testHeartbeatTimeoutWithTaskExecutor() throws Exception {
         final ResourceID taskExecutorId = ResourceID.generate();
         final CompletableFuture<ResourceID> heartbeatRequestFuture = new CompletableFuture<>();
@@ -338,7 +392,11 @@ public class ResourceManagerTest extends TestLogger {
         final TaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder()
                         .setDisconnectResourceManagerConsumer(disconnectFuture::complete)
-                        .setHeartbeatResourceManagerConsumer(heartbeatRequestFuture::complete)
+                        .setHeartbeatResourceManagerFunction(
+                                resourceId -> {
+                                    heartbeatRequestFuture.complete(resourceId);
+                                    return FutureUtils.completedVoidFuture();
+                                })
                         .createTestingTaskExecutorGateway();
         rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
@@ -359,6 +417,36 @@ public class ResourceManagerTest extends TestLogger {
                             anyOf(is(resourceManagerResourceId), is(nullValue())));
                     assertThat(disconnectFuture.get(), instanceOf(TimeoutException.class));
                 });
+    }
+
+    @Test
+    public void testTaskExecutorBecomesUnreachableTriggersDisconnect() throws Exception {
+        final ResourceID taskExecutorId = ResourceID.generate();
+        final CompletableFuture<Exception> disconnectFuture = new CompletableFuture<>();
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setAddress(UUID.randomUUID().toString())
+                        .setDisconnectResourceManagerConsumer(disconnectFuture::complete)
+                        .setHeartbeatResourceManagerFunction(
+                                resourceId ->
+                                        FutureUtils.completedExceptionally(
+                                                new RecipientUnreachableException(
+                                                        "sender",
+                                                        "recipient",
+                                                        "task executor is unreachable")))
+                        .createTestingTaskExecutorGateway();
+        rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
+
+        runHeartbeatTargetBecomesUnreachableTest(
+                resourceManagerGateway ->
+                        registerTaskExecutor(
+                                resourceManagerGateway,
+                                taskExecutorId,
+                                taskExecutorGateway.getAddress()),
+                resourceManagerResourceId ->
+                        assertThat(
+                                disconnectFuture.get(),
+                                instanceOf(ResourceManagerException.class)));
     }
 
     @Test
@@ -426,6 +514,18 @@ public class ResourceManagerTest extends TestLogger {
             ThrowingConsumer<ResourceID, Exception> verifyHeartbeatTimeout)
             throws Exception {
         resourceManager = createAndStartResourceManager(fastHeartbeatServices);
+        final ResourceManagerGateway resourceManagerGateway =
+                resourceManager.getSelfGateway(ResourceManagerGateway.class);
+
+        registerComponentAtResourceManager.accept(resourceManagerGateway);
+        verifyHeartbeatTimeout.accept(resourceManagerResourceId);
+    }
+
+    private void runHeartbeatTargetBecomesUnreachableTest(
+            ThrowingConsumer<ResourceManagerGateway, Exception> registerComponentAtResourceManager,
+            ThrowingConsumer<ResourceID, Exception> verifyHeartbeatTimeout)
+            throws Exception {
+        resourceManager = createAndStartResourceManager(new HeartbeatServices(5L, 10000L));
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -61,7 +61,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -98,8 +97,8 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
                     Tuple3<ResourceID, InstanceID, SlotReport>, CompletableFuture<Acknowledge>>
             sendSlotReportFunction;
 
-    private volatile BiConsumer<ResourceID, TaskExecutorHeartbeatPayload>
-            taskExecutorHeartbeatConsumer;
+    private volatile BiFunction<ResourceID, TaskExecutorHeartbeatPayload, CompletableFuture<Void>>
+            taskExecutorHeartbeatFunction;
 
     private volatile Consumer<Tuple3<InstanceID, SlotID, AllocationID>> notifySlotAvailableConsumer;
 
@@ -119,6 +118,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
             declareRequiredResourcesFunction =
                     (ignoredA, ignoredB) ->
                             FutureUtils.completedExceptionally(new UnsupportedOperationException());
+    private volatile Function<ResourceID, CompletableFuture<Void>> jobMasterHeartbeatFunction;
 
     public TestingResourceManagerGateway() {
         this(
@@ -208,9 +208,15 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
         this.sendSlotReportFunction = sendSlotReportFunction;
     }
 
-    public void setTaskExecutorHeartbeatConsumer(
-            BiConsumer<ResourceID, TaskExecutorHeartbeatPayload> taskExecutorHeartbeatConsumer) {
-        this.taskExecutorHeartbeatConsumer = taskExecutorHeartbeatConsumer;
+    public void setTaskExecutorHeartbeatFunction(
+            BiFunction<ResourceID, TaskExecutorHeartbeatPayload, CompletableFuture<Void>>
+                    taskExecutorHeartbeatFunction) {
+        this.taskExecutorHeartbeatFunction = taskExecutorHeartbeatFunction;
+    }
+
+    public void setJobMasterHeartbeatFunction(
+            Function<ResourceID, CompletableFuture<Void>> jobMasterHeartbeatFunction) {
+        this.jobMasterHeartbeatFunction = jobMasterHeartbeatFunction;
     }
 
     public void setNotifySlotAvailableConsumer(
@@ -319,18 +325,29 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     }
 
     @Override
-    public void heartbeatFromTaskManager(
+    public CompletableFuture<Void> heartbeatFromTaskManager(
             ResourceID heartbeatOrigin, TaskExecutorHeartbeatPayload heartbeatPayload) {
-        final BiConsumer<ResourceID, TaskExecutorHeartbeatPayload>
-                currentTaskExecutorHeartbeatConsumer = taskExecutorHeartbeatConsumer;
+        final BiFunction<ResourceID, TaskExecutorHeartbeatPayload, CompletableFuture<Void>>
+                currentTaskExecutorHeartbeatConsumer = taskExecutorHeartbeatFunction;
 
         if (currentTaskExecutorHeartbeatConsumer != null) {
-            currentTaskExecutorHeartbeatConsumer.accept(heartbeatOrigin, heartbeatPayload);
+            return currentTaskExecutorHeartbeatConsumer.apply(heartbeatOrigin, heartbeatPayload);
+        } else {
+            return FutureUtils.completedVoidFuture();
         }
     }
 
     @Override
-    public void heartbeatFromJobManager(ResourceID heartbeatOrigin) {}
+    public CompletableFuture<Void> heartbeatFromJobManager(ResourceID heartbeatOrigin) {
+        final Function<ResourceID, CompletableFuture<Void>> currentJobMasterHeartbeatFunction =
+                jobMasterHeartbeatFunction;
+
+        if (currentJobMasterHeartbeatFunction != null) {
+            return currentJobMasterHeartbeatFunction.apply(heartbeatOrigin);
+        } else {
+            return FutureUtils.completedVoidFuture();
+        }
+    }
 
     @Override
     public void disconnectTaskManager(ResourceID resourceID, Exception cause) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -401,7 +401,7 @@ public class AdaptiveSchedulerTest extends TestLogger {
         // With this approach we don't have to make assumption as to how many
         // tasks are being scheduled.
         final boolean b =
-                mainThreadExecutor.getNonPeriodicScheduledTask().stream()
+                mainThreadExecutor.getActiveNonPeriodicScheduledTask().stream()
                         .anyMatch(
                                 scheduledTask ->
                                         scheduledTask.getDelay(TimeUnit.MINUTES)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/RecordingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/RecordingHeartbeatServices.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.heartbeat.HeartbeatListener;
+import org.apache.flink.runtime.heartbeat.HeartbeatManager;
+import org.apache.flink.runtime.heartbeat.HeartbeatManagerImpl;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.heartbeat.HeartbeatTarget;
+import org.apache.flink.util.concurrent.ScheduledExecutor;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/** Special {@link HeartbeatServices} which creates a {@link RecordingHeartbeatManagerImpl}. */
+final class RecordingHeartbeatServices extends HeartbeatServices {
+
+    private final BlockingQueue<ResourceID> unmonitoredTargets;
+
+    private final BlockingQueue<ResourceID> monitoredTargets;
+
+    public RecordingHeartbeatServices(long heartbeatInterval, long heartbeatTimeout) {
+        super(heartbeatInterval, heartbeatTimeout);
+
+        this.unmonitoredTargets = new ArrayBlockingQueue<>(1);
+        this.monitoredTargets = new ArrayBlockingQueue<>(1);
+    }
+
+    @Override
+    public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
+            ResourceID resourceId,
+            HeartbeatListener<I, O> heartbeatListener,
+            ScheduledExecutor mainThreadExecutor,
+            Logger log) {
+        return new RecordingHeartbeatManagerImpl<>(
+                heartbeatTimeout,
+                resourceId,
+                heartbeatListener,
+                mainThreadExecutor,
+                log,
+                unmonitoredTargets,
+                monitoredTargets);
+    }
+
+    public BlockingQueue<ResourceID> getUnmonitoredTargets() {
+        return unmonitoredTargets;
+    }
+
+    public BlockingQueue<ResourceID> getMonitoredTargets() {
+        return monitoredTargets;
+    }
+
+    /** {@link HeartbeatManagerImpl} which records the unmonitored targets. */
+    private static final class RecordingHeartbeatManagerImpl<I, O>
+            extends HeartbeatManagerImpl<I, O> {
+
+        private final BlockingQueue<ResourceID> unmonitoredTargets;
+
+        private final BlockingQueue<ResourceID> monitoredTargets;
+
+        public RecordingHeartbeatManagerImpl(
+                long heartbeatTimeoutIntervalMs,
+                ResourceID ownResourceID,
+                HeartbeatListener<I, O> heartbeatListener,
+                ScheduledExecutor mainThreadExecutor,
+                Logger log,
+                BlockingQueue<ResourceID> unmonitoredTargets,
+                BlockingQueue<ResourceID> monitoredTargets) {
+            super(
+                    heartbeatTimeoutIntervalMs,
+                    ownResourceID,
+                    heartbeatListener,
+                    mainThreadExecutor,
+                    log);
+            this.unmonitoredTargets = unmonitoredTargets;
+            this.monitoredTargets = monitoredTargets;
+        }
+
+        @Override
+        public void unmonitorTarget(ResourceID resourceID) {
+            super.unmonitorTarget(resourceID);
+            unmonitoredTargets.offer(resourceID);
+        }
+
+        @Override
+        public void monitorTarget(ResourceID resourceID, HeartbeatTarget<O> heartbeatTarget) {
+            super.monitorTarget(resourceID, heartbeatTarget);
+            monitoredTargets.offer(resourceID);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/RecordingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/RecordingHeartbeatServices.java
@@ -53,6 +53,7 @@ final class RecordingHeartbeatServices extends HeartbeatServices {
             Logger log) {
         return new RecordingHeartbeatManagerImpl<>(
                 heartbeatTimeout,
+                failedRpcRequestsUntilUnreachable,
                 resourceId,
                 heartbeatListener,
                 mainThreadExecutor,
@@ -79,6 +80,7 @@ final class RecordingHeartbeatServices extends HeartbeatServices {
 
         public RecordingHeartbeatManagerImpl(
                 long heartbeatTimeoutIntervalMs,
+                int failedRpcRequestsUntilUnreachable,
                 ResourceID ownResourceID,
                 HeartbeatListener<I, O> heartbeatListener,
                 ScheduledExecutor mainThreadExecutor,
@@ -87,6 +89,7 @@ final class RecordingHeartbeatServices extends HeartbeatServices {
                 BlockingQueue<ResourceID> monitoredTargets) {
             super(
                     heartbeatTimeoutIntervalMs,
+                    failedRpcRequestsUntilUnreachable,
                     ownResourceID,
                     heartbeatListener,
                     mainThreadExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -251,12 +252,13 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
                             slotOfferLatch.trigger();
                             return CompletableFuture.completedFuture(slotOffers);
                         })
-                .setTaskManagerHeartbeatConsumer(
+                .setTaskManagerHeartbeatFunction(
                         (resourceID, taskExecutorToJobManagerHeartbeatPayload) -> {
                             ExecutionDeploymentReport executionDeploymentReport =
                                     taskExecutorToJobManagerHeartbeatPayload
                                             .getExecutionDeploymentReport();
                             deployedExecutionsFuture.add(executionDeploymentReport.getExecutions());
+                            return FutureUtils.completedVoidFuture();
                         })
                 .setUpdateTaskExecutionStateFunction(
                         taskExecutionState -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -184,6 +184,9 @@ public class TaskExecutorTest extends TestLogger {
 
     private static final Time timeout = Time.milliseconds(10000L);
 
+    private static final HeartbeatServices failedRpcEnabledHeartbeatServices =
+            new HeartbeatServices(1L, 10000000L, 1);
+
     private TestingRpcService rpc;
 
     private BlobCacheService dummyBlobCacheService;
@@ -314,7 +317,7 @@ public class TaskExecutorTest extends TestLogger {
         final ResourceID jmResourceId = ResourceID.generate();
         runJobManagerHeartbeatTest(
                 jmResourceId,
-                new HeartbeatServices(1L, 10000L),
+                failedRpcEnabledHeartbeatServices,
                 jobMasterGatewayBuilder ->
                         jobMasterGatewayBuilder.setTaskManagerHeartbeatFunction(
                                 (resourceID, taskExecutorToJobManagerHeartbeatPayload) ->
@@ -471,7 +474,7 @@ public class TaskExecutorTest extends TestLogger {
     @Test
     public void testResourceManagerBecomesUnreachableTriggersDisconnect() throws Exception {
         runResourceManagerHeartbeatTest(
-                new HeartbeatServices(1L, 10000L),
+                failedRpcEnabledHeartbeatServices,
                 (rmGateway) ->
                         rmGateway.setTaskExecutorHeartbeatFunction(
                                 (resourceID, taskExecutorHeartbeatPayload) ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -53,8 +53,9 @@ import java.util.function.Supplier;
 /** Builder for a {@link TestingTaskExecutorGateway}. */
 public class TestingTaskExecutorGatewayBuilder {
 
-    private static final BiConsumer<ResourceID, AllocatedSlotReport>
-            NOOP_HEARTBEAT_JOBMANAGER_CONSUMER = (ignoredA, ignoredB) -> {};
+    private static final BiFunction<ResourceID, AllocatedSlotReport, CompletableFuture<Void>>
+            NOOP_HEARTBEAT_JOBMANAGER_FUNCTION =
+                    (ignoredA, ignoredB) -> FutureUtils.completedVoidFuture();
     private static final BiConsumer<JobID, Throwable> NOOP_DISCONNECT_JOBMANAGER_CONSUMER =
             (ignoredA, ignoredB) -> {};
     private static final BiFunction<
@@ -70,8 +71,8 @@ public class TestingTaskExecutorGatewayBuilder {
             NOOP_FREE_SLOT_FUNCTION =
                     (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
     private static final Consumer<JobID> NOOP_FREE_INACTIVE_SLOTS_CONSUMER = ignored -> {};
-    private static final Consumer<ResourceID> NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER =
-            ignored -> {};
+    private static final Function<ResourceID, CompletableFuture<Void>>
+            NOOP_HEARTBEAT_RESOURCE_MANAGER_FUNCTION = ignored -> FutureUtils.completedVoidFuture();
     private static final Consumer<Exception> NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER =
             ignored -> {};
     private static final Function<ExecutionAttemptID, CompletableFuture<Acknowledge>>
@@ -95,8 +96,8 @@ public class TestingTaskExecutorGatewayBuilder {
 
     private String address = "foobar:1234";
     private String hostname = "foobar";
-    private BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer =
-            NOOP_HEARTBEAT_JOBMANAGER_CONSUMER;
+    private BiFunction<ResourceID, AllocatedSlotReport, CompletableFuture<Void>>
+            heartbeatJobManagerFunction = NOOP_HEARTBEAT_JOBMANAGER_FUNCTION;
     private BiConsumer<JobID, Throwable> disconnectJobManagerConsumer =
             NOOP_DISCONNECT_JOBMANAGER_CONSUMER;
     private BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>>
@@ -108,8 +109,8 @@ public class TestingTaskExecutorGatewayBuilder {
     private BiFunction<AllocationID, Throwable, CompletableFuture<Acknowledge>> freeSlotFunction =
             NOOP_FREE_SLOT_FUNCTION;
     private Consumer<JobID> freeInactiveSlotsConsumer = NOOP_FREE_INACTIVE_SLOTS_CONSUMER;
-    private Consumer<ResourceID> heartbeatResourceManagerConsumer =
-            NOOP_HEARTBEAT_RESOURCE_MANAGER_CONSUMER;
+    private Function<ResourceID, CompletableFuture<Void>> heartbeatResourceManagerFunction =
+            NOOP_HEARTBEAT_RESOURCE_MANAGER_FUNCTION;
     private Consumer<Exception> disconnectResourceManagerConsumer =
             NOOP_DISCONNECT_RESOURCE_MANAGER_CONSUMER;
     private Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction =
@@ -142,9 +143,10 @@ public class TestingTaskExecutorGatewayBuilder {
         return this;
     }
 
-    public TestingTaskExecutorGatewayBuilder setHeartbeatJobManagerConsumer(
-            BiConsumer<ResourceID, AllocatedSlotReport> heartbeatJobManagerConsumer) {
-        this.heartbeatJobManagerConsumer = heartbeatJobManagerConsumer;
+    public TestingTaskExecutorGatewayBuilder setHeartbeatJobManagerFunction(
+            BiFunction<ResourceID, AllocatedSlotReport, CompletableFuture<Void>>
+                    heartbeatJobManagerFunction) {
+        this.heartbeatJobManagerFunction = heartbeatJobManagerFunction;
         return this;
     }
 
@@ -188,9 +190,9 @@ public class TestingTaskExecutorGatewayBuilder {
         return this;
     }
 
-    public TestingTaskExecutorGatewayBuilder setHeartbeatResourceManagerConsumer(
-            Consumer<ResourceID> heartbeatResourceManagerConsumer) {
-        this.heartbeatResourceManagerConsumer = heartbeatResourceManagerConsumer;
+    public TestingTaskExecutorGatewayBuilder setHeartbeatResourceManagerFunction(
+            Function<ResourceID, CompletableFuture<Void>> heartbeatResourceManagerFunction) {
+        this.heartbeatResourceManagerFunction = heartbeatResourceManagerFunction;
         return this;
     }
 
@@ -251,13 +253,13 @@ public class TestingTaskExecutorGatewayBuilder {
         return new TestingTaskExecutorGateway(
                 address,
                 hostname,
-                heartbeatJobManagerConsumer,
+                heartbeatJobManagerFunction,
                 disconnectJobManagerConsumer,
                 submitTaskConsumer,
                 requestSlotFunction,
                 freeSlotFunction,
                 freeInactiveSlotsConsumer,
-                heartbeatResourceManagerConsumer,
+                heartbeatResourceManagerFunction,
                 disconnectResourceManagerConsumer,
                 cancelTaskFunction,
                 canBeReleasedSupplier,

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ManuallyTriggeredScheduledExecutorService.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ManuallyTriggeredScheduledExecutorService.java
@@ -202,24 +202,40 @@ public class ManuallyTriggeredScheduledExecutorService implements ScheduledExecu
         }
     }
 
-    public Collection<ScheduledFuture<?>> getScheduledTasks() {
+    public Collection<ScheduledFuture<?>> getActiveScheduledTasks() {
         final ArrayList<ScheduledFuture<?>> scheduledTasks =
                 new ArrayList<>(nonPeriodicScheduledTasks.size() + periodicScheduledTasks.size());
-        scheduledTasks.addAll(getNonPeriodicScheduledTask());
-        scheduledTasks.addAll(getPeriodicScheduledTask());
+        scheduledTasks.addAll(getActiveNonPeriodicScheduledTask());
+        scheduledTasks.addAll(getActivePeriodicScheduledTask());
         return scheduledTasks;
     }
 
-    public Collection<ScheduledFuture<?>> getPeriodicScheduledTask() {
+    public Collection<ScheduledFuture<?>> getActivePeriodicScheduledTask() {
         return periodicScheduledTasks.stream()
                 .filter(scheduledTask -> !scheduledTask.isCancelled())
                 .collect(Collectors.toList());
     }
 
-    public Collection<ScheduledFuture<?>> getNonPeriodicScheduledTask() {
+    public Collection<ScheduledFuture<?>> getActiveNonPeriodicScheduledTask() {
         return nonPeriodicScheduledTasks.stream()
                 .filter(scheduledTask -> !scheduledTask.isCancelled())
                 .collect(Collectors.toList());
+    }
+
+    public List<ScheduledFuture<?>> getAllScheduledTasks() {
+        final ArrayList<ScheduledFuture<?>> scheduledTasks =
+                new ArrayList<>(nonPeriodicScheduledTasks.size() + periodicScheduledTasks.size());
+        scheduledTasks.addAll(getAllNonPeriodicScheduledTask());
+        scheduledTasks.addAll(getAllPeriodicScheduledTask());
+        return scheduledTasks;
+    }
+
+    public List<ScheduledFuture<?>> getAllPeriodicScheduledTask() {
+        return new ArrayList<>(periodicScheduledTasks);
+    }
+
+    public List<ScheduledFuture<?>> getAllNonPeriodicScheduledTask() {
+        return new ArrayList<>(nonPeriodicScheduledTasks);
     }
 
     /** Triggers all registered tasks. */

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureBatchRecoveryITCase.java
@@ -67,7 +67,7 @@ public class TaskManagerProcessFailureBatchRecoveryITCase
         ExecutionEnvironment env =
                 ExecutionEnvironment.createRemoteEnvironment("localhost", 1337, configuration);
         env.setParallelism(PARALLELISM);
-        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, 1000L));
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 1000L));
         env.getConfig().setExecutionMode(executionMode);
 
         final long numElements = 100000L;


### PR DESCRIPTION
With this PR Flink's HeartbeatServices listen to the result of the heartbeat rpcs. If a rpc fails with `RecipientUnreachableException`, then it will fail the heartbeat and call `HeartbeatListener.notifyTargetUnreachable`. All Flink components (`ResourceManager`, `JobMaster` and `TaskExecutor`) will treat this signal similar to a heartbeat timeout. This means that connection failures on the TCP layer will now speed up the detection of lost components.

The basic change happens in the `HeartbeatMangerImpl` and `HeartbeatManagerSenderImpl` where we listen on the result future of `HeartbeatTarget.receiveHeartbeat` and `.requestHeartbeat`. This is necessary in order to any RPC related failures to the `HeartbeatManager` so that we can react on a `RecipientUnreachableException` and trigger `HeartbeatListener.notifyTargetUnreachable`.

The PR adds tests for the main components in `JobMasterTest`, `TaskExecutorTest` and `ResourceManagerTest`. Moreover, there are tests for the `HeartbeatManager` behaviour itself in `HeartbeatManagerTest`.

This PR is based on #16342.