### PR TITLE
[BP-1.12][FLINK-23182][connectors/rabbitmq] Fix connection leak in RMQSource

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -28,6 +28,8 @@ import org.apache.flink.streaming.api.functions.source.MessageAcknowledgingSourc
 import org.apache.flink.streaming.api.functions.source.MultipleIdsMessageAcknowledgingSourceBase;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
 import com.rabbitmq.client.AMQP;
@@ -257,6 +259,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
             channel.basicConsume(queueName, autoAck, consumer);
 
         } catch (IOException e) {
+            IOUtils.closeAllQuietly(channel, connection);
             throw new RuntimeException(
                     "Cannot create RMQ connection with "
                             + queueName
@@ -273,44 +276,38 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
     @Override
     public void close() throws Exception {
         super.close();
+        Exception exception = null;
 
         try {
             if (consumer != null && channel != null) {
                 channel.basicCancel(consumer.getConsumerTag());
             }
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while cancelling RMQ consumer on "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+            exception =
+                    new RuntimeException(
+                            "Error while cancelling RMQ consumer on "
+                                    + queueName
+                                    + " at "
+                                    + rmqConnectionConfig.getHost(),
+                            e);
         }
 
         try {
-            if (channel != null) {
-                channel.close();
-            }
+            IOUtils.closeAll(channel, connection);
         } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while closing RMQ channel with "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+            exception =
+                    ExceptionUtils.firstOrSuppressed(
+                            new RuntimeException(
+                                    "Error while closing RMQ source with "
+                                            + queueName
+                                            + " at "
+                                            + rmqConnectionConfig.getHost(),
+                                    e),
+                            exception);
         }
 
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    "Error while closing RMQ connection with "
-                            + queueName
-                            + " at "
-                            + rmqConnectionConfig.getHost(),
-                    e);
+        if (exception != null) {
+            throw exception;
         }
     }
 

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -42,9 +42,12 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Delivery;
 import com.rabbitmq.client.Envelope;
+import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 import org.mockito.internal.stubbing.answers.CallsRealMethods;
 import org.mockito.invocation.InvocationOnMock;
@@ -138,6 +141,8 @@ public class RMQSourceTest {
         sourceThread.join();
     }
 
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void throwExceptionIfConnectionFactoryReturnNull() throws Exception {
         RMQConnectionConfig connectionConfig = Mockito.mock(RMQConnectionConfig.class);
@@ -158,6 +163,25 @@ public class RMQSourceTest {
     }
 
     @Test
+    public void testResourceCleanupOnOpenFailure() throws Exception {
+        RMQConnectionConfig connectionConfig = Mockito.mock(RMQConnectionConfig.class);
+        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        Connection connection = Mockito.mock(Connection.class);
+        Mockito.when(connectionConfig.getConnectionFactory()).thenReturn(connectionFactory);
+        Mockito.when(connectionConfig.getHost()).thenReturn("hostDummy");
+        Mockito.when(connectionFactory.newConnection()).thenReturn(connection);
+        Mockito.when(connection.createChannel()).thenThrow(new IOException());
+
+        RMQSource<String> rmqSource =
+                new RMQSource<>(
+                        connectionConfig, "queueDummy", true, new StringDeserializationScheme());
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Cannot create RMQ connection with queueDummy at hostDummy");
+        rmqSource.open(new Configuration());
+        Mockito.verify(rmqSource.connection, Mockito.atLeastOnce()).close();
+    }
+
+    @Test
     public void testOpenCallDeclaresQueueInStandardMode() throws Exception {
         FunctionInitializationContext mockContext = getMockContext();
 
@@ -175,6 +199,47 @@ public class RMQSourceTest {
         rmqSource.open(new Configuration());
 
         Mockito.verify(channel).queueDeclare(RMQTestSource.QUEUE_NAME, true, false, false, null);
+    }
+
+    @Test
+    public void testResourceCleanupOnClose() throws Exception {
+        FunctionInitializationContext mockContext = getMockContext();
+
+        RMQConnectionConfig connectionConfig = Mockito.mock(RMQConnectionConfig.class);
+        ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+        Connection connection = Mockito.mock(Connection.class);
+        Channel channel = Mockito.mock(Channel.class);
+
+        Mockito.when(connectionConfig.getConnectionFactory()).thenReturn(connectionFactory);
+        Mockito.when(connectionFactory.newConnection()).thenReturn(connection);
+        Mockito.when(connectionConfig.getHost()).thenReturn("hostDummy");
+        Mockito.when(connection.createChannel()).thenReturn(channel);
+        Mockito.doThrow(new IOException("Consumer cancel error")).when(channel).basicCancel(any());
+        Mockito.doThrow(new IOException("Channel error")).when(channel).close();
+        Mockito.doThrow(new IOException("Connection error")).when(connection).close();
+
+        RMQSource<String> rmqSource = new RMQMockedRuntimeTestSource(connectionConfig);
+        rmqSource.initializeState(mockContext);
+        rmqSource.open(new Configuration());
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("Error while cancelling RMQ consumer on queueDummy at hostDummy");
+        thrown.expect(
+                new CustomTypeSafeMatcher<RuntimeException>("should have suppressed exceptions") {
+                    @Override
+                    protected boolean matchesSafely(RuntimeException ex) {
+                        if (ex.getSuppressed().length == 0) {
+                            return false;
+                        }
+                        String expectedMsg =
+                                "Error while closing RMQ source with queueDummy at hostDummy";
+                        return ex.getSuppressed()[0].getMessage().equals(expectedMsg);
+                    }
+                });
+        rmqSource.close();
+        Mockito.verify(rmqSource.channel, Mockito.atLeastOnce()).basicCancel(any());
+        Mockito.verify(rmqSource.channel, Mockito.atLeastOnce()).close();
+        Mockito.verify(rmqSource.connection, Mockito.atLeastOnce()).close();
     }
 
     @Test


### PR DESCRIPTION
This is a backport of #16333 (fixing FLINK-23182) to release-1.12. The fix is exactly the same as in #16333, just the unit tests had to be slightly adjusted. There is no `assertThrows` in junit 4.12, so an ExpectedException junit rule have been used instead (the logic remained the same though).

Please see #16333 for a detailed description.