### PR TITLE
[FLINK-23276][state/changelog] Fix missing delegation in getPartitionedState

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -284,6 +284,7 @@ public class ChangelogKeyedStateBackend<K>
             lastState = previous;
             lastState.setCurrentNamespace(namespace);
             lastName = stateDescriptor.getName();
+            functionDelegationHelper.addOrUpdate(stateDescriptor);
             return (S) previous;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

```
Changelog backend creates delegating functions on recovery
so that user can later provide function code.

Some branches do not register delegates currently,
this change fixes it.
```

## Verifying this change

Existing tests with changelog enabled (e.g. ``testGroupWindowWithoutKeyInProjection` in org.apache.flink.table.planner.runtime.stream.table.GroupWindowTableAggregateITCase` - )

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
