### PR TITLE
[BP-1.13][FLINK-23182][connectors/rabbitmq] Fix connection leak in RMQSource

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -28,6 +28,8 @@ import org.apache.flink.streaming.api.functions.source.MessageAcknowledgingSourc
 import org.apache.flink.streaming.api.functions.source.MultipleIdsMessageAcknowledgingSourceBase;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
 import com.rabbitmq.client.AMQP;
@@ -257,6 +259,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
             channel.basicConsume(queueName, autoAck, consumer);
 
         } catch (IOException e) {
+            IOUtils.closeAllQuietly(channel, connection);
             throw new RuntimeException(
                     "Cannot create RMQ connection with "
                             + queueName
@@ -273,44 +276,38 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
     @Override
     public void close() throws Exception {
         super.close();
+        Exception exception = null;
 
         try {
             if (consumer != null && channel != null) {
                 channel.basicCancel(consumer.getConsumerTag());
             }
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while cancelling RMQ consumer on "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+            exception =
+                    new RuntimeException(
+                            "Error while cancelling RMQ consumer on "
+                                    + queueName
+                                    + " at "
+                                    + rmqConnectionConfig.getHost(),
+                            e);
         }
 
         try {
-            if (channel != null) {
-                channel.close();
-            }
+            IOUtils.closeAll(channel, connection);
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while closing RMQ channel with "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+            exception =
+                    ExceptionUtils.firstOrSuppressed(
+                            new RuntimeException(
+                                    "Error while closing RMQ source with "
+                                            + queueName
+                                            + " at "
+                                            + rmqConnectionConfig.getHost(),
+                                    e),
+                            exception);
         }
 
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while closing RMQ connection with "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+        if (exception != null) {
+            throw exception;
         }
     }
 


### PR DESCRIPTION
This is a backport of #16333 (fixing FLINK-23182) to release-1.13. The fix is exactly the same as in #16333, just the unit tests had to be slightly adjusted. There is no `assertThrows` in junit 4.12, so an ExpectedException junit rule have been used instead (the logic remained the same though). 

Please see #16333 for a detailed description.