### PR TITLE
[hotfix][runtime] Log slot pool status if unable to fulfill job requirements

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -348,14 +348,17 @@ public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implem
             Collection<ResourceRequirement> acquiredResources) {
         assertRunningInMainThread();
 
-        failPendingRequests();
+        failPendingRequests(acquiredResources);
     }
 
-    private void failPendingRequests() {
+    private void failPendingRequests(Collection<ResourceRequirement> acquiredResources) {
         if (!pendingRequests.isEmpty()) {
             final NoResourceAvailableException cause =
                     new NoResourceAvailableException(
-                            "Could not acquire the minimum required resources.");
+                            "Could not acquire the minimum required resources. Acquired: "
+                                    + acquiredResources
+                                    + ". Current slot pool status: "
+                                    + getSlotServiceStatus());
 
             cancelPendingRequests(
                     request -> !isBatchSlotRequestTimeoutCheckDisabled || !request.isBatchRequest(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolService.java
@@ -306,4 +306,12 @@ public class DeclarativeSlotPoolService implements SlotPoolService {
         STARTED,
         CLOSED,
     }
+
+    protected String getSlotServiceStatus() {
+        return String.format(
+                "Registered TMs: %d, registered slots: %d free slots: %d",
+                registeredTaskManagers.size(),
+                declarativeSlotPool.getAllSlotsInformation().size(),
+                declarativeSlotPool.getFreeSlotsInformation().size());
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -647,7 +647,10 @@ public class DeclarativeSlotManager implements SlotManager {
                     pendingSlots = allocationResult.getNewAvailableResources();
                     if (!allocationResult.isSuccessfulAllocating()
                             && sendNotEnoughResourceNotifications) {
-                        LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
+                        LOG.warn(
+                                "Could not fulfill resource requirements of job {}. Free slots: {}",
+                                jobId,
+                                slotTracker.getFreeSlots().size());
                         resourceActions.notifyNotEnoughResourcesAvailable(
                                 jobId, resourceTracker.getAcquiredResources(jobId));
                         return pendingSlots;


### PR DESCRIPTION
## What is the purpose of the change

Log why job requirements can't be fulfilled (how many TMs and slots are alive). Motivated by debugging test failures.

This is more of a proposal.

Sample log messages are shown below (using minicluster and failing one task -> TM).

```
2021-07-12 03:19:58,603 WARN Could not fulfill resource requirements of job 6cd8e69cfbb5ec959bac512dedce65f5. Free slots: 0 [DeclarativeSlotManager flink-akka.actor.default-dispatcher-2]
```

```
2021-07-12 03:19:58,617 INFO Source: Custom Source -> Map -> Sink: Unnamed (1/4) (a2c20aa32818dcfacb518af9c47afe76) switched from SCHEDULED to FAILED on [unassigned resource]. [ExecutionGraph flink-akka.actor.default-dispatcher-2]
java.util.concurrent.CompletionException: org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException: Could not acquire the minimu m required resources. Acquired: [ResourceRequirement{resourceProfile=ResourceProfile{taskHeapMemory=1024.000gb (1099511627776 bytes), taskOffHeapM emory=1024.000gb (1099511627776 bytes), managedMemory=80.000mb (83886080 bytes), networkMemory=64.000mb (67108864 bytes)}, numberOfRequiredSlots=3*}]. Current slot service status: registered TMs: 0, registered slots: 0 free slots: 0
     at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:607) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:591) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1990) ~[?:1.8.0_271]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge$PendingRequest.failRequest(DeclarativeSlotPoolBridge.java:535) ~[ classes/:?]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge.cancelPendingRequests(DeclarativeSlotPoolBridge.java:128) ~[class es/:?]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge.failPendingRequests(DeclarativeSlotPoolBridge.java:363) ~[classes /:?]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge.notifyNotEnoughResourcesAvailable(DeclarativeSlotPoolBridge.java: 351) ~[classes/:?]
     at org.apache.flink.runtime.jobmaster.JobMaster.notifyNotEnoughResourcesAvailable(JobMaster.java:816) ~[classes/:?]
```

```
2021-07-12 03:20:54,053 INFO Source: Custom Source -> Map -> Sink: Unnamed (1/4) (06c5cf45f498cd98455ad9bcf37fac25) switched from SCHEDULED to FAILED on [unassigned resource]. [ExecutionGraph flink-akka.actor.default-dispatcher-7]
java.util.concurrent.CompletionException: org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException: Could not acquire the minimu m required resources. Acquired: [ResourceRequirement{resourceProfile=ResourceProfile{taskHeapMemory=1024.000gb (1099511627776 bytes), taskOffHeapM emory=1024.000gb (1099511627776 bytes), managedMemory=80.000mb (83886080 bytes), networkMemory=64.000mb (67108864 bytes)}, numberOfRequiredSlots=3*}]. Current slot service status: registered TMs: 1, registered slots: 0 free slots: 0
     at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:607) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:591) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488) ~[?:1.8.0_271]
     at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1990) ~[?:1.8.0_271]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge$PendingRequest.failRequest(DeclarativeSlotPoolBridge.java:535) ~[ classes/:?]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge.cancelPendingRequests(DeclarativeSlotPoolBridge.java:128) ~[class es/:?]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge.failPendingRequests(DeclarativeSlotPoolBridge.java:363) ~[classes /:?]
     at org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridge.notifyNotEnoughResourcesAvailable(DeclarativeSlotPoolBridge.java: 351) ~[classes/:?]
     at org.apache.flink.runtime.jobmaster.JobMaster.notifyNotEnoughResourcesAvailable(JobMaster.java:816) ~[classes/:?]
```

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no