### PR TITLE
[FLINK-23283][table-planner] Fix unstable case GroupWindowITCase#testWindowAggregateOnUpsertSource

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/GroupWindowITCase.scala
@@ -384,6 +384,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
 
   @Test
   def testWindowAggregateOnUpsertSource(): Unit = {
+    env.setParallelism(1)
     val upsertSourceDataId = registerData(upsertSourceCurrencyData)
     tEnv.executeSql(
       s"""
@@ -417,7 +418,8 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
     val expected = Seq(
       "US Dollar,1,102,1970-01-01T00:00,1970-01-01T00:00:05",
       "Yen,1,1,1970-01-01T00:00,1970-01-01T00:00:05",
-      "Euro,1,118,1970-01-01T00:00:15,1970-01-01T00:00:20")
+      "Euro,1,118,1970-01-01T00:00:15,1970-01-01T00:00:20",
+      "RMB,1,702,1970-01-01T00:00,1970-01-01T00:00:05")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 
@@ -472,6 +474,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
 
   @Test
   def testWindowAggregateOnUpsertSourcePushdownWatermark(): Unit = {
+    env.setParallelism(1)
     val upsertSourceDataId = registerData(upsertSourceCurrencyData)
     tEnv.executeSql(
       s"""
@@ -501,7 +504,7 @@ class GroupWindowITCase(mode: StateBackendMode, useTimestampLtz: Boolean)
     tEnv.sqlQuery(sql).toAppendStream[Row].addSink(sink)
     env.execute()
     val expected = Seq(
-      "1970-01-01T00:00,1970-01-01T00:00:05,102",
+      "1970-01-01T00:00,1970-01-01T00:00:05,702",
       "1970-01-01T00:00:15,1970-01-01T00:00:20,118")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }


### PR DESCRIPTION
## What is the purpose of the change

The pr aims to fix unstable itcases `GroupWindowITCase#testWindowAggregateOnUpsertSource`.
The unstable case is caused by whether the last two records dropped as late data is nonderterministic. It depends on the watermark on current task which is relates to what data is processed and the order of incoming data on each concurrent task.

And `GroupWindowITCase#testWindowAggregateOnUpsertSourcePushdownWatermark` has similar problems, I would set parallelism to 1 for those two cases to avoid unstable failure.

## Brief change log
  - Update Itcase `GroupWindowITCase#testWindowAggregateOnUpsertSourcePushdownWatermark`  and `GroupWindowITCase#testWindowAggregateOnUpsertSource` to set parallellism to 1.


## Verifying this change

  - Existed ITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
