### PR TITLE
[FLINK-22017][coordination] Allow BLOCKING result partition to be individually consumable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManager.java
@@ -41,6 +41,9 @@ public class EdgeManager {
     private final Map<ExecutionVertexID, List<ConsumedPartitionGroup>> vertexConsumedPartitions =
             new HashMap<>();
 
+    private final Map<IntermediateResultPartitionID, List<ConsumedPartitionGroup>>
+            consumedPartitionsById = new HashMap<>();
+
     public void connectPartitionWithConsumerVertexGroup(
             IntermediateResultPartitionID resultPartitionId,
             ConsumerVertexGroup consumerVertexGroup) {
@@ -88,5 +91,24 @@ public class EdgeManager {
             ExecutionVertexID executionVertexId) {
         return Collections.unmodifiableList(
                 getConsumedPartitionGroupsForVertexInternal(executionVertexId));
+    }
+
+    public void registerConsumedPartitionGroup(ConsumedPartitionGroup group) {
+        for (IntermediateResultPartitionID partitionId : group) {
+            consumedPartitionsById
+                    .computeIfAbsent(partitionId, ignore -> new ArrayList<>())
+                    .add(group);
+        }
+    }
+
+    private List<ConsumedPartitionGroup> getConsumedPartitionGroupsByIdInternal(
+            IntermediateResultPartitionID resultPartitionId) {
+        return consumedPartitionsById.computeIfAbsent(resultPartitionId, id -> new ArrayList<>());
+    }
+
+    public List<ConsumedPartitionGroup> getConsumedPartitionGroupsById(
+            IntermediateResultPartitionID resultPartitionId) {
+        return Collections.unmodifiableList(
+                getConsumedPartitionGroupsByIdInternal(resultPartitionId));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -969,19 +969,11 @@ public class Execution
     }
 
     private void finishPartitionsAndUpdateConsumers() {
-        final List<IntermediateResultPartition> newlyFinishedResults =
+        final List<IntermediateResultPartition> finishedPartitions =
                 getVertex().finishAllBlockingPartitions();
-        if (newlyFinishedResults.isEmpty()) {
-            return;
-        }
 
-        for (IntermediateResultPartition finishedPartition : newlyFinishedResults) {
-            final IntermediateResultPartition[] allPartitionsOfNewlyFinishedResults =
-                    finishedPartition.getIntermediateResult().getPartitions();
-
-            for (IntermediateResultPartition partition : allPartitionsOfNewlyFinishedResults) {
-                updatePartitionConsumers(partition);
-            }
+        for (IntermediateResultPartition partition : finishedPartitions) {
+            updatePartitionConsumers(partition);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -491,13 +491,17 @@ public class ExecutionVertex
     }
 
     /** Returns all blocking result partitions whose receivers can be scheduled/updated. */
-    List<IntermediateResultPartition> finishAllBlockingPartitions() {
+    @VisibleForTesting
+    public List<IntermediateResultPartition> finishAllBlockingPartitions() {
         List<IntermediateResultPartition> finishedBlockingPartitions = null;
 
         for (IntermediateResultPartition partition : resultPartitions.values()) {
-            if (partition.getResultType().isBlocking() && partition.markFinished()) {
+            if (partition.getResultType().isBlocking()) {
+
+                partition.markFinished();
+
                 if (finishedBlockingPartitions == null) {
-                    finishedBlockingPartitions = new LinkedList<IntermediateResultPartition>();
+                    finishedBlockingPartitions = new LinkedList<>();
                 }
 
                 finishedBlockingPartitions.add(partition);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import java.util.HashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -47,8 +46,6 @@ public class IntermediateResult {
 
     private final int numParallelProducers;
 
-    private final AtomicInteger numberOfRunningProducers;
-
     private int partitionsAssigned;
 
     private final int connectionIndex;
@@ -68,8 +65,6 @@ public class IntermediateResult {
         this.numParallelProducers = numParallelProducers;
 
         this.partitions = new IntermediateResultPartition[numParallelProducers];
-
-        this.numberOfRunningProducers = new AtomicInteger(numParallelProducers);
 
         // we do not set the intermediate result partitions here, because we let them be initialized
         // by
@@ -152,23 +147,6 @@ public class IntermediateResult {
         for (IntermediateResultPartition partition : partitions) {
             partition.resetForNewExecution();
         }
-    }
-
-    @VisibleForTesting
-    int getNumberOfRunningProducers() {
-        return numberOfRunningProducers.get();
-    }
-
-    int incrementNumberOfRunningProducersAndGetRemaining() {
-        return numberOfRunningProducers.incrementAndGet();
-    }
-
-    int decrementNumberOfRunningProducersAndGetRemaining() {
-        return numberOfRunningProducers.decrementAndGet();
-    }
-
-    boolean areAllPartitionsFinished() {
-        return numberOfRunningProducers.get() == 0;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 
 import java.util.List;
@@ -72,6 +73,10 @@ public class IntermediateResultPartition {
         return getEdgeManager().getConsumerVertexGroupsForPartition(partitionId);
     }
 
+    public List<ConsumedPartitionGroup> getConsumedPartitionGroups() {
+        return getEdgeManager().getConsumedPartitionGroupsById(partitionId);
+    }
+
     public void markDataProduced() {
         hasDataProduced = true;
     }
@@ -106,6 +111,12 @@ public class IntermediateResultPartition {
         if (!getResultType().isBlocking()) {
             throw new IllegalStateException(
                     "Tried to mark a non-blocking result partition as finished");
+        }
+
+        // Sanity check to make sure a result partition cannot be marked as finished twice.
+        if (hasDataProduced) {
+            throw new IllegalStateException(
+                    "Tried to mark a finished result partition as finished.");
         }
 
         hasDataProduced = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -216,7 +216,8 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                                                                 : ResultPartitionState.CREATED,
                                                 partitionConsumerVertexGroups.apply(
                                                         irp.getPartitionId()),
-                                                executionVertexRetriever)));
+                                                executionVertexRetriever,
+                                                irp::getConsumedPartitionGroups)));
 
         return producedSchedulingPartitions;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
@@ -18,18 +18,24 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Group of consumed {@link IntermediateResultPartitionID}s. */
 public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartitionID> {
+
     private final List<IntermediateResultPartitionID> resultPartitions;
+
+    private final AtomicInteger unfinishedPartitions;
 
     private ConsumedPartitionGroup(List<IntermediateResultPartitionID> resultPartitions) {
         this.resultPartitions = resultPartitions;
+        this.unfinishedPartitions = new AtomicInteger(resultPartitions.size());
     }
 
     public static ConsumedPartitionGroup fromMultiplePartitions(
@@ -57,5 +63,22 @@ public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartit
 
     public IntermediateResultPartitionID getFirst() {
         return iterator().next();
+    }
+
+    public int partitionUnfinished() {
+        return unfinishedPartitions.incrementAndGet();
+    }
+
+    public int partitionFinished() {
+        return unfinishedPartitions.decrementAndGet();
+    }
+
+    @VisibleForTesting
+    public int getNumberOfUnfinishedPartitions() {
+        return unfinishedPartitions.get();
+    }
+
+    public boolean areAllPartitionsFinished() {
+        return unfinishedPartitions.get() == 0;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingResultPartition.java
@@ -53,4 +53,11 @@ public interface SchedulingResultPartition
      * @return list of {@link ConsumerVertexGroup}s
      */
     List<ConsumerVertexGroup> getConsumerVertexGroups();
+
+    /**
+     * Gets the {@link ConsumedPartitionGroup}s this partition belongs to.
+     *
+     * @return list of {@link ConsumedPartitionGroup}s
+     */
+    List<ConsumedPartitionGroup> getConsumedPartitionGroups();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.SchedulerBase;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link EdgeManager}. */
+public class EdgeManagerTest {
+
+    @Test
+    public void testGetConsumedPartitionGroup() throws Exception {
+        JobVertex v1 = new JobVertex("source");
+        JobVertex v2 = new JobVertex("sink");
+
+        v1.setParallelism(2);
+        v2.setParallelism(2);
+
+        v1.setInvokableClass(NoOpInvokable.class);
+        v2.setInvokableClass(NoOpInvokable.class);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(v1, v2);
+        SchedulerBase scheduler =
+                SchedulerTestingUtils.createScheduler(
+                        jobGraph, ComponentMainThreadExecutorServiceAdapter.forMainThread());
+        ExecutionGraph eg = scheduler.getExecutionGraph();
+
+        ConsumedPartitionGroup groupRetrievedByDownstreamVertex =
+                Objects.requireNonNull(eg.getJobVertex(v2.getID()))
+                        .getTaskVertices()[0]
+                        .getAllConsumedPartitionGroups()
+                        .get(0);
+
+        IntermediateResultPartition consumedPartition =
+                Objects.requireNonNull(eg.getJobVertex(v1.getID()))
+                        .getProducedDataSets()[0]
+                        .getPartitions()[0];
+
+        ConsumedPartitionGroup groupRetrievedByIntermediateResultPartition =
+                consumedPartition.getConsumedPartitionGroups().get(0);
+
+        assertEquals(groupRetrievedByDownstreamVertex, groupRetrievedByIntermediateResultPartition);
+
+        ConsumedPartitionGroup groupRetrievedByScheduledResultPartition =
+                scheduler
+                        .getExecutionGraph()
+                        .getSchedulingTopology()
+                        .getResultPartition(consumedPartition.getPartitionId())
+                        .getConsumedPartitionGroups()
+                        .get(0);
+
+        assertEquals(groupRetrievedByDownstreamVertex, groupRetrievedByScheduledResultPartition);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
@@ -19,13 +19,10 @@
 package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
-
-import java.lang.reflect.Field;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
@@ -43,25 +40,15 @@ public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenc
         schedulingStrategy =
                 new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
 
-        // When we trying to scheduling downstream tasks via
-        // onExecutionStateChange(ExecutionState.FINISHED),
-        // the result partitions of upstream tasks need to be CONSUMABLE.
-        // The CONSUMABLE status is determined by the variable "numberOfRunningProducers" of the
-        // IntermediateResult.
-        // Its value cannot be changed by any public methods.
-        // So here we use reflections to modify this value and then schedule the downstream tasks.
-        for (IntermediateResult result : executionGraph.getAllIntermediateResults().values()) {
-            Field f = result.getClass().getDeclaredField("numberOfRunningProducers");
-            f.setAccessible(true);
-            AtomicInteger numberOfRunningProducers = (AtomicInteger) f.get(result);
-            numberOfRunningProducers.set(0);
-        }
-
         executionVertexID =
                 executionGraph
                         .getJobVertex(jobVertices.get(0).getID())
                         .getTaskVertices()[0]
                         .getID();
+        for (ExecutionVertex vertex :
+                executionGraph.getJobVertex(jobVertices.get(0).getID()).getTaskVertices()) {
+            vertex.finishAllBlockingPartitions();
+        }
     }
 
     public void schedulingDownstreamTasks() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -90,8 +90,12 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
     }
 
     void addConsumedPartition(TestingSchedulingResultPartition consumedPartition) {
-        this.consumedPartitionGroups.add(
-                ConsumedPartitionGroup.fromSinglePartition(consumedPartition.getId()));
+        final ConsumedPartitionGroup consumedPartitionGroup =
+                ConsumedPartitionGroup.fromSinglePartition(consumedPartition.getId());
+
+        consumedPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
+
+        this.consumedPartitionGroups.add(consumedPartitionGroup);
         this.resultPartitionsById.putIfAbsent(consumedPartition.getId(), consumedPartition);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -94,6 +94,9 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
                 ConsumedPartitionGroup.fromSinglePartition(consumedPartition.getId());
 
         consumedPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
+        if (consumedPartition.getState() == ResultPartitionState.CONSUMABLE) {
+            consumedPartitionGroup.partitionFinished();
+        }
 
         this.consumedPartitionGroups.add(consumedPartitionGroup);
         this.resultPartitionsById.putIfAbsent(consumedPartition.getId(), consumedPartition);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -129,6 +129,13 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
         this.producer = checkNotNull(producer);
     }
 
+    void markFinished() {
+        for (ConsumedPartitionGroup consumedPartitionGroup : consumedPartitionGroups) {
+            consumedPartitionGroup.partitionFinished();
+        }
+        setState(ResultPartitionState.CONSUMABLE);
+    }
+
     void setState(ResultPartitionState state) {
         this.state = state;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -374,6 +374,9 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 
             for (TestingSchedulingResultPartition resultPartition : resultPartitions) {
                 resultPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
+                if (resultPartition.getState() == ResultPartitionState.CONSUMABLE) {
+                    consumedPartitionGroup.partitionFinished();
+                }
             }
 
             return resultPartitions;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -372,6 +372,10 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                 consumer.addConsumedPartitionGroup(consumedPartitionGroup, consumedPartitionById);
             }
 
+            for (TestingSchedulingResultPartition resultPartition : resultPartitions) {
+                resultPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
+            }
+
             return resultPartitions;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

*In FLINK-22017, we construct a scenario that regions may never be scheduled when there is cross-region blocking edges in the graph. To solve this issue we should allow BLOCKING result partitions be consumable individually. Note that this will result in the scheduling to become execution-vertex-wise instead of stage-wise, with a nice side effect towards better resource utilization. The PipelinedRegionSchedulingStrategy can be simplified along with change to get rid of the correlatedResultPartitions.*

*There's three main concerns that need to be considered:*

*1. Since scheduling become execution-vertex-wise instead of stage-wise, we need to make sure the computation complexity in PipelinedRegionSchedulingStrategy won't fall back to O(n^2). We tested it with benchmark and end-to-end tests. Our pull request doesn't introduce significant performance regression.*

*2. Before this pull request,`finishPartitionsAndUpdateConsumers` already has the complexity of O(n^2). We intend to optimize it in FLINK-21915. Since each partition will finish individually, this optimization is not valid any more. As we tested in the job with two vertices (parallelism 8k, all-to-all, batch mode), it takes less than five seconds.*

*3. `SchedulingDownstreamTasksInBatchJobBenchmark` is modified in accordance with this change. We need to monitor the result of this benchmark.*

## Brief change log

  - *We can get the ConsumedPartitionGroup that an IntermediateResultPartition or a DefaultResultPartition belongs to*
  - *A blocking result partition will be consumable individually once its producer is finished. It doesn't need to wait until all other IntermediateResultPartitions that belong to the same IntermediateResult finish*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for getting ConsumedPartitionGroup from IntermediateResultPartition and DefaultResultPartition*
  - *Added unit tests for scheduling pointwise vertices in the batch job*
  - *Extended the unit tests that schedule vertices in the graph illustrated in FLINK-22017*
  - *Manually verified the change by running a job with two job vertices, their parallelisms are both 8k. Two distribution patterns (pointwise and all-to-all) and two job type (batch and streaming) are involved. All jobs finish correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
