### PR TITLE
[FLINK-23347][docs][datatream][operators] - Updated windowAll description

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/overview.md
+++ b/docs/content.zh/docs/dev/datastream/operators/overview.md
@@ -215,7 +215,7 @@ This feature is not yet supported in Python
 {{< /tabs>}}
 
 ### WindowAll
-#### DataStreamStream &rarr; AllWindowedStream
+#### DataStream &rarr; AllWindowedStream
 
 Windows can be defined on regular DataStreams. Windows group all the stream events according to some characteristic (e.g., the data that arrived within the last 5 seconds). See [windows](windows.html) for a complete description of windows.
 

--- a/docs/content/docs/dev/datastream/operators/overview.md
+++ b/docs/content/docs/dev/datastream/operators/overview.md
@@ -217,7 +217,7 @@ This feature is not yet supported in Python
 {{< /tabs>}}
 
 ### WindowAll
-#### DataStreamStream &rarr; AllWindowedStream
+#### DataStream &rarr; AllWindowedStream
 
 Windows can be defined on regular DataStreams. Windows group all the stream events according to some characteristic (e.g., the data that arrived within the last 5 seconds). See [windows](windows.html) for a complete description of windows.
 


### PR DESCRIPTION
## What is the purpose of the change

* The datastream operators overview document refers to DataStreamStream which perhaps should be DataStream.

## Brief change log

* The document refers to DataStreamStream but should refer to DataStream.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
