### PR TITLE
[FLINK-23249][runtime] Introduce ShuffleMasterContext to ShuffleMaster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
@@ -36,6 +35,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFac
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.runtime.util.Hardware;
@@ -55,8 +55,8 @@ public class NettyShuffleServiceFactory
     private static final String DIR_NAME_PREFIX = "netty-shuffle";
 
     @Override
-    public NettyShuffleMaster createShuffleMaster(Configuration configuration) {
-        return new NettyShuffleMaster(configuration);
+    public NettyShuffleMaster createShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
+        return new NettyShuffleMaster(shuffleMasterContext.getConfiguration());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContext.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Shuffle context used to create {@link ShuffleMaster}. It can work as a proxy to other cluster
+ * components and hide these components from users.
+ */
+public interface ShuffleMasterContext {
+
+    /** Returns the cluster configuration. */
+    Configuration getConfiguration();
+
+    /** Handles the fatal error if any. */
+    void onFatalError(Throwable throwable);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContextImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContextImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The default implementation of {@link ShuffleMasterContext}. */
+public class ShuffleMasterContextImpl implements ShuffleMasterContext {
+
+    private final Configuration configuration;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    public ShuffleMasterContextImpl(
+            Configuration configuration, FatalErrorHandler fatalErrorHandler) {
+        this.configuration = checkNotNull(configuration);
+        this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void onFatalError(Throwable throwable) {
+        fatalErrorHandler.onFatalError(throwable);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.shuffle;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 
@@ -39,10 +38,10 @@ public interface ShuffleServiceFactory<
     /**
      * Factory method to create a specific {@link ShuffleMaster} implementation.
      *
-     * @param configuration Flink configuration
+     * @param shuffleMasterContext shuffle context for shuffle master.
      * @return shuffle manager implementation
      */
-    ShuffleMaster<SD> createShuffleMaster(Configuration configuration);
+    ShuffleMaster<SD> createShuffleMaster(ShuffleMasterContext shuffleMasterContext);
 
     /**
      * Factory method to create a specific local {@link ShuffleEnvironment} implementation.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
@@ -76,7 +76,8 @@ public class ShuffleServiceLoaderTest extends TestLogger {
             implements ShuffleServiceFactory<
                     ShuffleDescriptor, ResultPartitionWriter, IndexedInputGate> {
         @Override
-        public ShuffleMaster<ShuffleDescriptor> createShuffleMaster(Configuration configuration) {
+        public ShuffleMaster<ShuffleDescriptor> createShuffleMaster(
+                ShuffleMasterContext shuffleMasterContext) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## What is the purpose of the change

Introduce ShuffleMasterContext to ShuffleMaster to let ShuffleMaster access other components of the cluster.

## Brief change log

  - Introduce ShuffleMasterContext to ShuffleMaster.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
