### PR TITLE
[FLINK-23314][cep] State left behind for short lived keys

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ComputationState.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ComputationState.java
@@ -109,6 +109,10 @@ public class ComputationState {
                 + '}';
     }
 
+    public boolean isStartState() {
+        return startEventID == null;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -139,19 +139,6 @@ public class NFA<T> {
         return states.get(state.getCurrentStateName());
     }
 
-    private boolean isStartState(ComputationState state) {
-        State<T> stateObject = getState(state);
-        if (stateObject == null) {
-            throw new FlinkRuntimeException(
-                    "State "
-                            + state.getCurrentStateName()
-                            + " does not exist in the NFA. NFA has states "
-                            + states.values());
-        }
-
-        return stateObject.isStart();
-    }
-
     private boolean isStopState(ComputationState state) {
         State<T> stateObject = getState(state);
         if (stateObject == null) {
@@ -297,7 +284,7 @@ public class NFA<T> {
     }
 
     private boolean isStateTimedOut(final ComputationState state, final long timestamp) {
-        return !isStartState(state)
+        return !state.isStartState()
                 && windowTime > 0L
                 && timestamp - state.getStartTimestamp() >= windowTime;
     }
@@ -603,7 +590,7 @@ public class NFA<T> {
             switch (edge.getAction()) {
                 case IGNORE:
                     {
-                        if (!isStartState(computationState)) {
+                        if (!computationState.isStartState()) {
                             final DeweyNumber version;
                             if (isEquivalentState(
                                     edge.getTargetState(), getState(computationState))) {
@@ -655,7 +642,7 @@ public class NFA<T> {
 
                     final long startTimestamp;
                     final EventId startEventId;
-                    if (isStartState(computationState)) {
+                    if (computationState.isStartState()) {
                         startTimestamp = event.getTimestamp();
                         startEventId = event.getEventId();
                     } else {
@@ -689,7 +676,7 @@ public class NFA<T> {
             }
         }
 
-        if (isStartState(computationState)) {
+        if (computationState.isStartState()) {
             int totalBranches =
                     calculateIncreasingSelfState(
                             outgoingEdges.getTotalIgnoreBranches(),

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAState.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAState.java
@@ -37,7 +37,7 @@ public class NFAState {
     private Queue<ComputationState> completedMatches;
 
     /** Flag indicating whether the matching status of the state machine has changed. */
-    private boolean stateChanged;
+    private boolean stateChanged = true;
 
     public static final Comparator<ComputationState> COMPUTATION_STATE_COMPARATOR =
             Comparator.<ComputationState>comparingLong(
@@ -95,6 +95,14 @@ public class NFAState {
 
     public void setNewPartialMatches(PriorityQueue<ComputationState> newPartialMatches) {
         this.partialMatches = newPartialMatches;
+    }
+
+    public boolean isEmpty() {
+        return completedMatches.isEmpty() && (partialMatches.isEmpty() || hasOnlyStartState());
+    }
+
+    private boolean hasOnlyStartState() {
+        return partialMatches.size() == 1 && partialMatches.poll().isStartState();
     }
 
     @Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
@@ -194,6 +194,12 @@ public class SharedBuffer<V> {
                 iterator.remove();
             }
         }
+
+        // we do that clear the namespace, removing based on the iterator, leaves an empty entry
+        // for the current key
+        if (eventsCount.isEmpty()) {
+            eventsCount.clear();
+        }
     }
 
     EventId registerEvent(V value, long timestamp) throws Exception {
@@ -311,8 +317,7 @@ public class SharedBuffer<V> {
         }
     }
 
-    @VisibleForTesting
-    Iterator<Map.Entry<Long, Integer>> getEventCounters() throws Exception {
+    public Iterator<Map.Entry<Long, Integer>> getEventCounters() throws Exception {
         return eventsCount.iterator();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Properly clean up state in CepOperator


## Brief change log

Couple of improvements for state cleaning in the CepOperator.
* register timer in order to advance time, if we keep count of records
for certain timestamps
* clear the namespace if there are no more timestamps we keep count of
events for
* clear up NfaState if there is only starting partial match

## Verifying this change

This is a Work in Progress, needs a test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
