### PR TITLE
[FLINK-23184][table-runtime] Fix compile error in code generation of unary plus and minus

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -154,11 +154,13 @@ object ScalarOperatorGens {
         } else if (isDecimal(operand.resultType) && operator == "+") {
           s"$operandTerm"
         } else {
-          s"$operator($operandTerm)"
+          // no need to check if result type might be null,
+          // because if this line of code is called, `operatorTerm` must not be null
+          val typeTerm = primitiveTypeTermForType(resultType)
+          s"($typeTerm) $operator($operandTerm)"
         }
     }
   }
-
 
   def generateTemporalPlusMinus(
     ctx: CodeGeneratorContext,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarOperatorsTest.scala
@@ -180,4 +180,22 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testSqlApi("CASE WHEN f2 = 1 THEN CAST ('' as INT) ELSE 0 END", "null")
     testSqlApi("IF(true, CAST ('non-numeric' AS BIGINT), 0)", "null")
   }
+
+  @Test
+  def testUnaryPlusMinus(): Unit = {
+    testSqlApi("-f0", "-1")
+    testSqlApi("+f0", "1")
+    testSqlApi("-f1", "-1")
+    testSqlApi("+f1", "1")
+    testSqlApi("-f2", "-1")
+    testSqlApi("+f2", "1")
+    testSqlApi("-f3", "-1")
+    testSqlApi("+f3", "1")
+    testSqlApi("-f4", "-1.0")
+    testSqlApi("+f4", "1.0")
+    testSqlApi("-f5", "-1.0")
+    testSqlApi("+f5", "1.0")
+    testSqlApi("-f17", "-10.0")
+    testSqlApi("+f17", "10.0")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently code generation of unary plus and minus will not cast the result term to its desired type. This will cause compile error if the desired type is `short` or `byte`. Consider the following java code.

```java
short a = 1;
short b = -a;
```

This code will not compile as `-a` is of `int` type.

This PR fixes this issue by casting the result term.

## Brief change log

 - Fix compile error in code generation of unary plus and minus

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
