### PR TITLE
[FLINK-22889] Add debug statements to JdbcExactlyOnceSinkE2eTest

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -89,7 +89,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
     private static final Random RANDOM = new Random(System.currentTimeMillis());
-    // debugging FLINK-22889
+
     private static final Logger LOG = LoggerFactory.getLogger(JdbcExactlyOnceSinkE2eTest.class);
 
     private interface JdbcExactlyOnceSinkTestEnv {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -50,6 +50,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.postgresql.xa.PGXADataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -87,6 +89,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
     private static final Random RANDOM = new Random(System.currentTimeMillis());
+    // debugging FLINK-22889
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcExactlyOnceSinkE2eTest.class);
 
     private interface JdbcExactlyOnceSinkTestEnv {
         void start();
@@ -167,6 +171,7 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
 
     @Test
     public void testInsert() throws Exception {
+        LOG.info("Test insert for {}", dbEnv);
         int elementsPerSource = 50;
         int numElementsPerCheckpoint = 7;
         int minElementsPerFailure = numElementsPerCheckpoint / 3;
@@ -295,9 +300,20 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
                 lastCheckpointId = -1L;
                 lastSnapshotConfirmed = false;
                 for (int j = start; j < start + count && running; j++) {
-                    ctx.collect(
-                            new TestEntry(
-                                    j, Integer.toString(j), Integer.toString(j), (double) (j), j));
+                    try {
+                        ctx.collect(
+                                new TestEntry(
+                                        j,
+                                        Integer.toString(j),
+                                        Integer.toString(j),
+                                        (double) (j),
+                                        j));
+                    } catch (Exception e) {
+                        if (!ExceptionUtils.findThrowable(e, TestException.class).isPresent()) {
+                            LOG.warn("Exception during record emission", e);
+                        }
+                        throw e;
+                    }
                     toAdvance.advance();
                 }
             }
@@ -335,6 +351,7 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
                                 SourceRange.forSubtask(
                                         getRuntimeContext().getIndexOfThisSubtask(), numElements)));
             }
+            LOG.debug("Source initialized with ranges: {}", ranges.get());
         }
 
         @Override
@@ -343,10 +360,15 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
         }
 
         private void sleep(Supplier<Boolean> condition) {
+            long start = System.currentTimeMillis();
             while (condition.get()
                     && running
                     && !Thread.currentThread().isInterrupted()
                     && haveActiveSources()) {
+                if (System.currentTimeMillis() - start > 10_000) {
+                    LOG.debug("Slept more than 10s", new Exception());
+                    start = Long.MAX_VALUE;
+                }
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
@@ -357,7 +379,12 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
         }
 
         private void waitOtherSources() throws InterruptedException {
+            long start = System.currentTimeMillis();
             while (running && haveActiveSources()) {
+                if (System.currentTimeMillis() - start > 10_000) {
+                    LOG.debug("Slept more than 10s", new Exception());
+                    start = Long.MAX_VALUE;
+                }
                 activeSources
                         .get(getRuntimeContext().getAttemptNumber())
                         .await(100, TimeUnit.MILLISECONDS);
@@ -386,6 +413,11 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
                 checkState(from < to);
                 from++;
             }
+
+            @Override
+            public String toString() {
+                return String.format("%d..%d", from, to);
+            }
         }
     }
 
@@ -409,11 +441,13 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
                                     new CountDownLatch(
                                             getRuntimeContext().getNumberOfParallelSubtasks()))
                     .countDown();
+            LOG.debug("Mapper will fail after {} records", remaining);
         }
 
         @Override
         public TestEntry map(TestEntry value) throws Exception {
             if (--remaining <= 0) {
+                LOG.debug("Mapper failing intentionally");
                 throw new TestException();
             }
             return value;
@@ -422,7 +456,9 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
 
     private static final class TestException extends Exception {
         public TestException() {
-            super("expected", null, true, false);
+            // use this string to prevent error parsing scripts from failing the build
+            // and still have exception type
+            super("java.lang.Exception: Artificial failure", null, true, false);
         }
     }
 

--- a/flink-connectors/flink-connector-jdbc/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-jdbc/src/test/resources/log4j2-test.properties
@@ -21,14 +21,6 @@
 rootLogger.level = OFF
 rootLogger.appenderRef.test.ref = TestLogger
 
-# debugging FLINK-22889
-logger.xa.name = org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest
-logger.xa.level = DEBUG
-logger.task.name = org.apache.flink.runtime.taskmanager.Task
-logger.task.level = WARN
-logger.jdbc.name = org.apache.flink.connector.jdbc
-logger.jdbc.level = ERROR
-
 appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR

--- a/flink-connectors/flink-connector-jdbc/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-jdbc/src/test/resources/log4j2-test.properties
@@ -21,6 +21,14 @@
 rootLogger.level = OFF
 rootLogger.appenderRef.test.ref = TestLogger
 
+# debugging FLINK-22889
+logger.xa.name = org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest
+logger.xa.level = DEBUG
+logger.task.name = org.apache.flink.runtime.taskmanager.Task
+logger.task.level = WARN
+logger.jdbc.name = org.apache.flink.connector.jdbc
+logger.jdbc.level = ERROR
+
 appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR


### PR DESCRIPTION
## What is the purpose of the change

Log for `JdbcExactlyOnceSinkE2eTest`: db type, progress, errors, task transitions, wait times.

Using hardcoded string to prevent log parsing scripts from failing CI (on expected exceptions).
Sample size: 200Kb
Sample output:
```
2021-07-06 22:31:29,074 INFO test insert for postgres:9.6.12, parallelism=4 [main JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,698 DEBUG Mapper will fail after 3 records [Source: Custom Source -> Map -> Sink: Unnamed (3/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,698 DEBUG Mapper will fail after 6 records [Source: Custom Source -> Map -> Sink: Unnamed (4/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,698 DEBUG Mapper will fail after 14 records [Source: Custom Source -> Map -> Sink: Unnamed (2/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,698 DEBUG Mapper will fail after 10 records [Source: Custom Source -> Map -> Sink: Unnamed (1/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,699 DEBUG Source initialized with ranges: [100..150] [Source: Custom Source -> Map -> Sink: Unnamed (3/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,700 DEBUG Source initialized with ranges: [0..50] [Source: Custom Source -> Map -> Sink: Unnamed (1/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,700 DEBUG Source initialized with ranges: [150..200] [Source: Custom Source -> Map -> Sink: Unnamed (4/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,701 DEBUG Source initialized with ranges: [50..100] [Source: Custom Source -> Map -> Sink: Unnamed (2/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,952 DEBUG Mapper failing intentionally [Legacy Source Thread - Source: Custom Source -> Map -> Sink: Unnamed (3/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:29,956 DEBUG Mapper failing intentionally [Legacy Source Thread - Source: Custom Source -> Map -> Sink: Unnamed (4/4)#0 JdbcExactlyOnceSinkE2eTest]
2021-07-06 22:31:30,018 WARN Source: Custom Source -> Map -> Sink: Unnamed (4/4)#0 (8571da132faab99391432bab1182eeed) switched from RUNNING to FAILED with failure cause: org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$TestException: java.lang.Exception: Artificial failure
 [Source: Custom Source -> Map -> Sink: Unnamed (4/4)#0 Task]
2021-07-06 22:31:30,018 WARN Source: Custom Source -> Map -> Sink: Unnamed (3/4)#0 (e96da42632e92d517950d5aed126d87f) switched from RUNNING to FAILED with failure cause: org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$TestException: java.lang.Exception: Artificial failure
 [Source: Custom Source -> Map -> Sink: Unnamed (3/4)#0 Task]
```