### PR TITLE
[FLINK-20321][formats] Fix NPE when using AvroDeserializationSchema to deserialize null input  in  1.12 version

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroRowDataSeDeSchemaTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/RegistryAvroRowDataSeDeSchemaTest.java
@@ -54,6 +54,7 @@ import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -148,6 +149,8 @@ public class RegistryAvroRowDataSeDeSchemaTest {
 
         serializer.open(null);
         deserializer.open(null);
+
+        assertNull(deserializer.deserialize(null));
 
         RowData oriData = address2RowData(address);
         byte[] serialized = serializer.serialize(oriData);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -127,7 +127,10 @@ public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
     }
 
     @Override
-    public T deserialize(byte[] message) throws IOException {
+    public T deserialize(@Nullable byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
         // read record
         checkAvroInitialized();
         inputStream.setBuffer(message);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataDeserializationSchema.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.avro.generic.GenericRecord;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Objects;
 
@@ -93,7 +95,10 @@ public class AvroRowDataDeserializationSchema implements DeserializationSchema<R
     }
 
     @Override
-    public RowData deserialize(byte[] message) throws IOException {
+    public RowData deserialize(@Nullable byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
         try {
             GenericRecord deserialize = nestedSchema.deserialize(message);
             return (RowData) runtimeConverter.convert(deserialize);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchema.java
@@ -64,7 +64,10 @@ public class RegistryAvroDeserializationSchema<T> extends AvroDeserializationSch
     }
 
     @Override
-    public T deserialize(byte[] message) throws IOException {
+    public T deserialize(@Nullable byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
         checkAvroInitialized();
         getInputStream().setBuffer(message);
         Schema writerSchema = schemaCoder.readSchema(getInputStream());

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -31,11 +31,21 @@ import java.util.Random;
 
 import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /** Tests for {@link AvroDeserializationSchema}. */
 public class AvroDeserializationSchemaTest {
 
     private static final Address address = TestDataGenerator.generateRandomAddress(new Random());
+
+    @Test
+    public void testNullRecord() throws Exception {
+        DeserializationSchema<Address> deserializer =
+                AvroDeserializationSchema.forSpecific(Address.class);
+
+        Address deserializedAddress = deserializer.deserialize(null);
+        assertNull(deserializedAddress);
+    }
 
     @Test
     public void testGenericRecord() throws Exception {

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowDataDeserializationSchema.java
@@ -30,6 +30,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectRea
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
@@ -140,7 +142,10 @@ public final class CsvRowDataDeserializationSchema implements DeserializationSch
     }
 
     @Override
-    public RowData deserialize(byte[] message) throws IOException {
+    public RowData deserialize(@Nullable byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
         try {
             final JsonNode root = objectReader.readValue(message);
             return (RowData) runtimeConverter.convert(root);

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDataSerDeSchemaTest.java
@@ -207,6 +207,12 @@ public class CsvRowDataSerDeSchemaTest {
     }
 
     @Test
+    public void testDeserializeNullRow() throws Exception {
+        // return null for null input
+        assertNull(testDeserialization(false, false, null));
+    }
+
+    @Test
     public void testDeserializeIncompleteRow() throws Exception {
         // last two columns are missing
         assertEquals(Row.of("Test", null, null), testDeserialization(true, false, "Test"));
@@ -404,7 +410,7 @@ public class CsvRowDataSerDeSchemaTest {
                 InstantiationUtil.deserializeObject(
                         InstantiationUtil.serializeObject(deserSchemaBuilder.build()),
                         CsvRowDeSerializationSchemaTest.class.getClassLoader());
-        return schema.deserialize(csv.getBytes());
+        return schema.deserialize(csv != null ? csv.getBytes() : null);
     }
 
     private static RowData rowData(String str1, int integer, String str2) {

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -30,6 +30,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.Deseriali
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Objects;
 
@@ -93,7 +95,10 @@ public class JsonRowDataDeserializationSchema implements DeserializationSchema<R
     }
 
     @Override
-    public RowData deserialize(byte[] message) throws IOException {
+    public RowData deserialize(@Nullable byte[] message) throws IOException {
+        if (message == null) {
+            return null;
+        }
         try {
             final JsonNode root = objectMapper.readTree(message);
             return (RowData) runtimeConverter.convert(root);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
@@ -160,7 +160,10 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
     }
 
     @Override
-    public void deserialize(byte[] message, Collector<RowData> out) throws IOException {
+    public void deserialize(@Nullable byte[] message, Collector<RowData> out) throws IOException {
+        if (message == null || message.length == 0) {
+            return;
+        }
         try {
             RowData row = jsonDeserializer.deserialize(message);
             if (database != null) {

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDataSerDeSchemaTest.java
@@ -72,6 +72,7 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZON
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -375,6 +376,18 @@ public class JsonRowDataSerDeSchemaTest {
             String result = new String(serializationSchema.serialize(row));
             assertEquals(expected[i], result);
         }
+    }
+
+    @Test
+    public void testDeserializationNullRow() throws Exception {
+        DataType dataType = ROW(FIELD("name", STRING()));
+        RowType schema = (RowType) dataType.getLogicalType();
+
+        JsonRowDataDeserializationSchema deserializationSchema =
+                new JsonRowDataDeserializationSchema(
+                        schema, InternalTypeInfo.of(schema), true, false, TimestampFormat.ISO_8601);
+
+        assertNull(deserializationSchema.deserialize(null));
     }
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/canal/CanalJsonSerDeSchemaTest.java
@@ -73,6 +73,20 @@ public class CanalJsonSerDeSchemaTest {
     }
 
     @Test
+    public void testDeserializeNullRow() throws Exception {
+        final CanalJsonDeserializationSchema deserializationSchema =
+                CanalJsonDeserializationSchema.builder(SCHEMA, InternalTypeInfo.of(SCHEMA))
+                        .setDatabase("mydb")
+                        .setTable("product")
+                        .build();
+        final SimpleCollector collector = new SimpleCollector();
+
+        deserializationSchema.deserialize(null, collector);
+        deserializationSchema.deserialize(new byte[0], collector);
+        assertEquals(0, collector.list.size());
+    }
+
+    @Test
     public void testSerializationDeserialization() throws Exception {
         List<String> lines = readLines("canal-data.txt");
         CanalJsonDeserializationSchema deserializationSchema =


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to fix JIRA issue FLINK-20321.


## Brief change log

Make deserialize(byte[]) method of following classes return null when argument is null, instead of throwing NPE. Test cases added.

1. AvroDeserializationSchema
2. AvroRowDataDeserializationSchema
3. RegistryAvroDeserializationSchema
4. CsvRowDataDeserializationSchema
5. JsonRowDataDeserializationSchema


## Verifying this change

This change added tests and can be verified via test cases.


## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: don't know

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
