### PR TITLE
[FLINK-23201][streaming] Calculate the alignment time only for the last checkpoint

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierHandler.java
@@ -60,6 +60,9 @@ public abstract class CheckpointBarrierHandler implements Closeable {
     /** The timestamp as in {@link System#nanoTime()} at which the last alignment started. */
     private long startOfAlignmentTimestamp = OUTSIDE_OF_ALIGNMENT;
 
+    /** ID of checkpoint for which alignment was started last. */
+    private long startAlignmentCheckpointId = -1;
+
     /**
      * Cumulative counter of bytes processed during alignment. Once we complete alignment, we will
      * put this value into the {@link #latestBytesProcessedDuringAlignment}.
@@ -123,11 +126,20 @@ public abstract class CheckpointBarrierHandler implements Closeable {
                         checkpointBarrier.getTimestamp(),
                         System.currentTimeMillis());
 
-        CheckpointMetricsBuilder checkpointMetrics =
-                new CheckpointMetricsBuilder()
-                        .setAlignmentDurationNanos(latestAlignmentDurationNanos)
-                        .setBytesProcessedDuringAlignment(latestBytesProcessedDuringAlignment)
-                        .setCheckpointStartDelayNanos(latestCheckpointStartDelayNanos);
+        CheckpointMetricsBuilder checkpointMetrics;
+        if (checkpointBarrier.getId() == startAlignmentCheckpointId) {
+            checkpointMetrics =
+                    new CheckpointMetricsBuilder()
+                            .setAlignmentDurationNanos(latestAlignmentDurationNanos)
+                            .setBytesProcessedDuringAlignment(latestBytesProcessedDuringAlignment)
+                            .setCheckpointStartDelayNanos(latestCheckpointStartDelayNanos);
+        } else {
+            checkpointMetrics =
+                    new CheckpointMetricsBuilder()
+                            .setAlignmentDurationNanos(0L)
+                            .setBytesProcessedDuringAlignment(0L)
+                            .setCheckpointStartDelayNanos(0);
+        }
 
         toNotifyOnCheckpoint.triggerCheckpointOnBarrier(
                 checkpointMetaData, checkpointBarrier.getCheckpointOptions(), checkpointMetrics);
@@ -145,17 +157,18 @@ public abstract class CheckpointBarrierHandler implements Closeable {
         toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId, cause);
     }
 
-    protected void markAlignmentStartAndEnd(long checkpointCreationTimestamp) {
-        markAlignmentStart(checkpointCreationTimestamp);
+    protected void markAlignmentStartAndEnd(long checkpointId, long checkpointCreationTimestamp) {
+        markAlignmentStart(checkpointId, checkpointCreationTimestamp);
         markAlignmentEnd(0);
     }
 
-    protected void markAlignmentStart(long checkpointCreationTimestamp) {
+    protected void markAlignmentStart(long checkpointId, long checkpointCreationTimestamp) {
         latestCheckpointStartDelayNanos =
                 1_000_000 * Math.max(0, clock.absoluteTimeMillis() - checkpointCreationTimestamp);
 
         resetAlignment();
         startOfAlignmentTimestamp = clock.relativeTimeNanos();
+        startAlignmentCheckpointId = checkpointId;
     }
 
     protected void markAlignmentEnd() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTracker.java
@@ -178,6 +178,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
         // 3. Received cancellation barrier from channel 1.
         // In this case we should cleanup the existing pending checkpoint.
         if (cancelBarrier.getCheckpointId() > latestPendingCheckpointID && numOpenChannels == 1) {
+            resetAlignment();
             notifyAbortOnCancellationBarrier(checkpointId);
             return;
         }
@@ -243,6 +244,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
                                             .CHECKPOINT_DECLINED_INPUT_END_OF_STREAM));
                 }
             }
+            resetAlignment();
         } else {
             checkAlignmentOnEndOfPartitionIfEnabled(channelInfo);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -378,6 +378,9 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
         targetChannelCount = 0;
         resetAlignmentTimer();
         currentState = currentState.abort(cancelledId);
+        if (cancelledId == currentCheckpointId) {
+            resetAlignment();
+        }
         notifyAbort(cancelledId, exception);
         allBarriersReceivedFuture.completeExceptionally(exception);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/SingleCheckpointBarrierHandler.java
@@ -221,9 +221,9 @@ public class SingleCheckpointBarrierHandler extends CheckpointBarrierHandler {
         alignedChannels.add(channelInfo);
         if (alignedChannels.size() == 1) {
             if (targetChannelCount == 1) {
-                markAlignmentStartAndEnd(barrier.getTimestamp());
+                markAlignmentStartAndEnd(barrierId, barrier.getTimestamp());
             } else {
-                markAlignmentStart(barrier.getTimestamp());
+                markAlignmentStart(barrierId, barrier.getTimestamp());
             }
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
@@ -40,6 +40,8 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.streaming.api.operators.SyncMailboxExecutor;
 import org.apache.flink.streaming.runtime.io.MockInputGate;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.After;
@@ -48,6 +50,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -733,6 +736,32 @@ public class CheckpointBarrierTrackerTest {
         assertFalse(inputGate.getCheckpointBarrierHandler().isCheckpointPending());
     }
 
+    @Test
+    public void testTwoLastBarriersOneByOne() throws Exception {
+        BufferOrEvent[] sequence = {
+            // start checkpoint 1
+            createBarrier(1, 1),
+            //  start checkpoint 2(just suppose checkpoint 1 was canceled)
+            createBarrier(2, 1),
+            // cancellation barrier of checkpoint 1
+            createBarrier(1, 0),
+            //  finish the checkpoint 2
+            createBarrier(2, 0)
+        };
+
+        ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler();
+        ManualClock manualClock = new ManualClock();
+        inputGate = createCheckpointedInputGate(2, sequence, validator, manualClock);
+
+        for (BufferOrEvent boe : sequence) {
+            assertEquals(boe, inputGate.pollNext().get());
+            manualClock.advanceTime(Duration.ofSeconds(1));
+        }
+        assertEquals(
+                Duration.ofSeconds(2).toNanos(),
+                validator.lastAlignmentDurationNanos.get().longValue());
+    }
+
     // ------------------------------------------------------------------------
     //  Utils
     // ------------------------------------------------------------------------
@@ -778,13 +807,28 @@ public class CheckpointBarrierTrackerTest {
     }
 
     private static CheckpointedInputGate createCheckpointedInputGate(
+            int numberOfChannels,
+            BufferOrEvent[] sequence,
+            @Nullable AbstractInvokable toNotifyOnCheckpoint,
+            Clock clock) {
+        MockInputGate gate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
+        return createCheckpointedInputGate(gate, toNotifyOnCheckpoint, clock);
+    }
+
+    private static CheckpointedInputGate createCheckpointedInputGate(
             IndexedInputGate inputGate, @Nullable AbstractInvokable toNotifyOnCheckpoint) {
+        return createCheckpointedInputGate(
+                inputGate, toNotifyOnCheckpoint, SystemClock.getInstance());
+    }
+
+    private static CheckpointedInputGate createCheckpointedInputGate(
+            IndexedInputGate inputGate,
+            @Nullable AbstractInvokable toNotifyOnCheckpoint,
+            Clock clock) {
         return new CheckpointedInputGate(
                 inputGate,
                 new CheckpointBarrierTracker(
-                        inputGate.getNumberOfInputChannels(),
-                        toNotifyOnCheckpoint,
-                        SystemClock.getInstance()),
+                        inputGate.getNumberOfInputChannels(), toNotifyOnCheckpoint, clock),
                 new SyncMailboxExecutor());
     }
 


### PR DESCRIPTION
…th monotony of time

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The broken scenarios:
org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler#markAlignmentEnd(long) is called with default value of startOfAlignmentTimestamp which is Long.MIN_VALUE. It means that markAlignmentEnd is called before markAlignmentStart. It can happen in the following situation:
```
A --
    |---> C
B --
```

1. A successfully checkpoints id = 1 = sends barrier = 1
2. B takes longer to take a checkpoint
3. we trigger checkpoint id = 2
4. A again checkpoints id = 2 successfully, sends barrier = 2, it does not send cancel = 1, cause it succeeded
5. B sends cancel id = 1, because it was pending
6. C receives barrier = 2 from A first, then cancel id = 1 from B

The second scenario:

1. C receives the first barrier = 1
2. C receives the first barrier = 2
3. C receives the last barrier = 1 (it sees the wrong start time)
4. C receives the last barrier = 2 (it sees nothing because the previous barrier reset the data)

## Brief change log

  - *Reset alignment time only when we don't wait for the last barriers*


## Verifying this change

The check was added which only check the existed invariant so only regression test needed.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
