### PR TITLE
[FLINK-23259][docs] Fix the Windows link for Page "docs/dev/datastream…

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/overview.md
+++ b/docs/content.zh/docs/dev/datastream/operators/overview.md
@@ -192,7 +192,7 @@ data_stream.key_by(lambda x: x[1]).reduce(lambda a, b: (a[0] + b[0], b[1]))
 #### KeyedStream &rarr; WindowedStream
 
 Windows can be defined on already partitioned KeyedStreams. Windows group the data in each key according to some characteristic (e.g., the data that arrived within the last 5 seconds).
-See [windows](windows.html) for a complete description of windows.
+See [windows]({{< ref "docs/dev/datastream/operators/windows" >}}) for a complete description of windows.
 
 {{< tabs window >}}
 {{< tab "Java">}}

--- a/docs/content/docs/dev/datastream/operators/overview.md
+++ b/docs/content/docs/dev/datastream/operators/overview.md
@@ -194,7 +194,7 @@ data_stream.key_by(lambda x: x[1]).reduce(lambda a, b: (a[0] + b[0], b[1]))
 #### KeyedStream &rarr; WindowedStream
 
 Windows can be defined on already partitioned KeyedStreams. Windows group the data in each key according to some characteristic (e.g., the data that arrived within the last 5 seconds).
-See [windows](windows.html) for a complete description of windows.
+See [windows]({{< ref "docs/dev/datastream/operators/windows" >}}) for a complete description of windows.
 
 {{< tabs window >}}
 {{< tab "Java">}}


### PR DESCRIPTION
 
https://ci.apache.org/projects/flink/flink-docs-master/docs/dev/datastream/operators/overview/#window

 
The 'window' link this page is failed and 404 is returned。

The modification is done as follows
```txt
[windows](windows.html)  ==> [windows](< ref "docs/dev/datastream/operators/windows" >)
```