### PR TITLE
FLINK-22969

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -646,7 +646,9 @@ public class FlinkKafkaProducer<IN>
                 new FlinkKafkaProducer.TransactionStateSerializer(),
                 new FlinkKafkaProducer.ContextStateSerializer());
 
-        checkArgument(!"".equals(defaultTopic),"defaultTopic is empty");
+        checkArgument(
+                !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(defaultTopic),
+                "defaultTopic cannot be null or empty string");
         this.defaultTopicId = checkNotNull(defaultTopic, "defaultTopic is null");
         if (kafkaSchema != null) {
             this.keyedSchema = null;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -88,7 +88,9 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.flink.util.Preconditions.*;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Flink Sink to produce data into a Kafka topic. By default producer will use {@link
@@ -649,7 +651,7 @@ public class FlinkKafkaProducer<IN>
         checkArgument(
                 !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(defaultTopic),
                 "defaultTopic cannot be null or empty string");
-        this.defaultTopicId = checkNotNull(defaultTopic, "defaultTopic is null");
+        this.defaultTopicId = defaultTopic;
         if (kafkaSchema != null) {
             this.keyedSchema = null;
             this.kafkaSchema = kafkaSchema;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -649,7 +649,7 @@ public class FlinkKafkaProducer<IN>
                 new FlinkKafkaProducer.ContextStateSerializer());
 
         checkArgument(
-                !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(defaultTopic),
+                StringUtils.isNoneBlank(defaultTopic),
                 "defaultTopic cannot be null or empty string");
         this.defaultTopicId = defaultTopic;
         if (kafkaSchema != null) {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -88,8 +88,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.flink.util.Preconditions.*;
 
 /**
  * Flink Sink to produce data into a Kafka topic. By default producer will use {@link
@@ -647,8 +646,8 @@ public class FlinkKafkaProducer<IN>
                 new FlinkKafkaProducer.TransactionStateSerializer(),
                 new FlinkKafkaProducer.ContextStateSerializer());
 
+        checkArgument(!"".equals(defaultTopic),"defaultTopic is empty");
         this.defaultTopicId = checkNotNull(defaultTopic, "defaultTopic is null");
-
         if (kafkaSchema != null) {
             this.keyedSchema = null;
             this.kafkaSchema = kafkaSchema;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A Kafka Topics Descriptor describes how the consumer subscribes to Kafka topics - either a fixed
@@ -41,17 +42,25 @@ public class KafkaTopicsDescriptor implements Serializable {
     private final Pattern topicPattern;
 
     public KafkaTopicsDescriptor(
-            @Nullable List<String> fixedTopics, @Nullable Pattern topicPattern) {
+        @Nullable List<String> fixedTopics, @Nullable Pattern topicPattern) {
         checkArgument(
-                (fixedTopics != null && topicPattern == null)
-                        || (fixedTopics == null && topicPattern != null),
-                "Exactly one of either fixedTopics or topicPattern must be specified.");
+            (fixedTopics != null && topicPattern == null)
+                || (fixedTopics == null && topicPattern != null),
+            "Exactly one of either fixedTopics or topicPattern must be specified.");
 
         if (fixedTopics != null) {
             checkArgument(
-                    !fixedTopics.isEmpty(),
-                    "If subscribing to a fixed topics list, the supplied list cannot be empty.");
+                !fixedTopics.isEmpty(),
+                "If subscribing to a fixed topics list, the supplied list cannot be empty.");
+            fixedTopics.forEach(topic -> {
+                checkNotNull(topic, "An null topic exists in the subscribed topics list.");
+                checkArgument(!"".equals(topic), "An empty topic exists in the subscribed topics list.");
+            });
         }
+        if (topicPattern != null) {
+            checkArgument(!"".equals(topicPattern.toString()), "topicPattern is an empty pattern.");
+        }
+
 
         this.fixedTopics = fixedTopics;
         this.topicPattern = topicPattern;
@@ -85,7 +94,7 @@ public class KafkaTopicsDescriptor implements Serializable {
     @Override
     public String toString() {
         return (fixedTopics == null)
-                ? "Topic Regex Pattern (" + topicPattern.pattern() + ")"
-                : "Fixed Topics (" + fixedTopics + ")";
+            ? "Topic Regex Pattern (" + topicPattern.pattern() + ")"
+            : "Fixed Topics (" + fixedTopics + ")";
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
@@ -53,14 +54,13 @@ public class KafkaTopicsDescriptor implements Serializable {
             fixedTopics.forEach(
                     topic -> {
                         checkArgument(
-                                !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(topic),
+                                !StringUtils.isNullOrWhitespaceOnly(topic),
                                 "topic in the subscribed topics list cannot be null or empty string.");
                     });
         }
         if (topicPattern != null) {
             checkArgument(
-                    !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(
-                            topicPattern.toString()),
+                    !StringUtils.isNullOrWhitespaceOnly(topicPattern.toString()),
                     "topicPattern is an empty pattern.");
         }
         this.fixedTopics = fixedTopics;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
@@ -25,9 +25,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
 import java.util.regex.Pattern;
-
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A Kafka Topics Descriptor describes how the consumer subscribes to Kafka topics - either a fixed
@@ -42,26 +40,29 @@ public class KafkaTopicsDescriptor implements Serializable {
     private final Pattern topicPattern;
 
     public KafkaTopicsDescriptor(
-        @Nullable List<String> fixedTopics, @Nullable Pattern topicPattern) {
+            @Nullable List<String> fixedTopics, @Nullable Pattern topicPattern) {
         checkArgument(
-            (fixedTopics != null && topicPattern == null)
-                || (fixedTopics == null && topicPattern != null),
-            "Exactly one of either fixedTopics or topicPattern must be specified.");
+                (fixedTopics != null && topicPattern == null)
+                        || (fixedTopics == null && topicPattern != null),
+                "Exactly one of either fixedTopics or topicPattern must be specified.");
 
         if (fixedTopics != null) {
             checkArgument(
-                !fixedTopics.isEmpty(),
-                "If subscribing to a fixed topics list, the supplied list cannot be empty.");
-            fixedTopics.forEach(topic -> {
-                checkNotNull(topic, "An null topic exists in the subscribed topics list.");
-                checkArgument(!"".equals(topic), "An empty topic exists in the subscribed topics list.");
-            });
+                    !fixedTopics.isEmpty(),
+                    "If subscribing to a fixed topics list, the supplied list cannot be empty.");
+            fixedTopics.forEach(
+                    topic -> {
+                        checkArgument(
+                                !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(topic),
+                                "topic in the subscribed topics list cannot be null or empty string.");
+                    });
         }
         if (topicPattern != null) {
-            checkArgument(!"".equals(topicPattern.toString()), "topicPattern is an empty pattern.");
+            checkArgument(
+                    !org.apache.flink.util.StringUtils.isNullOrWhitespaceOnly(
+                            topicPattern.toString()),
+                    "topicPattern is an empty pattern.");
         }
-
-
         this.fixedTopics = fixedTopics;
         this.topicPattern = topicPattern;
     }
@@ -94,7 +95,7 @@ public class KafkaTopicsDescriptor implements Serializable {
     @Override
     public String toString() {
         return (fixedTopics == null)
-            ? "Topic Regex Pattern (" + topicPattern.pattern() + ")"
-            : "Fixed Topics (" + fixedTopics + ")";
+                ? "Topic Regex Pattern (" + topicPattern.pattern() + ")"
+                : "Fixed Topics (" + fixedTopics + ")";
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptor.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.List;
 import java.util.regex.Pattern;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**


### PR DESCRIPTION

## What is the purpose of the change

Fix FLINK-22969, verify that topic is not null and not an empty string when creating KafkaSourceFunction and KafkaSinkFunction。


## Brief change log

The KafkaTopicsDescriptor object will be created in the constructor of the FlinkKafkaConsumerBase class, and I added a check topic in the constructor of KafkaTopicsDescriptor to see if the topic is empty。

in FlinkKafkaProducer.FlinkKafkaProducer(
String defaultTopic,
KeyedSerializationSchema<IN> keyedSchema,
FlinkKafkaPartitioner<IN> customPartitioner,
KafkaSerializationSchema<IN> kafkaSchema,
Properties producerConfig,
FlinkKafkaProducer.Semantic semantic,
The int kafkaProducersPoolSize) method is added to check whether the defaultTopic is empty, because all FlinkKafkaProducer constructors will call this constructor.


## Verifying this change
This change is a trivial rework without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

Does this pull request introduce a new feature? ( no)
