### PR TITLE
[FLINK-23277][state/changelog] Store and recover TTL metadata using changelog

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlValue.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * This class wraps user value of state with TTL. Visibility is public for usage with external
  * tools.
@@ -35,6 +37,7 @@ public class TtlValue<T> implements Serializable {
     private final long lastAccessTimestamp;
 
     public TtlValue(@Nullable T userValue, long lastAccessTimestamp) {
+        checkArgument(!(userValue instanceof TtlValue));
         this.userValue = userValue;
         this.lastAccessTimestamp = lastAccessTimestamp;
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
@@ -31,6 +32,7 @@ import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectOutputStream;
 
 import static org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType.KEY_VALUE;
 import static org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE;
@@ -52,14 +54,17 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
     protected final RegisteredStateMetaInfoBase metaInfo;
     private final StateMetaInfoSnapshot.BackendStateType stateType;
     private boolean metaDataWritten = false;
+    private final StateTtlConfig ttlConfig;
 
     public AbstractStateChangeLogger(
             StateChangelogWriter<?> stateChangelogWriter,
             InternalKeyContext<Key> keyContext,
-            RegisteredStateMetaInfoBase metaInfo) {
+            RegisteredStateMetaInfoBase metaInfo,
+            StateTtlConfig ttlConfig) {
         this.stateChangelogWriter = checkNotNull(stateChangelogWriter);
         this.keyContext = checkNotNull(keyContext);
         this.metaInfo = checkNotNull(metaInfo);
+        this.ttlConfig = checkNotNull(ttlConfig);
         if (metaInfo instanceof RegisteredKeyValueStateBackendMetaInfo) {
             this.stateType = KEY_VALUE;
         } else if (metaInfo instanceof RegisteredPriorityQueueStateBackendMetaInfo) {
@@ -148,8 +153,18 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns> implements StateChangeL
                                 out.writeInt(CURRENT_STATE_META_INFO_SNAPSHOT_VERSION);
                                 StateMetaInfoSnapshotReadersWriters.getWriter()
                                         .writeStateMetaInfoSnapshot(metaInfo.snapshot(), out);
+                                writeTtl(out);
                             }));
             metaDataWritten = true;
+        }
+    }
+
+    private void writeTtl(DataOutputViewStreamWrapper out) throws IOException {
+        out.writeBoolean(ttlConfig.isEnabled());
+        if (ttlConfig.isEnabled()) {
+            try (ObjectOutputStream o = new ObjectOutputStream(out)) {
+                o.writeObject(ttlConfig);
+            }
         }
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -124,6 +124,13 @@ public class ChangelogKeyedStateBackend<K>
      */
     private final HashMap<String, InternalKvState<K, ?, ?>> keyValueStatesByName;
 
+    /**
+     * Unwrapped changelog states used for recovery (not wrapped into e.g. TTL).
+     *
+     * <p>WARN: cleared upon recovery completion.
+     */
+    private final HashMap<String, ChangelogState> changelogStates;
+
     private final HashMap<String, ChangelogKeyGroupedPriorityQueue<?>> priorityQueueStatesByName;
 
     private final ExecutionConfig executionConfig;
@@ -190,6 +197,7 @@ public class ChangelogKeyedStateBackend<K>
         this.priorityQueueStatesByName = new HashMap<>();
         this.stateChangelogWriter = stateChangelogWriter;
         this.materializedTo = stateChangelogWriter.initialSequenceNumber();
+        this.changelogStates = new HashMap<>();
         this.completeRestore(initialState);
     }
 
@@ -485,11 +493,15 @@ public class ChangelogKeyedStateBackend<K>
                         state.getValueSerializer(),
                         keyedStateBackend.getKeyContext(),
                         stateChangelogWriter,
-                        meta);
-        return stateFactory.create(
-                state,
-                kvStateChangeLogger,
-                keyedStateBackend /* pass the nested backend as key context so that it get key updates on recovery*/);
+                        meta,
+                        stateDesc.getTtlConfig());
+        IS is =
+                stateFactory.create(
+                        state,
+                        kvStateChangeLogger,
+                        keyedStateBackend /* pass the nested backend as key context so that it get key updates on recovery*/);
+        changelogStates.put(stateDesc.getName(), (ChangelogState) is);
+        return is;
     }
 
     private void completeRestore(Collection<ChangelogStateBackendHandle> stateHandles) {
@@ -503,6 +515,7 @@ public class ChangelogKeyedStateBackend<K>
                 }
             }
         }
+        changelogStates.clear();
     }
 
     @Override
@@ -524,16 +537,19 @@ public class ChangelogKeyedStateBackend<K>
      * @param type state type (the only supported type currently are: {@link
      *     BackendStateType#KEY_VALUE key value}, {@link BackendStateType#PRIORITY_QUEUE priority
      *     queue})
-     * @return an existing state, i.e. the one that was already created
+     * @return an existing state, i.e. the one that was already created. The returned state will not
+     *     apply TTL to the passed values, regardless of the TTL settings. This prevents double
+     *     applying of TTL (recovered values are TTL values if TTL was enabled). The state will,
+     *     however, use TTL serializer if TTL is enabled. WARN: only valid during the recovery.
      * @throws NoSuchElementException if the state wasn't created
      * @throws UnsupportedOperationException if state type is not supported
      */
-    public ChangelogState getExistingState(String name, BackendStateType type)
+    public ChangelogState getExistingStateForRecovery(String name, BackendStateType type)
             throws NoSuchElementException, UnsupportedOperationException {
         ChangelogState state;
         switch (type) {
             case KEY_VALUE:
-                state = (ChangelogState) keyValueStatesByName.get(name);
+                state = changelogStates.get(name);
                 break;
             case PRIORITY_QUEUE:
                 state = priorityQueueStatesByName.get(name);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
@@ -45,8 +46,9 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
             TypeSerializer<Value> valueSerializer,
             InternalKeyContext<Key> keyContext,
             StateChangelogWriter<?> stateChangelogWriter,
-            RegisteredStateMetaInfoBase metaInfo) {
-        super(stateChangelogWriter, keyContext, metaInfo);
+            RegisteredStateMetaInfoBase metaInfo,
+            StateTtlConfig ttlConfig) {
+        super(stateChangelogWriter, keyContext, metaInfo, ttlConfig);
         this.keySerializer = checkNotNull(keySerializer);
         this.valueSerializer = checkNotNull(valueSerializer);
         this.namespaceSerializer = checkNotNull(namespaceSerializer);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
@@ -36,7 +37,7 @@ class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger
             InternalKeyContext<K> keyContext,
             StateChangelogWriter<?> stateChangelogWriter,
             RegisteredPriorityQueueStateBackendMetaInfo<T> meta) {
-        super(stateChangelogWriter, keyContext, meta);
+        super(stateChangelogWriter, keyContext, meta, StateTtlConfig.DISABLED);
         this.serializer = checkNotNull(serializer);
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/KvStateChangeLoggerImplTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.state.changelog;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
@@ -42,7 +43,13 @@ public class KvStateChangeLoggerImplTest extends StateChangeLoggerTestBase<Strin
                 new RegisteredKeyValueStateBackendMetaInfo<>(
                         VALUE, "test", nsSerializer, valueSerializer);
         return new KvStateChangeLoggerImpl<>(
-                keySerializer, nsSerializer, valueSerializer, keyContext, writer, metaInfo);
+                keySerializer,
+                nsSerializer,
+                valueSerializer,
+                keyContext,
+                writer,
+                metaInfo,
+                StateTtlConfig.DISABLED);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change
```
Upon recovery, changelog backend creates underlying states to apply changes.
TTL config is not available at that moment, so states are currently created
regardless of job TTL settings.

This change stores TTL config along with metadata (in changelog); and
uses it on recovery.

Note: values are already serialized as TTL values and serializers as TTL seralizers
Note: upgrading TTL settings is not possible (see FLINK-23143)
```

## Verifying this change

Existing table-planner tests with changelog enabled, e.g. `testGroupAggregate` in `org.apache.flink.table.planner.runtime.stream.table.AggregateITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
