### PR TITLE
[FLINK-23235][connector] Fix SinkITCase instability

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -46,6 +46,8 @@ import static org.junit.Assert.assertNotNull;
 /** A {@link Sink TestSink} for all the sink related tests. */
 public class TestSink implements Sink<Integer, String, String, String> {
 
+    public static final String END_OF_INPUT_STR = "end of input";
+
     private final DefaultSinkWriter writer;
 
     @Nullable private final SimpleVersionedSerializer<String> writerStateSerializer;
@@ -338,7 +340,7 @@ public class TestSink implements Sink<Integer, String, String, String> {
 
         @Override
         public void endOfInput() {
-            commit(Collections.singletonList("end of input"));
+            commit(Collections.singletonList(END_OF_INPUT_STR));
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkITCase.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
+import static org.apache.flink.streaming.runtime.operators.sink.TestSink.END_OF_INPUT_STR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
@@ -86,7 +87,7 @@ public class SinkITCase extends AbstractTestBase {
                             .map(x -> Tuple3.of(x, null, Long.MIN_VALUE).toString())
                             .sorted()
                             .collect(joining("+")),
-                    "end of input");
+                    END_OF_INPUT_STR);
 
     static final Queue<String> COMMIT_QUEUE = new ConcurrentLinkedQueue<>();
 
@@ -131,6 +132,13 @@ public class SinkITCase extends AbstractTestBase {
                                 .build());
 
         env.execute();
+
+        // TODO: At present, for a bounded scenario, the occurrence of final checkpoint is not a
+        // deterministic event, so
+        // we do not need to verify this matter. After the final checkpoint becomes ready in the
+        // future,
+        // the verification of "end of input" would be restored.
+        GLOBAL_COMMIT_QUEUE.remove(END_OF_INPUT_STR);
 
         assertThat(
                 COMMIT_QUEUE,
@@ -215,6 +223,14 @@ public class SinkITCase extends AbstractTestBase {
                                 .build());
 
         env.execute();
+
+        // TODO: At present, for a bounded scenario, the occurrence of final checkpoint is not a
+        // deterministic event, so
+        // we do not need to verify this matter. After the final checkpoint becomes ready in the
+        // future,
+        // the verification of "end of input" would be restored.
+        GLOBAL_COMMIT_QUEUE.remove(END_OF_INPUT_STR);
+
         assertThat(
                 getSplittedGlobalCommittedData(),
                 containsInAnyOrder(EXPECTED_GLOBAL_COMMITTED_DATA_IN_STREAMING_MODE.toArray()));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the current test case, it is assumed that final cp will not happen, but this is not the case. This causes the current `TestSink` sometimes to commit "end of input", which will also cause `writerAndCommitterAndGlobalCommitterExecuteInStreamingMode`/`writerAndGlobalCommitterExecuteInStreamingMode` to occasionally fail. Since final cp is not deterministic, this change will filter out the string "end of input" committed by `GlobalCommitter`. In the future, after final cp ready, the verification will be restored.


## Verifying this change

This change is already covered by existing tests, such as *SinkITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
