### PR TITLE
[FLINK-23074][connector-hive] Shade parquet class in hive-exec to prevent conflict. 

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
@@ -111,6 +111,12 @@ under the License.
 									<include>io.airlift:aircompressor</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.apache.parquet</pattern>
+									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.6/pom.xml
@@ -82,6 +82,12 @@ under the License.
 									<include>org.apache.hive:hive-exec</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.apache.parquet</pattern>
+									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
@@ -85,6 +85,12 @@ under the License.
 									<include>org.apache.thrift:libfb303</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.apache.parquet</pattern>
+									<shadedPattern>org.apache.hive.shaded.parquet</shadedPattern>
+								</relocation>
+							</relocations>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
## What is the purpose of the change

Before this pr has merged master, now I want to fix 1.12

flink-sql-connector-hive 2.3.6 include parquet-hadoop 1.8.1 version but flink-parquet include 1.11.1.

When  we custom connector and use GroupWriteSupport class, it will conflict.

## Brief change log

Alter flink-sql-connector-hive-2.2.0/2.3.6/3.1.2 pom.xml to shade org.apache.parquet

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
