### PR TITLE
[FLINK-23150][table-planner] Remove the old code split implementation

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -30,8 +30,6 @@ import org.apache.flink.table.types.logical.RowType
 
 import org.apache.calcite.rex._
 
-import scala.collection.JavaConversions._
-
 object CalcCodeGenerator {
 
   def generateCalcOperator(
@@ -55,8 +53,7 @@ object CalcCodeGenerator {
       projection,
       condition,
       eagerInputUnboxingCode = true,
-      retainHeader = retainHeader,
-      allowSplit = true)
+      retainHeader = retainHeader)
 
     val genOperator =
       OperatorCodeGenerator.generateOneInputStreamOperator[RowData, RowData](
@@ -115,8 +112,7 @@ object CalcCodeGenerator {
       collectorTerm: String = CodeGenUtils.DEFAULT_OPERATOR_COLLECTOR_TERM,
       eagerInputUnboxingCode: Boolean,
       retainHeader: Boolean = false,
-      outputDirectly: Boolean = false,
-      allowSplit: Boolean = false): String = {
+      outputDirectly: Boolean = false): String = {
 
     // according to the SQL standard, every table function should also be a scalar function
     // but we don't allow that for now
@@ -142,8 +138,7 @@ object CalcCodeGenerator {
       val projectionExpression = exprGenerator.generateResultExpression(
         projectionExprs,
         outRowType,
-        outRowClass,
-        allowSplit = allowSplit)
+        outRowClass)
 
       val projectionExpressionCode = projectionExpression.code
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.planner.codegen.agg.batch
 
-import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.table.data.binary.BinaryRowData
@@ -42,6 +41,8 @@ import org.apache.flink.table.runtime.typeutils.BinaryRowDataSerializer
 import org.apache.flink.table.runtime.util.KeyValueIterator
 import org.apache.flink.table.runtime.util.collections.binary.{BytesHashMap, BytesMap}
 import org.apache.flink.table.types.logical.{LogicalType, RowType}
+
+import org.apache.calcite.tools.RelBuilder
 
 import scala.collection.JavaConversions._
 
@@ -427,10 +428,7 @@ object HashAggCodeGenHelper {
       outRow = currentAggBufferTerm,
       outRowWriter = None,
       reusedOutRow = true,
-      outRowAlreadyExists = true,
-      allowSplit = false,
-      methodName = null
-    )
+      outRowAlreadyExists = true)
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

This is the final step of FLINK-23007. This parent issue aims to solve the issue in one shot, that some methods of the generated Java code may grow beyond 64KB and reaches the limit of JVM.

In this final step we clean up and remove the old code split implementation.

## Brief change log

 - Remove the old code split implementation

## Verifying this change

This change is already covered by existing tests, such as `CodeSplitITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
