### PR TITLE
[FLINK-23311][tests] minor improvements around PojoSerializer tests

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/Types.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/Types.java
@@ -319,7 +319,7 @@ public class Types {
             final Field f = TypeExtractor.getDeclaredField(pojoClass, field.getKey());
             if (f == null) {
                 throw new InvalidTypesException(
-                        "Field '" + field.getKey() + "'could not be accessed.");
+                        "Field '" + field.getKey() + "' could not be accessed.");
             }
             pojoFields.add(new PojoField(f, field.getValue()));
         }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -134,7 +134,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
 
         @Override
         public int hashCode() {
-            return Objects.hash(dumm1, dumm2, dumm3, dumm4, nestedClass);
+            return Objects.hash(dumm1, dumm2, dumm3, dumm4, dumm5, nestedClass);
         }
 
         @Override
@@ -166,6 +166,10 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
                         return false;
                     }
                 }
+            }
+            if ((dumm5 == null && otherTUC.dumm5 != null)
+                    || (dumm5 != null && !dumm5.equals(otherTUC.dumm5))) {
+                return false;
             }
 
             if ((nestedClass == null && otherTUC.nestedClass != null)

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -417,7 +419,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
         TypeSerializerSchemaCompatibility<TestUserClass> compatResult =
                 pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
         assertTrue(compatResult.isCompatibleWithReconfiguredSerializer());
-        assertTrue(compatResult.getReconfiguredSerializer() instanceof PojoSerializer);
+        assertThat(compatResult.getReconfiguredSerializer(), instanceOf(PojoSerializer.class));
 
         // reconfigure - check reconfiguration result and that registration ids remains the same
         // assertEquals(ReconfigureResult.COMPATIBLE,
@@ -487,7 +489,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
         TypeSerializerSchemaCompatibility<TestUserClass> compatResult =
                 pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
         assertTrue(compatResult.isCompatibleWithReconfiguredSerializer());
-        assertTrue(compatResult.getReconfiguredSerializer() instanceof PojoSerializer);
+        assertThat(compatResult.getReconfiguredSerializer(), instanceOf(PojoSerializer.class));
 
         PojoSerializer<TestUserClass> reconfiguredPojoSerializer =
                 (PojoSerializer<TestUserClass>) compatResult.getReconfiguredSerializer();
@@ -571,7 +573,7 @@ public class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.Te
         TypeSerializerSchemaCompatibility<TestUserClass> compatResult =
                 pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
         assertTrue(compatResult.isCompatibleWithReconfiguredSerializer());
-        assertTrue(compatResult.getReconfiguredSerializer() instanceof PojoSerializer);
+        assertThat(compatResult.getReconfiguredSerializer(), instanceOf(PojoSerializer.class));
 
         PojoSerializer<TestUserClass> reconfiguredPojoSerializer =
                 (PojoSerializer<TestUserClass>) compatResult.getReconfiguredSerializer();

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTestSpecifications.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerUpgradeTestSpecifications.java
@@ -210,7 +210,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -228,7 +228,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -275,7 +275,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<PojoBeforeSchemaUpgrade> serializer =
                     TypeExtractor.createTypeInfo(PojoBeforeSchemaUpgrade.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -342,7 +342,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<PojoAfterSchemaUpgrade> serializer =
                     TypeExtractor.createTypeInfo(PojoAfterSchemaUpgrade.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -384,7 +384,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<PojoWithIntField> serializer =
                     TypeExtractor.createTypeInfo(PojoWithIntField.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -416,7 +416,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<PojoWithStringField> serializer =
                     TypeExtractor.createTypeInfo(PojoWithStringField.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -478,7 +478,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
             TypeSerializer<BasePojo> serializer =
                     TypeExtractor.createTypeInfo(BasePojo.class).createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -557,7 +557,7 @@ public class PojoSerializerUpgradeTestSpecifications {
 
             TypeSerializer<BasePojo> serializer =
                     TypeExtractor.createTypeInfo(BasePojo.class).createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -603,7 +603,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -640,7 +640,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -670,7 +670,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -689,7 +689,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(new ExecutionConfig());
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -723,7 +723,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -746,7 +746,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -781,7 +781,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -803,7 +803,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -835,7 +835,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -858,7 +858,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -892,7 +892,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 
@@ -914,7 +914,7 @@ public class PojoSerializerUpgradeTestSpecifications {
             TypeSerializer<StaticSchemaPojo> serializer =
                     TypeExtractor.createTypeInfo(StaticSchemaPojo.class)
                             .createSerializer(executionConfig);
-            assertSame(serializer.getClass(), PojoSerializer.class);
+            assertSame(PojoSerializer.class, serializer.getClass());
             return serializer;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

While working with the PojoSerializer a bit more, I noticed a couple of minor things that are off in the current tests:

- the test Pojo does not take dumm5 into account for hashCode and equals
- error messages are not so nice (and mix up the order of expected and actual values)


## Brief change log

- hotfix typo in error message inside `Types.java`
- fix `PojoSerializerTest` user POJO not taking `dumm5` into account for `hashCode` and `equals`
- nicer error messages in `PojoSerializerTest` via hamcrest
- fix wrong parameter order in `assertSame()`


## Verifying this change

This change is a trivial rework / code cleanup without any new test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
