### PR TITLE
[FLINK-23188][table-planner-blink] Preserve function identifier durin…

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
@@ -210,4 +210,12 @@ Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testBuiltInFunctionWithFilterPushdown">
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a], where=[(IFNULL(a, 1) = 1)])
++- TableSourceScan(table=[[default_catalog, default_database, ProjectableTable, filter=[], project=[a]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/CalcJsonPlanTest_jsonplan/testComplexCalc.out
@@ -258,7 +258,7 @@
           "operands" : [ {
             "kind" : "REX_CALL",
             "operator" : {
-              "name" : "org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$JavaFunc0$ea91f94853664692cdbdcd38ac065769",
+              "name" : "udf1",
               "kind" : "OTHER_FUNCTION",
               "syntax" : "FUNCTION",
               "functionKind" : "SCALAR",
@@ -403,7 +403,7 @@
         }
       } ]
     },
-    "description" : "Calc(select=[a, CAST(a) AS a1, b, udf2(b, b, d) AS b1, udf3(c, b) AS c1, udf4(SUBSTRING(c, 1, 5)) AS c2, udf5(d, 1000) AS d1], where=[(((org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$JavaFunc0$ea91f94853664692cdbdcd38ac065769(a) > 0) OR ((a * b) < 100)) AND (b > 10))])"
+    "description" : "Calc(select=[a, CAST(a) AS a1, b, udf2(b, b, d) AS b1, udf3(c, b) AS c1, udf4(SUBSTRING(c, 1, 5)) AS c2, udf5(d, 1000) AS d1], where=[(((udf1(a) > 0) OR ((a * b) < 100)) AND (b > 10))])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
     "dynamicTableSink" : {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonCalcJsonPlanTest_jsonplan/testPythonFunctionInWhereClause.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/PythonCalcJsonPlanTest_jsonplan/testPythonFunctionInWhereClause.out
@@ -132,7 +132,7 @@
     }, {
       "kind" : "REX_CALL",
       "operator" : {
-        "name" : "org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$BooleanPythonScalarFunction$7a841a4bac68feb7427ad21acb894ac4",
+        "name" : "pyFunc",
         "kind" : "OTHER_FUNCTION",
         "syntax" : "FUNCTION",
         "functionKind" : "SCALAR",
@@ -178,7 +178,7 @@
         "f0" : "BOOLEAN NOT NULL"
       } ]
     },
-    "description" : "PythonCalc(select=[a, b, org$apache$flink$table$planner$runtime$utils$JavaUserDefinedScalarFunctions$BooleanPythonScalarFunction$7a841a4bac68feb7427ad21acb894ac4(b, f0) AS f0])"
+    "description" : "PythonCalc(select=[a, b, pyFunc(b, f0) AS f0])"
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
     "projection" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceRuleTest.xml
@@ -344,7 +344,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     </Resource>
     <Resource name="optimized rel plan">
       <![CDATA[
-FlinkLogicalCalc(select=[name, id, amount, price], where=[<(Func1$(amount), 32)])
+FlinkLogicalCalc(select=[name, id, amount, price], where=[<(myUdf(amount), 32)])
 +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]], fields=[name, id, amount, price])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoLegacyTableSourceScanRuleTest.xml
@@ -345,7 +345,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[<(org$apache$flink$table$planner$expressions$utils$Func1$$879c8537562dbe74f3349fa0e6502755($2), 32)])
++- LogicalFilter(condition=[<(myUdf($2), 32)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [filterPushedDown=[true], filter=[greaterThan(amount, 2)]]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRuleTest.xml
@@ -345,7 +345,7 @@ LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(name=[$0], id=[$1], amount=[$2], price=[$3])
-+- LogicalFilter(condition=[<(org$apache$flink$table$planner$expressions$utils$Func1$$879c8537562dbe74f3349fa0e6502755($2), 32)])
++- LogicalFilter(condition=[<(myUdf($2), 32)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, filter=[greaterThan(amount, 2)]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.scala
@@ -257,4 +257,9 @@ class TableSourceTest extends TableTestBase {
 
     util.verifyExecPlan(stmtSet)
   }
+
+  @Test
+  def testBuiltInFunctionWithFilterPushdown(): Unit = {
+    util.verifyExecPlan("SELECT a FROM ProjectableTable WHERE IFNULL(a, 1) = 1")
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -581,7 +581,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
         functionCatalog)
 
     assertEquals(1, convertedExpressions.length)
-    assertEquals("greaterThan(myUdf(amount), 100)",
+    assertEquals("greaterThan(MyUdf(amount), 100)",
       convertedExpressions(0).toString)
     assertEquals(0, unconvertedRexNodes.length)
   }


### PR DESCRIPTION
## What is the purpose of the change

Preserves the `functionIdentifier` when converting from RexNode to Expression during a filter pushdown.

## Brief change log

* `RexNodeToExpressionConverter` adjusted to preserve the `functionIdentifier` in a function lookup.

## Verifying this change

This change added tests and can be verified as follows:
* `org.apache.flink.table.planner.plan.batch.sql#testBuiltInFunctionWithFilterPushdown`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
