### PR TITLE
[FLINK-22889][tests] Improve logging in JdbcExactlyOnceSinkE2eTest

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -41,11 +41,13 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.LogLevelRule;
 import org.apache.flink.util.function.SerializableSupplier;
 
 import com.mysql.cj.jdbc.MysqlXADataSource;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -84,6 +86,7 @@ import static org.apache.flink.connector.jdbc.xa.JdbcXaFacadeTestHelper.getInser
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.junit.Assert.assertTrue;
+import static org.slf4j.event.Level.TRACE;
 
 /** A simple end-to-end test for {@link JdbcXaSinkFunction}. */
 @RunWith(Parameterized.class)
@@ -91,6 +94,13 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
     private static final Random RANDOM = new Random(System.currentTimeMillis());
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcExactlyOnceSinkE2eTest.class);
+
+    // todo: remove after fixing FLINK-22889
+    @ClassRule
+    public static final LogLevelRule TEST_LOG_LEVEL_RULE =
+            new LogLevelRule()
+                    .set(JdbcExactlyOnceSinkE2eTest.class, TRACE)
+                    .set(XaFacadeImpl.class, TRACE);
 
     private interface JdbcExactlyOnceSinkTestEnv {
         void start();

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/xa/JdbcExactlyOnceSinkE2eTest.java
@@ -62,6 +62,7 @@ import javax.sql.XADataSource;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
@@ -105,7 +106,8 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
     public static final LogLevelRule TEST_LOG_LEVEL_RULE =
             new LogLevelRule()
                     .set(JdbcExactlyOnceSinkE2eTest.class, TRACE)
-                    .set(XaFacadeImpl.class, TRACE);
+                    .set(XaFacadeImpl.class, TRACE)
+                    .set(MySqlJdbcExactlyOnceSinkTestEnv.InnoDbStatusLogger.class, TRACE);
 
     private interface JdbcExactlyOnceSinkTestEnv {
         void start();
@@ -520,6 +522,7 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
 
         private static final class MySqlXaDb extends MySQLContainer<MySqlXaDb> {
             private static final String IMAGE_NAME = "mysql:8.0.23"; // version 5 had issues with XA
+            private volatile InnoDbStatusLogger innoDbStatusLogger;
 
             @Override
             public String toString() {
@@ -541,6 +544,21 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
                     prepareDb(connection, lockWaitTimeout);
                 } catch (SQLException e) {
                     ExceptionUtils.rethrow(e);
+                }
+                this.innoDbStatusLogger =
+                        new InnoDbStatusLogger(
+                                getJdbcUrl(), "root", getPassword(), lockWaitTimeout / 2);
+                innoDbStatusLogger.start();
+            }
+
+            @Override
+            public void stop() {
+                try {
+                    innoDbStatusLogger.stop();
+                } catch (Exception e) {
+                    ExceptionUtils.rethrow(e);
+                } finally {
+                    super.stop();
                 }
             }
 
@@ -583,6 +601,109 @@ public class JdbcExactlyOnceSinkE2eTest extends JdbcTestBase {
         @Override
         public String toString() {
             return db + ", parallelism=" + parallelism;
+        }
+
+        private static class InnoDbStatusLogger {
+            private static final Logger LOG = LoggerFactory.getLogger(InnoDbStatusLogger.class);
+            private final Thread thread;
+            private volatile boolean running;
+
+            private InnoDbStatusLogger(String url, String user, String password, long intervalMs) {
+                running = true;
+                thread =
+                        new Thread(
+                                () -> {
+                                    LOG.info("Logging InnoDB status every {}ms", intervalMs);
+                                    try (Connection connection =
+                                            DriverManager.getConnection(url, user, password)) {
+                                        while (running) {
+                                            Thread.sleep(intervalMs);
+                                            queryAndLog(connection);
+                                        }
+                                    } catch (Exception e) {
+                                        LOG.warn("failed", e);
+                                    } finally {
+                                        LOG.info("Logging InnoDB status stopped");
+                                    }
+                                });
+            }
+
+            public void start() {
+                thread.start();
+            }
+
+            public void stop() throws InterruptedException {
+                running = false;
+                thread.join();
+            }
+
+            private void queryAndLog(Connection connection) throws SQLException {
+                try (Statement st = connection.createStatement()) {
+                    showBlockedTrx(st);
+                    showAllTrx(st);
+                    showEngineStatus(st);
+                    showRecoveredTrx(st);
+                    // additional query: show full processlist \G; -- only shows live
+                }
+            }
+
+            private void showRecoveredTrx(Statement st) throws SQLException {
+                try (ResultSet rs = st.executeQuery("xa recover convert xid ")) {
+                    while (rs.next()) {
+                        LOG.debug(
+                                "recovered trx: {} {} {} {}",
+                                rs.getString(1),
+                                rs.getString(2),
+                                rs.getString(3),
+                                rs.getString(4));
+                    }
+                }
+            }
+
+            private void showEngineStatus(Statement st) throws SQLException {
+                LOG.debug("Engine status");
+                try (ResultSet rs = st.executeQuery("show engine innodb status")) {
+                    while (rs.next()) {
+                        LOG.debug(rs.getString(3));
+                    }
+                }
+            }
+
+            private void showAllTrx(Statement st) throws SQLException {
+                LOG.debug("All TRX");
+                try (ResultSet rs =
+                        st.executeQuery("select * from information_schema.innodb_trx")) {
+                    while (rs.next()) {
+                        LOG.debug(
+                                "trx_id: {}, trx_state: {}, trx_started: {}, trx_requested_lock_id: {}, trx_wait_started: {}, trx_mysql_thread_id: {},",
+                                rs.getString("trx_id"),
+                                rs.getString("trx_state"),
+                                rs.getString("trx_started"),
+                                rs.getString("trx_requested_lock_id"),
+                                rs.getString("trx_wait_started"),
+                                rs.getString("trx_mysql_thread_id") /* 0 for recovered*/);
+                    }
+                }
+            }
+
+            private void showBlockedTrx(Statement st) throws SQLException {
+                LOG.debug("Blocked TRX");
+                try (ResultSet rs =
+                        st.executeQuery(
+                                " SELECT waiting_trx_id, waiting_pid, waiting_query, blocking_trx_id, blocking_pid, blocking_query "
+                                        + "FROM sys.innodb_lock_waits; ")) {
+                    while (rs.next()) {
+                        LOG.debug(
+                                "waiting_trx_id: {}, waiting_pid: {}, waiting_query: {}, blocking_trx_id: {}, blocking_pid: {}, blocking_query: {}",
+                                rs.getString(1),
+                                rs.getString(2),
+                                rs.getString(3),
+                                rs.getString(4),
+                                rs.getString(5),
+                                rs.getString(6));
+                    }
+                }
+            }
         }
     }
 

--- a/flink-connectors/flink-connector-jdbc/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-jdbc/src/test/resources/log4j2-test.properties
@@ -21,10 +21,6 @@
 rootLogger.level = OFF
 rootLogger.appenderRef.test.ref = TestLogger
 
-# debugging FLINK-22889 (TODO: remove after resolved)
-logger.jdbc.name = org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest
-logger.jdbc.level = DEBUG
-
 appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR


### PR DESCRIPTION
## What is the purpose of the change

1. Use `LogLevelRule` to enable debug logs for `JdbcExactlyOnceSinkE2eTest` (instead of `log4j2-test.properties` which isn't used in CI)
2. Configure MySQL lock wait timeout to make it clear if task cancellation or snapshot times out because of this
3. Log InnoDB and transactions statuses to see blocking transactions (every ~4s)

When running for ~20 minutes log size is ~110 Mb with #16523 applied (without the latter more than 1Gb).

Sample log output:
```
23346 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - Blocked TRX
23394 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - waiting_trx_id: 2117, waiting_pid: 48, waiting_query: insert into books (id, title,  ...  values (57,'57','57',57.0,57), blocking_trx_id: 2102, blocking_pid: 0, blocking_query: null
23394 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - All TRX
23396 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - trx_id: 2117, trx_state: LOCK WAIT, trx_started: 2021-07-17 22:33:40, trx_requested_lock_id: 139905730342296:2:4:30:139905741168352, trx_wait_started: 2021-07-17 22:33:40, trx_mysql_thread_id: 48,
23397 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - trx_id: 2103, trx_state: RUNNING, trx_started: 2021-07-17 22:33:39, trx_requested_lock_id: null, trx_wait_started: null, trx_mysql_thread_id: 0,
23397 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - trx_id: 2102, trx_state: RUNNING, trx_started: 2021-07-17 22:33:39, trx_requested_lock_id: null, trx_wait_started: null, trx_mysql_thread_id: 0,
23397 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - Engine status
23398 [Thread-14] DEBUG org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest$MySqlJdbcExactlyOnceSinkTestEnv$InnoDbStatusLogger [] - 
=====================================
2021-07-17 22:33:41 0x7f3e5c09e700 INNODB MONITOR OUTPUT
=====================================
Per second averages calculated from the last 4 seconds
-----------------
BACKGROUND THREAD
-----------------
srv_master_thread loops: 2 srv_active, 0 srv_shutdown, 1 srv_idle
srv_master_thread log flush and writes: 0
----------
SEMAPHORES
----------
OS WAIT ARRAY INFO: reservation count 33
OS WAIT ARRAY INFO: signal count 23
RW-shared spins 8, rounds 8, OS waits 0
RW-excl spins 11, rounds 141, OS waits 4
RW-sx spins 2, rounds 60, OS waits 2
Spin rounds per wait: 1.00 RW-shared, 12.82 RW-excl, 30.00 RW-sx
------------
TRANSACTIONS
------------
Trx id counter 2119
Purge done for trx's n:o < 2100 undo n:o < 0 state: running but idle
History list length 9
LIST OF TRANSACTIONS FOR EACH SESSION:
---TRANSACTION 421380707053808, not started
0 lock struct(s), heap size 1136, 0 row lock(s)
---TRANSACTION 421380707052096, not started
0 lock struct(s), heap size 1136, 0 row lock(s)
---TRANSACTION 421380707051240, not started
0 lock struct(s), heap size 1136, 0 row lock(s)
---TRANSACTION 2117, ACTIVE 1 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 2 lock struct(s), heap size 1136, 1 row lock(s)
MySQL thread id 48, OS thread handle 139905412962048, query id 761 172.17.0.1 test update
insert into books (id, title, author, price, qty) values (57,'57','57',57.0,57)
------- TRX HAS BEEN WAITING 1 SEC FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2 page no 4 n bits 112 index PRIMARY of table `test`.`books` trx id 2117 lock mode S locks rec but not gap waiting
Record lock, heap no 30 PHYSICAL RECORD: n_fields 7; compact format; info bits 0
 0: len 4; hex 80000039; asc    9;;
 1: len 6; hex 000000000836; asc      6;;
 2: len 7; hex 820000008a0110; asc        ;;
 3: len 2; hex 3537; asc 57;;
 4: len 2; hex 3537; asc 57;;
 5: len 4; hex 00006442; asc   dB;;
 6: len 4; hex 80000039; asc    9;;

------------------
TABLE LOCK table `test`.`books` trx id 2117 lock mode IX
RECORD LOCKS space id 2 page no 4 n bits 112 index PRIMARY of table `test`.`books` trx id 2117 lock mode S locks rec but not gap waiting
Record lock, heap no 30 PHYSICAL RECORD: n_fields 7; compact format; info bits 0
 0: len 4; hex 80000039; asc    9;;
 1: len 6; hex 000000000836; asc      6;;
 2: len 7; hex 820000008a0110; asc        ;;
 3: len 2; hex 3537; asc 57;;
 4: len 2; hex 3537; asc 57;;
 5: len 4; hex 00006442; asc   dB;;
 6: len 4; hex 80000039; asc    9;;

---TRANSACTION 2103, ACTIVE (PREPARED) 2 sec recovered trx
1 lock struct(s), heap size 1136, 0 row lock(s), undo log entries 7
TABLE LOCK table `test`.`books` trx id 2103 lock mode IX
---TRANSACTION 2102, ACTIVE (PREPARED) 2 sec recovered trx
2 lock struct(s), heap size 1136, 1 row lock(s), undo log entries 7
TABLE LOCK table `test`.`books` trx id 2102 lock mode IX
RECORD LOCKS space id 2 page no 4 n bits 112 index PRIMARY of table `test`.`books` trx id 2102 lock_mode X locks rec but not gap
Record lock, heap no 30 PHYSICAL RECORD: n_fields 7; compact format; info bits 0
 0: len 4; hex 80000039; asc    9;;
 1: len 6; hex 000000000836; asc      6;;
 2: len 7; hex 820000008a0110; asc        ;;
 3: len 2; hex 3537; asc 57;;
 4: len 2; hex 3537; asc 57;;
 5: len 4; hex 00006442; asc   dB;;
 6: len 4; hex 80000039; asc    9;;

--------
FILE I/O
--------
I/O thread 0 state: waiting for completed aio requests (insert buffer thread)
I/O thread 1 state: waiting for completed aio requests (log thread)
I/O thread 2 state: waiting for completed aio requests (read thread)
I/O thread 3 state: waiting for completed aio requests (read thread)
I/O thread 4 state: waiting for completed aio requests (read thread)
I/O thread 5 state: waiting for completed aio requests (read thread)
I/O thread 6 state: waiting for completed aio requests (write thread)
I/O thread 7 state: waiting for completed aio requests (write thread)
I/O thread 8 state: waiting for completed aio requests (write thread)
I/O thread 9 state: waiting for completed aio requests (write thread)
Pending normal aio reads: [0, 0, 0, 0] , aio writes: [0, 0, 0, 0] ,
 ibuf aio reads:, log i/o's:, sync i/o's:
Pending flushes (fsync) log: 0; buffer pool: 0
994 OS file reads, 394 OS file writes, 175 OS fsyncs
104.47 reads/s, 16428 avg bytes/read, 90.23 writes/s, 40.74 fsyncs/s
-------------------------------------
INSERT BUFFER AND ADAPTIVE HASH INDEX
-------------------------------------
Ibuf: size 1, free list len 0, seg size 2, 0 merges
merged operations:
 insert 0, delete mark 0, delete 0
discarded operations:
 insert 0, delete mark 0, delete 0
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 0 buffer(s)
Hash table size 4441, node heap has 1 buffer(s)
306.92 hash searches/s, 841.54 non-hash searches/s
---
LOG
---
Log sequence number          28624569
Log buffer assigned up to    28624569
Log buffer completed up to   28624569
Log written up to            28624569
Log flushed up to            28624569
Added dirty pages up to      28624569
Pages flushed up to          28522435
Last checkpoint at           28522435
192 log i/o's done, 47.50 log i/o's/second
----------------------
BUFFER POOL AND MEMORY
----------------------
Total large memory allocated 17121280
Dictionary memory allocated 464665
Buffer pool size   1023
Free buffers       718
Database pages     304
Old database pages 0
Modified db pages  148
Pending reads      0
Pending writes: LRU 0, flush list 0, single page 0
Pages made young 2, not young 333
0.00 youngs/s, 0.00 non-youngs/s
Pages read 969, created 171, written 155
0.00 reads/s, 0.00 creates/s, 0.00 writes/s
Buffer pool hit rate 972 / 1000, young-making rate 0 / 1000 not 23 / 1000
Pages read ahead 0.00/s, evicted without access 0.00/s, Random read ahead 0.00/s
LRU len: 304, unzip_LRU len: 0
I/O sum[509]:cur[48], unzip sum[0]:cur[0]
--------------
ROW OPERATIONS
--------------
0 queries inside InnoDB, 0 queries in queue
0 read views open inside InnoDB
Process ID=1, Main thread ID=139905455810304 , state=sleeping
Number of rows inserted 42, updated 0, deleted 0, read 1
10.50 inserts/s, 0.00 updates/s, 0.00 deletes/s, 0.25 reads/s
Number of system rows inserted 81, updated 379, deleted 0, read 5230
20.24 inserts/s, 94.73 updates/s, 0.00 deletes/s, 1307.17 reads/s
----------------------------
END OF INNODB MONITOR OUTPUT
============================

```