### PR TITLE
[FLINK-23312][ci] speed up compilation for e2e tests

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -224,7 +224,7 @@ jobs:
         sudo apt install ./libssl1.0.0_1.0.2n-1ubuntu5.6_amd64.deb
       displayName: Prepare E2E run
       condition: not(eq(variables['SKIP'], '1'))
-    - script: ${{parameters.environment}} ./tools/ci/compile.sh
+    - script: ${{parameters.environment}} PROFILE="$PROFILE -Dfast -Pskip-webui-build" ./tools/ci/compile.sh
       displayName: Build Flink
       condition: not(eq(variables['SKIP'], '1'))
     - script: ${{parameters.environment}} FLINK_DIR=`pwd`/build-target ./tools/azure-pipelines/uploading_watchdog.sh flink-end-to-end-tests/run-nightly-tests.sh e2e


### PR DESCRIPTION
## What is the purpose of the change

The "e2e" builder in Azure pipelines builds Flink again on top of what the "compile" builder is already doing. This unnecessary duplicates a couple of checks that are enough to execute once and can be skipped via providing `-Dfast` (and `-Pskip-webui-build` as suggested by the review comments).

On my local machine with 32GB RAM, 8 physical cores and a fast NVMe SSD, the difference is pretty big:

```
time mvn clean install -Dscala-2.12 -DskipTests -pl flink-dist -am
# -> 6:40 min

time mvn clean install -Dscala-2.12 -DskipTests -Dfast -pl flink-dist -am
# -> 5:40 min
```

I looked at a couple of Azure Pipeline runs and it seems like this for the "Build Flink" task in the "e2e_ci" builder:
- without this PR: 29-33 min
- with `-Dfast`: 20-25 min
- with `-Dfast` and `-Pskip-webui-build`: 16-20min

## Brief change log

- use `-Dfast` and `-Pskip-webui-build` for the e2e build

## Verifying this change

This change does not affect Flink code and instead influences the Azure pipeline definition
