### PR TITLE
 [FLINK-23080][datastream] Introduce SinkFunction#finish() method. 

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BufferedUpsertSinkFunction.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/BufferedUpsertSinkFunction.java
@@ -190,6 +190,18 @@ public class BufferedUpsertSinkFunction extends RichSinkFunction<RowData>
     }
 
     @Override
+    public void finish() {
+        if (batchCount > 0) {
+            try {
+                flush();
+            } catch (Exception e) {
+                LOG.warn("Writing records to kafka failed.", e);
+                throw new RuntimeException("Writing records to kafka failed.", e);
+            }
+        }
+    }
+
+    @Override
     public synchronized void close() throws Exception {
         if (!closed) {
             closed = true;
@@ -197,15 +209,6 @@ public class BufferedUpsertSinkFunction extends RichSinkFunction<RowData>
             if (this.scheduledFuture != null) {
                 scheduledFuture.cancel(false);
                 this.scheduler.shutdown();
-            }
-
-            if (batchCount > 0) {
-                try {
-                    flush();
-                } catch (Exception e) {
-                    LOG.warn("Writing records to kafka failed.", e);
-                    throw new RuntimeException("Writing records to kafka failed.", e);
-                }
             }
 
             producer.close();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -62,6 +62,22 @@ public interface SinkFunction<IN> extends Function, Serializable {
     default void writeWatermark(Watermark watermark) throws Exception {}
 
     /**
+     * This method is called at the end of data processing.
+     *
+     * <p>The method is expected to flush all remaining buffered data. Exceptions will cause the
+     * pipeline to be recognized as failed, because the last data items are not processed properly.
+     * You may use this method to flush remaining buffered elements in the state into transactions
+     * which you can commit in the last checkpoint.
+     *
+     * <p><b>NOTE:</b>This method does not need to close any resources. You should release external
+     * resources in the {@link RichSinkFunction#close()} method.
+     *
+     * @throws Exception This method may throw exceptions. Throwing an exception will cause the
+     *     operation to fail and may trigger recovery.
+     */
+    default void finish() throws Exception {}
+
+    /**
      * Context that {@link SinkFunction SinkFunctions } can use for getting additional data about an
      * input record.
      *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -211,6 +211,16 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT> extends RichS
      */
     protected void finishRecoveringContext(Collection<TXN> handledTransactions) {}
 
+    /**
+     * This method is called at the end of data processing.
+     *
+     * <p>The method is expected to flush all remaining buffered data. Exceptions will cause the
+     * pipeline to be recognized as failed, because the last data items are not processed properly.
+     * You may use this method to flush remaining buffered elements in the state into the current
+     * transaction which will be committed in the last checkpoint.
+     */
+    protected void finishProcessing(TXN transaction) {}
+
     // ------ entry points for above methods implementing {@CheckPointedFunction} and
     // {@CheckpointListener} ------
 
@@ -221,6 +231,11 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT> extends RichS
     @Override
     public final void invoke(IN value, Context context) throws Exception {
         invoke(currentTransactionHolder.handle, value, context);
+    }
+
+    @Override
+    public final void finish() throws Exception {
+        finishProcessing(currentTransaction());
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
@@ -97,6 +98,14 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
     public void open() throws Exception {
         super.open();
         FunctionUtils.openFunction(userFunction, new Configuration());
+    }
+
+    @Override
+    public void finish() throws Exception {
+        super.finish();
+        if (userFunction instanceof SinkFunction) {
+            ((SinkFunction<?>) userFunction).finish();
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Add an extension point for flushing buffered data in sinks before the final checkpoint.

## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
