### PR TITLE
[FLINK-22443][streaming-java] Fix overflow in MultipleInputSelectionHandler

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
@@ -35,7 +35,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class MultipleInputSelectionHandler {
-    public static final int MAX_SUPPORTED_INPUT_COUNT = Long.SIZE;
+    // if we directly use Long.SIZE, calculation of allSelectedMask will overflow
+    public static final int MAX_SUPPORTED_INPUT_COUNT = Long.SIZE - 1;
 
     @Nullable private final InputSelectable inputSelectable;
 
@@ -51,7 +52,7 @@ public class MultipleInputSelectionHandler {
             @Nullable InputSelectable inputSelectable, int inputCount) {
         checkSupportedInputCount(inputCount);
         this.inputSelectable = inputSelectable;
-        this.allSelectedMask = (1 << inputCount) - 1;
+        this.allSelectedMask = (1L << inputCount) - 1;
         this.availableInputsMask = allSelectedMask;
         this.notFinishedInputsMask = allSelectedMask;
     }
@@ -59,7 +60,7 @@ public class MultipleInputSelectionHandler {
     public static void checkSupportedInputCount(int inputCount) {
         checkArgument(
                 inputCount <= MAX_SUPPORTED_INPUT_COUNT,
-                "Only up to %d inputs are supported at once, while encountered %d",
+                "Only up to %s inputs are supported at once, while encountered %s",
                 MAX_SUPPORTED_INPUT_COUNT,
                 inputCount);
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandlerTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link MultipleInputSelectionHandler}. */
 public class MultipleInputSelectionHandlerTest {
+
     @Test
     public void testShouldSetAvailableForAnotherInput() {
         InputSelection secondAndThird = new InputSelection.Builder().select(2).select(3).build();
@@ -47,5 +48,27 @@ public class MultipleInputSelectionHandlerTest {
 
         selectionHandler.setAvailableInput(2);
         assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+    }
+
+    @Test
+    public void testLargeInputCount() {
+        int inputCount = MultipleInputSelectionHandler.MAX_SUPPORTED_INPUT_COUNT;
+
+        InputSelection.Builder builder = new InputSelection.Builder();
+        for (int i = 1; i <= inputCount; i++) {
+            builder.select(i);
+        }
+        InputSelection allSelected = builder.build();
+
+        MultipleInputSelectionHandler selectionHandler =
+                new MultipleInputSelectionHandler(() -> allSelected, inputCount);
+        selectionHandler.nextSelection();
+
+        for (int i = 0; i < inputCount - 1; i++) {
+            selectionHandler.setUnavailableInput(i);
+        }
+        assertTrue(selectionHandler.isAnyInputAvailable());
+        selectionHandler.setUnavailableInput(inputCount - 1);
+        assertFalse(selectionHandler.isAnyInputAvailable());
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MultipleInputITCase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.runtime.batch.sql
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO}
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler
 import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.types.Row
@@ -183,21 +184,21 @@ class MultipleInputITCase(shuffleMode: String) extends BatchTestBase {
   }
 
   @Test
-  def testManyInputs(): Unit = {
+  def testMaxSupportedInputs(): Unit = {
     val rowType = new RowTypeInfo(INT_TYPE_INFO, STRING_TYPE_INFO)
     val data = Seq(BatchTestBase.row(1, "test"))
     val nullables: Array[Boolean] = Array(true, true)
     registerCollection("left_table", data, rowType, "a, b", nullables)
     registerCollection("right_table", data, rowType, "c, d", nullables)
 
-    val numInputs = 56
+    val numJoins = MultipleInputSelectionHandler.MAX_SUPPORTED_INPUT_COUNT - 1
 
     val sql = new StringBuilder("SELECT t0.a, t0.b")
-    for (i <- 1 to numInputs) {
+    for (i <- 1 to numJoins) {
       sql.append(s", t$i.c, t$i.d")
     }
     sql.append(" from left_table as t0")
-    for (i <- 1 to numInputs) {
+    for (i <- 1 to numJoins) {
       sql.append(s" left join right_table as t$i on t0.a = t$i.c and t$i.c = 1")
     }
     checkMultipleInputResult(sql.toString())


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the overflow in `MultipleInputSelectionHandler` when there are too many inputs.

However, `MultipleInputSelectionHandler` currently can still only support up to 63 inputs. We currently will not remove this upper bound until a user asks for this.

## Brief change log

 - Fix overflow in `MultipleInputSelectionHandler`

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
