### PR TITLE
[FLINK-22898][Connectors/Hive] return default-parallelism in HiveParallelismInference when there is no source infer

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveParallelismInference.java
@@ -59,6 +59,10 @@ class HiveParallelismInference {
      * SELECT * FROM xxx LIMIT [limit]</code>.
      */
     int limit(Long limit) {
+        if (!infer) {
+            return parallelism;
+        }
+
         if (limit != null) {
             parallelism = Math.min(parallelism, (int) (limit / 1000));
         }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.HiveVersionTestUtil;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
@@ -524,7 +525,50 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
                         .get(0);
         Transformation<?> transformation =
                 (execNode.translateToPlan(planner).getInputs().get(0)).getInputs().get(0);
-        Assert.assertEquals(1, transformation.getParallelism());
+        // when there's no infer, should use the default parallelism configured
+        Assert.assertEquals(2, transformation.getParallelism());
+    }
+
+    @Test
+    public void testParallelismWithoutParallelismInfer() throws Exception {
+        final String dbName = "source_db";
+        final String tblName = "test_parallelism_no_infer";
+        EnvironmentSettings settings =
+                EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
+        TableEnvironment tEnv = TableEnvironment.create(settings);
+        tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        tEnv.registerCatalog("hive", hiveCatalog);
+        tEnv.useCatalog("hive");
+        tEnv.getConfig()
+                .getConfiguration()
+                .setBoolean(HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM, false);
+        tEnv.executeSql(
+                "CREATE TABLE source_db.test_parallelism_no_infer "
+                        + "(`year` STRING, `value` INT) partitioned by (pt int)");
+        HiveTestUtils.createTextTableInserter(hiveCatalog, dbName, tblName)
+                .addRow(new Object[] {"2014", 3})
+                .addRow(new Object[] {"2014", 4})
+                .commit("pt=0");
+        HiveTestUtils.createTextTableInserter(hiveCatalog, dbName, tblName)
+                .addRow(new Object[] {"2015", 2})
+                .addRow(new Object[] {"2015", 5})
+                .commit("pt=1");
+        Table table =
+                tEnv.sqlQuery("select * from hive.source_db.test_parallelism_no_infer limit 1");
+        PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tEnv).getPlanner();
+        RelNode relNode = planner.optimize(TableTestUtil.toRelNode(table));
+        ExecNode<?> execNode =
+                planner.translateToExecNodeGraph(toScala(Collections.singletonList(relNode)))
+                        .getRootNodes()
+                        .get(0);
+        Transformation<?> transformation =
+                (execNode.translateToPlan(planner).getInputs().get(0)).getInputs().get(0);
+        // when there's no infer, should use the default parallelism
+        Assert.assertEquals(
+                ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM
+                        .defaultValue()
+                        .intValue(),
+                transformation.getParallelism());
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*The pull request is to return default-parallelism in HiveParallelismInference when there is no source infer instead of max(1, default-parallelism) *


## Brief change log

  - *Return default-parallelism in  HiveParallelismInference directly when there's no source infer*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
