### PR TITLE
[FLINK-23164][tests] Harden JobMasterTest.testMultipleStartsWork

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -2309,7 +2309,7 @@ public class JobMasterTest extends TestLogger {
         try {
             jobMaster.start(JobMasterId.generate()).join();
 
-            jobMaster.suspend(new FlinkException("Test exception."));
+            jobMaster.suspend(new FlinkException("Test exception.")).join();
 
             jobMaster.start(JobMasterId.generate()).join();
         } finally {


### PR DESCRIPTION
The JobMasterTest.testMultipleStartsWork fails because we don't wait for the JobMaster
to finish its suspension before restarting the JobMaster. This can lead to ignoring the
underlying control START control message. This again can lead to a situation where we are
in the STOPPED state and try to send UnfencedMessage(startJobExecution) in JobMaster.start.

This commit fixes this problem by waiting on the suspension future to complete before restarting
the JobMaster.