### PR TITLE
[hotfix][docs][cassandra] Added missing cluster builder arg for cassa…

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/cassandra.md
+++ b/docs/content.zh/docs/connectors/datastream/cassandra.md
@@ -59,7 +59,7 @@ The following configuration methods can be used:
     * The query is internally treated as CQL statement.
     * __DO__ set the upsert query for processing __Tuple__ data type.
     * __DO NOT__ set the query for processing __POJO__ data types.
-2. _setClusterBuilder()_
+2. _setClusterBuilder(ClusterBuilder clusterBuilder)_
     * Sets the cluster builder that is used to configure the connection to cassandra with more sophisticated settings such as consistency level, retry policy and etc.
 3. _setHost(String host[, int port])_
     * Simple version of setClusterBuilder() with host/port information to connect to Cassandra instances

--- a/docs/content.zh/docs/connectors/datastream/cassandra.md
+++ b/docs/content.zh/docs/connectors/datastream/cassandra.md
@@ -75,7 +75,11 @@ The following configuration methods can be used:
 7. _setFailureHandler([CassandraFailureHandler failureHandler])_
     * An __optional__ setting
     * Sets the custom failure handler.
-8. _build()_
+8. _setDefaultKeyspace(String keyspace)_
+    * Sets the default keyspace to be used.
+9. _enableIgnoreNullFields()_
+    * Enables ignoring null values, treats null values as unset and avoids writing null fields and creating tombstones.
+10. _build()_
     * Finalizes the configuration and constructs the CassandraSink instance.
 
 ### Write-ahead Log

--- a/docs/content/docs/connectors/datastream/cassandra.md
+++ b/docs/content/docs/connectors/datastream/cassandra.md
@@ -59,7 +59,7 @@ The following configuration methods can be used:
     * The query is internally treated as CQL statement.
     * __DO__ set the upsert query for processing __Tuple__ data type.
     * __DO NOT__ set the query for processing __POJO__ data types.
-2. _setClusterBuilder()_
+2. _setClusterBuilder(ClusterBuilder clusterBuilder)_
     * Sets the cluster builder that is used to configure the connection to cassandra with more sophisticated settings such as consistency level, retry policy and etc.
 3. _setHost(String host[, int port])_
     * Simple version of setClusterBuilder() with host/port information to connect to Cassandra instances

--- a/docs/content/docs/connectors/datastream/cassandra.md
+++ b/docs/content/docs/connectors/datastream/cassandra.md
@@ -75,7 +75,11 @@ The following configuration methods can be used:
 7. _setFailureHandler([CassandraFailureHandler failureHandler])_
     * An __optional__ setting
     * Sets the custom failure handler.
-8. _build()_
+8. _setDefaultKeyspace(String keyspace)_
+    * Sets the default keyspace to be used.
+9. _enableIgnoreNullFields()_
+    * Enables ignoring null values, treats null values as unset and avoids writing null fields and creating tombstones.
+10. _build()_
     * Finalizes the configuration and constructs the CassandraSink instance.
 
 ### Write-ahead Log


### PR DESCRIPTION
## What is the purpose of the change

* Added cluster builder arg to setClusterBuilder method 

## Brief change log

* Added missing arg to setClusterBuilder method

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
