### PR TITLE
[FLINK-23306][table] Reduce usages of legacy TableSchema

### DIFF
--- a/docs/content.zh/docs/dev/table/sourcesSinks.md
+++ b/docs/content.zh/docs/dev/table/sourcesSinks.md
@@ -452,7 +452,8 @@ public class SocketDynamicTableFactory implements DynamicTableSourceFactory {
     final byte byteDelimiter = (byte) (int) options.get(BYTE_DELIMITER);
 
     // derive the produced data type (excluding computed columns) from the catalog table
-    final DataType producedDataType = context.getCatalogTable().getSchema().toPhysicalRowDataType();
+    final DataType producedDataType =
+            context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();
 
     // create and return dynamic table source
     return new SocketDynamicTableSource(hostname, port, byteDelimiter, decodingFormat, producedDataType);

--- a/docs/content/docs/dev/table/sourcesSinks.md
+++ b/docs/content/docs/dev/table/sourcesSinks.md
@@ -452,7 +452,8 @@ public class SocketDynamicTableFactory implements DynamicTableSourceFactory {
     final byte byteDelimiter = (byte) (int) options.get(BYTE_DELIMITER);
 
     // derive the produced data type (excluding computed columns) from the catalog table
-    final DataType producedDataType = context.getCatalogTable().getSchema().toPhysicalRowDataType();
+    final DataType producedDataType =
+            context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();
 
     // create and return dynamic table source
     return new SocketDynamicTableSource(hostname, port, byteDelimiter, decodingFormat, producedDataType);

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketDynamicTableFactory.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/connectors/SocketDynamicTableFactory.java
@@ -95,7 +95,7 @@ public final class SocketDynamicTableFactory implements DynamicTableSourceFactor
 
         // derive the produced data type (excluding computed columns) from the catalog table
         final DataType producedDataType =
-                context.getCatalogTable().getSchema().toPhysicalRowDataType();
+                context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();
 
         // create and return dynamic table source
         return new SocketDynamicTableSource(

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/PrintTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/factories/PrintTableSinkFactory.java
@@ -95,7 +95,7 @@ public class PrintTableSinkFactory implements DynamicTableSinkFactory {
         helper.validate();
         ReadableConfig options = helper.getOptions();
         return new PrintSink(
-                context.getCatalogTable().getSchema().toPhysicalRowDataType(),
+                context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType(),
                 options.get(PRINT_IDENTIFIER),
                 options.get(STANDARD_ERROR),
                 options.getOptional(FactoryUtil.SINK_PARALLELISM).orElse(null));

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -68,7 +68,7 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
           case act: CatalogTable =>
             val builder = ImmutableSet.builder[ImmutableBitSet]()
 
-            val schema = act.getSchema
+            val schema = act.getResolvedSchema
             if (schema.getPrimaryKey.isPresent) {
               // use relOptTable's type which may be projected based on original schema
               val columns = relOptTable.getRowType.getFieldNames

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalSinkRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalSinkRule.scala
@@ -59,7 +59,7 @@ class StreamPhysicalSinkRule extends ConverterRule(
           val dynamicPartFields = sink.catalogTable.getPartitionKeys
               .filter(!sink.staticPartitions.contains(_))
           val fieldNames = sink.catalogTable
-            .getSchema
+            .getResolvedSchema
             .toPhysicalRowDataType
             .getLogicalType.asInstanceOf[RowType]
             .getFieldNames

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
@@ -76,7 +76,7 @@ class StreamPhysicalTableSourceScanRule
         isSourceChangeEventsDuplicate(table.catalogTable, table.tableSource, config)) {
       // generate changelog normalize node
       // primary key has been validated in CatalogSourceTable
-      val primaryKey = table.catalogTable.getSchema.getPrimaryKey.get()
+      val primaryKey = table.catalogTable.getResolvedSchema.getPrimaryKey.get()
       val keyFields = primaryKey.getColumns
       val inputFieldNames = newScan.getRowType.getFieldNames
       val primaryKeyIndices = ScanUtil.getPrimaryKeyIndices(inputFieldNames, keyFields)


### PR DESCRIPTION
## What is the purpose of the change

Reduce usages of legacy TableSchema. There are more usages but those require a separate PR as the changes might not be merged into a patch release. This PR can be cherry-picked to 1.13 branch.

## Brief change log

Replace `TableSchema` at various locations.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
