### PR TITLE
[FLINK-23198][Documentation] Fix the demo of ConfigurableRocksDBOptionsFactory in Documentation.

### DIFF
--- a/docs/content.zh/docs/ops/state/large_state_tuning.md
+++ b/docs/content.zh/docs/ops/state/large_state_tuning.md
@@ -160,7 +160,7 @@ public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
     }
 
     @Override
-    public OptionsFactory configure(Configuration configuration) {
+    public OptionsFactory configure(ReadableConfig configuration) {
         return this;
     }
 }

--- a/docs/content/docs/ops/state/large_state_tuning.md
+++ b/docs/content/docs/ops/state/large_state_tuning.md
@@ -160,7 +160,7 @@ public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
     }
 
     @Override
-    public OptionsFactory configure(Configuration configuration) {
+    public OptionsFactory configure(ReadableConfig configuration) {
         return this;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The purpose of of this PR is to fix the demo of ConfigurableRocksDBOptionsFactory interface in the section of [State & Fault Tolerance] -> [State Backends] -> [Passing Options Factory to RocksDB] .

Changing the parameter type of ConfigurableRocksDBOptionsFactory#configure。

In Flink 1.12, the parameter of the configure method in the ConfigurableRocksDBOptionsFactory interface is ReadableConfig, not Configuration.The Configuration class is an implementation class of the ReadableConfig interface because it implements the ReadableConfig interface.

My suggestions are as follows,

```java
public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
    private static final long DEFAULT_SIZE = 256 * 1024 * 1024;  // 256 MB

    public static final ConfigOption<MemorySize> BLOCK_CACHE_SIZE = ConfigOptions
            .key("my.custom.rocksdb.block.cache.size")
            .memoryType()
            .noDefaultValue()
            .withDescription(
                    "The amount of the cache for data blocks in RocksDB. "
                            + "RocksDB has default block-cache size as '8MB'.");
    
    private MemorySize blockCacheSize = new MemorySize(DEFAULT_SIZE);    
    
    @Override
    public DBOptions createDBOptions(
            DBOptions currentOptions,
            Collection<AutoCloseable> handlesToClose) {
        return currentOptions.setIncreaseParallelism(4)
                .setUseFsync(false);
    }

    @Override
    public ColumnFamilyOptions createColumnOptions(
            ColumnFamilyOptions currentOptions, Collection<AutoCloseable> handlesToClose) {
        return currentOptions.setTableFormatConfig(
                new BlockBasedTableConfig()
                        .setBlockCacheSize(blockCacheSize.getBytes())
                        .setBlockSize(128 * 1024));            // 128 KB
    }

    @Override
    public RocksDBOptionsFactory configure(ReadableConfig configuration) {
        this.blockCacheSize = configuration.get(BLOCK_CACHE_SIZE);
        return this;
    }
}
```

## Brief change log

  - Same fix should be in the section of [State & Fault Tolerance] -> [Tuning Checkpoints and Large State] -> [Tuning RocksDB Memory] 


## Verifying this change





## Does this pull request potentially affect one of the following parts:



## Documentation


