### PR TITLE
[FLINK-23101][runtime] Flame Graphs initial view says it is 18800 day…

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
@@ -29,7 +29,7 @@ Type:
 </nz-radio-group>
 
 Measurement:
-<span *ngIf="flameGraph.endTimestamp">
+<span *ngIf="flameGraph.endTimestamp != -1; else notAvailable">
   {{ (now - flameGraph.endTimestamp) | humanizeDuration }} ago
 </span>
 
@@ -41,6 +41,6 @@ Measurement:
   <nz-spin *ngIf="isLoading"></nz-spin>
 </div>
 
-
-
-
+<ng-template #notAvailable>
+  <span>Flame graph is currently unavailable</span>
+</ng-template>


### PR DESCRIPTION
…s in the past

## What is the purpose of the change

Fixed flame graphs says it is 18800 days in the past when Flink returns an empty flame graph.

## Brief change log

- flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
