### PR TITLE
[FLINK-23308] Optimize checks if SourceContext is closed

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSourceContexts.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSourceContexts.java
@@ -173,7 +173,6 @@ public class StreamSourceContexts {
 
         @Override
         protected void processAndCollect(T element) {
-            checkNotClosed();
             lastRecordTime = this.timeService.getCurrentProcessingTime();
             output.collect(reuse.replace(element, lastRecordTime));
 
@@ -193,7 +192,6 @@ public class StreamSourceContexts {
 
         @Override
         protected void processAndCollectWithTimestamp(T element, long timestamp) {
-            checkNotClosed();
             processAndCollect(element);
         }
 
@@ -207,7 +205,6 @@ public class StreamSourceContexts {
         /** This will only be called if allowWatermark returned {@code true}. */
         @Override
         protected void processAndEmitWatermark(Watermark mark) {
-            checkNotClosed();
             nextWatermarkTime = Long.MAX_VALUE;
             output.emitWatermark(mark);
 
@@ -222,7 +219,6 @@ public class StreamSourceContexts {
 
         @Override
         protected void processAndEmitStreamStatus(StreamStatus streamStatus) {
-            checkNotClosed();
             if (idle != streamStatus.isIdle()) {
                 output.emitStreamStatus(streamStatus);
             }
@@ -320,25 +316,21 @@ public class StreamSourceContexts {
 
         @Override
         protected void processAndCollect(T element) {
-            checkNotClosed();
             output.collect(reuse.replace(element));
         }
 
         @Override
         protected void processAndCollectWithTimestamp(T element, long timestamp) {
-            checkNotClosed();
             output.collect(reuse.replace(element, timestamp));
         }
 
         @Override
         protected void processAndEmitWatermark(Watermark mark) {
-            checkNotClosed();
             output.emitWatermark(mark);
         }
 
         @Override
         protected void processAndEmitStreamStatus(StreamStatus streamStatus) {
-            checkNotClosed();
             if (idle != streamStatus.isIdle()) {
                 output.emitStreamStatus(streamStatus);
             }
@@ -410,7 +402,7 @@ public class StreamSourceContexts {
         }
 
         @Override
-        public void collect(T element) {
+        public final void collect(T element) {
             checkNotClosed();
 
             synchronized (checkpointLock) {
@@ -426,14 +418,14 @@ public class StreamSourceContexts {
             }
         }
 
-        protected void checkNotClosed() {
+        private void checkNotClosed() {
             if (closed) {
                 throw new FlinkRuntimeException("The Source Context has been closed already.");
             }
         }
 
         @Override
-        public void collectWithTimestamp(T element, long timestamp) {
+        public final void collectWithTimestamp(T element, long timestamp) {
             checkNotClosed();
 
             synchronized (checkpointLock) {
@@ -450,7 +442,7 @@ public class StreamSourceContexts {
         }
 
         @Override
-        public void emitWatermark(Watermark mark) {
+        public final void emitWatermark(Watermark mark) {
             checkNotClosed();
 
             if (allowWatermark(mark)) {
@@ -469,7 +461,7 @@ public class StreamSourceContexts {
         }
 
         @Override
-        public void markAsTemporarilyIdle() {
+        public final void markAsTemporarilyIdle() {
             checkNotClosed();
 
             synchronized (checkpointLock) {


### PR DESCRIPTION
* Remove unnecessary calls to `checkNotClosed`
* Make the `checkNotClosed` private to enable inlining