### PR TITLE
[FLINK-23144][metrics] Add percentiles to checkpoint statistics

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -928,7 +928,7 @@
           "properties" : {
             "state_size" : {
               "type" : "object",
-              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto",
               "properties" : {
                 "min" : {
                   "type" : "integer"
@@ -938,24 +938,39 @@
                 },
                 "avg" : {
                   "type" : "integer"
+                },
+                "p50" : {
+                  "type" : "number"
+                },
+                "p90" : {
+                  "type" : "number"
+                },
+                "p95" : {
+                  "type" : "number"
+                },
+                "p99" : {
+                  "type" : "number"
+                },
+                "p999" : {
+                  "type" : "number"
                 }
               }
             },
             "end_to_end_duration" : {
               "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
             },
             "alignment_buffered" : {
               "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
             },
             "processed_data" : {
               "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
             },
             "persisted_data" : {
               "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
             }
           }
         },
@@ -1429,7 +1444,7 @@
           "properties" : {
             "state_size" : {
               "type" : "object",
-              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics",
+              "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto",
               "properties" : {
                 "min" : {
                   "type" : "integer"
@@ -1439,12 +1454,27 @@
                 },
                 "avg" : {
                   "type" : "integer"
+                },
+                "p50" : {
+                  "type" : "number"
+                },
+                "p90" : {
+                  "type" : "number"
+                },
+                "p95" : {
+                  "type" : "number"
+                },
+                "p99" : {
+                  "type" : "number"
+                },
+                "p999" : {
+                  "type" : "number"
                 }
               }
             },
             "end_to_end_duration" : {
               "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
             },
             "checkpoint_duration" : {
               "type" : "object",
@@ -1452,11 +1482,11 @@
               "properties" : {
                 "sync" : {
                   "type" : "object",
-                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
                 },
                 "async" : {
                   "type" : "object",
-                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
                 }
               }
             },
@@ -1466,25 +1496,25 @@
               "properties" : {
                 "buffered" : {
                   "type" : "object",
-                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
                 },
                 "processed" : {
                   "type" : "object",
-                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
                 },
                 "persisted" : {
                   "type" : "object",
-                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
                 },
                 "duration" : {
                   "type" : "object",
-                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+                  "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
                 }
               }
             },
             "start_delay" : {
               "type" : "object",
-              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:StatsSummaryDto"
             }
           }
         },

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -75,6 +75,11 @@ export interface CheckPointMinMaxAvgStatisticsInterface {
   min: number;
   max: number;
   avg: number;
+  p50: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  p999: number;
 }
 
 export interface CheckPointCompletedStatisticsInterface {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.html
@@ -193,15 +193,74 @@
             <td>{{ checkPointStats['summary']['state_size']['avg'] | humanizeBytes }}</td>
             <td>{{ checkPointStats['summary']['processed_data']['avg'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['avg'] | humanizeBytes }})</td>
           </tr>
-          <tr>
-            <td><strong>Maximum</strong></td>
-            <td>{{ checkPointStats['summary']['end_to_end_duration']['max'] | humanizeDuration}}</td>
-            <td>{{ checkPointStats['summary']['state_size']['max'] | humanizeBytes }}</td>
-            <td>{{ checkPointStats['summary']['processed_data']['max'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['max'] | humanizeBytes }})</td>
-          </tr>
+            <tr>
+                <td><strong>Maximum</strong></td>
+                <td>{{ checkPointStats['summary']['end_to_end_duration']['max'] | humanizeDuration}}</td>
+                <td>{{ checkPointStats['summary']['state_size']['max'] | humanizeBytes }}</td>
+                <td>{{ checkPointStats['summary']['processed_data']['max'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['max'] | humanizeBytes }})</td>
+            </tr>
         </ng-container>
       </tbody>
     </nz-table>
+
+    <nz-collapse>
+        <nz-collapse-panel
+                [nzHeader]="'Percentiles'"
+                [nzActive]="moreDetailsPanel.active"
+                [nzDisabled]="moreDetailsPanel.disabled">
+            <nz-table
+                    *ngIf="checkPointStats"
+                    class="no-border small"
+                    [nzData]="(checkPointStats&&checkPointStats['summary'])?['']:[]"
+                    [nzSize]="'small'"
+                    [nzFrontPagination]="false"
+                    [nzShowPagination]="false">
+                <thead>
+                <tr>
+                    <th></th>
+                    <th><strong>End to End Duration</strong></th>
+                    <th><strong>Checkpointed Data Size</strong></th>
+                    <th><strong>Processed (persisted) in-flight data</strong></th>
+                </tr>
+                </thead>
+                <tbody>
+                <ng-container *ngIf="checkPointStats['summary']">
+                <tr>
+                    <td><strong>50% percentile</strong></td>
+                    <td>{{ checkPointStats['summary']['end_to_end_duration']['p50'] | humanizeDuration}}</td>
+                    <td>{{ checkPointStats['summary']['state_size']['p50'] | humanizeBytes }}</td>
+                    <td>{{ checkPointStats['summary']['processed_data']['p50'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['p50'] | humanizeBytes }})</td>
+                </tr>
+                <tr>
+                    <td><strong>90% percentile</strong></td>
+                    <td>{{ checkPointStats['summary']['end_to_end_duration']['p90'] | humanizeDuration}}</td>
+                    <td>{{ checkPointStats['summary']['state_size']['p90'] | humanizeBytes }}</td>
+                    <td>{{ checkPointStats['summary']['processed_data']['p90'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['p90'] | humanizeBytes }})</td>
+                </tr>
+                <tr>
+                    <td><strong>99% percentile</strong></td>
+                    <td>{{ checkPointStats['summary']['end_to_end_duration']['p99'] | humanizeDuration}}</td>
+                    <td>{{ checkPointStats['summary']['state_size']['p99'] | humanizeBytes }}</td>
+                    <td>{{ checkPointStats['summary']['processed_data']['p99'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['p99'] | humanizeBytes }})</td>
+                </tr>
+                <tr>
+                    <td><strong>99% percentile</strong></td>
+                    <td>{{ checkPointStats['summary']['end_to_end_duration']['p99'] | humanizeDuration}}</td>
+                    <td>{{ checkPointStats['summary']['state_size']['p99'] | humanizeBytes }}</td>
+                    <td>{{ checkPointStats['summary']['processed_data']['p99'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['p99'] | humanizeBytes }})</td>
+                </tr>
+                <tr>
+                    <td><strong>99.9% percentile</strong></td>
+                    <td>{{ checkPointStats['summary']['end_to_end_duration']['p999'] | humanizeDuration}}</td>
+                    <td>{{ checkPointStats['summary']['state_size']['p999'] | humanizeBytes }}</td>
+                    <td>{{ checkPointStats['summary']['processed_data']['p999'] | humanizeBytes }} ({{ checkPointStats['summary']['persisted_data']['p999'] | humanizeBytes }})</td>
+                </tr>
+            </ng-container>
+          </tbody>
+        </nz-table>
+        </nz-collapse-panel>
+    </nz-collapse>
+
   </nz-tab>
   <nz-tab nzTitle="Configuration">
     <nz-table

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/job-checkpoints.component.ts
@@ -37,6 +37,8 @@ export class JobCheckpointsComponent implements OnInit {
   checkPointConfig: CheckPointConfigInterface;
   jobDetail: JobDetailCorrectInterface;
 
+  moreDetailsPanel = { active: false, disabled: false }
+
   trackHistoryBy(_: number, node: CheckPointHistoryInterface) {
     return node.id;
   }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsSnapshot.java
@@ -33,7 +33,7 @@ public class CheckpointStatsSnapshot implements Serializable {
     private final CheckpointStatsCounts counts;
 
     /** Snapshot of the completed checkpoints summary stats. */
-    private final CompletedCheckpointStatsSummary summary;
+    private final CompletedCheckpointStatsSummarySnapshot summary;
 
     /** Snapshot of the checkpoint history. */
     private final CheckpointStatsHistory history;
@@ -44,7 +44,7 @@ public class CheckpointStatsSnapshot implements Serializable {
     public static CheckpointStatsSnapshot empty() {
         return new CheckpointStatsSnapshot(
                 new CheckpointStatsCounts(),
-                new CompletedCheckpointStatsSummary(),
+                CompletedCheckpointStatsSummarySnapshot.empty(),
                 new CheckpointStatsHistory(0),
                 null);
     }
@@ -59,7 +59,7 @@ public class CheckpointStatsSnapshot implements Serializable {
      */
     CheckpointStatsSnapshot(
             CheckpointStatsCounts counts,
-            CompletedCheckpointStatsSummary summary,
+            CompletedCheckpointStatsSummarySnapshot summary,
             CheckpointStatsHistory history,
             @Nullable RestoredCheckpointStats latestRestoredCheckpoint) {
 
@@ -83,7 +83,7 @@ public class CheckpointStatsSnapshot implements Serializable {
      *
      * @return Snapshotted completed checkpoint summary stats.
      */
-    public CompletedCheckpointStatsSummary getSummaryStats() {
+    public CompletedCheckpointStatsSummarySnapshot getSummaryStats() {
         return summary;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummary.java
@@ -28,28 +28,24 @@ public class CompletedCheckpointStatsSummary implements Serializable {
     private static final long serialVersionUID = 5784360461635814038L;
 
     /** State size statistics for all completed checkpoints. */
-    private final MinMaxAvgStats stateSize;
+    private final StatsSummary stateSize;
 
     /** Duration statistics for all completed checkpoints. */
-    private final MinMaxAvgStats duration;
+    private final StatsSummary duration;
 
-    private final MinMaxAvgStats processedData;
+    private final StatsSummary processedData;
 
-    private final MinMaxAvgStats persistedData;
+    private final StatsSummary persistedData;
 
     CompletedCheckpointStatsSummary() {
-        this(
-                new MinMaxAvgStats(),
-                new MinMaxAvgStats(),
-                new MinMaxAvgStats(),
-                new MinMaxAvgStats());
+        this(new StatsSummary(), new StatsSummary(), new StatsSummary(), new StatsSummary());
     }
 
     private CompletedCheckpointStatsSummary(
-            MinMaxAvgStats stateSize,
-            MinMaxAvgStats duration,
-            MinMaxAvgStats processedData,
-            MinMaxAvgStats persistedData) {
+            StatsSummary stateSize,
+            StatsSummary duration,
+            StatsSummary processedData,
+            StatsSummary persistedData) {
 
         this.stateSize = checkNotNull(stateSize);
         this.duration = checkNotNull(duration);
@@ -87,7 +83,7 @@ public class CompletedCheckpointStatsSummary implements Serializable {
      *
      * @return Summary stats for the state size.
      */
-    public MinMaxAvgStats getStateSizeStats() {
+    public StatsSummary getStateSizeStats() {
         return stateSize;
     }
 
@@ -96,15 +92,15 @@ public class CompletedCheckpointStatsSummary implements Serializable {
      *
      * @return Summary stats for the duration.
      */
-    public MinMaxAvgStats getEndToEndDurationStats() {
+    public StatsSummary getEndToEndDurationStats() {
         return duration;
     }
 
-    public MinMaxAvgStats getProcessedDataStats() {
+    public StatsSummary getProcessedDataStats() {
         return processedData;
     }
 
-    public MinMaxAvgStats getPersistedDataStats() {
+    public StatsSummary getPersistedDataStats() {
         return persistedData;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummary.java
@@ -70,12 +70,12 @@ public class CompletedCheckpointStatsSummary implements Serializable {
      *
      * @return A snapshot of the current state.
      */
-    CompletedCheckpointStatsSummary createSnapshot() {
-        return new CompletedCheckpointStatsSummary(
-                stateSize.createSnapshot(),
+    CompletedCheckpointStatsSummarySnapshot createSnapshot() {
+        return new CompletedCheckpointStatsSummarySnapshot(
                 duration.createSnapshot(),
                 processedData.createSnapshot(),
-                persistedData.createSnapshot());
+                persistedData.createSnapshot(),
+                stateSize.createSnapshot());
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummary.java
@@ -27,6 +27,8 @@ public class CompletedCheckpointStatsSummary implements Serializable {
 
     private static final long serialVersionUID = 5784360461635814038L;
 
+    private static final int HISTOGRAM_WINDOW_SIZE = 10_000; // ~300Kb per job with four histograms
+
     /** State size statistics for all completed checkpoints. */
     private final StatsSummary stateSize;
 
@@ -38,7 +40,11 @@ public class CompletedCheckpointStatsSummary implements Serializable {
     private final StatsSummary persistedData;
 
     CompletedCheckpointStatsSummary() {
-        this(new StatsSummary(), new StatsSummary(), new StatsSummary(), new StatsSummary());
+        this(
+                new StatsSummary(HISTOGRAM_WINDOW_SIZE),
+                new StatsSummary(HISTOGRAM_WINDOW_SIZE),
+                new StatsSummary(HISTOGRAM_WINDOW_SIZE),
+                new StatsSummary(HISTOGRAM_WINDOW_SIZE));
     }
 
     private CompletedCheckpointStatsSummary(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummarySnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummarySnapshot.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Immutable snapshot of {@link CompletedCheckpointStatsSummary}. */
+@Internal
+public class CompletedCheckpointStatsSummarySnapshot implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final StatsSummarySnapshot duration;
+    private final StatsSummarySnapshot persistedData;
+    private final StatsSummarySnapshot processedData;
+    private final StatsSummarySnapshot stateSize;
+
+    public CompletedCheckpointStatsSummarySnapshot(
+            StatsSummarySnapshot duration,
+            StatsSummarySnapshot processedData,
+            StatsSummarySnapshot persistedData,
+            StatsSummarySnapshot stateSize) {
+        this.duration = checkNotNull(duration);
+        this.persistedData = checkNotNull(persistedData);
+        this.processedData = checkNotNull(processedData);
+        this.stateSize = checkNotNull(stateSize);
+    }
+
+    public static CompletedCheckpointStatsSummarySnapshot empty() {
+        return new CompletedCheckpointStatsSummarySnapshot(
+                StatsSummarySnapshot.empty(),
+                StatsSummarySnapshot.empty(),
+                StatsSummarySnapshot.empty(),
+                StatsSummarySnapshot.empty());
+    }
+
+    public StatsSummarySnapshot getEndToEndDurationStats() {
+        return duration;
+    }
+
+    public StatsSummarySnapshot getPersistedDataStats() {
+        return persistedData;
+    }
+
+    public StatsSummarySnapshot getProcessedDataStats() {
+        return processedData;
+    }
+
+    public StatsSummarySnapshot getStateSizeStats() {
+        return stateSize;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummary.java
@@ -20,8 +20,11 @@ package org.apache.flink.runtime.checkpoint;
 
 import java.io.Serializable;
 
-/** Helper for keeping track of min/max/average summaries. */
-public class MinMaxAvgStats implements Serializable {
+/**
+ * Aggregated values of some measurement such as min/max/average state size. Used in reporting
+ * {@link CompletedCheckpointStatsSummary checkpoint statistics}.
+ */
+public class StatsSummary implements Serializable {
 
     private static final long serialVersionUID = 1769601903483446707L;
 
@@ -37,9 +40,9 @@ public class MinMaxAvgStats implements Serializable {
     /** Count of added values. */
     private long count;
 
-    MinMaxAvgStats() {}
+    StatsSummary() {}
 
-    private MinMaxAvgStats(long min, long max, long sum, long count) {
+    private StatsSummary(long min, long max, long sum, long count) {
         this.min = min;
         this.max = max;
         this.sum = sum;
@@ -71,8 +74,8 @@ public class MinMaxAvgStats implements Serializable {
      *
      * @return A snapshot of the current state.
      */
-    MinMaxAvgStats createSnapshot() {
-        return new MinMaxAvgStats(min, max, sum, count);
+    StatsSummary createSnapshot() {
+        return new StatsSummary(min, max, sum, count);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummary.java
@@ -42,13 +42,6 @@ public class StatsSummary implements Serializable {
 
     StatsSummary() {}
 
-    private StatsSummary(long min, long max, long sum, long count) {
-        this.min = min;
-        this.max = max;
-        this.sum = sum;
-        this.count = count;
-    }
-
     /**
      * Adds the value to the stats if it is >= 0.
      *
@@ -74,8 +67,8 @@ public class StatsSummary implements Serializable {
      *
      * @return A snapshot of the current state.
      */
-    StatsSummary createSnapshot() {
-        return new StatsSummary(min, max, sum, count);
+    public StatsSummarySnapshot createSnapshot() {
+        return new StatsSummarySnapshot(min, max, sum, count);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummarySnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummarySnapshot.java
@@ -18,6 +18,9 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.HistogramStatistics;
+
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
 
@@ -30,12 +33,19 @@ public class StatsSummarySnapshot implements Serializable {
     private final long max;
     private final long sum;
     private final long count;
+    @Nullable private final HistogramStatistics histogram;
 
-    public StatsSummarySnapshot(long min, long max, long sum, long count) {
+    public StatsSummarySnapshot(
+            long min, long max, long sum, long count, @Nullable HistogramStatistics histogram) {
         this.min = min;
         this.max = max;
         this.sum = sum;
         this.count = count;
+        this.histogram = histogram;
+    }
+
+    public static StatsSummarySnapshot empty() {
+        return new StatsSummarySnapshot(0, 0, 0, 0, null);
     }
 
     /**
@@ -85,5 +95,16 @@ public class StatsSummarySnapshot implements Serializable {
         } else {
             return sum / count;
         }
+    }
+
+    /**
+     * Returns the value for the given quantile based on the represented histogram statistics or
+     * {@link Double#NaN} if the histogram was not built.
+     *
+     * @param quantile Quantile to calculate the value for
+     * @return Value for the given quantile
+     */
+    public double getQuantile(double quantile) {
+        return histogram == null ? Double.NaN : histogram.getQuantile(quantile);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummarySnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StatsSummarySnapshot.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+
+/** Immutable snapshot of {@link StatsSummary}. */
+@Internal
+public class StatsSummarySnapshot implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final long min;
+    private final long max;
+    private final long sum;
+    private final long count;
+
+    public StatsSummarySnapshot(long min, long max, long sum, long count) {
+        this.min = min;
+        this.max = max;
+        this.sum = sum;
+        this.count = count;
+    }
+
+    /**
+     * Returns the minimum seen value.
+     *
+     * @return The current minimum value.
+     */
+    public long getMinimum() {
+        return min;
+    }
+
+    /**
+     * Returns the maximum seen value.
+     *
+     * @return The current maximum value.
+     */
+    public long getMaximum() {
+        return max;
+    }
+
+    /**
+     * Returns the sum of all seen values.
+     *
+     * @return Sum of all values.
+     */
+    public long getSum() {
+        return sum;
+    }
+
+    /**
+     * Returns the count of all seen values.
+     *
+     * @return Count of all values.
+     */
+    public long getCount() {
+        return count;
+    }
+
+    /**
+     * Calculates the average over all seen values.
+     *
+     * @return Average over all seen values.
+     */
+    public long getAverage() {
+        if (count == 0) {
+            return 0;
+        } else {
+            return sum / count;
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
@@ -166,14 +166,14 @@ public class TaskStateStats implements Serializable {
 
         private static final long serialVersionUID = 1009476026522091909L;
 
-        private MinMaxAvgStats stateSize = new MinMaxAvgStats();
-        private MinMaxAvgStats ackTimestamp = new MinMaxAvgStats();
-        private MinMaxAvgStats syncCheckpointDuration = new MinMaxAvgStats();
-        private MinMaxAvgStats asyncCheckpointDuration = new MinMaxAvgStats();
-        private MinMaxAvgStats processedData = new MinMaxAvgStats();
-        private MinMaxAvgStats persistedData = new MinMaxAvgStats();
-        private MinMaxAvgStats alignmentDuration = new MinMaxAvgStats();
-        private MinMaxAvgStats checkpointStartDelay = new MinMaxAvgStats();
+        private StatsSummary stateSize = new StatsSummary();
+        private StatsSummary ackTimestamp = new StatsSummary();
+        private StatsSummary syncCheckpointDuration = new StatsSummary();
+        private StatsSummary asyncCheckpointDuration = new StatsSummary();
+        private StatsSummary processedData = new StatsSummary();
+        private StatsSummary persistedData = new StatsSummary();
+        private StatsSummary alignmentDuration = new StatsSummary();
+        private StatsSummary checkpointStartDelay = new StatsSummary();
 
         void updateSummary(SubtaskStateStats subtaskStats) {
             stateSize.add(subtaskStats.getStateSize());
@@ -188,35 +188,35 @@ public class TaskStateStats implements Serializable {
             checkpointStartDelay.add(subtaskStats.getCheckpointStartDelay());
         }
 
-        public MinMaxAvgStats getStateSizeStats() {
+        public StatsSummary getStateSizeStats() {
             return stateSize;
         }
 
-        public MinMaxAvgStats getAckTimestampStats() {
+        public StatsSummary getAckTimestampStats() {
             return ackTimestamp;
         }
 
-        public MinMaxAvgStats getSyncCheckpointDurationStats() {
+        public StatsSummary getSyncCheckpointDurationStats() {
             return syncCheckpointDuration;
         }
 
-        public MinMaxAvgStats getAsyncCheckpointDurationStats() {
+        public StatsSummary getAsyncCheckpointDurationStats() {
             return asyncCheckpointDuration;
         }
 
-        public MinMaxAvgStats getProcessedDataStats() {
+        public StatsSummary getProcessedDataStats() {
             return processedData;
         }
 
-        public MinMaxAvgStats getPersistedDataStats() {
+        public StatsSummary getPersistedDataStats() {
             return persistedData;
         }
 
-        public MinMaxAvgStats getAlignmentDurationStats() {
+        public StatsSummary getAlignmentDurationStats() {
             return alignmentDuration;
         }
 
-        public MinMaxAvgStats getCheckpointStartDelayStats() {
+        public StatsSummary getCheckpointStartDelayStats() {
             return checkpointStartDelay;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
@@ -22,11 +22,15 @@ import org.apache.flink.metrics.HistogramStatistics;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
+import java.io.Serializable;
+
 /**
  * The {@link DescriptiveStatisticsHistogram} use a DescriptiveStatistics {@link
  * DescriptiveStatistics} as a Flink {@link Histogram}.
  */
-public class DescriptiveStatisticsHistogram implements org.apache.flink.metrics.Histogram {
+public class DescriptiveStatisticsHistogram
+        implements org.apache.flink.metrics.Histogram, Serializable {
+    private static final long serialVersionUID = 1L;
 
     private final CircularDoubleArray descriptiveStatistics;
 
@@ -50,7 +54,8 @@ public class DescriptiveStatisticsHistogram implements org.apache.flink.metrics.
     }
 
     /** Fixed-size array that wraps around at the end and has a dynamic start position. */
-    static class CircularDoubleArray {
+    static class CircularDoubleArray implements Serializable {
+        private static final long serialVersionUID = 1L;
         private final double[] backingArray;
         private int nextPos = 0;
         private boolean fullSize = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -27,6 +27,7 @@ import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 import org.apache.commons.math3.stat.ranking.NaNStrategy;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 /**
@@ -36,7 +37,9 @@ import java.util.Arrays;
  * <p>The statistics takes a point-in-time snapshot of a {@link DescriptiveStatistics} instance and
  * allows optimised metrics retrieval from this.
  */
-public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistics {
+public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistics
+        implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final CommonMetricsSnapshot statisticsSummary = new CommonMetricsSnapshot();
 
     public DescriptiveStatisticsHistogramStatistics(
@@ -87,7 +90,9 @@ public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistic
      * will not return a value but instead populate this class so that further values can be
      * retrieved from it.
      */
-    private static class CommonMetricsSnapshot implements UnivariateStatistic {
+    private static class CommonMetricsSnapshot implements UnivariateStatistic, Serializable {
+        private static final long serialVersionUID = 1L;
+
         private long count = 0;
         private double min = Double.NaN;
         private double max = Double.NaN;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
@@ -129,7 +129,7 @@ public class CheckpointingStatisticsHandler
                             StatsSummaryDto.valueOf(checkpointStatsSummary.getStateSizeStats()),
                             StatsSummaryDto.valueOf(
                                     checkpointStatsSummary.getEndToEndDurationStats()),
-                            new StatsSummaryDto(0, 0, 0),
+                            new StatsSummaryDto(0, 0, 0, 0, 0, 0, 0, 0),
                             StatsSummaryDto.valueOf(checkpointStatsSummary.getProcessedDataStats()),
                             StatsSummaryDto.valueOf(
                                     checkpointStatsSummary.getPersistedDataStats()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
@@ -38,7 +38,7 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatistics;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatistics;
-import org.apache.flink.runtime.rest.messages.checkpoints.MinMaxAvgStatistics;
+import org.apache.flink.runtime.rest.messages.checkpoints.StatsSummaryDto;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.OnlyExecutionGraphJsonArchivist;
@@ -126,13 +126,12 @@ public class CheckpointingStatisticsHandler
 
             final CheckpointingStatistics.Summary summary =
                     new CheckpointingStatistics.Summary(
-                            MinMaxAvgStatistics.valueOf(checkpointStatsSummary.getStateSizeStats()),
-                            MinMaxAvgStatistics.valueOf(
+                            StatsSummaryDto.valueOf(checkpointStatsSummary.getStateSizeStats()),
+                            StatsSummaryDto.valueOf(
                                     checkpointStatsSummary.getEndToEndDurationStats()),
-                            new MinMaxAvgStatistics(0, 0, 0),
-                            MinMaxAvgStatistics.valueOf(
-                                    checkpointStatsSummary.getProcessedDataStats()),
-                            MinMaxAvgStatistics.valueOf(
+                            new StatsSummaryDto(0, 0, 0),
+                            StatsSummaryDto.valueOf(checkpointStatsSummary.getProcessedDataStats()),
+                            StatsSummaryDto.valueOf(
                                     checkpointStatsSummary.getPersistedDataStats()));
 
             final CheckpointStatsHistory checkpointStatsHistory =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsCounts;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
-import org.apache.flink.runtime.checkpoint.CompletedCheckpointStatsSummary;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStatsSummarySnapshot;
 import org.apache.flink.runtime.checkpoint.RestoredCheckpointStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -121,7 +121,7 @@ public class CheckpointingStatisticsHandler
                             checkpointStatsCounts.getNumberOfCompletedCheckpoints(),
                             checkpointStatsCounts.getNumberOfFailedCheckpoints());
 
-            final CompletedCheckpointStatsSummary checkpointStatsSummary =
+            final CompletedCheckpointStatsSummarySnapshot checkpointStatsSummary =
                     checkpointStatsSnapshot.getSummaryStats();
 
             final CheckpointingStatistics.Summary summary =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.checkpoint.AbstractCheckpointStats;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
-import org.apache.flink.runtime.checkpoint.MinMaxAvgStats;
+import org.apache.flink.runtime.checkpoint.StatsSummary;
 import org.apache.flink.runtime.checkpoint.SubtaskStateStats;
 import org.apache.flink.runtime.checkpoint.TaskStateStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointIdPathParameter;
-import org.apache.flink.runtime.rest.messages.checkpoints.MinMaxAvgStatistics;
+import org.apache.flink.runtime.rest.messages.checkpoints.StatsSummaryDto;
 import org.apache.flink.runtime.rest.messages.checkpoints.SubtaskCheckpointStatistics;
 import org.apache.flink.runtime.rest.messages.checkpoints.TaskCheckpointMessageParameters;
 import org.apache.flink.runtime.rest.messages.checkpoints.TaskCheckpointStatisticsWithSubtaskDetails;
@@ -155,32 +155,31 @@ public class TaskCheckpointStatisticDetailsHandler
 
     private static TaskCheckpointStatisticsWithSubtaskDetails.Summary createSummary(
             TaskStateStats.TaskStateStatsSummary taskStatisticsSummary, long triggerTimestamp) {
-        final MinMaxAvgStats ackTSStats = taskStatisticsSummary.getAckTimestampStats();
+        final StatsSummary ackTSStats = taskStatisticsSummary.getAckTimestampStats();
 
         final TaskCheckpointStatisticsWithSubtaskDetails.CheckpointDuration checkpointDuration =
                 new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointDuration(
-                        MinMaxAvgStatistics.valueOf(
+                        StatsSummaryDto.valueOf(
                                 taskStatisticsSummary.getSyncCheckpointDurationStats()),
-                        MinMaxAvgStatistics.valueOf(
+                        StatsSummaryDto.valueOf(
                                 taskStatisticsSummary.getAsyncCheckpointDurationStats()));
 
         final TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment checkpointAlignment =
                 new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment(
-                        new MinMaxAvgStatistics(0, 0, 0),
-                        MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getProcessedDataStats()),
-                        MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getPersistedDataStats()),
-                        MinMaxAvgStatistics.valueOf(
-                                taskStatisticsSummary.getAlignmentDurationStats()));
+                        new StatsSummaryDto(0, 0, 0),
+                        StatsSummaryDto.valueOf(taskStatisticsSummary.getProcessedDataStats()),
+                        StatsSummaryDto.valueOf(taskStatisticsSummary.getPersistedDataStats()),
+                        StatsSummaryDto.valueOf(taskStatisticsSummary.getAlignmentDurationStats()));
 
         return new TaskCheckpointStatisticsWithSubtaskDetails.Summary(
-                MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getStateSizeStats()),
-                new MinMaxAvgStatistics(
+                StatsSummaryDto.valueOf(taskStatisticsSummary.getStateSizeStats()),
+                new StatsSummaryDto(
                         Math.max(0L, ackTSStats.getMinimum() - triggerTimestamp),
                         Math.max(0L, ackTSStats.getMaximum() - triggerTimestamp),
                         Math.max(0L, ackTSStats.getAverage() - triggerTimestamp)),
                 checkpointDuration,
                 checkpointAlignment,
-                MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getCheckpointStartDelayStats()));
+                StatsSummaryDto.valueOf(taskStatisticsSummary.getCheckpointStartDelayStats()));
     }
 
     private static List<SubtaskCheckpointStatistics> createSubtaskCheckpointStatistics(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -166,7 +166,7 @@ public class TaskCheckpointStatisticDetailsHandler
 
         final TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment checkpointAlignment =
                 new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment(
-                        new StatsSummaryDto(0, 0, 0),
+                        new StatsSummaryDto(0, 0, 0, 0, 0, 0, 0, 0),
                         StatsSummaryDto.valueOf(taskStatisticsSummary.getProcessedDataStats()),
                         StatsSummaryDto.valueOf(taskStatisticsSummary.getPersistedDataStats()),
                         StatsSummaryDto.valueOf(taskStatisticsSummary.getAlignmentDurationStats()));
@@ -176,7 +176,12 @@ public class TaskCheckpointStatisticDetailsHandler
                 new StatsSummaryDto(
                         Math.max(0L, ackTSStats.getMinimum() - triggerTimestamp),
                         Math.max(0L, ackTSStats.getMaximum() - triggerTimestamp),
-                        Math.max(0L, ackTSStats.getAverage() - triggerTimestamp)),
+                        Math.max(0L, ackTSStats.getAverage() - triggerTimestamp),
+                        ackTSStats.createSnapshot().getQuantile(.50d),
+                        ackTSStats.createSnapshot().getQuantile(.90d),
+                        ackTSStats.createSnapshot().getQuantile(.95d),
+                        ackTSStats.createSnapshot().getQuantile(.99d),
+                        ackTSStats.createSnapshot().getQuantile(.999d)),
                 checkpointDuration,
                 checkpointAlignment,
                 StatsSummaryDto.valueOf(taskStatisticsSummary.getCheckpointStartDelayStats()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatistics.java
@@ -217,27 +217,27 @@ public class CheckpointingStatistics implements ResponseBody {
         public static final String FIELD_NAME_PERSISTED_DATA = "persisted_data";
 
         @JsonProperty(FIELD_NAME_STATE_SIZE)
-        private final MinMaxAvgStatistics stateSize;
+        private final StatsSummaryDto stateSize;
 
         @JsonProperty(FIELD_NAME_DURATION)
-        private final MinMaxAvgStatistics duration;
+        private final StatsSummaryDto duration;
 
         @JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED)
-        private final MinMaxAvgStatistics alignmentBuffered;
+        private final StatsSummaryDto alignmentBuffered;
 
         @JsonProperty(FIELD_NAME_PROCESSED_DATA)
-        private final MinMaxAvgStatistics processedData;
+        private final StatsSummaryDto processedData;
 
         @JsonProperty(FIELD_NAME_PERSISTED_DATA)
-        private final MinMaxAvgStatistics persistedData;
+        private final StatsSummaryDto persistedData;
 
         @JsonCreator
         public Summary(
-                @JsonProperty(FIELD_NAME_STATE_SIZE) MinMaxAvgStatistics stateSize,
-                @JsonProperty(FIELD_NAME_DURATION) MinMaxAvgStatistics duration,
-                @JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) MinMaxAvgStatistics alignmentBuffered,
-                @JsonProperty(FIELD_NAME_PROCESSED_DATA) MinMaxAvgStatistics processedData,
-                @JsonProperty(FIELD_NAME_PERSISTED_DATA) MinMaxAvgStatistics persistedData) {
+                @JsonProperty(FIELD_NAME_STATE_SIZE) StatsSummaryDto stateSize,
+                @JsonProperty(FIELD_NAME_DURATION) StatsSummaryDto duration,
+                @JsonProperty(FIELD_NAME_ALIGNMENT_BUFFERED) StatsSummaryDto alignmentBuffered,
+                @JsonProperty(FIELD_NAME_PROCESSED_DATA) StatsSummaryDto processedData,
+                @JsonProperty(FIELD_NAME_PERSISTED_DATA) StatsSummaryDto persistedData) {
             this.stateSize = stateSize;
             this.duration = duration;
             this.alignmentBuffered = alignmentBuffered;
@@ -245,11 +245,11 @@ public class CheckpointingStatistics implements ResponseBody {
             this.persistedData = persistedData;
         }
 
-        public MinMaxAvgStatistics getStateSize() {
+        public StatsSummaryDto getStateSize() {
             return stateSize;
         }
 
-        public MinMaxAvgStatistics getDuration() {
+        public StatsSummaryDto getDuration() {
             return duration;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/StatsSummaryDto.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/StatsSummaryDto.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.runtime.rest.messages.checkpoints;
 
-import org.apache.flink.runtime.checkpoint.MinMaxAvgStats;
+import org.apache.flink.runtime.checkpoint.StatsSummary;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-/** Minimum, maximum and average statistics. */
-public final class MinMaxAvgStatistics {
+/** Transfer object for {@link StatsSummary statistics summary}. */
+public final class StatsSummaryDto {
 
     public static final String FIELD_NAME_MINIMUM = "min";
 
@@ -43,12 +43,12 @@ public final class MinMaxAvgStatistics {
     @JsonProperty(FIELD_NAME_AVERAGE)
     private final long average;
 
-    public static MinMaxAvgStatistics valueOf(MinMaxAvgStats stats) {
-        return new MinMaxAvgStatistics(stats.getMinimum(), stats.getMaximum(), stats.getAverage());
+    public static StatsSummaryDto valueOf(StatsSummary stats) {
+        return new StatsSummaryDto(stats.getMinimum(), stats.getMaximum(), stats.getAverage());
     }
 
     @JsonCreator
-    public MinMaxAvgStatistics(
+    public StatsSummaryDto(
             @JsonProperty(FIELD_NAME_MINIMUM) long minimum,
             @JsonProperty(FIELD_NAME_MAXIMUM) long maximum,
             @JsonProperty(FIELD_NAME_AVERAGE) long average) {
@@ -77,7 +77,7 @@ public final class MinMaxAvgStatistics {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MinMaxAvgStatistics that = (MinMaxAvgStatistics) o;
+        StatsSummaryDto that = (StatsSummaryDto) o;
         return minimum == that.minimum && maximum == that.maximum && average == that.average;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/StatsSummaryDto.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/StatsSummaryDto.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.checkpoints;
 
 import org.apache.flink.runtime.checkpoint.StatsSummary;
+import org.apache.flink.runtime.checkpoint.StatsSummarySnapshot;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,8 +44,13 @@ public final class StatsSummaryDto {
     @JsonProperty(FIELD_NAME_AVERAGE)
     private final long average;
 
-    public static StatsSummaryDto valueOf(StatsSummary stats) {
-        return new StatsSummaryDto(stats.getMinimum(), stats.getMaximum(), stats.getAverage());
+    public static StatsSummaryDto valueOf(StatsSummary s) {
+        return valueOf(s.createSnapshot());
+    }
+
+    public static StatsSummaryDto valueOf(StatsSummarySnapshot snapshot) {
+        return new StatsSummaryDto(
+                snapshot.getMinimum(), snapshot.getMaximum(), snapshot.getAverage());
     }
 
     @JsonCreator

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/StatsSummaryDto.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/StatsSummaryDto.java
@@ -35,6 +35,16 @@ public final class StatsSummaryDto {
 
     public static final String FIELD_NAME_AVERAGE = "avg";
 
+    public static final String FIELD_NAME_P50 = "p50";
+
+    public static final String FIELD_NAME_P90 = "p90";
+
+    public static final String FIELD_NAME_P95 = "p95";
+
+    public static final String FIELD_NAME_P99 = "p99";
+
+    public static final String FIELD_NAME_P999 = "p999";
+
     @JsonProperty(FIELD_NAME_MINIMUM)
     private final long minimum;
 
@@ -44,23 +54,55 @@ public final class StatsSummaryDto {
     @JsonProperty(FIELD_NAME_AVERAGE)
     private final long average;
 
+    @JsonProperty(FIELD_NAME_P50)
+    private final double p50;
+
+    @JsonProperty(FIELD_NAME_P90)
+    private final double p90;
+
+    @JsonProperty(FIELD_NAME_P95)
+    private final double p95;
+
+    @JsonProperty(FIELD_NAME_P99)
+    private final double p99;
+
+    @JsonProperty(FIELD_NAME_P999)
+    private final double p999;
+
     public static StatsSummaryDto valueOf(StatsSummary s) {
         return valueOf(s.createSnapshot());
     }
 
     public static StatsSummaryDto valueOf(StatsSummarySnapshot snapshot) {
         return new StatsSummaryDto(
-                snapshot.getMinimum(), snapshot.getMaximum(), snapshot.getAverage());
+                snapshot.getMinimum(),
+                snapshot.getMaximum(),
+                snapshot.getAverage(),
+                snapshot.getQuantile(.50d),
+                snapshot.getQuantile(.90d),
+                snapshot.getQuantile(.95d),
+                snapshot.getQuantile(.99d),
+                snapshot.getQuantile(.999d));
     }
 
     @JsonCreator
     public StatsSummaryDto(
             @JsonProperty(FIELD_NAME_MINIMUM) long minimum,
             @JsonProperty(FIELD_NAME_MAXIMUM) long maximum,
-            @JsonProperty(FIELD_NAME_AVERAGE) long average) {
+            @JsonProperty(FIELD_NAME_AVERAGE) long average,
+            @JsonProperty(FIELD_NAME_P50) double p50,
+            @JsonProperty(FIELD_NAME_P90) double p90,
+            @JsonProperty(FIELD_NAME_P95) double p95,
+            @JsonProperty(FIELD_NAME_P99) double p99,
+            @JsonProperty(FIELD_NAME_P999) double p999) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.average = average;
+        this.p50 = p50;
+        this.p90 = p90;
+        this.p95 = p95;
+        this.p99 = p99;
+        this.p999 = p999;
     }
 
     public long getMinimum() {
@@ -75,6 +117,26 @@ public final class StatsSummaryDto {
         return average;
     }
 
+    public double getP50() {
+        return p50;
+    }
+
+    public double getP90() {
+        return p90;
+    }
+
+    public double getP95() {
+        return p95;
+    }
+
+    public double getP99() {
+        return p99;
+    }
+
+    public double getP999() {
+        return p999;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -84,11 +146,18 @@ public final class StatsSummaryDto {
             return false;
         }
         StatsSummaryDto that = (StatsSummaryDto) o;
-        return minimum == that.minimum && maximum == that.maximum && average == that.average;
+        return minimum == that.minimum
+                && maximum == that.maximum
+                && average == that.average
+                && p50 == that.p50
+                && p90 == that.p90
+                && p95 == that.p95
+                && p99 == that.p99
+                && p999 == that.p999;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(minimum, maximum, average);
+        return Objects.hash(minimum, maximum, average, p50, p90, p95, p99, p999);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
@@ -128,10 +128,10 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
         public static final String FIELD_NAME_START_DELAY = "start_delay";
 
         @JsonProperty(FIELD_NAME_STATE_SIZE)
-        private final MinMaxAvgStatistics stateSize;
+        private final StatsSummaryDto stateSize;
 
         @JsonProperty(FIELD_NAME_DURATION)
-        private final MinMaxAvgStatistics duration;
+        private final StatsSummaryDto duration;
 
         @JsonProperty(FIELD_NAME_CHECKPOINT_DURATION)
         private final CheckpointDuration checkpointDuration;
@@ -140,15 +140,15 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
         private final CheckpointAlignment checkpointAlignment;
 
         @JsonProperty(FIELD_NAME_START_DELAY)
-        private final MinMaxAvgStatistics checkpointStartDelay;
+        private final StatsSummaryDto checkpointStartDelay;
 
         @JsonCreator
         public Summary(
-                @JsonProperty(FIELD_NAME_STATE_SIZE) MinMaxAvgStatistics stateSize,
-                @JsonProperty(FIELD_NAME_DURATION) MinMaxAvgStatistics duration,
+                @JsonProperty(FIELD_NAME_STATE_SIZE) StatsSummaryDto stateSize,
+                @JsonProperty(FIELD_NAME_DURATION) StatsSummaryDto duration,
                 @JsonProperty(FIELD_NAME_CHECKPOINT_DURATION) CheckpointDuration checkpointDuration,
                 @JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment checkpointAlignment,
-                @JsonProperty(FIELD_NAME_START_DELAY) MinMaxAvgStatistics checkpointStartDelay) {
+                @JsonProperty(FIELD_NAME_START_DELAY) StatsSummaryDto checkpointStartDelay) {
             this.stateSize = Preconditions.checkNotNull(stateSize);
             this.duration = Preconditions.checkNotNull(duration);
             this.checkpointDuration = Preconditions.checkNotNull(checkpointDuration);
@@ -156,11 +156,11 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
             this.checkpointStartDelay = Preconditions.checkNotNull(checkpointStartDelay);
         }
 
-        public MinMaxAvgStatistics getStateSize() {
+        public StatsSummaryDto getStateSize() {
             return stateSize;
         }
 
-        public MinMaxAvgStatistics getDuration() {
+        public StatsSummaryDto getDuration() {
             return duration;
         }
 
@@ -172,7 +172,7 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
             return checkpointAlignment;
         }
 
-        public MinMaxAvgStatistics getCheckpointStartDelay() {
+        public StatsSummaryDto getCheckpointStartDelay() {
             return checkpointStartDelay;
         }
 
@@ -211,26 +211,25 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
         public static final String FIELD_NAME_ASYNCHRONOUS_DURATION = "async";
 
         @JsonProperty(FIELD_NAME_SYNCHRONOUS_DURATION)
-        private final MinMaxAvgStatistics synchronousDuration;
+        private final StatsSummaryDto synchronousDuration;
 
         @JsonProperty(FIELD_NAME_ASYNCHRONOUS_DURATION)
-        private final MinMaxAvgStatistics asynchronousDuration;
+        private final StatsSummaryDto asynchronousDuration;
 
         @JsonCreator
         public CheckpointDuration(
-                @JsonProperty(FIELD_NAME_SYNCHRONOUS_DURATION)
-                        MinMaxAvgStatistics synchronousDuration,
+                @JsonProperty(FIELD_NAME_SYNCHRONOUS_DURATION) StatsSummaryDto synchronousDuration,
                 @JsonProperty(FIELD_NAME_ASYNCHRONOUS_DURATION)
-                        MinMaxAvgStatistics asynchronousDuration) {
+                        StatsSummaryDto asynchronousDuration) {
             this.synchronousDuration = Preconditions.checkNotNull(synchronousDuration);
             this.asynchronousDuration = Preconditions.checkNotNull(asynchronousDuration);
         }
 
-        public MinMaxAvgStatistics getSynchronousDuration() {
+        public StatsSummaryDto getSynchronousDuration() {
             return synchronousDuration;
         }
 
-        public MinMaxAvgStatistics getAsynchronousDuration() {
+        public StatsSummaryDto getAsynchronousDuration() {
             return asynchronousDuration;
         }
 
@@ -265,42 +264,42 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
         public static final String FIELD_NAME_DURATION = "duration";
 
         @JsonProperty(FIELD_NAME_BUFFERED_DATA)
-        private final MinMaxAvgStatistics bufferedData;
+        private final StatsSummaryDto bufferedData;
 
         @JsonProperty(FIELD_NAME_PROCESSED)
-        private final MinMaxAvgStatistics processedData;
+        private final StatsSummaryDto processedData;
 
         @JsonProperty(FIELD_NAME_PERSISTED)
-        private final MinMaxAvgStatistics persistedData;
+        private final StatsSummaryDto persistedData;
 
         @JsonProperty(FIELD_NAME_DURATION)
-        private final MinMaxAvgStatistics duration;
+        private final StatsSummaryDto duration;
 
         @JsonCreator
         public CheckpointAlignment(
-                @JsonProperty(FIELD_NAME_BUFFERED_DATA) MinMaxAvgStatistics bufferedData,
-                @JsonProperty(FIELD_NAME_PROCESSED) MinMaxAvgStatistics processedData,
-                @JsonProperty(FIELD_NAME_PERSISTED) MinMaxAvgStatistics persistedData,
-                @JsonProperty(FIELD_NAME_DURATION) MinMaxAvgStatistics duration) {
+                @JsonProperty(FIELD_NAME_BUFFERED_DATA) StatsSummaryDto bufferedData,
+                @JsonProperty(FIELD_NAME_PROCESSED) StatsSummaryDto processedData,
+                @JsonProperty(FIELD_NAME_PERSISTED) StatsSummaryDto persistedData,
+                @JsonProperty(FIELD_NAME_DURATION) StatsSummaryDto duration) {
             this.bufferedData = bufferedData;
             this.processedData = processedData;
             this.persistedData = persistedData;
             this.duration = duration;
         }
 
-        public MinMaxAvgStatistics getBufferedData() {
+        public StatsSummaryDto getBufferedData() {
             return bufferedData;
         }
 
-        public MinMaxAvgStatistics getProcessedData() {
+        public StatsSummaryDto getProcessedData() {
             return processedData;
         }
 
-        public MinMaxAvgStatistics getPersistedData() {
+        public StatsSummaryDto getPersistedData() {
             return persistedData;
         }
 
-        public MinMaxAvgStatistics getDuration() {
+        public StatsSummaryDto getDuration() {
             return duration;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsSnapshotTest.java
@@ -53,7 +53,7 @@ public class CheckpointStatsSnapshotTest {
                         null);
 
         CheckpointStatsSnapshot snapshot =
-                new CheckpointStatsSnapshot(counts, summary, history, restored);
+                new CheckpointStatsSnapshot(counts, summary.createSnapshot(), history, restored);
 
         CheckpointStatsSnapshot copy = CommonTestUtils.createCopySerializable(snapshot);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -115,7 +115,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(1, counts.getTotalNumberOfCheckpoints());
 
         // Summary should be available
-        CompletedCheckpointStatsSummary summary = snapshot.getSummaryStats();
+        CompletedCheckpointStatsSummarySnapshot summary = snapshot.getSummaryStats();
         assertEquals(1, summary.getStateSizeStats().getCount());
         assertEquals(1, summary.getEndToEndDurationStats().getCount());
 
@@ -207,7 +207,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(1, counts.getNumberOfFailedCheckpoints());
 
         // Summary stats
-        CompletedCheckpointStatsSummary summary = snapshot.getSummaryStats();
+        CompletedCheckpointStatsSummarySnapshot summary = snapshot.getSummaryStats();
         assertEquals(2, summary.getStateSizeStats().getCount());
         assertEquals(2, summary.getEndToEndDurationStats().getCount());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -112,5 +113,36 @@ public class CompletedCheckpointStatsSummaryTest {
                 persistedData,
                 latest,
                 null);
+    }
+
+    /** Simply test that quantiles can be computed and fields are not permuted. */
+    @Test
+    public void testQuantiles() {
+        int stateSize = 100;
+        int processedData = 200;
+        int persistedData = 300;
+        long triggerTimestamp = 1234;
+        long lastAck = triggerTimestamp + 123;
+
+        CompletedCheckpointStatsSummary summary = new CompletedCheckpointStatsSummary();
+        summary.updateSummary(
+                new CompletedCheckpointStats(
+                        1L,
+                        triggerTimestamp,
+                        CheckpointProperties.forSavepoint(false),
+                        1,
+                        singletonMap(new JobVertexID(), new TaskStateStats(new JobVertexID(), 1)),
+                        1,
+                        stateSize,
+                        processedData,
+                        persistedData,
+                        new SubtaskStateStats(0, lastAck),
+                        ""));
+        CompletedCheckpointStatsSummarySnapshot snapshot = summary.createSnapshot();
+        assertEquals(stateSize, snapshot.getStateSizeStats().getQuantile(1), 0);
+        assertEquals(processedData, snapshot.getProcessedDataStats().getQuantile(1), 0);
+        assertEquals(persistedData, snapshot.getPersistedDataStats().getQuantile(1), 0);
+        assertEquals(
+                lastAck - triggerTimestamp, snapshot.getEndToEndDurationStats().getQuantile(1), 0);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
@@ -66,20 +66,20 @@ public class CompletedCheckpointStatsSummaryTest {
             assertEquals(i + 1, summary.getPersistedDataStats().getCount());
         }
 
-        MinMaxAvgStats stateSizeStats = summary.getStateSizeStats();
+        StatsSummary stateSizeStats = summary.getStateSizeStats();
         assertEquals(stateSize, stateSizeStats.getMinimum());
         assertEquals(stateSize + numCheckpoints - 1, stateSizeStats.getMaximum());
 
-        MinMaxAvgStats durationStats = summary.getEndToEndDurationStats();
+        StatsSummary durationStats = summary.getEndToEndDurationStats();
         assertEquals(ackTimestamp - triggerTimestamp, durationStats.getMinimum());
         assertEquals(
                 ackTimestamp - triggerTimestamp + numCheckpoints - 1, durationStats.getMaximum());
 
-        MinMaxAvgStats processedDataStats = summary.getProcessedDataStats();
+        StatsSummary processedDataStats = summary.getProcessedDataStats();
         assertEquals(processedData, processedDataStats.getMinimum());
         assertEquals(processedData + numCheckpoints - 1, processedDataStats.getMaximum());
 
-        MinMaxAvgStats persistedDataStats = summary.getPersistedDataStats();
+        StatsSummary persistedDataStats = summary.getPersistedDataStats();
         assertEquals(persistedData, persistedDataStats.getMinimum());
         assertEquals(persistedData + numCheckpoints - 1, persistedDataStats.getMaximum());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StatsSummaryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StatsSummaryTest.java
@@ -86,4 +86,19 @@ public class StatsSummaryTest {
         assertEquals(count, mma.getCount());
         assertEquals(sum / count, mma.getAverage());
     }
+
+    @Test
+    public void testQuantile() {
+        StatsSummary summary = new StatsSummary(100);
+        for (int i = 0; i < 123; i++) {
+            summary.add(100000); // should be forced out by the later values
+        }
+        for (int i = 1; i <= 100; i++) {
+            summary.add(i);
+        }
+        StatsSummarySnapshot snapshot = summary.createSnapshot();
+        for (double q = 0.01; q <= 1; q++) {
+            assertEquals(q, snapshot.getQuantile(q), 1);
+        }
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StatsSummaryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StatsSummaryTest.java
@@ -24,12 +24,12 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
 
-public class MinMaxAvgStatsTest {
+public class StatsSummaryTest {
 
     /** Test the initial/empty state. */
     @Test
     public void testInitialState() throws Exception {
-        MinMaxAvgStats mma = new MinMaxAvgStats();
+        StatsSummary mma = new StatsSummary();
 
         assertEquals(0, mma.getMinimum());
         assertEquals(0, mma.getMaximum());
@@ -41,7 +41,7 @@ public class MinMaxAvgStatsTest {
     /** Test that non-positive numbers are not counted. */
     @Test
     public void testAddNonPositiveStats() throws Exception {
-        MinMaxAvgStats mma = new MinMaxAvgStats();
+        StatsSummary mma = new StatsSummary();
         mma.add(-1);
 
         assertEquals(0, mma.getMinimum());
@@ -64,7 +64,7 @@ public class MinMaxAvgStatsTest {
     public void testAddRandomNumbers() throws Exception {
         ThreadLocalRandom rand = ThreadLocalRandom.current();
 
-        MinMaxAvgStats mma = new MinMaxAvgStats();
+        StatsSummary mma = new StatsSummary();
 
         long count = 13;
         long sum = 0;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -259,7 +259,12 @@ public class ArchivedExecutionGraphTest extends TestLogger {
                         StatsSummarySnapshot::getMinimum,
                         StatsSummarySnapshot::getMaximum,
                         StatsSummarySnapshot::getSum,
-                        StatsSummarySnapshot::getCount);
+                        StatsSummarySnapshot::getCount,
+                        s -> s.getQuantile(0.5d),
+                        s -> s.getQuantile(0.9d),
+                        s -> s.getQuantile(0.95d),
+                        s -> s.getQuantile(0.99d),
+                        s -> s.getQuantile(0.999d));
         for (Function<CompletedCheckpointStatsSummarySnapshot, StatsSummarySnapshot> meter :
                 meters) {
             StatsSummarySnapshot runtime = meter.apply(runtimeSnapshot.getSummaryStats());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -27,6 +27,8 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStatsSummarySnapshot;
+import org.apache.flink.runtime.checkpoint.StatsSummarySnapshot;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -47,12 +49,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Function;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertArrayEquals;
@@ -108,7 +112,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 
         final JobGraph jobGraph =
                 JobGraphBuilder.newStreamingJobGraphBuilder()
-                        .addJobVertices(Arrays.asList(v1, v2))
+                        .addJobVertices(asList(v1, v2))
                         .setJobCheckpointingSettings(checkpointingSettings)
                         .setExecutionConfig(config)
                         .build();
@@ -242,25 +246,28 @@ public class ArchivedExecutionGraphTest extends TestLogger {
         CheckpointStatsSnapshot runtimeSnapshot = runtimeGraph.getCheckpointStatsSnapshot();
         CheckpointStatsSnapshot archivedSnapshot = archivedGraph.getCheckpointStatsSnapshot();
 
-        assertEquals(
-                runtimeSnapshot.getSummaryStats().getEndToEndDurationStats().getAverage(),
-                archivedSnapshot.getSummaryStats().getEndToEndDurationStats().getAverage());
-        assertEquals(
-                runtimeSnapshot.getSummaryStats().getEndToEndDurationStats().getMinimum(),
-                archivedSnapshot.getSummaryStats().getEndToEndDurationStats().getMinimum());
-        assertEquals(
-                runtimeSnapshot.getSummaryStats().getEndToEndDurationStats().getMaximum(),
-                archivedSnapshot.getSummaryStats().getEndToEndDurationStats().getMaximum());
+        List<Function<CompletedCheckpointStatsSummarySnapshot, StatsSummarySnapshot>> meters =
+                asList(
+                        CompletedCheckpointStatsSummarySnapshot::getEndToEndDurationStats,
+                        CompletedCheckpointStatsSummarySnapshot::getPersistedDataStats,
+                        CompletedCheckpointStatsSummarySnapshot::getProcessedDataStats,
+                        CompletedCheckpointStatsSummarySnapshot::getStateSizeStats);
 
-        assertEquals(
-                runtimeSnapshot.getSummaryStats().getStateSizeStats().getAverage(),
-                archivedSnapshot.getSummaryStats().getStateSizeStats().getAverage());
-        assertEquals(
-                runtimeSnapshot.getSummaryStats().getStateSizeStats().getMinimum(),
-                archivedSnapshot.getSummaryStats().getStateSizeStats().getMinimum());
-        assertEquals(
-                runtimeSnapshot.getSummaryStats().getStateSizeStats().getMaximum(),
-                archivedSnapshot.getSummaryStats().getStateSizeStats().getMaximum());
+        List<Function<StatsSummarySnapshot, Object>> aggs =
+                asList(
+                        StatsSummarySnapshot::getAverage,
+                        StatsSummarySnapshot::getMinimum,
+                        StatsSummarySnapshot::getMaximum,
+                        StatsSummarySnapshot::getSum,
+                        StatsSummarySnapshot::getCount);
+        for (Function<CompletedCheckpointStatsSummarySnapshot, StatsSummarySnapshot> meter :
+                meters) {
+            StatsSummarySnapshot runtime = meter.apply(runtimeSnapshot.getSummaryStats());
+            StatsSummarySnapshot archived = meter.apply(runtimeSnapshot.getSummaryStats());
+            for (Function<StatsSummarySnapshot, Object> agg : aggs) {
+                assertEquals(agg.apply(runtime), agg.apply(archived));
+            }
+        }
 
         assertEquals(
                 runtimeSnapshot.getCounts().getTotalNumberOfCheckpoints(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
@@ -44,11 +44,11 @@ public class CheckpointingStatisticsTest
                 new CheckpointingStatistics.Counts(1, 2, 3, 4, 5);
         final CheckpointingStatistics.Summary summary =
                 new CheckpointingStatistics.Summary(
-                        new StatsSummaryDto(1L, 1L, 1L),
-                        new StatsSummaryDto(2L, 2L, 2L),
-                        new StatsSummaryDto(3L, 3L, 3L),
-                        new StatsSummaryDto(4L, 4L, 4L),
-                        new StatsSummaryDto(5L, 5L, 5L));
+                        new StatsSummaryDto(1L, 1L, 1L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(2L, 2L, 2L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(3L, 3L, 3L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(4L, 4L, 4L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(5L, 5L, 5L, 0, 0, 0, 0, 0));
 
         final Map<JobVertexID, TaskCheckpointStatistics> checkpointStatisticsPerTask =
                 new HashMap<>(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
@@ -44,11 +44,11 @@ public class CheckpointingStatisticsTest
                 new CheckpointingStatistics.Counts(1, 2, 3, 4, 5);
         final CheckpointingStatistics.Summary summary =
                 new CheckpointingStatistics.Summary(
-                        new MinMaxAvgStatistics(1L, 1L, 1L),
-                        new MinMaxAvgStatistics(2L, 2L, 2L),
-                        new MinMaxAvgStatistics(3L, 3L, 3L),
-                        new MinMaxAvgStatistics(4L, 4L, 4L),
-                        new MinMaxAvgStatistics(5L, 5L, 5L));
+                        new StatsSummaryDto(1L, 1L, 1L),
+                        new StatsSummaryDto(2L, 2L, 2L),
+                        new StatsSummaryDto(3L, 3L, 3L),
+                        new StatsSummaryDto(4L, 4L, 4L),
+                        new StatsSummaryDto(5L, 5L, 5L));
 
         final Map<JobVertexID, TaskCheckpointStatistics> checkpointStatisticsPerTask =
                 new HashMap<>(2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
@@ -38,16 +38,17 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest
             throws Exception {
         final TaskCheckpointStatisticsWithSubtaskDetails.Summary summary =
                 new TaskCheckpointStatisticsWithSubtaskDetails.Summary(
-                        new StatsSummaryDto(1L, 2L, 3L),
-                        new StatsSummaryDto(1L, 2L, 3L),
+                        new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0),
+                        new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0),
                         new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointDuration(
-                                new StatsSummaryDto(1L, 2L, 3L), new StatsSummaryDto(1L, 2L, 3L)),
+                                new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0),
+                                new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0)),
                         new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment(
-                                new StatsSummaryDto(1L, 2L, 3L),
-                                new StatsSummaryDto(1L, 2L, 3L),
-                                new StatsSummaryDto(1L, 2L, 3L),
-                                new StatsSummaryDto(1L, 2L, 3L)),
-                        new StatsSummaryDto(1L, 2L, 3L));
+                                new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0),
+                                new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0),
+                                new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0),
+                                new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0)),
+                        new StatsSummaryDto(1L, 2L, 3L, 0, 0, 0, 0, 0));
 
         List<SubtaskCheckpointStatistics> subtaskCheckpointStatistics = new ArrayList<>(2);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
@@ -38,17 +38,16 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest
             throws Exception {
         final TaskCheckpointStatisticsWithSubtaskDetails.Summary summary =
                 new TaskCheckpointStatisticsWithSubtaskDetails.Summary(
-                        new MinMaxAvgStatistics(1L, 2L, 3L),
-                        new MinMaxAvgStatistics(1L, 2L, 3L),
+                        new StatsSummaryDto(1L, 2L, 3L),
+                        new StatsSummaryDto(1L, 2L, 3L),
                         new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointDuration(
-                                new MinMaxAvgStatistics(1L, 2L, 3L),
-                                new MinMaxAvgStatistics(1L, 2L, 3L)),
+                                new StatsSummaryDto(1L, 2L, 3L), new StatsSummaryDto(1L, 2L, 3L)),
                         new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment(
-                                new MinMaxAvgStatistics(1L, 2L, 3L),
-                                new MinMaxAvgStatistics(1L, 2L, 3L),
-                                new MinMaxAvgStatistics(1L, 2L, 3L),
-                                new MinMaxAvgStatistics(1L, 2L, 3L)),
-                        new MinMaxAvgStatistics(1L, 2L, 3L));
+                                new StatsSummaryDto(1L, 2L, 3L),
+                                new StatsSummaryDto(1L, 2L, 3L),
+                                new StatsSummaryDto(1L, 2L, 3L),
+                                new StatsSummaryDto(1L, 2L, 3L)),
+                        new StatsSummaryDto(1L, 2L, 3L));
 
         List<SubtaskCheckpointStatistics> subtaskCheckpointStatistics = new ArrayList<>(2);
 


### PR DESCRIPTION
## What is the purpose of the change

Add percentiles to checkpoint statistics to better understand backends and checkpointing behaviour.
In particular, compare checkpoint times when using different backends.

Percentiles are computed using histogram (from apache commons-math) which in turn is computed over a sliding window (size = 10000).
I used sliding window histogram because:
- no new dependencies (or algorithm implementations) required
- forcing out old values makes sense to me

I didn't use history.size as sliding window size as I think some users may need histograms but not long history.
With 10K values memory overhead is around 300Kb per job (4 arrays of 10K doubles).

## Verifying this change

- Added `CompletedCheckpointStatsSummaryTest.testQuantiles`, `StatsSummaryTest.testQuantile`, updated `ArchivedExecutionGraphTest.compareExecutionGraph`
- Tested manually via UI
- Tested history server

![Screenshot_2021-07-16_15-26-00](https://user-images.githubusercontent.com/3939322/125955695-e3c8b91e-39e4-46c9-8f8e-f40d7883caa9.png)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no