### PR TITLE
[FLINK-23076][tests] Harden DispatcherTest.testWaitingForJobMasterLeadership

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -651,10 +651,10 @@ public class DispatcherTest extends TestLogger {
         // INITIALIZING status
         // after the jobMasterLeaderElectionService has been started.
         CompletableFuture<JobStatus> jobStatusFuture = null;
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 50; i++) {
             jobStatusFuture = dispatcherGateway.requestJobStatus(jobGraph.getJobID(), TIMEOUT);
             try {
-                JobStatus status = jobStatusFuture.get(10, TimeUnit.MILLISECONDS);
+                JobStatus status = jobStatusFuture.get(200, TimeUnit.MILLISECONDS);
                 if (status == JobStatus.INITIALIZING) {
                     jobStatusFuture = null;
                     Thread.sleep(100);


### PR DESCRIPTION
The test DispatcherTest.testWaitingForJobMasterLeadership is unstable because it uses a
10 ms timeout to decide whether the JobMasterService has been created or not. On our CI
infrastructure this 10 ms can be too short to complete the future with JobStatus.INITIALIZING
which indicates that the JobMasterService has not been created. This commit hardens the
test by increasing the timeout to 200 ms and to increase the number of retries from 5 to 50.