### PR TITLE
[FLINK-23292][docs] Fix some link issues on page  "docs/content/docs/…

### DIFF
--- a/docs/content.zh/docs/dev/table/concepts/dynamic_tables.md
+++ b/docs/content.zh/docs/dev/table/concepts/dynamic_tables.md
@@ -117,7 +117,7 @@ DataStream 上的关系查询
 
 当查询开始，`clicks` 表(左侧)是空的。当第一行数据被插入到 `clicks` 表时，查询开始计算结果表。第一行数据 `[Mary,./home]` 插入后，结果表(右侧，上部)由一行 `[Mary, 1]` 组成。当第二行 `[Bob, ./cart]` 插入到 `clicks` 表时，查询会更新结果表并插入了一行新数据 `[Bob, 1]`。第三行 `[Mary, ./prod?id=1]` 将产生已计算的结果行的更新，`[Mary, 1]` 更新成 `[Mary, 2]`。最后，当第四行数据加入 `clicks` 表时，查询将第三行 `[Liz, 1]` 插入到结果表中。
 
-第二条查询与第一条类似，但是除了用户属性之外，还将 `clicks` 分组至[每小时滚动窗口]({{< ref "docs/dev/table/sql/overview" >}}#group-windows)中，然后计算 url 数量(基于时间的计算，例如基于特定[时间属性](time_attributes.html)的窗口，后面会讨论)。同样，该图显示了不同时间点的输入和输出，以可视化动态表的变化特性。
+第二条查询与第一条类似，但是除了用户属性之外，还将 `clicks` 分组至[每小时滚动窗口]({{< ref "docs/dev/table/sql/overview" >}}#group-windows)中，然后计算 url 数量(基于时间的计算，例如基于特定[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}})的窗口，后面会讨论)。同样，该图显示了不同时间点的输入和输出，以可视化动态表的变化特性。
 
 {{< img alt="Continuous Group-Window Query" src="/fig/table-streaming/query-groupBy-window-cnt.png" width="100%">}}
 
@@ -156,7 +156,7 @@ FROM (
 );
 ```
 
-[查询配置](query_configuration.html)章节讨论了控制连续查询执行的参数。一些参数可以用来在维持状态的大小和获得结果的准确性之间做取舍。
+[查询配置]({{< ref "docs/dev/table/config" >}})章节讨论了控制连续查询执行的参数。一些参数可以用来在维持状态的大小和获得结果的准确性之间做取舍。
 
 <a name="table-to-stream-conversion"></a>
 
@@ -179,6 +179,6 @@ FROM (
 {{< img alt="Dynamic tables" src="/fig/table-streaming/redo-mode.png" width="85%" >}}
 
 
-在[通用概念]({{< ref "docs/dev/table/common" >}}#convert-a-table-into-a-datastream)中讨论了将动态表转换为 `DataStream` 的 API。请注意，在将动态表转换为 `DataStream` 时，只支持 append 流和 retract 流。在 [TableSources 和 TableSinks](../sourceSinks.html#define-a-tablesink) 章节讨论向外部系统输出动态表的 `TableSink` 接口。
+在[通用概念]({{< ref "docs/dev/table/common" >}}#convert-a-table-into-a-datastream)中讨论了将动态表转换为 `DataStream` 的 API。请注意，在将动态表转换为 `DataStream` 时，只支持 append 流和 retract 流。在 [TableSources 和 TableSinks]({{< ref "docs/dev/table/sourcesSinks">}}#dynamic-table-sink) 章节讨论向外部系统输出动态表的 `TableSink` 接口。
 
 {{< top >}}

--- a/docs/content/docs/dev/table/concepts/dynamic_tables.md
+++ b/docs/content/docs/dev/table/concepts/dynamic_tables.md
@@ -118,7 +118,7 @@ The first query is a simple `GROUP-BY COUNT` aggregation query. It groups the `c
 
 When the query starts, the `clicks` table (left-hand side) is empty. The query computes the result table when the first row is inserted. After the first row `[Mary, ./home]` arrives, the result table (right-hand side, top) consists of a single row `[Mary, 1]`. When the second row `[Bob, ./cart]` is inserted into the `clicks` table, the query updates the result table and inserts a new row `[Bob, 1]`. The third row, `[Mary, ./prod?id=1]` yields an update of an already computed result row such that `[Mary, 1]` is updated to `[Mary, 2]`. Finally, the query inserts a third row `[Liz, 1]` into the result table, when the fourth row is appended to the `clicks` table.
 
-The second query is similar to the first one but groups the `clicks` table in addition to the `user` attribute also on an [hourly tumbling window]({{< ref "docs/dev/table/sql/queries/window-agg" >}}#group-window-functions) before it counts the number of URLs (time-based computations such as windows are based on special [time attributes](time_attributes.html) are discussed later). Again, the figure shows the input and output at different points in time to visualize the changing nature of dynamic tables.
+The second query is similar to the first one but groups the `clicks` table in addition to the `user` attribute also on an [hourly tumbling window]({{< ref "docs/dev/table/sql/queries/window-agg" >}}#group-window-functions) before it counts the number of URLs (time-based computations such as windows are based on special [time attributes]({{< ref "docs/dev/table/concepts/time_attributes" >}}) are discussed later). Again, the figure shows the input and output at different points in time to visualize the changing nature of dynamic tables.
 
 {{< img alt="Continuous Group-Window Query" src="/fig/table-streaming/query-groupBy-window-cnt.png" width="80%" >}}
 
@@ -155,7 +155,7 @@ FROM (
 );
 ```
 
-The [Query Configuration](query_configuration.html) page discusses parameters to control the execution of continuous queries. Some parameters can be used to trade the size of the maintained state for result accuracy.
+The [Query Configuration]({{< ref "docs/dev/table/config" >}}) page discusses parameters to control the execution of continuous queries. Some parameters can be used to trade the size of the maintained state for result accuracy.
 
 Table to Stream Conversion
 --------------------------
@@ -177,6 +177,6 @@ When converting a dynamic table into a stream or writing it to an external syste
 
 <br><br>
 
-The API to convert a dynamic table into a `DataStream` is discussed on the [Common Concepts]({{< ref "docs/dev/table/common" >}}#convert-a-table-into-a-datastream) page. Please note that only append and retract streams are supported when converting a dynamic table into a `DataStream`. The `TableSink` interface to emit a dynamic table to an external system are discussed on the [TableSources and TableSinks](../sourceSinks.html#define-a-tablesink) page.
+The API to convert a dynamic table into a `DataStream` is discussed on the [Common Concepts]({{< ref "docs/dev/table/common" >}}#convert-a-table-into-a-datastream) page. Please note that only append and retract streams are supported when converting a dynamic table into a `DataStream`. The `TableSink` interface to emit a dynamic table to an external system are discussed on the [TableSources and TableSinks]({{< ref "docs/dev/table/sourcesSinks">}}#dynamic-table-sink) page.
 
 {{< top >}}


### PR DESCRIPTION
Some links on page docs/content/docs/dev/table/concepts/dynamic_tables is failed and 404 is returned.




The English page is：https://ci.apache.org/projects/flink/flink-docs-master/docs/dev/table/concepts/dynamic_tables



```bash
//The markdown file: docs/content/docs/dev/table/concepts/dynamic_tables.md
//1、 line 121
 [time attributes](time_attributes.html) 
This link should be modified to [time attributes]({{< ref "docs/dev/table/concepts/time_attributes" >}})
 
//2、 line 158
  [Query Configuration](query_configuration.html)
  
This link should be modified to  [Query Configuration]({{< ref "docs/dev/table/config" >}})


//3、line 180
  [TableSources and TableSinks](../sourceSinks.html#define-a-tablesink)
This link should be modified to [TableSources and TableSinks]({{< ref "docs/dev/table/sourcesSinks">}}#dynamic-table-sink)
```



The Chinese page is：https://ci.apache.org/projects/flink/flink-docs-master/zh/docs/dev/table/concepts/dynamic_tables/

```txt
//The markdown file: docs/content.zh/docs/dev/table/concepts/dynamic_tables.md

//1、 line 120
 [时间属性](time_attributes.html)
This link should be modified to [time attributes]({{< ref "docs/dev/table/concepts/time_attributes" >}})
 
//2、 line 159
  [查询配置](query_configuration.html)
  
This link should be modified to  [查询配置]({{< ref "docs/dev/table/config" >}})


//3、line 182
   [TableSources and TableSinks](../sourceSinks.html#define-a-tablesink)
This link should be modified to [TableSources and TableSinks]({{< ref "docs/dev/table/sourcesSinks">}}#dynamic-table-sink)
```

