### PR TITLE
[FLINK-23095][runtime] Close the channel unspilling thread pool after restore

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -575,6 +575,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>> extends Ab
                 allGatesRecoveredFuture.isDone(),
                 "Mailbox loop interrupted before recovery was finished.");
 
+        // we recovered all the gates, we can close the channel IO executor as it is no longer
+        // needed
+        channelIOExecutor.shutdown();
+
         isRunning = true;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

We should close the channelIOExecutor which is used purely for restoring inputgates state from UC once we finish restoring. It will get rid off a dangling unnecessary thread pool during processing.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
