### PR TITLE
[FLINK-23290][table-runtime] Fix NullPointerException when filter contains casting to boolean

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1059,13 +1059,22 @@ object ScalarOperatorGens {
 
     // String -> Boolean
     case (VARCHAR | CHAR, BOOLEAN) =>
-      generateUnaryOperatorIfNotNull(
+      val castedExpression = generateUnaryOperatorIfNotNull(
         ctx,
         targetType,
         operand,
         resultNullable = true) {
         operandTerm => s"$BINARY_STRING_UTIL.toBooleanSQL($operandTerm)"
       }
+      val resultTerm = newName("primitiveCastResult")
+      castedExpression.copy(
+        resultTerm = resultTerm,
+        code =
+          s"""
+             |${castedExpression.code}
+             |boolean $resultTerm = Boolean.TRUE.equals(${castedExpression.resultTerm});
+             |""".stripMargin
+      )
 
     // String -> NUMERIC TYPE (not Character)
     case (VARCHAR | CHAR, _)


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes FLINK-23290. When filter is a function call which returns null values, `NullPointerException` might happen.

## Brief change log

 - Fix `NullPointerException` when filter is a function call which returns null values

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
