### PR TITLE
[FLINK-22819][yarn] Remove 'yarn.am.liveness-monitor.expiry-interval-ms' override for tests.

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -217,12 +217,8 @@ public abstract class YarnTestBase extends TestLogger {
         YARN_CONFIGURATION.setInt(
                 YarnConfiguration.NM_VCORES, 666); // memory is overwritten in the MiniYARNCluster.
         // so we have to change the number of cores for testing.
-        YARN_CONFIGURATION.setInt(
-                YarnConfiguration.RM_AM_EXPIRY_INTERVAL_MS,
-                20000); // 20 seconds expiry (to ensure we properly heartbeat with YARN).
         YARN_CONFIGURATION.setFloat(
                 YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, 99.0F);
-
         YARN_CONFIGURATION.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH, getYarnClasspath());
     }
 


### PR DESCRIPTION
## What is the purpose of the change

* Fixing one of the causes of flaky YARN test suite. Reasoning in [jira comments](https://issues.apache.org/jira/browse/FLINK-22819).

## Brief change log

* Remove 'yarn.am.liveness-monitor.expiry-interval-ms' override for tests.

## Verifying this change

This change is already covered by existing tests, such as *YarnTestBase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
