### PR TITLE
[FLINK-23223] Notifies if there are available data on resumption for pipelined subpartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -463,11 +463,10 @@ public class PipelinedSubpartition extends ResultSubpartition
             }
             // if there is more then 1 buffer, we already notified the reader
             // (at the latest when adding the second buffer)
-            notifyDataAvailable =
-                    !isBlocked
-                            && buffers.size() == 1
-                            && buffers.peek().getBufferConsumer().isDataAvailable();
-            flushRequested = buffers.size() > 1 || notifyDataAvailable;
+            boolean isDataAvailableInUnfinishedBuffer =
+                    buffers.size() == 1 && buffers.peek().getBufferConsumer().isDataAvailable();
+            notifyDataAvailable = !isBlocked && isDataAvailableInUnfinishedBuffer;
+            flushRequested = buffers.size() > 1 || isDataAvailableInUnfinishedBuffer;
         }
         if (notifyDataAvailable) {
             notifyDataAvailable();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -487,8 +487,7 @@ public class PipelinedSubpartitionWithReadViewTest {
     }
 
     @Test
-    public void testBlockedByCheckpointAndResumeConsumption()
-            throws IOException, InterruptedException {
+    public void testResumeBlockedSubpartitionWithEvents() throws IOException, InterruptedException {
         blockSubpartitionByCheckpoint(1);
 
         // add an event after subpartition blocked
@@ -496,31 +495,51 @@ public class PipelinedSubpartitionWithReadViewTest {
         // no data available notification after adding an event
         checkNumNotificationsAndAvailability(1);
 
+        // Resumption will make the subpartition available.
         resumeConsumptionAndCheckAvailability(0, true);
         assertNextEvent(readView, BUFFER_SIZE, null, false, 0, false, true);
+    }
 
-        blockSubpartitionByCheckpoint(2);
+    @Test
+    public void testResumeBlockedSubpartitionWithUnfinishedBuffer()
+            throws IOException, InterruptedException {
+        blockSubpartitionByCheckpoint(1);
 
         // add a buffer and flush the subpartition
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
         subpartition.flush();
         // no data available notification after adding a buffer and flushing the subpartition
-        checkNumNotificationsAndAvailability(2);
+        checkNumNotificationsAndAvailability(1);
 
-        resumeConsumptionAndCheckAvailability(Integer.MAX_VALUE, false);
+        // Resumption will make the subpartition available.
+        resumeConsumptionAndCheckAvailability(Integer.MAX_VALUE, true);
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
+    }
 
-        blockSubpartitionByCheckpoint(3);
+    @Test
+    public void testResumeBlockedSubpartitionWithFinishedBuffers()
+            throws IOException, InterruptedException {
+        blockSubpartitionByCheckpoint(1);
 
         // add two buffers to the subpartition
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
         // no data available notification after adding the second buffer
-        checkNumNotificationsAndAvailability(3);
+        checkNumNotificationsAndAvailability(1);
 
+        // Resumption will make the subpartition available.
         resumeConsumptionAndCheckAvailability(Integer.MAX_VALUE, true);
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
+    }
+
+    @Test
+    public void testResumeBLockedEmptySubpartition() throws IOException, InterruptedException {
+        blockSubpartitionByCheckpoint(1);
+
+        // Resumption will not make the subpartition available since it is empty.
+        resumeConsumptionAndCheckAvailability(Integer.MAX_VALUE, false);
+        assertNoNextBuffer(readView);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -501,7 +501,7 @@ public class PipelinedSubpartitionWithReadViewTest {
     }
 
     @Test
-    public void testResumeBlockedSubpartitionWithUnfinishedBuffer()
+    public void testResumeBlockedSubpartitionWithUnfinishedBufferFlushed()
             throws IOException, InterruptedException {
         blockSubpartitionByCheckpoint(1);
 
@@ -514,6 +514,20 @@ public class PipelinedSubpartitionWithReadViewTest {
         // Resumption will make the subpartition available.
         resumeConsumptionAndCheckAvailability(Integer.MAX_VALUE, true);
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
+    }
+
+    @Test
+    public void testResumeBlockedSubpartitionWithUnfinishedBufferNotFlushed()
+            throws IOException, InterruptedException {
+        blockSubpartitionByCheckpoint(1);
+
+        // add a buffer but not flush the subpartition.
+        subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
+        // no data available notification after adding a buffer.
+        checkNumNotificationsAndAvailability(1);
+
+        // Resumption will not make the subpartition available since the data is not flushed before.
+        resumeConsumptionAndCheckAvailability(Integer.MAX_VALUE, false);
     }
 
     @Test
@@ -534,7 +548,7 @@ public class PipelinedSubpartitionWithReadViewTest {
     }
 
     @Test
-    public void testResumeBLockedEmptySubpartition() throws IOException, InterruptedException {
+    public void testResumeBlockedEmptySubpartition() throws IOException, InterruptedException {
         blockSubpartitionByCheckpoint(1);
 
         // Resumption will not make the subpartition available since it is empty.


### PR DESCRIPTION
## What is the purpose of the change

This PR tries to fix the issue that when flushAlways is enabled, the data emitted during the channel get blocked might not be able to get notified. 

To fix this issue, we propose to do one additional notify if there is data available when resuming. This piece of data must be emitted after the channel get blocked since the event cause block has been polled, thus the notification would not be repeated (although repeat notification is also not a problem).

There are two cases that might add available data to the channel:
1. There is only one unfinished buffer, and it has been flushed at least once.
2. There is at least one finished buffer. 

When resuming, for the second case, we could detect it according to the buffers in queue, but with the current implementation we could not know if the unfinished buffer is flushed or not. To solve this issue, we could decouple `flushRequested` with `isBlocked`, namely whenever get flushed `flushRequested` will be set to `true` no matter what value `isBlocked` is. This would not cause problem to other parts since we still have checks on `isBlocked` when computing if notify is required and `isAvailable()`. Then when resumed, we could detect if there are available data due to case 1 via `flushRequested`. 

## Brief change log

- 72a7a8aa4ab9a351214f467cb6c8f65d0e3a7384 modifies the logic according to the above proposal. 

## Verifying this change

This change could be verified by the modified UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes** but should not affect the performance
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
