### PR TITLE
[FLINK-23107][table-runtime] Separate implementation of deduplicate r…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RankUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RankUtil.scala
@@ -295,6 +295,11 @@ object RankUtil {
     literals.head
   }
 
+  def isTop1(rankRange: RankRange): Boolean = rankRange match {
+    case crg: ConstantRankRange => crg.getRankEnd == 1L
+    case _ => false
+  }
+
   def getRankNumberColumnIndex(rank: Rank): Option[Int] = {
     if (rank.outputRankNumber) {
       require(rank.getRowType.getFieldCount == rank.getInput.getRowType.getFieldCount + 1)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RankUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RankUtil.scala
@@ -296,7 +296,7 @@ object RankUtil {
   }
 
   def isTop1(rankRange: RankRange): Boolean = rankRange match {
-    case crg: ConstantRankRange => crg.getRankEnd == 1L
+    case crg: ConstantRankRange => crg.getRankStart == 1L && crg.getRankEnd == 1L
     case _ => false
   }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/FastTop1Function.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/FastTop1Function.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalCause;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalNotification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A more concise implementation for {@link AppendOnlyTopNFunction} and {@link
+ * UpdatableTopNFunction} when only Top-1 is desired.
+ */
+public class FastTop1Function extends AbstractTopNFunction implements CheckpointedFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FastTop1Function.class);
+
+    private final TypeSerializer<RowData> inputRowSer;
+    private final long cacheSize;
+
+    // a map state stores list of records
+    private transient ValueState<RowData> dataState;
+
+    // the kvMap stores mapping from partition key to its current top-1 value
+    private transient Cache<RowData, RowData> kvCache;
+
+    public FastTop1Function(
+            StateTtlConfig ttlConfig,
+            InternalTypeInfo<RowData> inputRowType,
+            GeneratedRecordComparator generatedSortKeyComparator,
+            RowDataKeySelector sortKeySelector,
+            RankType rankType,
+            RankRange rankRange,
+            boolean generateUpdateBefore,
+            boolean outputRankNumber,
+            long cacheSize) {
+        super(
+                ttlConfig,
+                inputRowType,
+                generatedSortKeyComparator,
+                sortKeySelector,
+                rankType,
+                rankRange,
+                generateUpdateBefore,
+                outputRankNumber);
+
+        this.inputRowSer = inputRowType.createSerializer(new ExecutionConfig());
+        this.cacheSize = cacheSize;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        int lruCacheSize = Math.max(1, (int) (cacheSize / getDefaultTopNSize()));
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (ttlConfig.isEnabled()) {
+            cacheBuilder.expireAfterWrite(
+                    ttlConfig.getTtl().toMilliseconds(), TimeUnit.MILLISECONDS);
+        }
+        kvCache =
+                cacheBuilder
+                        .maximumSize(lruCacheSize)
+                        .removalListener(new CacheRemovalListener())
+                        .build();
+        LOG.info("Top-1 operator is using LRU caches key-size: {}", lruCacheSize);
+
+        ValueStateDescriptor<RowData> valueStateDescriptor =
+                new ValueStateDescriptor<>("Top1-Rank-State", inputRowType);
+        if (ttlConfig.isEnabled()) {
+            valueStateDescriptor.enableTimeToLive(ttlConfig);
+        }
+        dataState = getRuntimeContext().getState(valueStateDescriptor);
+
+        // metrics
+        registerMetric(kvCache.size() * getDefaultTopNSize());
+    }
+
+    @Override
+    public void processElement(RowData input, Context ctx, Collector<RowData> out)
+            throws Exception {
+        requestCount += 1;
+        // load state under current key if necessary
+        RowData currentKey = (RowData) keyContext.getCurrentKey();
+        RowData prevRow = kvCache.getIfPresent(currentKey);
+        if (prevRow == null) {
+            prevRow = dataState.value();
+        } else {
+            hitCount += 1;
+        }
+
+        // first row under current key.
+        if (prevRow == null) {
+            kvCache.put(currentKey, inputRowSer.copy(input));
+            if (outputRankNumber) {
+                collectInsert(out, input, 1);
+            } else {
+                collectInsert(out, input);
+            }
+            return;
+        }
+
+        RowData curSortKey = sortKeySelector.getKey(input);
+        RowData oldSortKey = sortKeySelector.getKey(prevRow);
+        int compare = sortKeyComparator.compare(curSortKey, oldSortKey);
+        // current sort key is higher than old sort key
+        if (compare < 0) {
+            kvCache.put(currentKey, inputRowSer.copy(input));
+            // Note: partition key is unique key if only top-1 is desired,
+            //  thus emitting UB and UA here
+            if (outputRankNumber) {
+                collectUpdateBefore(out, prevRow, 1);
+                collectUpdateAfter(out, input, 1);
+            } else {
+                collectUpdateBefore(out, prevRow);
+                collectUpdateAfter(out, input);
+            }
+        }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        for (Map.Entry<RowData, RowData> entry : kvCache.asMap().entrySet()) {
+            keyContext.setCurrentKey(entry.getKey());
+            dataState.update(entry.getValue());
+        }
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        // nothing to do
+    }
+
+    private class CacheRemovalListener implements RemovalListener<RowData, RowData> {
+        @Override
+        public void onRemoval(RemovalNotification<RowData, RowData> notification) {
+            if (notification.getCause() != RemovalCause.SIZE || notification.getValue() == null) {
+                // Don't flush values to state if cause is ttl expired
+                return;
+            }
+
+            RowData previousKey = (RowData) keyContext.getCurrentKey();
+            RowData partitionKey = notification.getKey();
+            keyContext.setCurrentKey(partitionKey);
+            try {
+                dataState.update(notification.getValue());
+            } catch (Throwable e) {
+                LOG.error("Fail to synchronize state!", e);
+                throw new RuntimeException(e);
+            } finally {
+                keyContext.setCurrentKey(previousKey);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/FastTop1Function.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/FastTop1Function.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class FastTop1Function extends AbstractTopNFunction implements CheckpointedFunction {
 
-    private static final long serialVersionUID = -1379466658843676156L;
+    private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(FastTop1Function.class);
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/FastTop1Function.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/FastTop1Function.java
@@ -47,9 +47,13 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A more concise implementation for {@link AppendOnlyTopNFunction} and {@link
- * UpdatableTopNFunction} when only Top-1 is desired.
+ * UpdatableTopNFunction} when only Top-1 is desired. This function can handle updating stream
+ * because the RankProcessStrategy is inferred as UpdateFastStrategy, i.e., 1) the upsert key of
+ * input steam contains partition key; 2) the sort field is updated monotonely under the upsert key.
  */
 public class FastTop1Function extends AbstractTopNFunction implements CheckpointedFunction {
+
+    private static final long serialVersionUID = -1379466658843676156L;
 
     private static final Logger LOG = LoggerFactory.getLogger(FastTop1Function.class);
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank;
+
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
+
+/** Tests for {@link FastTop1Function}. */
+public class FastTop1FunctionTest extends TopNFunctionTestBase {
+    @Override
+    AbstractTopNFunction createFunction(
+            RankType rankType,
+            RankRange rankRange,
+            boolean generateUpdateBefore,
+            boolean outputRankNumber) {
+        return new FastTop1Function(
+                ttlConfig,
+                inputRowType,
+                generatedSortKeyComparator,
+                sortKeySelector,
+                rankType,
+                rankRange,
+                generateUpdateBefore,
+                outputRankNumber,
+                cacheSize);
+    }
+
+    @Override
+    public void testDisableGenerateUpdateBefore() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 1L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 3L, 19));
+        testHarness.processElement(insertRecord("book", 4L, 11));
+        testHarness.processElement(insertRecord("book", 5L, 11));
+        testHarness.processElement(insertRecord("fruit", 4L, 33));
+        testHarness.processElement(insertRecord("fruit", 3L, 44));
+        testHarness.processElement(insertRecord("fruit", 5L, 22));
+        testHarness.close();
+
+        // Notes: partition key is unique key if only top-1 is desired.
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 1L, 12));
+        expectedOutput.add(updateAfterRecord("book", 4L, 11));
+        expectedOutput.add(insertRecord("fruit", 4L, 33));
+        expectedOutput.add(updateAfterRecord("fruit", 5L, 22));
+        assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    public void testOutputRankNumberWithConstantRankRange() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 1L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 4L, 11));
+        testHarness.processElement(insertRecord("book", 5L, 11));
+        testHarness.processElement(insertRecord("fruit", 4L, 33));
+        testHarness.processElement(insertRecord("fruit", 3L, 44));
+        testHarness.processElement(insertRecord("fruit", 5L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+        expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
+        expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
+        expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+        expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+        expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    public void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 1L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 4L, 11));
+        testHarness.processElement(insertRecord("book", 5L, 11));
+        testHarness.processElement(insertRecord("fruit", 4L, 33));
+        testHarness.processElement(insertRecord("fruit", 3L, 44));
+        testHarness.processElement(insertRecord("fruit", 5L, 22));
+        testHarness.close();
+
+        // Notes: partition key is unique key if only top-1 is desired.
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+        expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
+        expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+        expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    public void testConstantRankRangeWithoutOffset() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 1L, 12));
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 4L, 11));
+        testHarness.processElement(insertRecord("fruit", 4L, 33));
+        testHarness.processElement(insertRecord("fruit", 3L, 44));
+        testHarness.processElement(insertRecord("fruit", 5L, 22));
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 1L, 12));
+        expectedOutput.add(updateBeforeRecord("book", 1L, 12));
+        expectedOutput.add(updateAfterRecord("book", 4L, 11));
+
+        expectedOutput.add(insertRecord("fruit", 4L, 33));
+        expectedOutput.add(updateBeforeRecord("fruit", 4L, 33));
+        expectedOutput.add(updateAfterRecord("fruit", 5L, 22));
+        assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+
+        // do a snapshot, data could be recovered from state
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+        expectedOutput.clear();
+
+        func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
+        testHarness = createTestHarness(func);
+        testHarness.setup();
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 5L, 10));
+        testHarness.close();
+
+        expectedOutput.add(updateBeforeRecord("book", 4L, 11));
+        expectedOutput.add(updateAfterRecord("book", 5L, 10));
+        assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Override
+    public void testConstantRankRangeWithOffset() throws Exception {
+        // skip
+    }
+
+    @Override
+    public void testOutputRankNumberWithVariableRankRange() throws Exception {
+        // skip
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -166,6 +168,183 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
         expectedOutput.add(updateBeforeRecord("book", 4L, 11));
         expectedOutput.add(updateAfterRecord("book", 5L, 10));
         assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    // ------------ Tests with UPDATE input records ---------------
+
+    @Test
+    public void testVariableRankRange() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(updateAfterRecord("book", 2L, 18));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(updateAfterRecord("fruit", 1L, 33));
+        testHarness.processElement(updateAfterRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 19));
+        expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+        expectedOutput.add(updateAfterRecord("book", 2L, 18));
+        expectedOutput.add(insertRecord("fruit", 1L, 44));
+        expectedOutput.add(updateBeforeRecord("fruit", 1L, 44));
+        expectedOutput.add(updateAfterRecord("fruit", 1L, 33));
+        expectedOutput.add(updateBeforeRecord("fruit", 1L, 33));
+        expectedOutput.add(updateAfterRecord("fruit", 1L, 22));
+        assertorWithoutRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testOutputRankNumberWithUpdateInputs() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(updateAfterRecord("book", 2L, 12));
+        testHarness.processElement(updateAfterRecord("book", 2L, 11));
+        testHarness.processElement(insertRecord("fruit", 1L, 44));
+        testHarness.processElement(updateAfterRecord("fruit", 1L, 33));
+        testHarness.processElement(updateAfterRecord("fruit", 1L, 22));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 19, 1L));
+        expectedOutput.add(updateBeforeRecord("book", 2L, 19, 1L));
+        expectedOutput.add(updateAfterRecord("book", 2L, 12, 1L));
+        expectedOutput.add(updateBeforeRecord("book", 2L, 12, 1L));
+        expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
+        expectedOutput.add(insertRecord("fruit", 1L, 44, 1L));
+        expectedOutput.add(updateBeforeRecord("fruit", 1L, 44, 1L));
+        expectedOutput.add(updateAfterRecord("fruit", 1L, 33, 1L));
+        expectedOutput.add(updateBeforeRecord("fruit", 1L, 33, 1L));
+        expectedOutput.add(updateAfterRecord("fruit", 1L, 22, 1L));
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testSortKeyChangesWhenOutputRankNumber() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 3L, 16));
+        testHarness.processElement(updateAfterRecord("book", 2L, 11));
+        testHarness.processElement(updateAfterRecord("book", 3L, 15));
+        testHarness.processElement(insertRecord("book", 4L, 2));
+        testHarness.processElement(updateAfterRecord("book", 2L, 1));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        // ("book", 2L, 19)
+        expectedOutput.add(insertRecord("book", 2L, 19, 1L));
+        // ("book", 3L, 16)
+        expectedOutput.add(updateBeforeRecord("book", 2L, 19, 1L));
+        expectedOutput.add(updateAfterRecord("book", 3L, 16, 1L));
+        // U ("book", 2L, 11)
+        expectedOutput.add(updateBeforeRecord("book", 3L, 16, 1L));
+        expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
+        // ("book", 4L, 2)
+        expectedOutput.add(updateBeforeRecord("book", 2L, 11, 1L));
+        expectedOutput.add(updateAfterRecord("book", 4L, 2, 1L));
+        // U ("book", 2L, 1)
+        expectedOutput.add(updateBeforeRecord("book", 4L, 2, 1L));
+        expectedOutput.add(updateAfterRecord("book", 2L, 1, 1L));
+
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore()
+            throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, true);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 3L, 16));
+        testHarness.processElement(updateAfterRecord("book", 2L, 11));
+        testHarness.processElement(updateAfterRecord("book", 3L, 15));
+        testHarness.processElement(insertRecord("book", 4L, 2));
+        testHarness.processElement(updateAfterRecord("book", 2L, 1));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        // ("book", 2L, 19)
+        expectedOutput.add(insertRecord("book", 2L, 19, 1L));
+        // ("book", 3L, 16)
+        expectedOutput.add(updateAfterRecord("book", 3L, 16, 1L));
+        // U ("book", 2L, 11)
+        expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
+        // ("book", 4L, 2)
+        expectedOutput.add(updateAfterRecord("book", 4L, 2, 1L));
+        // U ("book", 2L, 1)
+        expectedOutput.add(updateAfterRecord("book", 2L, 1, 1L));
+
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 3L, 16));
+        testHarness.processElement(updateAfterRecord("book", 2L, 11));
+        testHarness.processElement(updateAfterRecord("book", 3L, 15));
+        testHarness.processElement(insertRecord("book", 4L, 2));
+        testHarness.processElement(updateAfterRecord("book", 2L, 1));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 19));
+        expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+        expectedOutput.add(updateAfterRecord("book", 3L, 16));
+        expectedOutput.add(updateBeforeRecord("book", 3L, 16));
+        expectedOutput.add(updateAfterRecord("book", 2L, 11));
+        expectedOutput.add(updateBeforeRecord("book", 2L, 11));
+        expectedOutput.add(updateAfterRecord("book", 4L, 2));
+        expectedOutput.add(updateBeforeRecord("book", 4L, 2));
+        expectedOutput.add(updateAfterRecord("book", 2L, 1));
+
+        assertorWithRowNumber.assertOutputEquals(
+                "output wrong.", expectedOutput, testHarness.getOutput());
+    }
+
+    @Test
+    public void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore()
+            throws Exception {
+        AbstractTopNFunction func =
+                createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, false);
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
+        testHarness.open();
+        testHarness.processElement(insertRecord("book", 2L, 19));
+        testHarness.processElement(insertRecord("book", 3L, 16));
+        testHarness.processElement(updateAfterRecord("book", 2L, 11));
+        testHarness.processElement(updateAfterRecord("book", 3L, 15));
+        testHarness.processElement(insertRecord("book", 4L, 2));
+        testHarness.processElement(updateAfterRecord("book", 2L, 1));
+        testHarness.close();
+
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(insertRecord("book", 2L, 19));
+        expectedOutput.add(updateAfterRecord("book", 3L, 16));
+        expectedOutput.add(updateAfterRecord("book", 2L, 11));
+        expectedOutput.add(updateAfterRecord("book", 4L, 2));
+        expectedOutput.add(updateAfterRecord("book", 2L, 1));
+
+        assertorWithRowNumber.assertOutputEquals(
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 


### PR DESCRIPTION
…ank from other rank functions

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Consider the following sql:

```
SELECT * 
FROM (
  SELECT *, ROW_NUMBER() OVER (PARTITION BY d ORDER BY e DESC) AS rownum from T
) WHERE rownum = 1
```

It's very common for users to write the above sql to achieve the deduplication of records, but the sql cannot be translated to 
`Deduplcate` when the field `e` is not time attribute field, then it'll be translated to `Rank` instead. The common implementation for rank currently is a bit of complex and error-prone. 

This pr aims to  separate the implementation for the deduplicate rank and reduce bugs.

## Brief change log
  - Add a new rank function `FastTop1Function` for deduplicate rank


## Verifying this change
- Add unit tests for the new rank function
- Add IT case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
