### PR TITLE
[FLINK-22590][table-api-scala-bridge] Add Scala implicit conversions for new API methods

### DIFF
--- a/docs/content.zh/docs/dev/table/data_stream_api.md
+++ b/docs/content.zh/docs/dev/table/data_stream_api.md
@@ -1680,6 +1680,49 @@ watermarks in a subsequent `ProcessFunction` in DataStream API.
 
 {{< top >}}
 
+Implicit Conversions in Scala
+-----------------------------
+
+Users of the Scala API can use all the conversion methods above in a more fluent way by leveraging
+Scala's *implicit* feature.
+
+Those implicits are available in the API when importing the package object via `org.apache.flink.table.api.bridge.scala._`.
+
+If enabled, methods such as `toTable` or `toChangelogTable` can be called directly on a `DataStream`
+object. Similarly, `toDataStream` and `toChangelogStream` are available on `Table` objects. Furthermore,
+`Table` objects will be converted to a changelog stream when requesting a DataStream API specific
+method for `DataStream[Row]`.
+
+{{< hint warning >}}
+The use of an implicit conversion should always be a conscious decision. One should pay attention whether
+the IDE proposes an actual Table API method, or a DataStream API method via implicits.
+
+For example, a `table.execute().collect()` stays in Table API whereas `table.executeAndCollect()` implicitly
+uses the DataStream API's `executeAndCollect()` method and therefore forces an API conversion.
+{{< /hint >}}
+
+```scala
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.types.Row
+
+val env = StreamExecutionEnvironment.getExecutionEnvironment
+val tableEnv = StreamTableEnvironment.create(env)
+
+val dataStream: DataStream[(Int, String)] = env.fromElements((42, "hello"))
+
+// call toChangelogTable() implicitly on the DataStream object
+val table: Table = dataStream.toChangelogTable(tableEnv)
+
+// force implicit conversion
+val dataStreamAgain1: DataStream[Row] = table
+
+// call toChangelogStream() implicitly on the Table object
+val dataStreamAgain2: DataStream[Row] = table.toChangelogStream
+```
+
+{{< top >}}
+
 Mapping between TypeInformation and DataType
 --------------------------------------------
 

--- a/docs/content/docs/dev/table/data_stream_api.md
+++ b/docs/content/docs/dev/table/data_stream_api.md
@@ -1680,6 +1680,49 @@ watermarks in a subsequent `ProcessFunction` in DataStream API.
 
 {{< top >}}
 
+Implicit Conversions in Scala
+-----------------------------
+
+Users of the Scala API can use all the conversion methods above in a more fluent way by leveraging
+Scala's *implicit* feature.
+
+Those implicits are available in the API when importing the package object via `org.apache.flink.table.api.bridge.scala._`.
+
+If enabled, methods such as `toTable` or `toChangelogTable` can be called directly on a `DataStream`
+object. Similarly, `toDataStream` and `toChangelogStream` are available on `Table` objects. Furthermore,
+`Table` objects will be converted to a changelog stream when requesting a DataStream API specific
+method for `DataStream[Row]`.
+
+{{< hint warning >}}
+The use of an implicit conversion should always be a conscious decision. One should pay attention whether
+the IDE proposes an actual Table API method, or a DataStream API method via implicits.
+
+For example, a `table.execute().collect()` stays in Table API whereas `table.executeAndCollect()` implicitly
+uses the DataStream API's `executeAndCollect()` method and therefore forces an API conversion.
+{{< /hint >}}
+
+```scala
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.table.api.bridge.scala._
+import org.apache.flink.types.Row
+
+val env = StreamExecutionEnvironment.getExecutionEnvironment
+val tableEnv = StreamTableEnvironment.create(env)
+
+val dataStream: DataStream[(Int, String)] = env.fromElements((42, "hello"))
+
+// call toChangelogTable() implicitly on the DataStream object
+val table: Table = dataStream.toChangelogTable(tableEnv)
+
+// force implicit conversion
+val dataStreamAgain1: DataStream[Row] = table
+
+// call toChangelogStream() implicitly on the Table object
+val dataStreamAgain2: DataStream[Row] = table.toChangelogStream
+```
+
+{{< top >}}
+
 Mapping between TypeInformation and DataType
 --------------------------------------------
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -278,6 +278,13 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
             ChangelogMode changelogMode) {
         Preconditions.checkNotNull(dataStream, "Data stream must not be null.");
         Preconditions.checkNotNull(changelogMode, "Changelog mode must not be null.");
+
+        if (dataStream.getExecutionEnvironment() != executionEnvironment) {
+            throw new ValidationException(
+                    "The DataStream's StreamExecutionEnvironment must be identical to the one that "
+                            + "has been passed to the StreamTableEnvironment during instantiation.");
+        }
+
         final CatalogManager catalogManager = getCatalogManager();
         final SchemaResolver schemaResolver = catalogManager.getSchemaResolver();
         final OperationTreeBuilder operationTreeBuilder = getOperationTreeBuilder();

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -134,6 +134,13 @@ class StreamTableEnvironmentImpl (
       @Nullable viewPath: String,
       changelogMode: ChangelogMode): Table = {
     Preconditions.checkNotNull(changelogMode, "Changelog mode must not be null.")
+
+    if (dataStream.getExecutionEnvironment ne scalaExecutionEnvironment.getJavaEnv) {
+      throw new ValidationException(
+        "The DataStream's StreamExecutionEnvironment must be identical to the one that " +
+          "has been passed to the StreamTableEnvironment during instantiation.")
+    }
+
     val catalogManager = getCatalogManager
     val schemaResolver = catalogManager.getSchemaResolver
     val operationTreeBuilder = getOperationTreeBuilder

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/package.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/package.scala
@@ -17,7 +17,6 @@
  */
 package org.apache.flink.table.api.bridge
 
-import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.table.api.internal.TableImpl
 import org.apache.flink.table.api.{ImplicitExpressionConversions, ImplicitExpressionOperations, Table, ValidationException}
@@ -26,46 +25,60 @@ import org.apache.flink.types.Row
 import _root_.scala.language.implicitConversions
 
 /**
-  * == Table & SQL API with Flink's DataStream API ==
-  *
-  * This package contains the API of the Table & SQL API that bridges to Flink's [[DataStream]] API
-  * for the Scala programming language. Users can create [[Table]]s from [[DataStream]]s on which
-  * relational operations can be performed. Tables can also be converted back to [[DataStream]]s for
-  * further processing.
-  *
-  * For accessing all API classes and implicit conversions, use the following imports:
-  *
-  * {{{
-  *   import org.apache.flink.table.api._
-  *   import org.apache.flink.table.api.bridge.scala._
-  * }}}
-  *
-  * More information about the entry points of the API can be found in [[StreamTableEnvironment]].
-  *
-  * Available implicit expressions are listed in [[ImplicitExpressionConversions]] and
-  * [[ImplicitExpressionOperations]].
-  *
-  * Available implicit table-to-stream conversions are listed in this package object.
-  *
-  * Please refer to the website documentation about how to construct and run table programs that are
-  * connected to the DataStream API.
-  */
+ * == Table & SQL API with Flink's DataStream API ==
+ *
+ * This package contains the API of the Table & SQL API that bridges to Flink's [[DataStream]] API
+ * for the Scala programming language. Users can create [[Table]]s from [[DataStream]]s on which
+ * relational operations can be performed. Tables can also be converted back to [[DataStream]]s for
+ * further processing.
+ *
+ * For accessing all API classes and implicit conversions, use the following imports:
+ *
+ * {{{
+ *   import org.apache.flink.table.api._
+ *   import org.apache.flink.table.api.bridge.scala._
+ * }}}
+ *
+ * More information about the entry points of the API can be found in [[StreamTableEnvironment]].
+ *
+ * Available implicit expressions are listed in [[ImplicitExpressionConversions]] and
+ * [[ImplicitExpressionOperations]].
+ *
+ * Available implicit table-to-stream conversions are listed in this package object.
+ *
+ * Please refer to the website documentation about how to construct and run table programs that are
+ * connected to the DataStream API.
+ */
 package object scala {
 
+  /**
+   * Conversions from [[Table]] to [[DataStream]].
+   */
   implicit def tableConversions(table: Table): TableConversions = {
-    new TableConversions(table.asInstanceOf[TableImpl])
+    new TableConversions(table)
   }
 
-  implicit def dataStreamConversions[T](set: DataStream[T]): DataStreamConversions[T] = {
-    new DataStreamConversions[T](set, set.dataType)
-  }
-
-  implicit def table2RowDataStream(table: Table): DataStream[Row] = {
+  /**
+   * Conversions from [[Table]] to [[DataStream]] of changelog entries.
+   *
+   * See [[StreamTableEnvironment.toChangelogStream(Table)]] for more information.
+   *
+   * Use [[TableConversions.toChangelogStream]] for more options during the implicit conversion.
+   */
+  implicit def tableToChangelogDataStream(table: Table): DataStream[Row] = {
     val tableEnv = table.asInstanceOf[TableImpl].getTableEnvironment
     if (!tableEnv.isInstanceOf[StreamTableEnvironment]) {
-      throw new ValidationException("Table cannot be converted into a DataStream. " +
-        "It is not part of a stream table environment.")
+      throw new ValidationException(
+        "Table cannot be converted into a Scala DataStream. " +
+        "It is not part of a Scala StreamTableEnvironment.")
     }
-    tableEnv.asInstanceOf[StreamTableEnvironment].toAppendStream[Row](table)
+    tableEnv.asInstanceOf[StreamTableEnvironment].toChangelogStream(table)
+  }
+
+  /**
+   * Conversions from [[DataStream]] to [[Table]].
+   */
+  implicit def dataStreamConversions[T](set: DataStream[T]): DataStreamConversions[T] = {
+    new DataStreamConversions[T](set)
   }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
@@ -477,15 +477,15 @@ public final class DynamicSourceUtils {
             if (!schema.getPrimaryKey().isPresent()) {
                 throw new TableException(
                         String.format(
-                                "Table '%s' produces a changelog stream contains UPDATE_AFTER, no UPDATE_BEFORE. "
-                                        + "This requires to define primary key constraint on the table.",
+                                "Table '%s' produces a changelog stream that contains UPDATE_AFTER but no UPDATE_BEFORE. "
+                                        + "This requires defining a primary key constraint on the table.",
                                 sourceIdentifier.asSummaryString()));
             }
         } else if (hasUpdateBefore && !hasUpdateAfter) {
             // only UPDATE_BEFORE
             throw new ValidationException(
                     String.format(
-                            "Invalid source for table '%s'. A %s doesn't support a changelog which contains "
+                            "Invalid source for table '%s'. A %s doesn't support a changelog stream that contains "
                                     + "UPDATE_BEFORE but no UPDATE_AFTER. Please adapt the implementation of class '%s'.",
                             sourceIdentifier.asSummaryString(),
                             ScanTableSource.class.getSimpleName(),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -629,7 +629,7 @@ class TableScanTest extends TableTestBase {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage(
       "Invalid source for table 'default_catalog.default_database.src'. A ScanTableSource " +
-      "doesn't support a changelog which contains UPDATE_BEFORE but no UPDATE_AFTER. Please " +
+      "doesn't support a changelog stream that contains UPDATE_BEFORE but no UPDATE_AFTER. Please " +
       "adapt the implementation of class 'org.apache.flink.table.planner.factories." +
       "TestValuesTableFactory$TestValuesScanLookupTableSource'.")
     util.verifyRelPlan("SELECT * FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
@@ -650,8 +650,8 @@ class TableScanTest extends TableTestBase {
       """.stripMargin)
     thrown.expect(classOf[TableException])
     thrown.expectMessage("Table 'default_catalog.default_database.src' produces a " +
-      "changelog stream contains UPDATE_AFTER, no UPDATE_BEFORE. " +
-      "This requires to define primary key constraint on the table.")
+      "changelog stream that contains UPDATE_AFTER but no UPDATE_BEFORE. " +
+      "This requires defining a primary key constraint on the table.")
     util.verifyRelPlan("SELECT * FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -629,8 +629,8 @@ class TableScanTest extends TableTestBase {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage(
       "Invalid source for table 'default_catalog.default_database.src'. A ScanTableSource " +
-      "doesn't support a changelog stream that contains UPDATE_BEFORE but no UPDATE_AFTER. Please " +
-      "adapt the implementation of class 'org.apache.flink.table.planner.factories." +
+      "doesn't support a changelog stream that contains UPDATE_BEFORE but no UPDATE_AFTER. " +
+      "Please adapt the implementation of class 'org.apache.flink.table.planner.factories." +
       "TestValuesTableFactory$TestValuesScanLookupTableSource'.")
     util.verifyRelPlan("SELECT * FROM src WHERE a > 1", ExplainDetail.CHANGELOG_MODE)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DataStreamScalaITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/DataStreamScalaITCase.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.runtime.stream.sql
 
 import org.apache.flink.streaming.api.scala.{CloseableIterator, DataStream, StreamExecutionEnvironment}
-import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
+import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.{DataTypes, Table, TableResult}
@@ -82,6 +82,17 @@ class DataStreamScalaITCase extends AbstractTestBase {
     val resultStream = tableEnv.toDataStream(table, classOf[ComplexCaseClass])
 
     testResult(resultStream, caseClasses: _*)
+  }
+
+  @Test
+  def testImplicitConversions(): Unit = {
+    // DataStream to Table implicit
+    val table = env.fromElements((42, "hello")).toTable(tableEnv)
+
+    // Table to DataStream implicit
+    assertEquals(
+      List(Row.of(Int.box(42), "hello")),
+      table.executeAndCollect().toList)
   }
 
   // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Updates the Scala implicit conversions for FLIP-136.

## Brief change log

See commit messages.

## Verifying this change

This change added tests and can be verified as follows: `DataStreamScalaITCase#testImplicitConversions`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
