### PR TITLE
[FLINK-23165][python] Add StreamExecutionEnvironment#registerSlotSharingGroup to PyFlink and Scala

### DIFF
--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -73,6 +73,7 @@ from pyflink.datastream.functions import (MapFunction, CoMapFunction, FlatMapFun
                                           CoFlatMapFunction, ReduceFunction, RuntimeContext,
                                           KeySelector, FilterFunction, Partitioner, SourceFunction,
                                           SinkFunction)
+from pyflink.datastream.slot_sharing_group import SlotSharingGroup
 from pyflink.datastream.state_backend import (StateBackend, MemoryStateBackend, FsStateBackend,
                                               RocksDBStateBackend, CustomStateBackend,
                                               PredefinedOptions, HashMapStateBackend,
@@ -127,5 +128,6 @@ __all__ = [
     'WindowAssigner',
     'MergingWindowAssigner',
     'TriggerResult',
-    'Trigger'
+    'Trigger',
+    'SlotSharingGroup'
 ]

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -21,6 +21,7 @@ import warnings
 from typing import Callable, Union, List, cast
 
 from pyflink.common import typeinfo, ExecutionConfig, Row
+from pyflink.datastream.slot_sharing_group import SlotSharingGroup
 from pyflink.datastream.window import TimeWindowSerializer, CountWindowSerializer, WindowAssigner, \
     Trigger, WindowOperationDescriptor
 from pyflink.common.typeinfo import RowTypeInfo, Types, TypeInformation, _from_java_type
@@ -207,7 +208,7 @@ class DataStream(object):
         self._j_data_stream.disableChaining()
         return self
 
-    def slot_sharing_group(self, slot_sharing_group: str) -> 'DataStream':
+    def slot_sharing_group(self, slot_sharing_group: Union[str, SlotSharingGroup]) -> 'DataStream':
         """
         Sets the slot sharing group of this operation. Parallel instances of operations that are in
         the same slot sharing group will be co-located in the same TaskManager slot, if possible.
@@ -218,10 +219,14 @@ class DataStream(object):
         Initially an operation is in the default slot sharing group. An operation can be put into
         the default group explicitly by setting the slot sharing group to 'default'.
 
-        :param slot_sharing_group: The slot sharing group name.
+        :param slot_sharing_group: The slot sharing group name or which contains name and its
+                        resource spec.
         :return: This operator.
         """
-        self._j_data_stream.slotSharingGroup(slot_sharing_group)
+        if isinstance(slot_sharing_group, SlotSharingGroup):
+            self._j_data_stream.slotSharingGroup(slot_sharing_group.get_java_slot_sharing_group())
+        else:
+            self._j_data_stream.slotSharingGroup(slot_sharing_group)
         return self
 
     def map(self, func: Union[Callable, MapFunction], output_type: TypeInformation = None) \
@@ -784,7 +789,8 @@ class DataStreamSink(object):
         self._j_data_stream_sink.disableChaining()
         return self
 
-    def slot_sharing_group(self, slot_sharing_group: str) -> 'DataStreamSink':
+    def slot_sharing_group(self, slot_sharing_group: Union[str, SlotSharingGroup]) \
+            -> 'DataStreamSink':
         """
         Sets the slot sharing group of this operation. Parallel instances of operations that are in
         the same slot sharing group will be co-located in the same TaskManager slot, if possible.
@@ -795,10 +801,15 @@ class DataStreamSink(object):
         Initially an operation is in the default slot sharing group. An operation can be put into
         the default group explicitly by setting the slot sharing group to 'default'.
 
-        :param slot_sharing_group: The slot sharing group name.
+        :param slot_sharing_group: The slot sharing group name or which contains name and its
+                        resource spec.
         :return: This operator.
         """
-        self._j_data_stream_sink.slotSharingGroup(slot_sharing_group)
+        if isinstance(slot_sharing_group, SlotSharingGroup):
+            self._j_data_stream_sink.slotSharingGroup(
+                slot_sharing_group.get_java_slot_sharing_group())
+        else:
+            self._j_data_stream_sink.slotSharingGroup(slot_sharing_group)
         return self
 
 
@@ -1109,7 +1120,7 @@ class KeyedStream(DataStream):
     def disable_chaining(self) -> 'DataStream':
         raise Exception("Disable chaining for KeyedStream is not supported.")
 
-    def slot_sharing_group(self, slot_sharing_group: str) -> 'DataStream':
+    def slot_sharing_group(self, slot_sharing_group: Union[str, SlotSharingGroup]) -> 'DataStream':
         raise Exception("Setting slot sharing group for KeyedStream is not supported.")
 
 

--- a/flink-python/pyflink/datastream/slot_sharing_group.py
+++ b/flink-python/pyflink/datastream/slot_sharing_group.py
@@ -1,0 +1,281 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+__all__ = ['MemorySize', 'SlotSharingGroup']
+
+from typing import Optional
+
+from pyflink.java_gateway import get_gateway
+
+
+class MemorySize(object):
+    """
+    MemorySize is a representation of a number of bytes, viewable in different units.
+    """
+
+    def __init__(self, j_memory_size=None, bytes_size: int = None):
+        self._j_memory_size = get_gateway().jvm \
+            .org.apache.flink.configuration.MemorySize(bytes_size) \
+            if j_memory_size is None else j_memory_size
+
+    @staticmethod
+    def of_mebi_bytes(mebi_bytes: int) -> 'MemorySize':
+        return MemorySize(
+            get_gateway().jvm.org.apache.flink.configuration.MemorySize.ofMebiBytes(mebi_bytes))
+
+    def get_bytes(self) -> int:
+        """
+        Gets the memory size in bytes.
+
+        :return: The memory size in bytes.
+        """
+        return self._j_memory_size.getBytes()
+
+    def get_kibi_bytes(self) -> int:
+        """
+        Gets the memory size in Kibibytes (= 1024 bytes).
+
+        :return: The memory size in Kibibytes.
+        """
+        return self._j_memory_size.getKibiBytes()
+
+    def get_mebi_bytes(self) -> int:
+        """
+        Gets the memory size in Mebibytes (= 1024 Kibibytes).
+
+        :return: The memory size in Mebibytes.
+        """
+        return self._j_memory_size.getMebiBytes()
+
+    def get_gibi_bytes(self) -> int:
+        """
+        Gets the memory size in Gibibytes (= 1024 Mebibytes).
+
+        :return: The memory size in Gibibytes.
+        """
+        return self._j_memory_size.getGibiBytes()
+
+    def get_tebi_bytes(self) -> int:
+        """
+        Gets the memory size in Tebibytes (= 1024 Gibibytes).
+
+        :return: The memory size in Tebibytes.
+        """
+        return self._j_memory_size.getTebiBytes()
+
+    def get_java_memory_size(self):
+        """
+        Get the Java MemorySize object.
+
+        :return: The Java MemorySize object.
+        """
+        return self._j_memory_size
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._j_memory_size == other._j_memory_size
+
+    def __hash__(self):
+        return self._j_memory_size.hashCode()
+
+
+class SlotSharingGroup(object):
+    """
+    Describe the name and the the different resource components of a slot sharing group.
+    """
+
+    def __init__(self, j_slot_sharing_group):
+        self._j_slot_sharing_group = j_slot_sharing_group
+
+    def get_name(self) -> str:
+        """
+        Get the name of this SlotSharingGroup.
+
+        :return: The name of the SlotSharingGroup.
+        """
+        return self._j_slot_sharing_group.getName()
+
+    def get_managed_memory(self) -> Optional[MemorySize]:
+        """
+        Get the task managed memory for this SlotSharingGroup.
+
+        :return: The task managed memory of the SlotSharingGroup.
+        """
+        managed_memory = self._j_slot_sharing_group.getManagedMemory()
+        return MemorySize(managed_memory.get()) if managed_memory.isPresent() else None
+
+    def get_task_heap_memory(self) -> Optional[MemorySize]:
+        """
+        Get the task heap memory for this SlotSharingGroup.
+
+        :return: The task heap memory of the SlotSharingGroup.
+        """
+        task_heap_memory = self._j_slot_sharing_group.getTaskHeapMemory()
+        return MemorySize(task_heap_memory.get()) if task_heap_memory.isPresent() else None
+
+    def get_task_off_heap_memory(self) -> Optional[MemorySize]:
+        """
+        Get the task off-heap memory for this SlotSharingGroup.
+
+        :return: The task off-heap memory of the SlotSharingGroup.
+        """
+        task_off_heap_memory = self._j_slot_sharing_group.getTaskOffHeapMemory()
+        return MemorySize(task_off_heap_memory.get()) if task_off_heap_memory.isPresent() else None
+
+    def get_cpu_cores(self) -> Optional[float]:
+        """
+       Get the CPU cores for this SlotSharingGroup.
+
+        :return: The CPU cores of the SlotSharingGroup.
+        """
+        cpu_cores = self._j_slot_sharing_group.getCpuCores()
+        return cpu_cores.get() if cpu_cores.isPresent() else None
+
+    def get_external_resources(self) -> dict:
+        """
+        Get the external resource from this SlotSharingGroup.
+
+        :return: User specified resources of the SlotSharingGroup.
+        """
+        return dict(self._j_slot_sharing_group.getExternalResources())
+
+    def get_java_slot_sharing_group(self):
+        """
+        Get the Java SlotSharingGroup object.
+
+        :return: The Java SlotSharingGroup object.
+        """
+        return self._j_slot_sharing_group
+
+    @staticmethod
+    def builder(name: str) -> 'Builder':
+        """
+        Get the Builder with the given name for this SlotSharingGroup.
+
+        :param name: The name of the SlotSharingGroup.
+        :return: The builder for the SlotSharingGroup.
+        """
+        return SlotSharingGroup.Builder(
+            get_gateway().jvm.org.apache.flink.api.common.operators.SlotSharingGroup.newBuilder(
+                name))
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and \
+            self._j_slot_sharing_group == other._j_slot_sharing_group
+
+    def __hash__(self):
+        return self._j_slot_sharing_group.hashCode()
+
+    class Builder(object):
+        """
+        Builder for the SlotSharingGroup.
+        """
+
+        def __init__(self, j_builder):
+            self._j_builder = j_builder
+
+        def set_cpu_cores(self, cpu_cores: float) -> 'SlotSharingGroup.Builder':
+            """
+            Set the CPU cores for this SlotSharingGroup.
+
+            :param cpu_cores: The CPU cores of the SlotSharingGroup.
+            :return: This object.
+            """
+            self._j_builder.setCpuCores(cpu_cores)
+            return self
+
+        def set_task_heap_memory(self, task_heap_memory: MemorySize) -> 'SlotSharingGroup.Builder':
+            """
+            Set the task heap memory for this SlotSharingGroup.
+
+            :param task_heap_memory: The task heap memory of the SlotSharingGroup.
+            :return: This object.
+            """
+            self._j_builder.setTaskHeapMemory(task_heap_memory.get_java_memory_size())
+            return self
+
+        def set_task_heap_memory_mb(self, task_heap_memory_mb: int) -> 'SlotSharingGroup.Builder':
+            """
+            Set the task heap memory for this SlotSharingGroup in MB.
+
+            :param task_heap_memory_mb: The task heap memory of the SlotSharingGroup in MB.
+            :return: This object.
+            """
+            self._j_builder.setTaskHeapMemoryMB(task_heap_memory_mb)
+            return self
+
+        def set_task_off_heap_memory(self, task_off_heap_memory: MemorySize) \
+                -> 'SlotSharingGroup.Builder':
+            """
+            Set the task off-heap memory for this SlotSharingGroup.
+
+            :param task_off_heap_memory: The task off-heap memory of the SlotSharingGroup.
+            :return: This object.
+            """
+            self._j_builder.setTaskOffHeapMemory(task_off_heap_memory.get_java_memory_size())
+            return self
+
+        def set_task_off_heap_memory_mb(self, task_off_heap_memory_mb: int) \
+                -> 'SlotSharingGroup.Builder':
+            """
+            Set the task off-heap memory for this SlotSharingGroup in MB.
+
+            :param task_off_heap_memory_mb: The task off-heap memory of the SlotSharingGroup in MB.
+            :return: This object.
+            """
+            self._j_builder.setTaskOffHeapMemoryMB(task_off_heap_memory_mb)
+            return self
+
+        def set_managed_memory(self, managed_memory: MemorySize) -> 'SlotSharingGroup.Builder':
+            """
+            Set the task managed memory for this SlotSharingGroup.
+
+            :param managed_memory: The task managed memory of the SlotSharingGroup.
+            :return: This object.
+            """
+            self._j_builder.setManagedMemory(managed_memory.get_java_memory_size())
+            return self
+
+        def set_managed_memory_mb(self, managed_memory_mb: int) -> 'SlotSharingGroup.Builder':
+            """
+            Set the task managed memory for this SlotSharingGroup in MB.
+
+            :param managed_memory_mb: The task managed memory of the SlotSharingGroup in MB.
+            :return: This object.
+            """
+            self._j_builder.setManagedMemoryMB(managed_memory_mb)
+            return self
+
+        def set_external_resource(self, name: str, value: float) -> 'SlotSharingGroup.Builder':
+            """
+            Add the given external resource. The old value with the same resource name will be
+            replaced if present.
+
+            :param name: The resource name of the given external resource.
+            :param value: The value of the given external resource.
+            :return: This object.
+            """
+            self._j_builder.setExternalResource(name, value)
+            return self
+
+        def build(self) -> 'SlotSharingGroup':
+            """
+            Build the SlotSharingGroup.
+
+            :return: The SlotSharingGroup object.
+            """
+            return SlotSharingGroup(j_slot_sharing_group=self._j_builder.build())

--- a/flink-python/pyflink/datastream/slot_sharing_group.py
+++ b/flink-python/pyflink/datastream/slot_sharing_group.py
@@ -80,7 +80,7 @@ class MemorySize(object):
 
     def get_java_memory_size(self):
         """
-        Get the Java MemorySize object.
+        Gets the Java MemorySize object.
 
         :return: The Java MemorySize object.
         """
@@ -91,6 +91,18 @@ class MemorySize(object):
 
     def __hash__(self):
         return self._j_memory_size.hashCode()
+
+    def __lt__(self, other: 'MemorySize'):
+        if not isinstance(other, MemorySize):
+            raise Exception("Does not support comparison with non-MemorySize %s" % other)
+
+        return self._j_memory_size.compareTo(other._j_memory_size) == -1
+
+    def __le__(self, other: 'MemorySize'):
+        return self.__eq__(other) and self.__lt__(other)
+
+    def __str__(self):
+        return self._j_memory_size.toString()
 
 
 class SlotSharingGroup(object):
@@ -103,7 +115,7 @@ class SlotSharingGroup(object):
 
     def get_name(self) -> str:
         """
-        Get the name of this SlotSharingGroup.
+        Gets the name of this SlotSharingGroup.
 
         :return: The name of the SlotSharingGroup.
         """
@@ -111,7 +123,7 @@ class SlotSharingGroup(object):
 
     def get_managed_memory(self) -> Optional[MemorySize]:
         """
-        Get the task managed memory for this SlotSharingGroup.
+        Gets the task managed memory for this SlotSharingGroup.
 
         :return: The task managed memory of the SlotSharingGroup.
         """
@@ -120,7 +132,7 @@ class SlotSharingGroup(object):
 
     def get_task_heap_memory(self) -> Optional[MemorySize]:
         """
-        Get the task heap memory for this SlotSharingGroup.
+        Gets the task heap memory for this SlotSharingGroup.
 
         :return: The task heap memory of the SlotSharingGroup.
         """
@@ -129,7 +141,7 @@ class SlotSharingGroup(object):
 
     def get_task_off_heap_memory(self) -> Optional[MemorySize]:
         """
-        Get the task off-heap memory for this SlotSharingGroup.
+        Gets the task off-heap memory for this SlotSharingGroup.
 
         :return: The task off-heap memory of the SlotSharingGroup.
         """
@@ -138,7 +150,7 @@ class SlotSharingGroup(object):
 
     def get_cpu_cores(self) -> Optional[float]:
         """
-       Get the CPU cores for this SlotSharingGroup.
+       Gets the CPU cores for this SlotSharingGroup.
 
         :return: The CPU cores of the SlotSharingGroup.
         """
@@ -147,7 +159,7 @@ class SlotSharingGroup(object):
 
     def get_external_resources(self) -> dict:
         """
-        Get the external resource from this SlotSharingGroup.
+        Gets the external resource from this SlotSharingGroup.
 
         :return: User specified resources of the SlotSharingGroup.
         """
@@ -155,7 +167,7 @@ class SlotSharingGroup(object):
 
     def get_java_slot_sharing_group(self):
         """
-        Get the Java SlotSharingGroup object.
+        Gets the Java SlotSharingGroup object.
 
         :return: The Java SlotSharingGroup object.
         """
@@ -164,7 +176,7 @@ class SlotSharingGroup(object):
     @staticmethod
     def builder(name: str) -> 'Builder':
         """
-        Get the Builder with the given name for this SlotSharingGroup.
+        Gets the Builder with the given name for this SlotSharingGroup.
 
         :param name: The name of the SlotSharingGroup.
         :return: The builder for the SlotSharingGroup.
@@ -190,7 +202,7 @@ class SlotSharingGroup(object):
 
         def set_cpu_cores(self, cpu_cores: float) -> 'SlotSharingGroup.Builder':
             """
-            Set the CPU cores for this SlotSharingGroup.
+            Sets the CPU cores for this SlotSharingGroup.
 
             :param cpu_cores: The CPU cores of the SlotSharingGroup.
             :return: This object.
@@ -200,7 +212,7 @@ class SlotSharingGroup(object):
 
         def set_task_heap_memory(self, task_heap_memory: MemorySize) -> 'SlotSharingGroup.Builder':
             """
-            Set the task heap memory for this SlotSharingGroup.
+            Sets the task heap memory for this SlotSharingGroup.
 
             :param task_heap_memory: The task heap memory of the SlotSharingGroup.
             :return: This object.
@@ -210,7 +222,7 @@ class SlotSharingGroup(object):
 
         def set_task_heap_memory_mb(self, task_heap_memory_mb: int) -> 'SlotSharingGroup.Builder':
             """
-            Set the task heap memory for this SlotSharingGroup in MB.
+            Sets the task heap memory for this SlotSharingGroup in MB.
 
             :param task_heap_memory_mb: The task heap memory of the SlotSharingGroup in MB.
             :return: This object.
@@ -221,7 +233,7 @@ class SlotSharingGroup(object):
         def set_task_off_heap_memory(self, task_off_heap_memory: MemorySize) \
                 -> 'SlotSharingGroup.Builder':
             """
-            Set the task off-heap memory for this SlotSharingGroup.
+            Sets the task off-heap memory for this SlotSharingGroup.
 
             :param task_off_heap_memory: The task off-heap memory of the SlotSharingGroup.
             :return: This object.
@@ -232,7 +244,7 @@ class SlotSharingGroup(object):
         def set_task_off_heap_memory_mb(self, task_off_heap_memory_mb: int) \
                 -> 'SlotSharingGroup.Builder':
             """
-            Set the task off-heap memory for this SlotSharingGroup in MB.
+            Sets the task off-heap memory for this SlotSharingGroup in MB.
 
             :param task_off_heap_memory_mb: The task off-heap memory of the SlotSharingGroup in MB.
             :return: This object.
@@ -242,7 +254,7 @@ class SlotSharingGroup(object):
 
         def set_managed_memory(self, managed_memory: MemorySize) -> 'SlotSharingGroup.Builder':
             """
-            Set the task managed memory for this SlotSharingGroup.
+            Sets the task managed memory for this SlotSharingGroup.
 
             :param managed_memory: The task managed memory of the SlotSharingGroup.
             :return: This object.
@@ -252,7 +264,7 @@ class SlotSharingGroup(object):
 
         def set_managed_memory_mb(self, managed_memory_mb: int) -> 'SlotSharingGroup.Builder':
             """
-            Set the task managed memory for this SlotSharingGroup in MB.
+            Sets the task managed memory for this SlotSharingGroup in MB.
 
             :param managed_memory_mb: The task managed memory of the SlotSharingGroup in MB.
             :return: This object.
@@ -262,7 +274,7 @@ class SlotSharingGroup(object):
 
         def set_external_resource(self, name: str, value: float) -> 'SlotSharingGroup.Builder':
             """
-            Add the given external resource. The old value with the same resource name will be
+            Adds the given external resource. The old value with the same resource name will be
             replaced if present.
 
             :param name: The resource name of the given external resource.
@@ -274,7 +286,7 @@ class SlotSharingGroup(object):
 
         def build(self) -> 'SlotSharingGroup':
             """
-            Build the SlotSharingGroup.
+            Builds the SlotSharingGroup.
 
             :return: The SlotSharingGroup object.
             """

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -28,6 +28,7 @@ from pyflink.common.job_client import JobClient
 from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
 from pyflink.common.typeinfo import TypeInformation, Types
+from pyflink.datastream import SlotSharingGroup
 from pyflink.datastream.checkpoint_config import CheckpointConfig
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.connectors import Source
@@ -98,6 +99,24 @@ class StreamExecutionEnvironment(object):
         """
         self._j_stream_execution_environment = \
             self._j_stream_execution_environment.setMaxParallelism(max_parallelism)
+        return self
+
+    def register_slot_sharing_group(self, slot_sharing_group: SlotSharingGroup) \
+            -> 'StreamExecutionEnvironment':
+        """
+        Register a slot sharing group with its resource spec.
+
+        Note that a slot sharing group hints the scheduler that the grouped operators CAN be
+        deployed into a shared slot. There's no guarantee that the scheduler always deploy the
+        grouped operators together. In cases grouped operators are deployed into separate slots, the
+        slot resources will be derived from the specified group requirements.
+
+        :param slot_sharing_group: Which contains name and its resource spec.
+        :return: This object.
+        """
+        self._j_stream_execution_environment = \
+            self._j_stream_execution_environment.registerSlotSharingGroup(
+                slot_sharing_group.get_java_slot_sharing_group())
         return self
 
     def get_parallelism(self) -> int:

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -26,7 +26,7 @@ from pyflink.common.serializer import TypeSerializer
 from pyflink.common.typeinfo import Types
 from pyflink.common.watermark_strategy import WatermarkStrategy, TimestampAssigner
 from pyflink.datastream import TimeCharacteristic, RuntimeContext, WindowAssigner, Trigger, \
-    TriggerResult, CountWindow
+    TriggerResult, CountWindow, SlotSharingGroup
 from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.functions import CoMapFunction, CoFlatMapFunction, AggregateFunction, \
     ReduceFunction, KeyedCoProcessFunction, WindowFunction, ProcessWindowFunction
@@ -1025,8 +1025,9 @@ class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
         slot_sharing_group_1 = 'slot_sharing_group_1'
         slot_sharing_group_2 = 'slot_sharing_group_2'
         ds_1 = self.env.from_collection([1, 2, 3]).name(source_operator_name)
-        ds_1.slot_sharing_group(slot_sharing_group_1).map(lambda x: x + 1).set_parallelism(3)\
-            .name(map_operator_name).slot_sharing_group(slot_sharing_group_2)\
+        ds_1.slot_sharing_group(SlotSharingGroup.builder(slot_sharing_group_1).build()) \
+            .map(lambda x: x + 1).set_parallelism(3) \
+            .name(map_operator_name).slot_sharing_group(slot_sharing_group_2) \
             .add_sink(self.test_sink)
 
         j_generated_stream_graph = self.env._j_stream_execution_environment \

--- a/flink-python/pyflink/datastream/tests/test_slot_sharing_group.py
+++ b/flink-python/pyflink/datastream/tests/test_slot_sharing_group.py
@@ -1,0 +1,66 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.datastream.slot_sharing_group import MemorySize, SlotSharingGroup
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class SlotSharingGroupTests(PyFlinkTestCase):
+
+    def test_build_slot_sharing_group_with_specific_resource(self):
+        name = 'slot_sharing_group'
+        heap_memory = MemorySize.of_mebi_bytes(100)
+        off_heap_memory = MemorySize.of_mebi_bytes(200)
+        managed_memory = MemorySize.of_mebi_bytes(300)
+        slot_sharing_group = SlotSharingGroup.builder(name) \
+            .set_cpu_cores(1.0) \
+            .set_task_heap_memory(heap_memory) \
+            .set_task_off_heap_memory(off_heap_memory) \
+            .set_managed_memory(managed_memory) \
+            .set_external_resource('gpu', 1.0) \
+            .build()
+        self.assertEqual(slot_sharing_group.get_name(), name)
+        self.assertEqual(slot_sharing_group.get_cpu_cores(), 1.0)
+        self.assertEqual(slot_sharing_group.get_task_heap_memory(), heap_memory)
+        self.assertEqual(slot_sharing_group.get_task_off_heap_memory(), off_heap_memory)
+        self.assertEqual(slot_sharing_group.get_managed_memory(), managed_memory)
+        self.assertEqual(slot_sharing_group.get_external_resources(), {'gpu': 1.0})
+
+    def test_build_slot_sharing_group_with_unknown_resource(self):
+        name = 'slot_sharing_group'
+        slot_sharing_group = SlotSharingGroup.builder(name).build()
+        self.assertEqual(slot_sharing_group.get_name(), name)
+        self.assertIsNone(slot_sharing_group.get_cpu_cores())
+        self.assertIsNone(slot_sharing_group.get_task_heap_memory())
+        self.assertIsNone(slot_sharing_group.get_task_off_heap_memory())
+        self.assertIsNone(slot_sharing_group.get_managed_memory())
+        self.assertEqual(slot_sharing_group.get_external_resources(), {})
+
+    def test_build_slot_sharing_group_with_illegal_config(self):
+        with self.assertRaises(Exception):
+            SlotSharingGroup.builder("slot_sharing_group") \
+                .set_cpu_cores(1.0) \
+                .set_task_heap_memory(MemorySize(bytes_size=0)) \
+                .set_task_off_heap_memory_mb(10) \
+                .build()
+
+    def test_build_slot_sharing_group_without_all_required_config(self):
+        with self.assertRaises(Exception):
+            SlotSharingGroup.builder("slot_sharing_group") \
+                .set_cpu_cores(1.0) \
+                .set_task_off_heap_memory_mb(10) \
+                .build()

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment_completeness.py
@@ -39,7 +39,6 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
         # Currently only the methods for configuration is added.
         # 'isForceCheckpointing', 'getNumberOfExecutionRetries', 'setNumberOfExecutionRetries'
         # is deprecated, exclude them.
-        # TODO the registerSlotSharingGroup should be removed from this list after FLINK-23165.
         return {'getLastJobExecutionResult', 'getId', 'getIdString',
                 'registerCachedFile', 'createCollectionsEnvironment', 'createLocalEnvironment',
                 'createRemoteEnvironment', 'addOperator', 'fromElements',
@@ -49,7 +48,7 @@ class StreamExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createInput', 'createLocalEnvironmentWithWebUI', 'fromCollection',
                 'socketTextStream', 'initializeContextEnvironment', 'readTextFile',
                 'setNumberOfExecutionRetries', 'configure', 'executeAsync', 'registerJobListener',
-                'clearJobListeners', 'getJobListeners', "fromSequence", "registerSlotSharingGroup"}
+                'clearJobListeners', 'getJobListeners', "fromSequence"}
 
 
 if __name__ == '__main__':

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -384,7 +384,7 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
      * <p>Initially an operation is in the default slot sharing group. An operation can be put into
      * the default group explicitly by setting the slot sharing group with name {@code "default"}.
      *
-     * @param slotSharingGroup which contains name and its resource spec.
+     * @param slotSharingGroup Which contains name and its resource spec.
      */
     @PublicEvolving
     public SingleOutputStreamOperator<T> slotSharingGroup(SlotSharingGroup slotSharingGroup) {

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.eventtime.{TimestampAssigner, WatermarkGenerator, WatermarkStrategy}
 import org.apache.flink.api.common.functions.{FilterFunction, FlatMapFunction, MapFunction, Partitioner}
 import org.apache.flink.api.common.io.OutputFormat
-import org.apache.flink.api.common.operators.ResourceSpec
+import org.apache.flink.api.common.operators.{ResourceSpec, SlotSharingGroup}
 import org.apache.flink.api.common.serialization.SerializationSchema
 import org.apache.flink.api.common.state.MapStateDescriptor
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -319,6 +319,29 @@ class DataStream[T](stream: JavaStream[T]) {
    */
   @PublicEvolving
   def slotSharingGroup(slotSharingGroup: String): DataStream[T] = {
+    stream match {
+      case ds: SingleOutputStreamOperator[T] => ds.slotSharingGroup(slotSharingGroup)
+      case _ =>
+        throw new UnsupportedOperationException("Only supported for operators.")
+    }
+    this
+  }
+
+  /**
+   * Sets the slot sharing group of this operation. Parallel instances of
+   * operations that are in the same slot sharing group will be co-located in the same
+   * TaskManager slot, if possible.
+   *
+   * Operations inherit the slot sharing group of input operations if all input operations
+   * are in the same slot sharing group and no slot sharing group was explicitly specified.
+   *
+   * Initially an operation is in the default slot sharing group. An operation can be put into
+   * the default group explicitly by setting the slot sharing group to `"default"`.
+   *
+   * @param slotSharingGroup Which contains name and its resource spec.
+   */
+  @PublicEvolving
+  def slotSharingGroup(slotSharingGroup: SlotSharingGroup): DataStream[T] = {
     stream match {
       case ds: SingleOutputStreamOperator[T] => ds.slotSharingGroup(slotSharingGroup)
       case _ =>


### PR DESCRIPTION
## What is the purpose of the change

*Flink supports configuring fine grained resource requirements via DataStream API. PyFlink should add `StreamExecutionEnvironment#registerSlotSharingGroup`.*

## Brief change log

  - *Introduce `SlotSharingGroup` in pyflink. Users can use this class to describe the name and the the different resource components of a slot sharing group.*
  - *Add `DataStream#slotSharingGroup(SlotSharingGroup)`.*
  - *Add `StreamExecutionEnvironment#registerSlotSharingGroup(SlotSharingGroup)`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)