### PR TITLE
[FLINK-22880][table] Remove 'blink' term from code base

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_catalog.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_catalog.md
@@ -147,7 +147,6 @@ Add all Hive dependencies to `/lib` dir in Flink distribution, and modify SQL CL
 ```yaml
 
 execution:
-    planner: blink
     type: streaming
     ...
     current-catalog: myhive  # set the HiveCatalog as the current catalog of the session
@@ -394,4 +393,4 @@ Something to note about the type mapping:
 
 ## Scala Shell
 
-NOTE: since blink planner is not well supported in Scala Shell at the moment, it's **NOT** recommended to use Hive connector in Scala Shell.
+Note: It's **NOT** recommended to use the Hive connector in the Scala Shell.

--- a/docs/content.zh/docs/connectors/table/hive/hive_dialect.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_dialect.md
@@ -40,7 +40,6 @@ SQL 方言可以通过 `table.sql-dialect` 属性指定。因此你可以通过 
 ```yaml
 
 execution:
-  planner: blink
   type: batch
   result-mode: table
 

--- a/docs/content.zh/docs/connectors/table/hive/hive_functions.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_functions.md
@@ -97,7 +97,6 @@ To use a Hive User Defined Function, user have to
 
 - set a HiveCatalog backed by Hive Metastore that contains that function as current catalog of the session
 - include a jar that contains that function in Flink's classpath
-- use Blink planner.
 
 ## Using Hive User Defined Functions
 

--- a/docs/content.zh/docs/connectors/table/hive/overview.md
+++ b/docs/content.zh/docs/connectors/table/hive/overview.md
@@ -39,8 +39,6 @@ Flink 与 Hive 的集成包含两个层面。
 `HiveCatalog`的设计提供了与 Hive 良好的兼容性，用户可以"开箱即用"的访问其已有的 Hive 数仓。
 您不需要修改现有的 Hive Metastore，也不需要更改表的数据位置或分区。
 
-* 我们强烈建议用户使用 [Blink planner]({{< ref "docs/dev/table/overview" >}}#dependency-structure) 与 Hive 集成。
-
 ## 支持的Hive版本
 
 Flink 支持一下的 Hive 版本。
@@ -303,8 +301,6 @@ export HADOOP_CLASSPATH=`hadoop classpath`
 
 通过 TableEnvironment 或者 YAML 配置，使用 [Catalog 接口]({{< ref "docs/dev/table/catalogs" >}}) 和 [HiveCatalog]({{< ref "docs/connectors/table/hive/hive_catalog" >}})连接到现有的 Hive 集群。
 
-请注意，虽然 HiveCatalog 不需要特定的 planner，但读写Hive表仅适用于 Blink planner。因此，强烈建议您在连接到 Hive 仓库时使用 Blink planner。
-
 以下是如何连接到 Hive 的示例：
 
 {{< tabs "2ca7cad8-0b84-45db-92d9-a75abd8808e7" >}}
@@ -367,7 +363,6 @@ tableEnv.use_catalog("myhive")
 ```yaml
 
 execution:
-    planner: blink
     ...
     current-catalog: myhive  # set the HiveCatalog as the current catalog of the session
     current-database: mydatabase

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -414,7 +414,6 @@ t_env.use_catalog("mypg")
 ```yaml
 
 execution:
-    planner: blink
     ...
     current-catalog: mypg  # 设置 JdbcCatalog 为会话的当前 catalog
     current-database: mydb

--- a/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content.zh/docs/dev/python/table/intro_to_table_api.md
@@ -91,11 +91,11 @@ table_env.execute_sql("INSERT INTO print SELECT * FROM datagen").wait()
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# create a blink streaming TableEnvironment
+# create a streaming TableEnvironment
 env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
-# or create a blink batch TableEnvironment
+# or create a batch TableEnvironment
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 ```
@@ -111,10 +111,6 @@ table_env = TableEnvironment.create(env_settings)
 * 配置作业，更多细节可查阅 [Python 配置]({{< ref "docs/dev/python/python_config" >}})
 * 管理 Python 依赖，更多细节可查阅 [依赖管理]({{< ref "docs/dev/python/dependency_management" >}})
 * 提交作业执行
-
-目前有2个可用的执行器 : flink 执行器 和 blink 执行器。
-
-你应该在当前程序中显式地设置使用哪个执行器，建议尽可能使用 blink 执行器。
 
 {{< top >}}
 
@@ -132,7 +128,7 @@ table_env = TableEnvironment.create(env_settings)
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# 创建 blink 批 TableEnvironment
+# 创建 批 TableEnvironment
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
@@ -196,7 +192,7 @@ print('Now the type of the "id" column is %s.' % type)
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# 创建 blink 流 TableEnvironment
+# 创建 流 TableEnvironment
 env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 

--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -50,7 +50,7 @@ table_env = TableEnvironment.create(env_settings)
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import StreamTableEnvironment
 
-# create a blink streaming TableEnvironment from a StreamExecutionEnvironment
+# create a streaming TableEnvironment from a StreamExecutionEnvironment
 env = StreamExecutionEnvironment.get_execution_environment()
 table_env = StreamTableEnvironment.create(env)
 ```

--- a/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
@@ -235,7 +235,7 @@ def iterable_func(x):
 
 A user-defined aggregate function (_UDAGG_) maps scalar values of multiple rows to a new scalar value.
 
-**NOTE:** Currently the general user-defined aggregate function is only supported in the GroupBy aggregation and Group Window Aggregation of the blink planner in streaming mode. For batch mode, it's currently not supported and it is recommended to use the [Vectorized Aggregate Functions]({{< ref "docs/dev/python/table/udfs/vectorized_python_udfs" >}}#vectorized-aggregate-functions).
+**NOTE:** Currently the general user-defined aggregate function is only supported in the GroupBy aggregation and Group Window Aggregation in streaming mode. For batch mode, it's currently not supported and it is recommended to use the [Vectorized Aggregate Functions]({{< ref "docs/dev/python/table/udfs/vectorized_python_udfs" >}}#vectorized-aggregate-functions).
 
 The behavior of an aggregate function is centered around the concept of an accumulator. The _accumulator_
 is an intermediate data structure that stores the aggregated values until a final aggregation result
@@ -416,8 +416,7 @@ A user-defined table aggregate function (_UDTAGG_) maps scalar values of multipl
 The returned record may consist of one or more fields. If an output record consists of only a single field,
 the structured record can be omitted, and a scalar value can be emitted that will be implicitly wrapped into a row by the runtime.
 
-**NOTE:** Currently the general user-defined table aggregate function is only supported in the GroupBy aggregation
-of the blink planner in streaming mode.
+**NOTE:** Currently the general user-defined table aggregate function is only supported in the GroupBy aggregation in streaming mode.
 
 Similar to an [aggregate function](#aggregate-functions), the behavior of a table aggregate is centered around the concept of an accumulator.
 The accumulator is an intermediate data structure that stores the aggregated values until a final aggregation result is computed.

--- a/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -77,8 +77,6 @@ table_env.sql_query("SELECT add(bigint, bigint) FROM MyTable")
 <span class="label label-info">注意</span> 向量化聚合函数不支持部分聚合，而且一个组或者窗口内的所有数据，
 在执行的过程中，会被同时加载到内存，所以需要确保所配置的内存大小足够容纳这些数据。
 
-<span class="label label-info">注意</span> 向量化聚合函数只支持运行在 Blink Planner 上。
-
 以下示例显示了如何定一个自己的向量化聚合函数，该函数计算一列的平均值，并在 `GroupBy Aggregation`, `GroupBy Window Aggregation`
 and `Over Window Aggregation` 使用它:
 

--- a/docs/content.zh/docs/dev/table/common.md
+++ b/docs/content.zh/docs/dev/table/common.md
@@ -183,11 +183,11 @@ val tEnv = TableEnvironment.create(settings)
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# create a blink streaming TableEnvironment
+# create a streaming TableEnvironment
 env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
-# create a blink batch TableEnvironment
+# create a batch TableEnvironment
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
@@ -310,7 +310,7 @@ table_env.register_table("projectedTable", proj_table)
 
 **注意：** 从传统数据库系统的角度来看，`Table` 对象与 `VIEW` 视图非常像。也就是，定义了 `Table` 的查询是没有被优化的，
 而且会被内嵌到另一个引用了这个注册了的 `Table`的查询中。如果多个查询都引用了同一个注册了的`Table`，那么它会被内嵌每个查询中并被执行多次，
-也就是说注册了的`Table`的结果**不会**被共享（注：Blink 计划器的`TableEnvironment`会优化成只执行一次）。
+也就是说注册了的`Table`的结果**不会**被共享。
 
 {{< top >}}
 

--- a/docs/content.zh/docs/dev/table/concepts/versioned_tables.md
+++ b/docs/content.zh/docs/dev/table/concepts/versioned_tables.md
@@ -115,7 +115,6 @@ Yen       1
 
 时态表
 -----
-<span class="label label-danger">注意</span> 仅 Blink planner 支持此功能。
 
 Flink 使用主键约束和事件时间来定义一张版本表和版本视图。
 

--- a/docs/content.zh/docs/dev/table/config.md
+++ b/docs/content.zh/docs/dev/table/config.md
@@ -91,8 +91,6 @@ Flink SQL> SET 'table.exec.mini-batch.size' = '5000';
 {{< /tab >}}
 {{< /tabs >}}
 
-<span class="label label-danger">注意</span> 目前，key-value 配置项仅被 Blink planner 支持。
-
 ### 执行配置
 
 以下选项可用于优化查询执行的性能。

--- a/docs/content.zh/docs/dev/table/sql/set.md
+++ b/docs/content.zh/docs/dev/table/sql/set.md
@@ -43,11 +43,11 @@ The following examples show how to run a `SET` statement in SQL CLI.
 {{< tabs "set" >}}
 {{< tab "SQL CLI" >}}
 ```sql
-Flink SQL> SET 'table.planner' = 'blink';
+Flink SQL> SET 'table.local-time-zone' = 'Europe/Berlin';
 [INFO] Session property has been set.
 
 Flink SQL> SET;
-'table.planner' = 'blink'
+'table.local-time-zone' = 'Europe/Berlin'
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -58,6 +58,6 @@ Flink SQL> SET;
 SET ('key' = 'value')?
 ```
 
-If no key and value are specified, it just print all the properties. Otherwise, set the key with specified value.
+If no key and value are specified, it just prints all the properties. Otherwise, set the key with specified value.
 
 {{< top >}}

--- a/docs/content/docs/connectors/table/formats/raw.md
+++ b/docs/content/docs/connectors/table/formats/raw.md
@@ -33,7 +33,7 @@ The Raw format allows to read and write raw (byte based) values as a single colu
 
 Note: this format encodes `null` values as `null` of `byte[]` type. This may have limitation when used in `upsert-kafka`, because `upsert-kafka` treats `null` values as a tombstone message (DELETE on the key). Therefore, we recommend avoiding using `upsert-kafka` connector and the `raw` format as a `value.format` if the field can have a `null` value.
 
-The Raw connector is built-in into the Blink planner, no additional dependencies are required.
+The Raw connector is built-in, no additional dependencies are required.
 
 Example
 ----------------

--- a/docs/content/docs/connectors/table/hive/hive_catalog.md
+++ b/docs/content/docs/connectors/table/hive/hive_catalog.md
@@ -147,7 +147,6 @@ Add all Hive dependencies to `/lib` dir in Flink distribution, and modify SQL CL
 ```yaml
 
 execution:
-    planner: blink
     type: streaming
     ...
     current-catalog: myhive  # set the HiveCatalog as the current catalog of the session
@@ -394,4 +393,4 @@ Something to note about the type mapping:
 
 ## Scala Shell
 
-NOTE: since blink planner is not well supported in Scala Shell at the moment, it's **NOT** recommended to use Hive connector in Scala Shell.
+Note: It's **NOT** recommended to use Hive connector in Scala Shell.

--- a/docs/content/docs/connectors/table/hive/hive_dialect.md
+++ b/docs/content/docs/connectors/table/hive/hive_dialect.md
@@ -46,7 +46,6 @@ the `configuration` section of the yaml file for your SQL Client.
 ```yaml
 
 execution:
-  planner: blink
   type: batch
   result-mode: table
 
@@ -59,10 +58,10 @@ You can also set the dialect after the SQL Client has launched.
 
 ```bash
 
-Flink SQL> set table.sql-dialect=hive; -- to use hive dialect
+Flink SQL> SET 'table.sql-dialect' = 'hive'; -- to use hive dialect
 [INFO] Session property has been set.
 
-Flink SQL> set table.sql-dialect=default; -- to use default dialect
+Flink SQL> SET 'table.sql-dialect' = 'default'; -- to use default dialect
 [INFO] Session property has been set.
 
 ```

--- a/docs/content/docs/connectors/table/hive/hive_functions.md
+++ b/docs/content/docs/connectors/table/hive/hive_functions.md
@@ -97,7 +97,6 @@ To use a Hive User Defined Function, user have to
 
 - set a HiveCatalog backed by Hive Metastore that contains that function as current catalog of the session
 - include a jar that contains that function in Flink's classpath
-- use Blink planner.
 
 ## Using Hive User Defined Functions
 

--- a/docs/content/docs/connectors/table/hive/overview.md
+++ b/docs/content/docs/connectors/table/hive/overview.md
@@ -39,10 +39,6 @@ The second is to offer Flink as an alternative engine for reading and writing Hi
 The `HiveCatalog` is designed to be “out of the box” compatible with existing Hive installations.
 You do not need to modify your existing Hive Metastore or change the data placement or partitioning of your tables.
 
-* Note that we highly recommend users using the [blink planner]({{< ref "docs/dev/table/overview" >}}#dependency-structure) with Hive integration.
-
-
-
 ## Supported Hive Versions
 
 Flink supports the following Hive versions.
@@ -309,9 +305,6 @@ You're supposed to add dependencies as stated above at runtime.
 Connect to an existing Hive installation using the [catalog interface]({{< ref "docs/dev/table/catalogs" >}}) 
 and [HiveCatalog]({{< ref "docs/connectors/table/hive/hive_catalog" >}}) through the table environment or YAML configuration.
 
-Please note while HiveCatalog doesn't require a particular planner, reading/writing Hive tables only works with blink planner.
-Therefore it's highly recommended that you use blink planner when connecting to your Hive warehouse.
-
 Following is an example of how to connect to Hive:
 
 {{< tabs "5d3cc7e1-a304-4f9e-b36e-ff1f32394ec7" >}}
@@ -374,7 +367,6 @@ tableEnv.use_catalog("myhive")
 ```yaml
 
 execution:
-    planner: blink
     ...
     current-catalog: myhive  # set the HiveCatalog as the current catalog of the session
     current-database: mydatabase

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -413,7 +413,6 @@ t_env.use_catalog("mypg")
 ```yaml
 
 execution:
-    planner: blink
     ...
     current-catalog: mypg  # set the JdbcCatalog as the current catalog of the session
     current-database: mydb

--- a/docs/content/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content/docs/dev/python/table/intro_to_table_api.md
@@ -89,11 +89,11 @@ The `TableEnvironment` is a central concept of the Table API and SQL integration
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# create a blink streaming TableEnvironment
+# create a streaming TableEnvironment
 env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
-# or create a blink batch TableEnvironment
+# or create a batch TableEnvironment
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 ```
@@ -109,11 +109,6 @@ The `TableEnvironment` is responsible for:
 * Configuring the job, see [Python Configuration]({{< ref "docs/dev/python/python_config" >}}) for more details
 * Managing Python dependencies, see [Dependency Management]({{< ref "docs/dev/python/dependency_management" >}}) for more details
 * Submitting the jobs for execution
-
-Currently there are 2 planners available: flink planner and blink planner.
-
-You should explicitly set which planner to use in the current program.
-We recommend using the blink planner as much as possible. 
 
 {{< top >}}
 
@@ -131,7 +126,7 @@ You can create a Table from a list object:
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# create a blink batch TableEnvironment
+# create a batch TableEnvironment
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
@@ -195,7 +190,7 @@ You can create a Table using connector DDL:
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# create a blink stream TableEnvironment
+# create a stream TableEnvironment
 env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -51,7 +51,7 @@ Alternatively, users can create a `StreamTableEnvironment` from an existing `Str
 from pyflink.datastream import StreamExecutionEnvironment
 from pyflink.table import StreamTableEnvironment
 
-# create a blink streaming TableEnvironment from a StreamExecutionEnvironment
+# create a streaming TableEnvironment from a StreamExecutionEnvironment
 env = StreamExecutionEnvironment.get_execution_environment()
 table_env = StreamTableEnvironment.create(env)
 ```

--- a/docs/content/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/python_udfs.md
@@ -235,7 +235,7 @@ def iterable_func(x):
 
 A user-defined aggregate function (_UDAGG_) maps scalar values of multiple rows to a new scalar value.
 
-**NOTE:** Currently the general user-defined aggregate function is only supported in the GroupBy aggregation and Group Window Aggregation of the blink planner in streaming mode. For batch mode, it's currently not supported and it is recommended to use the [Vectorized Aggregate Functions]({{< ref "docs/dev/python/table/udfs/vectorized_python_udfs" >}}#vectorized-aggregate-functions).
+**NOTE:** Currently the general user-defined aggregate function is only supported in the GroupBy aggregation and Group Window Aggregation in streaming mode. For batch mode, it's currently not supported and it is recommended to use the [Vectorized Aggregate Functions]({{< ref "docs/dev/python/table/udfs/vectorized_python_udfs" >}}#vectorized-aggregate-functions).
 
 The behavior of an aggregate function is centered around the concept of an accumulator. The _accumulator_
 is an intermediate data structure that stores the aggregated values until a final aggregation result
@@ -417,8 +417,7 @@ A user-defined table aggregate function (_UDTAGG_) maps scalar values of multipl
 The returned record may consist of one or more fields. If an output record consists of only a single field,
 the structured record can be omitted, and a scalar value can be emitted that will be implicitly wrapped into a row by the runtime.
 
-**NOTE:** Currently the general user-defined table aggregate function is only supported in the GroupBy aggregation
-of the blink planner in streaming mode.
+**NOTE:** Currently the general user-defined table aggregate function is only supported in the GroupBy aggregation in streaming mode.
 
 Similar to an [aggregate function](#aggregate-functions), the behavior of a table aggregate is centered around the concept of an accumulator.
 The accumulator is an intermediate data structure that stores the aggregated values until a final aggregation result is computed.

--- a/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -76,8 +76,6 @@ to [the relevant documentation]({{< ref "docs/dev/table/tableApi" >}}?code_tab=p
 
 <span class="label label-info">Note</span> Pandas UDAF does not support partial aggregation. Besides, all the data for a group or window will be loaded into memory at the same time during execution and so you must make sure that the data of a group or window could fit into the memory.
 
-<span class="label label-info">Note</span> Pandas UDAF is only supported in Blink Planner.
-
 The following example shows how to define your own vectorized Python aggregate function which computes mean,
 and use it in `GroupBy Aggregation`, `GroupBy Window Aggregation` and `Over Window Aggregation`:
 

--- a/docs/content/docs/dev/table/common.md
+++ b/docs/content/docs/dev/table/common.md
@@ -183,11 +183,11 @@ val tEnv = TableEnvironment.create(settings)
 ```python
 from pyflink.table import EnvironmentSettings, TableEnvironment
 
-# create a blink streaming TableEnvironment
+# create a streaming TableEnvironment
 env_settings = EnvironmentSettings.in_streaming_mode()
 table_env = TableEnvironment.create(env_settings)
 
-# create a blink batch TableEnvironment
+# create a batch TableEnvironment
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 

--- a/docs/content/docs/dev/table/sql/set.md
+++ b/docs/content/docs/dev/table/sql/set.md
@@ -43,11 +43,11 @@ The following examples show how to run a `SET` statement in SQL CLI.
 {{< tabs "set" >}}
 {{< tab "SQL CLI" >}}
 ```sql
-Flink SQL> SET 'table.planner' = 'blink';
+Flink SQL> SET 'table.local-time-zone' = 'Europe/Berlin';
 [INFO] Session property has been set.
 
 Flink SQL> SET;
-'table.planner' = 'blink'
+'table.local-time-zone' = 'Europe/Berlin'
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -58,6 +58,6 @@ Flink SQL> SET;
 SET ('key' = 'value')?
 ```
 
-If no key and value are specified, it just print all the properties. Otherwise, set the key with specified value.
+If no key and value are specified, it just prints all the properties. Otherwise, set the key with specified value.
 
 {{< top >}}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDAF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDAF.java
@@ -151,9 +151,9 @@ public class HiveGenericUDAF
     }
 
     /**
-     * This is invoked without calling open() in Blink, so we need to call init() for
+     * This is invoked without calling open(), so we need to call init() for
      * getNewAggregationBuffer(). TODO: re-evaluate how this will fit into Flink's new type
-     * inference and udf systemß
+     * inference and udf system
      */
     @Override
     public GenericUDAFEvaluator.AggregationBuffer createAccumulator() {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -102,7 +102,7 @@ public class HiveDialectITCase {
                         HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES, false);
         hiveCatalog.open();
         warehouse = hiveCatalog.getHiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE);
-        tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        tableEnv = HiveTestUtils.createTableEnvInBatchMode();
         tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -388,8 +388,7 @@ public class HiveDialectQueryITCase {
     }
 
     private static TableEnvironment getTableEnvWithHiveCatalog() {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         // automatically load hive module in hive-compatible mode

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveLookupJoinITCase.java
@@ -170,8 +170,7 @@ public class HiveLookupJoinITCase {
     @Test
     public void testPartitionFetcherAndReader() throws Exception {
         // constructs test data using dynamic partition
-        TableEnvironment batchEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment batchEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         batchEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         batchEnv.useCatalog(hiveCatalog.getName());
         batchEnv.executeSql(
@@ -232,8 +231,7 @@ public class HiveLookupJoinITCase {
     @Test
     public void testLookupJoinBoundedPartitionedTable() throws Exception {
         // constructs test data using dynamic partition
-        TableEnvironment batchEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment batchEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         batchEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         batchEnv.useCatalog(hiveCatalog.getName());
         batchEnv.executeSql(
@@ -259,8 +257,7 @@ public class HiveLookupJoinITCase {
     @Test
     public void testLookupJoinPartitionedTable() throws Exception {
         // constructs test data using dynamic partition
-        TableEnvironment batchEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment batchEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         batchEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         batchEnv.useCatalog(hiveCatalog.getName());
         batchEnv.executeSql(
@@ -290,8 +287,7 @@ public class HiveLookupJoinITCase {
     @Test
     public void testLookupJoinPartitionedTableWithPartitionTime() throws Exception {
         // constructs test data using dynamic partition
-        TableEnvironment batchEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment batchEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         batchEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         batchEnv.useCatalog(hiveCatalog.getName());
         batchEnv.executeSql(
@@ -320,8 +316,7 @@ public class HiveLookupJoinITCase {
     @Test
     public void testLookupJoinPartitionedTableWithCreateTime() throws Exception {
         // constructs test data using dynamic partition
-        TableEnvironment batchEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment batchEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         batchEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         batchEnv.useCatalog(hiveCatalog.getName());
         batchEnv.executeSql(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveRunnerITCase.java
@@ -209,8 +209,7 @@ public class HiveRunnerITCase {
 
     @Test
     public void testWriteNullValues() throws Exception {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         tableEnv.executeSql("create database db1");
@@ -617,8 +616,7 @@ public class HiveRunnerITCase {
     }
 
     private static TableEnvironment getTableEnvWithHiveCatalog() {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         return tableEnv;
@@ -627,7 +625,7 @@ public class HiveRunnerITCase {
     private TableEnvironment getStreamTableEnvWithHiveCatalog() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         return tableEnv;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -86,8 +86,7 @@ public class HiveTableSinkITCase {
 
     @Test
     public void testHiveTableSinkWithParallelismInBatch() {
-        final TableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        final TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         testHiveTableSinkWithParallelismBase(
                 tEnv, "/explain/testHiveTableSinkWithParallelismInBatch.out");
     }
@@ -96,7 +95,7 @@ public class HiveTableSinkITCase {
     public void testHiveTableSinkWithParallelismInStreaming() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final TableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         testHiveTableSinkWithParallelismBase(
                 tEnv, "/explain/testHiveTableSinkWithParallelismInStreaming.out");
     }
@@ -131,8 +130,7 @@ public class HiveTableSinkITCase {
 
     @Test
     public void testBatchAppend() throws Exception {
-        TableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
         tEnv.executeSql("create database db1");
@@ -202,8 +200,7 @@ public class HiveTableSinkITCase {
                     StreamExecutionEnvironment env =
                             StreamExecutionEnvironment.getExecutionEnvironment();
                     env.setParallelism(1);
-                    StreamTableEnvironment tEnv =
-                            HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env);
+                    StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvInStreamingMode(env);
                     tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
                     tEnv.useCatalog(hiveCatalog.getName());
 
@@ -237,7 +234,7 @@ public class HiveTableSinkITCase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         env.enableCheckpointing(100);
-        StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env);
+        StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvInStreamingMode(env);
 
         tEnv.getConfig().setLocalTimeZone(ZoneId.of("Asia/Shanghai"));
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
@@ -405,7 +402,7 @@ public class HiveTableSinkITCase {
         env.setParallelism(1);
         env.enableCheckpointing(100);
 
-        StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env);
+        StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvInStreamingMode(env);
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
@@ -498,7 +495,7 @@ public class HiveTableSinkITCase {
     private void assertBatch(String table, List<String> expected) {
         // using batch table env to query.
         List<String> results = new ArrayList<>();
-        TableEnvironment batchTEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment batchTEnv = HiveTestUtils.createTableEnvInBatchMode();
         batchTEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         batchTEnv.useCatalog(hiveCatalog.getName());
         batchTEnv

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -225,8 +225,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 
     @Test
     public void testPartitionFilter() throws Exception {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         TestPartitionFilterCatalog catalog =
                 new TestPartitionFilterCatalog(
                         hiveCatalog.getName(),
@@ -326,8 +325,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 
     @Test
     public void testPartitionFilterDateTimestamp() throws Exception {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         TestPartitionFilterCatalog catalog =
                 new TestPartitionFilterCatalog(
                         hiveCatalog.getName(),
@@ -594,7 +592,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(100);
         StreamTableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         tEnv.registerCatalog(catalogName, hiveCatalog);
         tEnv.useCatalog(catalogName);
         tEnv.executeSql(
@@ -649,7 +647,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(100);
         StreamTableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         tEnv.registerCatalog(catalogName, hiveCatalog);
         tEnv.useCatalog(catalogName);
         tEnv.executeSql(
@@ -704,7 +702,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(100);
         StreamTableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         tEnv.registerCatalog(catalogName, hiveCatalog);
         tEnv.useCatalog(catalogName);
         tEnv.executeSql(
@@ -773,7 +771,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         final String catalogName = "hive";
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         tEnv.getConfig()
                 .getConfiguration()
                 .setBoolean(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, useMapredReader);
@@ -838,7 +836,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         HiveCatalog catalogSpy = spy(hiveCatalog);
         doReturn(Optional.of(tableFactorySpy)).when(catalogSpy).getTableFactory();
 
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
         tableEnv.getConfig()
                 .getConfiguration()
                 .setBoolean(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, fallbackMR);
@@ -893,7 +891,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(100);
         StreamTableEnvironment tEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.HIVE);
+                HiveTestUtils.createTableEnvInStreamingMode(env, SqlDialect.HIVE);
         tEnv.registerCatalog(catalogName, hiveCatalog);
         tEnv.useCatalog(catalogName);
         tEnv.executeSql(
@@ -940,8 +938,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
     }
 
     private static TableEnvironment createTableEnv() {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog("hive", hiveCatalog);
         tableEnv.useCatalog("hive");
         return tableEnv;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorITCase.java
@@ -558,8 +558,7 @@ public class TableEnvHiveConnectorITCase {
     }
 
     private TableEnvironment getTableEnvWithHiveCatalog() {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         return tableEnv;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReaderITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReaderITCase.java
@@ -43,8 +43,7 @@ public class HiveInputFormatPartitionReaderITCase {
     @Test
     public void testReadMultipleSplits() throws Exception {
         HiveCatalog hiveCatalog = HiveTestUtils.createHiveCatalog();
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogITCase.java
@@ -482,7 +482,7 @@ public class HiveCatalogITCase {
 
     @Test
     public void testCreateTableLike() throws Exception {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         tableEnv.executeSql("create table generic_table (x int) with ('connector'='COLLECTION')");
@@ -504,8 +504,7 @@ public class HiveCatalogITCase {
 
     @Test
     public void testViewSchema() throws Exception {
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.DEFAULT);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.DEFAULT);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogUdfITCase.java
@@ -75,7 +75,7 @@ import static java.lang.String.format;
  * IT case for HiveCatalog. TODO: move to flink-connector-hive-test end-to-end test module once it's
  * setup
  */
-public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
+public class HiveCatalogUdfITCase extends AbstractTestBase {
 
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -98,7 +98,7 @@ public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
     }
 
     @Test
-    public void testBlinkUdf() throws Exception {
+    public void testFlinkUdf() throws Exception {
         TableSchema schema =
                 TableSchema.builder()
                         .field("name", DataTypes.STRING())
@@ -247,8 +247,7 @@ public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
     @Test
     public void testTimestampUDF() throws Exception {
 
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         tableEnv.executeSql(
@@ -275,8 +274,7 @@ public class HiveCatalogUseBlinkITCase extends AbstractTestBase {
     @Test
     public void testDateUDF() throws Exception {
 
-        TableEnvironment tableEnv =
-                HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode(SqlDialect.HIVE);
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
         tableEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tableEnv.useCatalog(hiveCatalog.getName());
         tableEnv.executeSql(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -147,11 +147,11 @@ public class HiveTestUtils {
         throw new RuntimeException("Exhausted all ephemeral ports and didn't find a free one");
     }
 
-    public static TableEnvironment createTableEnvWithBlinkPlannerBatchMode() {
-        return createTableEnvWithBlinkPlannerBatchMode(SqlDialect.DEFAULT);
+    public static TableEnvironment createTableEnvInBatchMode() {
+        return createTableEnvInBatchMode(SqlDialect.DEFAULT);
     }
 
-    public static TableEnvironment createTableEnvWithBlinkPlannerBatchMode(SqlDialect dialect) {
+    public static TableEnvironment createTableEnvInBatchMode(SqlDialect dialect) {
         TableEnvironment tableEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
         tableEnv.getConfig()
                 .getConfiguration()
@@ -160,12 +160,12 @@ public class HiveTestUtils {
         return tableEnv;
     }
 
-    public static StreamTableEnvironment createTableEnvWithBlinkPlannerStreamMode(
+    public static StreamTableEnvironment createTableEnvInStreamingMode(
             StreamExecutionEnvironment env) {
-        return createTableEnvWithBlinkPlannerStreamMode(env, SqlDialect.DEFAULT);
+        return createTableEnvInStreamingMode(env, SqlDialect.DEFAULT);
     }
 
-    public static StreamTableEnvironment createTableEnvWithBlinkPlannerStreamMode(
+    public static StreamTableEnvironment createTableEnvInStreamingMode(
             StreamExecutionEnvironment env, SqlDialect dialect) {
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
         tableEnv.getConfig()
@@ -176,7 +176,7 @@ public class HiveTestUtils {
     }
 
     public static TableEnvironment createTableEnvWithHiveCatalog(HiveCatalog catalog) {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
         tableEnv.registerCatalog(catalog.getName(), catalog);
         tableEnv.useCatalog(catalog.getName());
         return tableEnv;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleTest.java
@@ -60,7 +60,7 @@ public class HiveModuleTest {
         verifyNumBuiltInFunctions(hiveVersion, hiveModule);
 
         // creating functions shouldn't change the number of built in functions
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
         tableEnv.executeSql("create function myudf as 'org.apache.hadoop.hive.ql.udf.UDFPI'");
         tableEnv.executeSql(
                 "create function mygenericudf as 'org.apache.hadoop.hive.ql.udf.generic.GenericUDFAbs'");
@@ -130,7 +130,7 @@ public class HiveModuleTest {
 
     @Test
     public void testConstantArguments() {
-        TableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode();
 
         tEnv.unloadModule("core");
         tEnv.loadModule("hive", new HiveModule());
@@ -172,7 +172,7 @@ public class HiveModuleTest {
 
     @Test
     public void testDecimalReturnType() {
-        TableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode();
 
         tEnv.unloadModule("core");
         tEnv.loadModule("hive", new HiveModule());
@@ -195,7 +195,7 @@ public class HiveModuleTest {
 
     @Test
     public void testConstantReturnValue() {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
 
         tableEnv.unloadModule("core");
         tableEnv.loadModule("hive", new HiveModule());
@@ -211,7 +211,7 @@ public class HiveModuleTest {
 
     @Test
     public void testEmptyStringLiteralParameters() {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
 
         tableEnv.unloadModule("core");
         tableEnv.loadModule("hive", new HiveModule());
@@ -233,7 +233,7 @@ public class HiveModuleTest {
 
     @Test
     public void testFunctionsNeedSessionState() {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
 
         tableEnv.unloadModule("core");
         tableEnv.loadModule("hive", new HiveModule());
@@ -249,7 +249,7 @@ public class HiveModuleTest {
 
     @Test
     public void testCallUDFWithNoParam() {
-        TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+        TableEnvironment tableEnv = HiveTestUtils.createTableEnvInBatchMode();
 
         tableEnv.unloadModule("core");
         tableEnv.loadModule("hive", new HiveModule());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/AbstractDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/AbstractDialect.java
@@ -50,7 +50,6 @@ abstract class AbstractDialect implements JdbcDialect {
                                 dialectName(), dt.toString()));
             }
 
-            // only validate precision of DECIMAL type for blink planner
             if (dt.getLogicalType() instanceof DecimalType) {
                 int precision = ((DecimalType) dt.getLogicalType()).getPrecision();
                 if (precision > maxDecimalPrecision() || precision < minDecimalPrecision()) {
@@ -65,7 +64,6 @@ abstract class AbstractDialect implements JdbcDialect {
                 }
             }
 
-            // only validate precision of DECIMAL type for blink planner
             if (dt.getLogicalType() instanceof TimestampType) {
                 int precision = ((TimestampType) dt.getLogicalType()).getPrecision();
                 if (precision > maxTimestampPrecision() || precision < minTimestampPrecision()) {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTestBase.java
@@ -260,7 +260,7 @@ public class PostgresCatalogTestBase {
                         + "500");
     }
 
-    // TODO: add back timestamptz once blink planner supports timestamp with timezone
+    // TODO: add back timestamptz once planner supports timestamp with timezone
     public static TestTable getArrayTable() {
         return new TestTable(
                 TableSchema.builder()

--- a/flink-core/src/test/java/org/apache/flink/util/CloseableIteratorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CloseableIteratorTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertFalse;
 @SuppressWarnings("unchecked")
 public class CloseableIteratorTest {
 
-    private static final String[] ELEMENTS = new String[] {"flink", "blink"};
+    private static final String[] ELEMENTS = new String[] {"element-1", "element-2"};
 
     @Test
     public void testFlattenEmpty() throws Exception {

--- a/flink-end-to-end-tests/flink-python-test/pom.xml
+++ b/flink-end-to-end-tests/flink-python-test/pom.xml
@@ -78,7 +78,7 @@
 							<finalName>PythonUdfSqlJobExample</finalName>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>org.apache.flink.python.tests.BlinkStreamPythonUdfSqlJob</mainClass>
+									<mainClass>org.apache.flink.python.tests.StreamPythonUdfSqlJob</mainClass>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/flink-end-to-end-tests/flink-python-test/python/python_job.py
+++ b/flink-end-to-end-tests/flink-python-test/python/python_job.py
@@ -33,8 +33,7 @@ def word_count():
               "License you may not use this file except in compliance " \
               "with the License"
 
-    env_settings = EnvironmentSettings.new_instance().in_batch_mode().use_blink_planner().build()
-    t_env = TableEnvironment.create(environment_settings=env_settings)
+    t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
 
     # used to test pipeline.jars and pipleline.classpaths
     config_key = sys.argv[1]

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BatchPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BatchPythonUdfSqlJob.java
@@ -27,8 +27,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-/** A simple job used to test submitting the Python UDF job in blink batch mode. */
-public class BlinkBatchPythonUdfSqlJob {
+/** A simple job used to test submitting the Python UDF job in batch mode. */
+public class BatchPythonUdfSqlJob {
 
     public static void main(String[] args) {
         TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/StreamPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/StreamPythonUdfSqlJob.java
@@ -26,8 +26,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-/** A simple job used to test submitting the Python UDF job in blink stream mode. */
-public class BlinkStreamPythonUdfSqlJob {
+/** A simple job used to test submitting the Python UDF job in stream mode. */
+public class StreamPythonUdfSqlJob {
 
     public static void main(String[] args) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -214,8 +214,8 @@ run_test "State TTL RocksDb backend end-to-end test" "$END_TO_END_DIR/test-scrip
 
 run_test "SQL Client end-to-end test" "$END_TO_END_DIR/test-scripts/test_sql_client.sh"
 
-run_test "TPC-H end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpch.sh"
-run_test "TPC-DS end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpcds.sh"
+run_test "TPC-H end-to-end test" "$END_TO_END_DIR/test-scripts/test_tpch.sh"
+run_test "TPC-DS end-to-end test" "$END_TO_END_DIR/test-scripts/test_tpcds.sh"
 
 run_test "Heavy deployment end-to-end test" "$END_TO_END_DIR/test-scripts/test_heavy_deployment.sh" "skip_check_exceptions"
 

--- a/flink-end-to-end-tests/test-scripts/test-data/tpch/modified-query/q15.sql
+++ b/flink-end-to-end-tests/test-scripts/test-data/tpch/modified-query/q15.sql
@@ -29,7 +29,7 @@
 --   )
 -- ORDER BY
 --   s_suppkey;
--- Blink does not support view
+-- we don't support view
 
 SELECT
   s_suppkey,

--- a/flink-end-to-end-tests/test-scripts/test-data/tpch/modified-query/q20.sql
+++ b/flink-end-to-end-tests/test-scripts/test-data/tpch/modified-query/q20.sql
@@ -26,7 +26,7 @@ WHERE
           AND l_suppkey = ps_suppkey
           -- AND l_shipdate >= date('1994-01-01')
           -- AND l_shipdate < date('1994-01-01') + interval '1' YEAR
-          -- Blink does not support the above format
+          -- we don't support the above format
           AND l_shipdate >= date '1994-01-01'
           AND l_shipdate < date '1994-01-01' + interval '1' YEAR
 )

--- a/flink-end-to-end-tests/test-scripts/test-data/tpch/modified-query/q6.sql
+++ b/flink-end-to-end-tests/test-scripts/test-data/tpch/modified-query/q6.sql
@@ -6,6 +6,6 @@ WHERE
   l_shipdate >= DATE '1994-01-01'
   AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
 -- AND l_discount BETWEEN decimal '0.06' - decimal '0.01' AND decimal '0.06' + decimal '0.01'
--- Blink currently does not support the above feature
+-- we don't support the above feature
 AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
 AND l_quantity < 24

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -136,7 +136,7 @@ PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py" \
     pipeline.classpaths "file://${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
-echo "Test blink stream python udf sql job:\n"
+echo "Test stream python udf sql job:\n"
 PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -p 2 \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
@@ -145,14 +145,14 @@ PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -pyexec "venv.zip/.conda/bin/python" \
     "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
-echo "Test blink batch python udf sql job:\n"
+echo "Test batch python udf sql job:\n"
 PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
     -p 2 \
     -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
     -pyreq "${REQUIREMENTS_PATH}" \
     -pyarch "${TEST_DATA_DIR}/venv.zip" \
     -pyexec "venv.zip/.conda/bin/python" \
-    -c org.apache.flink.python.tests.BlinkBatchPythonUdfSqlJob \
+    -c org.apache.flink.python.tests.BatchPythonUdfSqlJob \
     "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
 
 echo "Test using python udf in sql client:\n"

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -68,7 +68,6 @@ do
     cat > "$INIT_SQL" << EOF
 ${SOURCES_SQL}
 ${SINK_SQL}
-SET table.planner=blink;
 SET execution.runtime-mode=batch;
 SET parallelism.default=2;
 EOF

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -105,10 +105,10 @@ public class JsonRowDataSerDeSchemaTest {
                         .toInstant();
 
         Map<String, Long> map = new HashMap<>();
-        map.put("flink", 123L);
+        map.put("element", 123L);
 
         Map<String, Integer> multiSet = new HashMap<>();
-        multiSet.put("blink", 2);
+        multiSet.put("element", 2);
 
         Map<String, Map<String, Integer>> nestedMap = new HashMap<>();
         Map<String, Integer> innerMap = new HashMap<>();
@@ -135,8 +135,8 @@ public class JsonRowDataSerDeSchemaTest {
         root.put("timestamp3", "1990-10-14T12:12:43.123");
         root.put("timestamp9", "1990-10-14T12:12:43.123456789");
         root.put("timestampWithLocalZone", "1990-10-14T12:12:43.123456789Z");
-        root.putObject("map").put("flink", 123);
-        root.putObject("multiSet").put("blink", 2);
+        root.putObject("map").put("element", 123);
+        root.putObject("multiSet").put("element", 2);
         root.putObject("map2map").putObject("inner_map").put("key", 234);
 
         byte[] serializedJson = objectMapper.writeValueAsBytes(root);

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -36,8 +36,7 @@ class TableConfig(object):
     with detailed inline documentation.
 
     For more advanced configuration, users can directly access the underlying key-value map via
-    :func:`~pyflink.table.TableConfig.get_configuration`. Currently, key-value options are only
-    supported for the Blink planner.
+    :func:`~pyflink.table.TableConfig.get_configuration`.
 
     .. note::
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1637,8 +1637,7 @@ class StreamTableEnvironment(TableEnvironment):
                                              of the TableEnvironment.
         :param table_config: The configuration of the TableEnvironment, optional.
         :param environment_settings: The environment settings used to instantiate the
-                                     TableEnvironment. It provides the interfaces about planner
-                                     selection(flink or blink), optional.
+                                     TableEnvironment.
         :return: The StreamTableEnvironment created from given StreamExecutionEnvironment and
                  configuration.
         """

--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -25,10 +25,10 @@ from pyflink.table import DataTypes
 from pyflink.table.expressions import row
 from pyflink.table.tests.test_types import PythonOnlyPoint, PythonOnlyUDT
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
-class StreamTableCalcTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableCalcTests(PyFlinkStreamTableTestCase):
 
     def test_select(self):
         t = self.t_env.from_elements([(1, 'hi', 'hello')], ['a', 'b', 'c'])

--- a/flink-python/pyflink/table/tests/test_column_operation.py
+++ b/flink-python/pyflink/table/tests/test_column_operation.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
-class StreamTableColumnsOperationTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableColumnsOperationTests(PyFlinkStreamTableTestCase):
 
     def test_add_columns(self):
         t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])

--- a/flink-python/pyflink/table/tests/test_correlate.py
+++ b/flink-python/pyflink/table/tests/test_correlate.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 ################################################################################
 from pyflink.table import expressions as expr
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
-class CorrelateTests(PyFlinkBlinkStreamTableTestCase):
+class CorrelateTests(PyFlinkStreamTableTestCase):
 
     def test_join_lateral(self):
         t_env = self.t_env

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -26,8 +26,8 @@ from pyflink.table import DataTypes
 from pyflink.table import expressions as expr
 from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import (PyFlinkBlinkStreamTableTestCase,
-                                             PyFlinkBlinkBatchTableTestCase)
+from pyflink.testing.test_case_utils import (PyFlinkStreamTableTestCase,
+                                             PyFlinkBatchTableTestCase)
 
 
 class DependencyTests(object):
@@ -65,12 +65,12 @@ class DependencyTests(object):
         self.assert_equals(actual, ["+I[3, 1]", "+I[4, 2]", "+I[5, 3]"])
 
 
-class BlinkBatchDependencyTests(DependencyTests, PyFlinkBlinkBatchTableTestCase):
+class BatchDependencyTests(DependencyTests, PyFlinkBatchTableTestCase):
 
     pass
 
 
-class BlinkStreamDependencyTests(DependencyTests, PyFlinkBlinkStreamTableTestCase):
+class StreamDependencyTests(DependencyTests, PyFlinkStreamTableTestCase):
 
     def test_set_requirements_without_cached_directory(self):
         requirements_txt_path = os.path.join(self.tempdir, str(uuid.uuid4()))

--- a/flink-python/pyflink/table/tests/test_distinct.py
+++ b/flink-python/pyflink/table/tests/test_distinct.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
-class StreamTableDistinctTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableDistinctTests(PyFlinkStreamTableTestCase):
 
     def test_distinct(self):
         t = self.t_env.from_elements([(1, "Hi", "Hello")], ['a', 'b', 'c'])

--- a/flink-python/pyflink/table/tests/test_explain.py
+++ b/flink-python/pyflink/table/tests/test_explain.py
@@ -16,11 +16,11 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 from pyflink.table.explain_detail import ExplainDetail
 
 
-class StreamTableExplainTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableExplainTests(PyFlinkStreamTableTestCase):
 
     def test_explain(self):
         t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -29,7 +29,7 @@ from pyflink.table.expressions import (col, lit, range_, and_, or_, current_date
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 
-class PyFlinkBlinkBatchExpressionTests(PyFlinkTestCase):
+class PyFlinkBatchExpressionTests(PyFlinkTestCase):
 
     def test_expression(self):
         expr1 = col('a')

--- a/flink-python/pyflink/table/tests/test_join.py
+++ b/flink-python/pyflink/table/tests/test_join.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
-class StreamTableJoinTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableJoinTests(PyFlinkStreamTableTestCase):
 
     def test_join_without_where(self):
         t_env = self.t_env

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -23,8 +23,8 @@ from pandas.util.testing import assert_frame_equal
 from pyflink.common import Row
 from pyflink.table.types import DataTypes
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
-    PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase, \
+    PyFlinkStreamTableTestCase
 
 
 class PandasConversionTestBase(object):
@@ -172,14 +172,14 @@ class PandasConversionITTests(PandasConversionTestBase):
             self.assertTrue(expected_field == result_field)
 
 
-class BlinkBatchPandasConversionTests(PandasConversionTests,
-                                      PandasConversionITTests,
-                                      PyFlinkBlinkBatchTableTestCase):
+class BatchPandasConversionTests(PandasConversionTests,
+                                 PandasConversionITTests,
+                                 PyFlinkBatchTableTestCase):
     pass
 
 
-class BlinkStreamPandasConversionTests(PandasConversionITTests,
-                                       PyFlinkBlinkStreamTableTestCase):
+class StreamPandasConversionTests(PandasConversionITTests,
+                                  PyFlinkStreamTableTestCase):
     def test_to_pandas_with_event_time(self):
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "1")
         # create source file path

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -21,11 +21,11 @@ from pyflink.table import expressions as expr
 from pyflink.table.types import DataTypes
 from pyflink.table.udf import udaf, udf, AggregateFunction
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
-    PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase, \
+    PyFlinkStreamTableTestCase
 
 
-class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
+class BatchPandasUDAFITTests(PyFlinkBatchTableTestCase):
 
     def test_check_result_type(self):
         def pandas_udaf():
@@ -280,7 +280,7 @@ class BatchPandasUDAFITTests(PyFlinkBlinkBatchTableTestCase):
                             "+I[3, 2.0, 3, 2.0, 1.0, 1.0, 2.0, 2.0, 1.0, 1.0]"])
 
 
-class StreamPandasUDAFITTests(PyFlinkBlinkStreamTableTestCase):
+class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
     def test_sliding_group_window_over_time(self):
         # create source file path
         import tempfile

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -24,8 +24,8 @@ from pyflink.table import DataTypes
 from pyflink.table.tests.test_udf import SubtractOne
 from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
-    PyFlinkBlinkStreamTableTestCase, PyFlinkTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase, \
+    PyFlinkStreamTableTestCase, PyFlinkTestCase
 
 
 class PandasUDFTests(PyFlinkTestCase):
@@ -306,7 +306,7 @@ class PandasUDFITTests(object):
         with self.assertRaisesRegex(Py4JJavaError, expected_regex=msg):
             t.select(result_type_not_series(t.a)).to_pandas()
 
-    def test_data_types_only_supported_in_blink_planner(self):
+    def test_data_types(self):
         import pandas as pd
 
         timezone = self.t_env.get_config().get_local_timezone()
@@ -338,13 +338,13 @@ class PandasUDFITTests(object):
         self.assert_equals(actual, ["+I[1970-01-02T00:00:00.123Z]"])
 
 
-class BlinkBatchPandasUDFITTests(PandasUDFITTests,
-                                 PyFlinkBlinkBatchTableTestCase):
+class BatchPandasUDFITTests(PandasUDFITTests,
+                            PyFlinkBatchTableTestCase):
     pass
 
 
-class BlinkStreamPandasUDFITTests(PandasUDFITTests,
-                                  PyFlinkBlinkStreamTableTestCase):
+class StreamPandasUDFITTests(PandasUDFITTests,
+                             PyFlinkStreamTableTestCase):
     pass
 
 

--- a/flink-python/pyflink/table/tests/test_row_based_operation.py
+++ b/flink-python/pyflink/table/tests/test_row_based_operation.py
@@ -22,8 +22,8 @@ from pyflink.table import expressions as expr, ListView
 from pyflink.table.types import DataTypes
 from pyflink.table.udf import udf, udtf, udaf, AggregateFunction, TableAggregateFunction, udtaf
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
-    PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase, \
+    PyFlinkStreamTableTestCase
 
 
 class RowBasedOperationTests(object):
@@ -137,7 +137,7 @@ class RowBasedOperationTests(object):
              "+I[1, 5, 1, 5, 1, 5]", "+I[1, 6, 1, 6, 1, 6]", "+I[1, 7, 1, 7, 1, 7]"])
 
 
-class BatchRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkBatchTableTestCase):
+class BatchRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBatchTableTestCase):
     def test_aggregate_with_pandas_udaf(self):
         t = self.t_env.from_elements(
             [(1, 2, 3), (2, 1, 3), (1, 5, 4), (1, 8, 6), (2, 3, 4)],
@@ -237,7 +237,7 @@ class BatchRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkBatchTab
                             "+I[2018-03-11 04:59:59.999, 8.0, 8]"])
 
 
-class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkBlinkStreamTableTestCase):
+class StreamRowBasedOperationITTests(RowBasedOperationTests, PyFlinkStreamTableTestCase):
     def test_aggregate(self):
         import pandas as pd
         t = self.t_env.from_elements(

--- a/flink-python/pyflink/table/tests/test_schema_operation.py
+++ b/flink-python/pyflink/table/tests/test_schema_operation.py
@@ -17,10 +17,10 @@
 ################################################################################
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import DataTypes
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
-class StreamTableSchemaTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableSchemaTests(PyFlinkStreamTableTestCase):
 
     def test_print_schema(self):
         t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])

--- a/flink-python/pyflink/table/tests/test_set_operation.py
+++ b/flink-python/pyflink/table/tests/test_set_operation.py
@@ -16,10 +16,10 @@
 # # limitations under the License.
 ################################################################################
 
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase
 
 
-class StreamTableSetOperationTests(PyFlinkBlinkBatchTableTestCase):
+class StreamTableSetOperationTests(PyFlinkBatchTableTestCase):
 
     data1 = [(1, "Hi", "Hello")]
     data2 = [(3, "Hello", "Hello")]

--- a/flink-python/pyflink/table/tests/test_sort.py
+++ b/flink-python/pyflink/table/tests/test_sort.py
@@ -16,10 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkBatchTableTestCase
 
 
-class BatchTableSortTests(PyFlinkBlinkBatchTableTestCase):
+class BatchTableSortTests(PyFlinkBatchTableTestCase):
 
     def test_order_by_offset_fetch(self):
         t = self.t_env.from_elements([(1, "Hello")], ["a", "b"])

--- a/flink-python/pyflink/table/tests/test_sql.py
+++ b/flink-python/pyflink/table/tests/test_sql.py
@@ -23,11 +23,11 @@ from pyflink.find_flink_home import _find_flink_source_root
 from pyflink.java_gateway import get_gateway
 from pyflink.table import DataTypes, ResultKind
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase, \
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
     PyFlinkTestCase
 
 
-class StreamSqlTests(PyFlinkBlinkStreamTableTestCase):
+class StreamSqlTests(PyFlinkStreamTableTestCase):
 
     def test_sql_ddl(self):
         self.t_env.execute_sql("create temporary function func1 as "

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -34,7 +34,7 @@ from pyflink.table.expressions import col
 from pyflink.table.types import RowType, Row
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import \
-    PyFlinkBlinkBatchTableTestCase, PyFlinkBlinkStreamTableTestCase, \
+    PyFlinkBatchTableTestCase, PyFlinkStreamTableTestCase, \
     _load_specific_flink_module_jars
 from pyflink.util.java_utils import get_j_env_configuration
 
@@ -258,7 +258,7 @@ class DataStreamConversionTestCases(object):
         self.assertEqual(result, expected)
 
 
-class BlinkStreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkBlinkStreamTableTestCase):
+class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCase):
 
     def test_collect_with_retract(self):
         expected_row_kinds = [RowKind.INSERT, RowKind.UPDATE_BEFORE, RowKind.UPDATE_AFTER,
@@ -329,7 +329,7 @@ class BlinkStreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkBlinkStreamT
             self.assertEqual(expected_result, collected_result)
 
 
-class BlinkBatchTableEnvironmentTests(PyFlinkBlinkBatchTableTestCase):
+class BatchTableEnvironmentTests(PyFlinkBatchTableTestCase):
 
     def test_explain_with_multi_sinks(self):
         t_env = self.t_env

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -846,12 +846,12 @@ class DataTypeConvertTests(PyFlinkTestCase):
 
         # Legacy type tests
         Types = gateway.jvm.org.apache.flink.table.api.Types
-        BlinkBigDecimalTypeInfo = \
+        InternalBigDecimalTypeInfo = \
             gateway.jvm.org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo
 
         java_types = [Types.STRING(),
                       Types.DECIMAL(),
-                      BlinkBigDecimalTypeInfo(12, 5)]
+                      InternalBigDecimalTypeInfo(12, 5)]
 
         converted_python_types = [_from_java_type(item) for item in java_types]
 

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -29,7 +29,7 @@ from pyflink.table.data_view import ListView, MapView
 from pyflink.table.expressions import col
 from pyflink.table.udf import AggregateFunction, udaf
 from pyflink.table.window import Tumble, Slide, Session
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
 
 
 class CountAggregateFunction(AggregateFunction):
@@ -239,7 +239,7 @@ class TestIterateAggregateFunction(AggregateFunction):
             DataTypes.FIELD("f3", DataTypes.BIGINT())])
 
 
-class StreamTableAggregateTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableAggregateTests(PyFlinkStreamTableTestCase):
 
     def test_double_aggregate(self):
         self.t_env.register_function("my_count", CountAggregateFunction())

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -24,8 +24,8 @@ import pytz
 from pyflink.table import DataTypes, expressions as expr
 from pyflink.table.udf import ScalarFunction, udf
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase, \
-    PyFlinkBlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
+    PyFlinkBatchTableTestCase
 
 
 class UserDefinedFunctionTests(object):
@@ -638,8 +638,8 @@ def float_equal(a, b, rel_tol=1e-09, abs_tol=0.0):
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 
-class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
-                                                 PyFlinkBlinkStreamTableTestCase):
+class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
+                                            PyFlinkStreamTableTestCase):
     def test_deterministic(self):
         add_one = udf(lambda i: i + 1, result_type=DataTypes.BIGINT())
         self.assertTrue(add_one._deterministic)
@@ -704,7 +704,7 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
             self.t_env.create_temporary_system_function(
                 "non-callable-udf", udf(Plus(), DataTypes.BIGINT(), DataTypes.BIGINT()))
 
-    def test_data_types_only_supported_in_blink_planner(self):
+    def test_data_types(self):
         timezone = self.t_env.get_config().get_local_timezone()
         local_datetime = pytz.timezone(timezone).localize(
             datetime.datetime(1970, 1, 1, 0, 0, 0, 123000))
@@ -778,8 +778,8 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
         self.assertEqual(lines, ['1,2', '2,3', '3,4'])
 
 
-class PyFlinkBlinkBatchUserDefinedFunctionTests(UserDefinedFunctionTests,
-                                                PyFlinkBlinkBatchTableTestCase):
+class PyFlinkBatchUserDefinedFunctionTests(UserDefinedFunctionTests,
+                                           PyFlinkBatchTableTestCase):
     pass
 
 

--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -20,8 +20,8 @@ import unittest
 from pyflink.table import DataTypes
 from pyflink.table.udf import TableFunction, udtf, ScalarFunction, udf
 from pyflink.testing import source_sink_utils
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase, \
-    PyFlinkBlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
+    PyFlinkBatchTableTestCase
 
 
 class UserDefinedTableFunctionTests(object):
@@ -71,8 +71,8 @@ class UserDefinedTableFunctionTests(object):
         return source_sink_utils.results()
 
 
-class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedTableFunctionTests,
-                                                 PyFlinkBlinkStreamTableTestCase):
+class PyFlinkStreamUserDefinedFunctionTests(UserDefinedTableFunctionTests,
+                                            PyFlinkStreamTableTestCase):
     def test_execute_from_json_plan(self):
         # create source file path
         tmp_dir = self.tempdir
@@ -124,8 +124,8 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedTableFunctionTests,
         self.assertEqual(lines, ['1,1,0', '2,2,0', '3,3,0', '3,3,1'])
 
 
-class PyFlinkBlinkBatchUserDefinedFunctionTests(UserDefinedTableFunctionTests,
-                                                PyFlinkBlinkBatchTableTestCase):
+class PyFlinkBatchUserDefinedFunctionTests(UserDefinedTableFunctionTests,
+                                           PyFlinkBatchTableTestCase):
     pass
 
 

--- a/flink-python/pyflink/table/tests/test_window.py
+++ b/flink-python/pyflink/table/tests/test_window.py
@@ -20,11 +20,11 @@ from py4j.protocol import Py4JJavaError
 
 from pyflink.table import expressions as expr
 from pyflink.table.window import Session, Slide, Tumble, Over
-from pyflink.testing.test_case_utils import PyFlinkBlinkStreamTableTestCase, \
-    PyFlinkBlinkBatchTableTestCase
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
+    PyFlinkBatchTableTestCase
 
 
-class StreamTableWindowTests(PyFlinkBlinkStreamTableTestCase):
+class StreamTableWindowTests(PyFlinkStreamTableTestCase):
 
     def test_over_window(self):
         t_env = self.t_env
@@ -42,7 +42,7 @@ class StreamTableWindowTests(PyFlinkBlinkStreamTableTestCase):
             result.select, "b.sum over w")
 
 
-class BatchTableWindowTests(PyFlinkBlinkBatchTableTestCase):
+class BatchTableWindowTests(PyFlinkBatchTableTestCase):
 
     def test_tumble_window(self):
         t = self.t_env.from_elements([(1, 1, "Hello")], ["a", "b", "c"])

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -2667,8 +2667,7 @@ class DataTypes(object):
                           It must have a value between 0 and 9 (both inclusive). (default: 6)
         :param nullable: boolean, whether the type can be null (None) or not.
 
-        .. note:: `LocalZonedTimestampType` is currently only supported in blink planner and the
-                  precision must be 3.
+        .. note:: `LocalZonedTimestampType` only supports precision of 3 currently.
         """
         return LocalZonedTimestampType(precision, nullable)
 

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -143,26 +143,26 @@ class PyFlinkTestCase(unittest.TestCase):
         return CsvTableSource(path, fields, data_types)
 
 
-class PyFlinkBlinkStreamTableTestCase(PyFlinkTestCase):
+class PyFlinkStreamTableTestCase(PyFlinkTestCase):
     """
-    Base class for stream tests of blink planner.
+    Base class for table stream tests.
     """
 
     def setUp(self):
-        super(PyFlinkBlinkStreamTableTestCase, self).setUp()
+        super(PyFlinkStreamTableTestCase, self).setUp()
         self.t_env = TableEnvironment.create(EnvironmentSettings.in_streaming_mode())
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(
             "python.fn-execution.bundle.size", "1")
 
 
-class PyFlinkBlinkBatchTableTestCase(PyFlinkTestCase):
+class PyFlinkBatchTableTestCase(PyFlinkTestCase):
     """
-    Base class for batch tests of blink planner.
+    Base class for table batch tests.
     """
 
     def setUp(self):
-        super(PyFlinkBlinkBatchTableTestCase, self).setUp()
+        super(PyFlinkBatchTableTestCase, self).setUp()
         self.t_env = TableEnvironment.create(EnvironmentSettings.in_batch_mode())
         self.t_env.get_config().get_configuration().set_string("parallelism.default", "2")
         self.t_env.get_config().get_configuration().set_string(

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -205,9 +205,7 @@ public final class ArrowUtils {
         return new Field(fieldName, fieldType, children);
     }
 
-    /**
-     * Creates an {@link ArrowWriter} for blink planner for the specified {@link VectorSchemaRoot}.
-     */
+    /** Creates an {@link ArrowWriter} for the specified {@link VectorSchemaRoot}. */
     public static ArrowWriter<RowData> createRowDataArrowWriter(
             VectorSchemaRoot root, RowType rowType) {
         ArrowFieldWriter<RowData>[] fieldWriters =
@@ -346,9 +344,7 @@ public final class ArrowUtils {
         }
     }
 
-    /**
-     * Creates an {@link ArrowReader} for blink planner for the specified {@link VectorSchemaRoot}.
-     */
+    /** Creates an {@link ArrowReader} for the specified {@link VectorSchemaRoot}. */
     public static RowDataArrowReader createRowDataArrowReader(
             VectorSchemaRoot root, RowType rowType) {
         List<ColumnVector> columnVectors = new ArrayList<>();

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/AbstractPythonStreamAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/AbstractPythonStreamAggregateOperator.java
@@ -172,11 +172,10 @@ public abstract class AbstractPythonStreamAggregateOperator
         baos = new ByteArrayOutputStreamWithPos();
         baosWrapper = new DataOutputViewStreamWrapper(baos);
         userDefinedFunctionInputType = getUserDefinedFunctionInputType();
-        udfInputTypeSerializer =
-                PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionInputType);
+        udfInputTypeSerializer = PythonTypeUtils.toInternalSerializer(userDefinedFunctionInputType);
         userDefinedFunctionOutputType = getUserDefinedFunctionOutputType();
         udfOutputTypeSerializer =
-                PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionOutputType);
+                PythonTypeUtils.toInternalSerializer(userDefinedFunctionOutputType);
         rowDataWrapper = new StreamRecordRowDataWrappingCollector(output);
         super.open();
     }
@@ -243,7 +242,7 @@ public abstract class AbstractPythonStreamAggregateOperator
 
     @VisibleForTesting
     TypeSerializer getKeySerializer() {
-        return PythonTypeUtils.toBlinkTypeSerializer(getKeyType());
+        return PythonTypeUtils.toInternalSerializer(getKeyType());
     }
 
     protected RowType getKeyType() {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperator.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo;
 import org.apache.flink.table.planner.typeutils.DataViewUtils;
 import org.apache.flink.table.types.logical.RowType;
 
-/** The Python AggregateFunction operator for the blink planner. */
+/** The Python AggregateFunction operator. */
 @Internal
 public class PythonStreamGroupAggregateOperator extends AbstractPythonStreamGroupAggregateOperator {
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupTableAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupTableAggregateOperator.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions.python.PythonAggregateFunctionInfo;
 import org.apache.flink.table.planner.typeutils.DataViewUtils;
 import org.apache.flink.table.types.logical.RowType;
 
-/** The Python TableAggregateFunction operator for the blink planner. */
+/** The Python TableAggregateFunction operator. */
 @Internal
 public class PythonStreamGroupTableAggregateOperator
         extends AbstractPythonStreamGroupAggregateOperator {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperator.java
@@ -65,7 +65,7 @@ import static org.apache.flink.fnexecution.v1.FlinkFnApi.GroupWindow.WindowPrope
 import static org.apache.flink.table.runtime.util.TimeWindowUtil.toEpochMillsForTimer;
 import static org.apache.flink.table.runtime.util.TimeWindowUtil.toUtcTimestampMills;
 
-/** The Python Group Window AggregateFunction operator for the blink planner. */
+/** The Python Group Window AggregateFunction operator. */
 @Internal
 public class PythonStreamGroupWindowAggregateOperator<K, W extends Window>
         extends AbstractPythonStreamAggregateOperator implements Triggerable<K, W> {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/AbstractRowDataPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/AbstractRowDataPythonScalarFunctionOperator.java
@@ -37,7 +37,7 @@ import org.apache.flink.table.types.logical.RowType;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-/** The Python {@link ScalarFunction} operator for the blink planner. */
+/** The Python {@link ScalarFunction} operator. */
 @Internal
 public abstract class AbstractRowDataPythonScalarFunctionOperator
         extends AbstractPythonScalarFunctionOperator<RowData, RowData, RowData> {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/RowDataPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/RowDataPythonScalarFunctionOperator.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.types.logical.RowType;
 
 import java.io.IOException;
 
-/** The Python {@link ScalarFunction} operator for the blink planner. */
+/** The Python {@link ScalarFunction} operator. */
 @Internal
 public class RowDataPythonScalarFunctionOperator
         extends AbstractRowDataPythonScalarFunctionOperator {
@@ -66,10 +66,9 @@ public class RowDataPythonScalarFunctionOperator
     @SuppressWarnings("unchecked")
     public void open() throws Exception {
         super.open();
-        udfInputTypeSerializer =
-                PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionInputType);
+        udfInputTypeSerializer = PythonTypeUtils.toInternalSerializer(userDefinedFunctionInputType);
         udfOutputTypeSerializer =
-                PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionOutputType);
+                PythonTypeUtils.toInternalSerializer(userDefinedFunctionOutputType);
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.runtime.arrow.serializers.RowDataArrowSerializer;
 import org.apache.flink.table.runtime.operators.python.scalar.AbstractRowDataPythonScalarFunctionOperator;
 import org.apache.flink.table.types.logical.RowType;
 
-/** Arrow Python {@link ScalarFunction} operator for the blink planner. */
+/** Arrow Python {@link ScalarFunction} operator. */
 @Internal
 public class RowDataArrowPythonScalarFunctionOperator
         extends AbstractRowDataPythonScalarFunctionOperator {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/RowDataPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/RowDataPythonTableFunctionOperator.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.RowType;
 
-/** The Python {@link TableFunction} operator for the blink planner. */
+/** The Python {@link TableFunction} operator. */
 @Internal
 public class RowDataPythonTableFunctionOperator
         extends AbstractPythonTableFunctionOperator<RowData, RowData, RowData> {
@@ -84,9 +84,9 @@ public class RowDataPythonTableFunctionOperator
         udtfInputProjection = createUdtfInputProjection();
         forwardedInputSerializer = new RowDataSerializer(inputType);
         udtfInputTypeSerializer =
-                PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionInputType);
+                PythonTypeUtils.toInternalSerializer(userDefinedFunctionInputType);
         udtfOutputTypeSerializer =
-                PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionOutputType);
+                PythonTypeUtils.toInternalSerializer(userDefinedFunctionOutputType);
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -81,8 +81,8 @@ public final class PythonTypeUtils {
         return logicalType.accept(new PythonTypeUtils.LogicalTypeToProtoTypeConverter());
     }
 
-    public static TypeSerializer toBlinkTypeSerializer(LogicalType logicalType) {
-        return logicalType.accept(new LogicalTypeToBlinkTypeSerializerConverter());
+    public static TypeSerializer toInternalSerializer(LogicalType logicalType) {
+        return logicalType.accept(new LogicalTypetoInternalSerializerConverter());
     }
 
     /**
@@ -137,7 +137,7 @@ public final class PythonTypeUtils {
         return time + LOCAL_TZ.getOffset(time);
     }
 
-    private static class LogicalTypeToBlinkTypeSerializerConverter
+    private static class LogicalTypetoInternalSerializerConverter
             extends LogicalTypeDefaultVisitor<TypeSerializer> {
         @Override
         public TypeSerializer visit(BooleanType booleanType) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/ArrayDataSerializer.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 /**
  * A {@link TypeSerializer} for {@link ArrayData}. It should be noted that the header will not be
  * encoded. Currently Python doesn't support BinaryArrayData natively, so we can't use
- * BaseArraySerializer in blink directly.
+ * BaseArraySerializer directly.
  */
 @Internal
 public class ArrayDataSerializer

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
@@ -30,9 +30,7 @@ import java.io.IOException;
 import java.sql.Date;
 
 /**
- * Takes int instead of long as the serialized value. It not only reduces the length of the
- * serialized value, but also makes the serialized value consistent between the legacy planner and
- * the blink planner.
+ * Takes int instead of long as the serialized value. It reduces the length of the serialized value.
  */
 @Internal
 public class DateSerializer extends TypeSerializerSingleton<Date> {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/MapDataSerializer.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 /**
  * A {@link TypeSerializer} for {@link MapData}. It should be noted that the header will not be
  * encoded. Currently Python doesn't support BinaryMapData natively, so we can't use
- * BaseArraySerializer in blink directly.
+ * BaseArraySerializer directly.
  */
 @Internal
 public class MapDataSerializer extends org.apache.flink.table.runtime.typeutils.MapDataSerializer {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/RowDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/RowDataSerializer.java
@@ -44,7 +44,7 @@ import static org.apache.flink.api.java.typeutils.runtime.MaskUtils.writeMask;
 /**
  * A {@link TypeSerializer} for {@link RowData}. It should be noted that the row kind will be
  * encoded as the first 2 bits instead of the first byte. Currently Python doesn't support RowData
- * natively, so we can't use RowDataSerializer in blink directly.
+ * natively, so we can't use RowDataSerializer directly.
  */
 @Internal
 public class RowDataSerializer extends org.apache.flink.table.runtime.typeutils.RowDataSerializer {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/StringSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/StringSerializer.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  * We create the StringSerializer instead of using the StringSerializer of flink-core module because
  * the StringSerializer of flink-core module serialize every Char of String in serialize method and
  * deserialize the Char to build the String. We want to convert String to UTF-8 bytes to serialize
- * which is compatible with BinaryStringSerializer in blink.
+ * which is compatible with BinaryStringSerializer.
  *
  * <p>So we create this StringSerializer (only used in Java and Python data communication in udf).
  *

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimeSerializer.java
@@ -30,9 +30,7 @@ import java.sql.Time;
 import java.util.TimeZone;
 
 /**
- * Uses int instead of long as the serialized value. It not only reduces the length of the
- * serialized value, but also makes the serialized value consistent between the legacy planner and
- * the blink planner.
+ * Uses int instead of long as the serialized value. It reduces the length of the serialized value.
  */
 @Internal
 public class TimeSerializer extends TypeSerializerSingleton<Time> {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializer.java
@@ -33,9 +33,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 /**
- * Uses similar serialization/deserialization of SqlTimestampSerializer in blink to serialize
- * Timestamp. It not only deals with Daylight saving time problem and precision problem, but also
- * makes the serialized value consistent between the legacy planner and the blink planner.
+ * Uses similar serialization/deserialization of SqlTimestampSerializer to serialize Timestamp. It
+ * deals with Daylight saving time problem and precision problem.
  */
 @Internal
 public class TimestampSerializer extends TypeSerializerSingleton<Timestamp> {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtilsTest.java
@@ -39,11 +39,11 @@ import static org.junit.Assert.assertTrue;
 public class PythonTypeUtilsTest {
 
     @Test
-    public void testLogicalTypeToBlinkTypeSerializer() {
+    public void testLogicalTypetoInternalSerializer() {
         List<RowType.RowField> rowFields = new ArrayList<>();
         rowFields.add(new RowType.RowField("f1", new BigIntType()));
         RowType rowType = new RowType(rowFields);
-        TypeSerializer baseSerializer = PythonTypeUtils.toBlinkTypeSerializer(rowType);
+        TypeSerializer baseSerializer = PythonTypeUtils.toInternalSerializer(rowType);
         assertTrue(baseSerializer instanceof RowDataSerializer);
 
         assertEquals(1, ((RowDataSerializer) baseSerializer).getArity());
@@ -70,7 +70,7 @@ public class PythonTypeUtilsTest {
         String expectedTestException =
                 "Python UDF doesn't support logical type `cat`.`db`.`MyType` currently.";
         try {
-            PythonTypeUtils.toBlinkTypeSerializer(logicalType);
+            PythonTypeUtils.toInternalSerializer(logicalType);
         } catch (Exception e) {
             assertTrue(
                     ExceptionUtils.findThrowableWithMessage(e, expectedTestException).isPresent());

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSinkFactory.java
@@ -32,8 +32,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory consumes
  * @deprecated This interface has been replaced by {@link DynamicTableSinkFactory}. The new
- *     interface creates instances of {@link DynamicTableSink} and only works with the Blink
- *     planner. See FLIP-95 for more information.
+ *     interface creates instances of {@link DynamicTableSink}. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/StreamTableSourceFactory.java
@@ -32,8 +32,7 @@ import java.util.Map;
  *
  * @param <T> type of records that the factory produces
  * @deprecated This interface has been replaced by {@link DynamicTableSourceFactory}. The new
- *     interface creates instances of {@link DynamicTableSource} and only works with the Blink
- *     planner. See FLIP-95 for more information.
+ *     interface creates instances of {@link DynamicTableSource}. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/AppendStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/AppendStreamTableSink.java
@@ -32,8 +32,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  *
  * @param <T> Type of {@link DataStream} that this {@link TableSink} expects and supports.
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
- *     consumes internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
@@ -31,8 +31,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  * @param <T> Type of the bounded {@link OutputFormat} that this {@link TableSink} expects and
  *     supports.
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
- *     consumes internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/RetractStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/RetractStreamTableSink.java
@@ -40,8 +40,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  *
  * @param <T> Type of records that this {@link TableSink} expects and supports.
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
- *     consumes internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/StreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/StreamTableSink.java
@@ -27,8 +27,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  *
  * @param <T> Type of the {@link DataStream} created by this {@link TableSink}.
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
- *     consumes internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 public interface StreamTableSink<T> extends TableSink<T> {

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/UpsertStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/UpsertStreamTableSink.java
@@ -51,8 +51,7 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
  *
  * @param <T> Type of records that this {@link TableSink} expects and supports.
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
- *     consumes internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/InputFormatTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/InputFormatTableSource.java
@@ -32,8 +32,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToL
  *
  * @param <T> Type of the bounded {@link InputFormat} created by this {@link TableSource}.
  * @deprecated This interface has been replaced by {@link DynamicTableSource}. The new interface
- *     produces internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/StreamTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/StreamTableSource.java
@@ -27,8 +27,7 @@ import org.apache.flink.table.connector.source.DynamicTableSource;
  *
  * @param <T> Type of the {@link DataStream} created by this {@link TableSource}.
  * @deprecated This interface has been replaced by {@link DynamicTableSource}. The new interface
- *     produces internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 public interface StreamTableSource<T> extends TableSource<T> {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -44,8 +44,10 @@ import static java.time.ZoneId.SHORT_IDS;
  * with detailed inline documentation.
  *
  * <p>For more advanced configuration, users can directly access the underlying key-value map via
- * {@link #getConfiguration()}. Currently, key-value options are only supported for the Blink
- * planner. Users can configure also underlying execution parameters via this object. E.g.
+ * {@link #getConfiguration()}. Users can configure also underlying execution parameters via this
+ * object.
+ *
+ * <p>For example:
  *
  * <pre>{@code
  * tEnv.getConfig().addConfiguration(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -33,8 +33,6 @@ import static org.apache.flink.configuration.description.TextElement.text;
 /**
  * This class holds configuration constants used by Flink's table module.
  *
- * <p>This is only used for the Blink planner.
- *
  * <p>NOTE: All option keys in this class must start with "table.exec".
  */
 @PublicEvolving

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -27,8 +27,6 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 /**
  * This class holds configuration constants used by Flink's table planner module.
  *
- * <p>This is only used for the Blink planner.
- *
  * <p>NOTE: All option keys in this class must start with "table.optimizer".
  */
 @PublicEvolving

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -111,8 +111,6 @@ class StatementSetImpl implements StatementSet {
      *
      * <p>The added statements and Tables will NOT be cleared when executing this method.
      *
-     * <p>NOTES: Only the Blink planner supports this method.
-     *
      * <p><b>NOTES</b>: This is an experimental feature now.
      *
      * @return the string json representation of an optimized ExecNode plan for the statements and

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -119,8 +119,6 @@ public interface TableEnvironmentInternal extends TableEnvironment {
      * given statement. An ExecNode plan can be serialized to json plan, and a json plan can be
      * deserialized to an ExecNode plan.
      *
-     * <p>NOTES: Only the Blink planner supports this method.
-     *
      * <p><b>NOTES</b>: This is an experimental feature now.
      *
      * @param stmt The SQL statement to generate json plan.
@@ -132,8 +130,6 @@ public interface TableEnvironmentInternal extends TableEnvironment {
     /**
      * Get the json plan for the given {@link ModifyOperation}s. see {@link #getJsonPlan(String)}
      * for more info about json plan.
-     *
-     * <p>NOTES: Only the Blink planner supports this method.
      *
      * <p><b>NOTES</b>: This is an experimental feature now.
      *
@@ -148,8 +144,6 @@ public interface TableEnvironmentInternal extends TableEnvironment {
      * Returns the execution plan for the given json plan. A SQL statement can be converted to json
      * plan through {@link #getJsonPlan(String)}.
      *
-     * <p>NOTES: Only the Blink planner supports this method.
-     *
      * <p><b>NOTES</b>: This is an experimental feature now.
      *
      * @param jsonPlan The json plan to be explained.
@@ -163,8 +157,6 @@ public interface TableEnvironmentInternal extends TableEnvironment {
     /**
      * Execute the given json plan, and return the execution result. A SQL statement can be
      * converted to json plan through {@link #getJsonPlan(String)}.
-     *
-     * <p>NOTES: Only the Blink planner supports this method.
      *
      * <p><b>NOTES</b>: This is an experimental feature now.
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -93,8 +93,6 @@ public interface Planner {
      * given statement. An ExecNode plan can be serialized to json plan, and a json plan can be
      * deserialized to an ExecNode plan.
      *
-     * <p>NOTES: Only the Blink planner supports this method.
-     *
      * <p><b>NOTES:</b>: This is an experimental feature now.
      *
      * @param modifyOperations the {@link ModifyOperation}s to generate json plan.
@@ -106,8 +104,6 @@ public interface Planner {
 
     /**
      * Returns the execution plan for the given json plan.
-     *
-     * <p>NOTES: Only the Blink planner supports this method.
      *
      * <p><b>NOTES:</b>: This is an experimental feature now.
      *
@@ -125,8 +121,6 @@ public interface Planner {
      * <p>The json plan is the string json representation of an optimized ExecNode plan for the
      * given statement. An ExecNode plan can be serialized to json plan, and a json plan can be
      * deserialized to an ExecNode plan.
-     *
-     * <p>NOTES: Only the Blink planner supports this method.
      *
      * <p><b>NOTES:</b>: This is an experimental feature now.
      *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/OverwritableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/OverwritableTableSink.java
@@ -28,8 +28,7 @@ import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
  *
  * @see PartitionableTableSink for the definition of partition.
  * @deprecated This interface will not be supported in the new sink design around {@link
- *     DynamicTableSink} which only works with the Blink planner. Use {@link SupportsOverwrite}
- *     instead. See FLIP-95 for more information.
+ *     DynamicTableSink}. Use {@link SupportsOverwrite} instead. See FLIP-95 for more information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/PartitionableTableSink.java
@@ -63,8 +63,8 @@ import java.util.Map;
  * from each record.
  *
  * @deprecated This interface will not be supported in the new sink design around {@link
- *     DynamicTableSink} which only works with the Blink planner. Use {@link SupportsPartitioning}
- *     instead. See FLIP-95 for more information.
+ *     DynamicTableSink}. Use {@link SupportsPartitioning} instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sinks/TableSink.java
@@ -35,8 +35,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  *
  * @param <T> The return type of the {@link TableSink}.
  * @deprecated This interface has been replaced by {@link DynamicTableSink}. The new interface
- *     consumes internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     consumes internal data structures. See FLIP-95 for more information.
  */
 @PublicEvolving
 public interface TableSink<T> {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedFieldMapping.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedFieldMapping.java
@@ -42,8 +42,7 @@ import java.util.Map;
  * <p>If a mapping is provided, all fields must be explicitly mapped.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     DynamicTableSource}. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedProctimeAttribute.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedProctimeAttribute.java
@@ -29,8 +29,8 @@ import javax.annotation.Nullable;
  * Extends a {@link TableSource} to specify a processing time attribute.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use the concept of computed
- *     columns instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use the concept of computed columns instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedRowtimeAttributes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/DefinedRowtimeAttributes.java
@@ -30,8 +30,8 @@ import java.util.List;
  * RowtimeAttributeDescriptor}.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use the concept of computed
- *     columns instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use the concept of computed columns instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FieldComputer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FieldComputer.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.expressions.ResolvedFieldReference;
  *
  * @param <T> The result type of the provided expression.
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use the concept of computed
- *     columns instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use the concept of computed columns instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FilterableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/FilterableTableSource.java
@@ -29,8 +29,8 @@ import java.util.List;
  * this interface is able to filter records before returning.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use {@link
- *     SupportsFilterPushDown} instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use {@link SupportsFilterPushDown} instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 public interface FilterableTableSource<T> {
@@ -39,11 +39,6 @@ public interface FilterableTableSource<T> {
      * Check and pick all predicates this table source can support. The passed in predicates have
      * been translated in conjunctive form, and table source can only pick those predicates that it
      * supports.
-     *
-     * <p><strong>WARNING:</strong> Flink planner will push down PlannerExpressions (which are
-     * defined in flink-table-planner module), while Blink planner will push down {@link
-     * Expression}s. So the implementation for Flink planner and Blink planner should be different
-     * and incompatible. PlannerExpression will be removed in the future.
      *
      * <p>After trying to push predicates down, we should return a new {@link TableSource} instance
      * which holds all pushed down predicates. Even if we actually pushed nothing down, it is

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LimitableTableSource.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
  * but does not need to guarantee that the number must be less than or equal to the limit.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use {@link
- *     SupportsLimitPushDown} instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use {@link SupportsLimitPushDown} instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/LookupableTableSource.java
@@ -31,8 +31,7 @@ import org.apache.flink.table.functions.TableFunction;
  *
  * @param <T> type of the result
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use {@link LookupTableSource}
- *     instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use {@link LookupTableSource} instead. See FLIP-95 for more information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/NestedFieldsProjectableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/NestedFieldsProjectableTableSource.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
  *
  * @param <T> The return type of the {@link TableSource}.
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use {@link
- *     SupportsProjectionPushDown} instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use {@link SupportsProjectionPushDown} instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/PartitionableTableSource.java
@@ -37,8 +37,8 @@ import java.util.Map;
  * should be obtained via partition keys of catalog table.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use {@link
- *     SupportsPartitionPushDown} instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use {@link SupportsPartitionPushDown} instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @Experimental

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/ProjectableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/ProjectableTableSource.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
  *
  * @param <T> The return type of the {@link TableSource}.
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use {@link
- *     SupportsProjectionPushDown} instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use {@link SupportsProjectionPushDown} instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/RowtimeAttributeDescriptor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/RowtimeAttributeDescriptor.java
@@ -28,8 +28,8 @@ import java.util.Objects;
  * Describes a rowtime attribute of a {@link TableSource}.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use the concept of computed
- *     columns instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use the concept of computed columns instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 public final class RowtimeAttributeDescriptor {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSource.java
@@ -42,8 +42,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  *
  * @param <T> The return type of the {@link TableSource}.
  * @deprecated This interface has been replaced by {@link DynamicTableSource}. The new interface
- *     produces internal data structures and only works with the Blink planner. See FLIP-95 for more
- *     information.
+ *     produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/tsextractors/TimestampExtractor.java
@@ -35,8 +35,8 @@ import java.util.Map;
  * Provides an expression to extract the timestamp for a rowtime attribute.
  *
  * @deprecated This interface will not be supported in the new source design around {@link
- *     DynamicTableSource} which only works with the Blink planner. Use the concept of computed
- *     columns instead. See FLIP-95 for more information.
+ *     DynamicTableSource}. Use the concept of computed columns instead. See FLIP-95 for more
+ *     information.
  */
 @Deprecated
 @PublicEvolving

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LegacyTypeInfoDataTypeConverter.java
@@ -90,7 +90,7 @@ import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isRow
  *
  * @deprecated Use {@link DataTypeFactory#createDataType(TypeInformation)} instead. Note that this
  *     method will not create legacy types anymore. It fully uses the new type system available only
- *     in the Blink planner.
+ *     in the planner.
  */
 @Internal
 @Deprecated

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -28,13 +28,12 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
-	<name>Flink : Table : Planner Blink</name>
+	<name>Flink : Table : Planner</name>
 	<description>
-		This module bridges Table/SQL API and runtime. It contains
-		all resources that are required during pre-flight and runtime
-		phase. The content of this module is work-in-progress. It will
-		replace flink-table-planner once it is stable. See FLINK-11439
-		and FLIP-32 for more details.
+		This module connects Table/SQL API and runtime. It is responsible
+		for translating and optimizing a table program into a Flink pipeline.
+		The module can access all resources that are required during
+		pre-flight and runtime phase for planning.
 	</description>
 
 	<packaging>jar</packaging>

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/CustomizedConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/CustomizedConvertRule.java
@@ -99,7 +99,7 @@ public class CustomizedConvertRule implements CallExpressionConvertRule {
         DEFINITION_RULE_MAP.put(
                 BuiltInFunctionDefinitions.SQRT, CustomizedConvertRule::convertSqrt);
 
-        // blink expression
+        // planner specific expression
         DEFINITION_RULE_MAP.put(
                 InternalFunctionDefinitions.THROW_EXCEPTION,
                 CustomizedConvertRule::convertThrowException);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
@@ -170,7 +170,7 @@ public class OverConvertRule implements CallExpressionConvertRule {
             default:
                 if (nullDirection == null) {
                     // Set the null direction if not specified.
-                    // Consistent with HIVE/SPARK/MYSQL/BLINK-RUNTIME.
+                    // Consistent with HIVE/SPARK/MYSQL
                     if (FlinkPlannerImpl.defaultNullCollation()
                             .last(direction.equals(RelFieldCollation.Direction.DESCENDING))) {
                         kinds.add(SqlKind.NULLS_LAST);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/RichTableSourceQueryOperation.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/RichTableSourceQueryOperation.java
@@ -48,7 +48,7 @@ public class RichTableSourceQueryOperation<T> extends TableSourceQueryOperation<
         super(tableSource, false);
         Preconditions.checkArgument(
                 tableSource instanceof StreamTableSource,
-                "Blink planner should always use StreamTableSource.");
+                "Planner should always use StreamTableSource.");
         this.statistic = statistic;
         this.identifier = identifier;
     }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
@@ -174,7 +174,7 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
         if (!(tableSource instanceof StreamTableSource
                 || tableSource instanceof LookupableTableSource)) {
             throw new ValidationException(
-                    "Only StreamTableSource and LookupableTableSource can be used in Blink planner.");
+                    "Only StreamTableSource and LookupableTableSource can be used in planner.");
         }
         if (!isStreamingMode
                 && tableSource instanceof StreamTableSource

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/InternalConfigOptions.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/InternalConfigOptions.java
@@ -26,8 +26,6 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 /**
  * This class holds internal configuration constants used by Flink's table module.
  *
- * <p>This is only used for the Blink planner.
- *
  * <p>NOTE: All option keys in this class must start with "__" and end up with "__", and all options
  * shouldn't expose to users, all options should erase after plan finished.
  */

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -581,7 +581,7 @@ object FlinkTypeFactory {
           throw new TableException(
             s"TIME precision is not supported: ${relDataType.getPrecision}")
         }
-        // blink runner support precision 3, but for consistent with flink runner, we set to 0.
+        // the planner supports precision 3, but for consistency with old planner, we set it to 0.
         new TimeType()
       case TIMESTAMP =>
         new TimestampType(relDataType.getPrecision)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -66,7 +66,7 @@ import java.util.TimeZone
 import _root_.scala.collection.JavaConversions._
 
 /**
-  * Implementation of [[Planner]] for blink planner. It supports only streaming use cases.
+  * Implementation of a [[Planner]]. It supports only streaming use cases.
   * (The new [[org.apache.flink.table.sources.InputFormatTableSource]] should work, but will be
   * handled as streaming sources, and no batch specific optimizations will be applied).
   *

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/parse/SetOperationParseStrategyTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/parse/SetOperationParseStrategyTest.java
@@ -29,12 +29,18 @@ public class SetOperationParseStrategyTest {
     @Test
     public void testMatches() {
         assertTrue(SetOperationParseStrategy.INSTANCE.match("SET"));
-        assertTrue(SetOperationParseStrategy.INSTANCE.match("SET table.planner = blink"));
-        assertTrue(SetOperationParseStrategy.INSTANCE.match("SET table.planner = 'blink'"));
+        assertTrue(
+                SetOperationParseStrategy.INSTANCE.match(
+                        "SET table.local-time-zone = Europe/Berlin"));
+        assertTrue(
+                SetOperationParseStrategy.INSTANCE.match(
+                        "SET table.local-time-zone = 'Europe/Berlin'"));
     }
 
     @Test
     public void testDoesNotMatchQuotedKey() {
-        assertFalse(SetOperationParseStrategy.INSTANCE.match("SET 'table.planner' = blink"));
+        assertFalse(
+                SetOperationParseStrategy.INSTANCE.match(
+                        "SET 'table.local-time-zone' = Europe/Berlin"));
     }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -220,7 +220,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func8('a', 'a')",
       "c")
 
-    // TODO fix FLINK-13580 to blink-planner
+    // TODO fix FLINK-13580
 //    testAllApis(
 //      Func21('f15),
 //      "Func21(f15)",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -808,7 +808,7 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
     )
   }
 
-  // NOTE: select from values -- supported by Spark, but not Blink
+  // NOTE: select from values -- supported by Spark, but not us
   //       "select sum(a) over () from values 1.0, 2.0, 3.0 T(a)"
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -678,7 +678,7 @@ class AggregateITCase(
     tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink)
     env.execute()
 
-    // TODO: [BLINK-16716210] the string result of collect is not determinist
+    // TODO: the string result of collect is not deterministic
     // TODO: sort the map result in the future
     val expected = List(
       "1,{1=1}",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CorrelateITCase.scala
@@ -43,7 +43,7 @@ class CorrelateITCase extends StreamingTestBase {
   }
 
   @Test
-  // BLINK-13614111: Fix IndexOutOfBoundsException when UDTF is used on the
+  // Fix IndexOutOfBoundsException when UDTF is used on the
   // same name field of different tables
   def testUdtfForSameFieldofDifferentSource(): Unit = {
     val data = List(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -142,8 +142,8 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
   def testCodeSplitsAreProperlyGenerated(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
-    // TODO: this code is ported from flink-planner,
-    //  However code split is not supported in blink-planner yet.
+    // TODO: this code is ported from old planner,
+    //  However code split is not supported in planner yet.
     tEnv.getConfig.setMaxGeneratedCodeLength(1)
 
     val data = new mutable.MutableList[(Int, String, String, String)]

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -28,12 +28,10 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
-	<name>Flink : Table : Runtime Blink</name>
+	<name>Flink : Table : Runtime</name>
 	<description>
 		This module contains classes that are required by a task manager for
-		execution of table programs. The content of this module is work-in-progress.
-		It will replace the runtime classes contained in flink-table-planner once
-		it is stable. See FLINK-11439 and FLIP-32 for more details.
+		execution of table programs.
 	</description>
 
 	<packaging>jar</packaging>

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -28,11 +28,10 @@ under the License.
 	</parent>
 
 	<artifactId>flink-table-uber-blink_${scala.binary.version}</artifactId>
-	<name>Flink : Table : Uber Blink</name>
+	<name>Flink : Table : Uber</name>
 	<description>
 		This module contains the entire Table/SQL distribution for writing table programs
-		within the table ecosystem or between other Flink APIs. This module uses the Blink planner
-		for generating optimized runnable plan from relational query. Users can either use the
+		within the table ecosystem or between other Flink APIs. Users can either use the
 		Scala or Java programming language.
 	</description>
 

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -92,8 +92,8 @@ jobs:
         module: python
       libraries:
         module: libraries
-      blink_planner:
-        module: blink_planner
+      table:
+        module: table
       connectors:
         module: connectors
       kafka_gelly:

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -65,7 +65,8 @@ flink-table/flink-table-api-java-bridge,\
 flink-table/flink-table-api-scala-bridge,\
 flink-table/flink-sql-client,\
 flink-table/flink-table-planner-blink,\
-flink-table/flink-table-runtime-blink"
+flink-table/flink-table-runtime-blink,\
+flink-table/flink-table-code-splitter"
 
 MODULES_CONNECTORS="\
 flink-contrib/flink-connector-wikiedits,\

--- a/tools/ci/stage.sh
+++ b/tools/ci/stage.sh
@@ -21,7 +21,7 @@ STAGE_COMPILE="compile"
 STAGE_CORE="core"
 STAGE_PYTHON="python"
 STAGE_LIBRARIES="libraries"
-STAGE_BLINK_PLANNER="blink_planner"
+STAGE_TABLE="table"
 STAGE_CONNECTORS="connectors"
 STAGE_KAFKA_GELLY="kafka/gelly"
 STAGE_TESTS="tests"
@@ -53,7 +53,9 @@ flink-external-resources/flink-external-resource-gpu"
 MODULES_LIBRARIES="\
 flink-libraries/flink-cep,\
 flink-libraries/flink-cep-scala,\
-flink-libraries/flink-state-processing-api,\
+flink-libraries/flink-state-processing-api"
+
+MODULES_TABLE="\
 flink-table/flink-sql-parser,\
 flink-table/flink-sql-parser-hive,\
 flink-table/flink-table-common,\
@@ -61,9 +63,7 @@ flink-table/flink-table-api-java,\
 flink-table/flink-table-api-scala,\
 flink-table/flink-table-api-java-bridge,\
 flink-table/flink-table-api-scala-bridge,\
-flink-table/flink-sql-client"
-
-MODULES_BLINK_PLANNER="\
+flink-table/flink-sql-client,\
 flink-table/flink-table-planner-blink,\
 flink-table/flink-table-runtime-blink"
 
@@ -145,8 +145,8 @@ function get_compile_modules_for_stage() {
         (${STAGE_LIBRARIES})
             echo "-pl $MODULES_LIBRARIES -am"
         ;;
-        (${STAGE_BLINK_PLANNER})
-            echo "-pl $MODULES_BLINK_PLANNER -am"
+        (${STAGE_TABLE})
+            echo "-pl $MODULES_TABLE -am"
         ;;
         (${STAGE_CONNECTORS})
             echo "-pl $MODULES_CONNECTORS -am"
@@ -177,16 +177,17 @@ function get_test_modules_for_stage() {
 
     local modules_core=$MODULES_CORE
     local modules_libraries=$MODULES_LIBRARIES
-    local modules_blink_planner=$MODULES_BLINK_PLANNER
+    local modules_table=$MODULES_TABLE
+    local modules_kafka_gelly=$MODULES_KAFKA_GELLY
     local modules_connectors=$MODULES_CONNECTORS
     local modules_tests=$MODULES_TESTS
     local negated_core=\!${MODULES_CORE//,/,\!}
     local negated_libraries=\!${MODULES_LIBRARIES//,/,\!}
-    local negated_blink_planner=\!${MODULES_BLINK_PLANNER//,/,\!}
+    local negated_table=\!${MODULES_TABLE//,/,\!}
     local negated_kafka_gelly=\!${MODULES_KAFKA_GELLY//,/,\!}
     local negated_connectors=\!${MODULES_CONNECTORS//,/,\!}
     local negated_tests=\!${MODULES_TESTS//,/,\!}
-    local modules_misc="$negated_core,$negated_libraries,$negated_blink_planner,$negated_connectors,$negated_kafka_gelly,$negated_tests"
+    local modules_misc="$negated_core,$negated_libraries,$negated_table,$negated_connectors,$negated_kafka_gelly,$negated_tests"
     local modules_finegrained_resource_management=$MODULES_FINEGRAINED_RESOURCE_MANAGEMENT
 
     case ${stage} in
@@ -196,14 +197,14 @@ function get_test_modules_for_stage() {
         (${STAGE_LIBRARIES})
             echo "-pl $modules_libraries"
         ;;
-        (${STAGE_BLINK_PLANNER})
-            echo "-pl $modules_blink_planner"
+        (${STAGE_TABLE})
+            echo "-pl $modules_table"
         ;;
         (${STAGE_CONNECTORS})
             echo "-pl $modules_connectors"
         ;;
         (${STAGE_KAFKA_GELLY})
-            echo "-pl $MODULES_KAFKA_GELLY"
+            echo "-pl $modules_kafka_gelly"
         ;;
         (${STAGE_TESTS})
             echo "-pl $modules_tests"


### PR DESCRIPTION
## What is the purpose of the change

This removes all mentionings of the term "blink" in the code base. In order to reduce user confusion, do not use this term
    anymore but refer to as "Flink SQL" or "Flink Table API".

## Brief change log

- Docs
- Tests
- CI stages
- Comments and JavaDocs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
