### PR TITLE
[FLINK-21928][clients] JobManager failover should success, when tryin…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
@@ -271,7 +271,7 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
                     ExceptionUtils.findThrowable(t, DuplicateJobSubmissionException.class);
             if (enforceSingleJobExecution
                     && maybeDuplicate.isPresent()
-                    && maybeDuplicate.get().isTerminated()) {
+                    && maybeDuplicate.get().isGloballyTerminated()) {
                 final JobID jobId = maybeDuplicate.get().getJobID();
                 tolerateMissingResult.add(jobId);
                 jobIdsFuture.complete(Collections.singletonList(jobId));

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -670,8 +670,8 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         .setSubmitFunction(
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
-                                                new DuplicateJobSubmissionException(
-                                                        testJobID, true)))
+                                                DuplicateJobSubmissionException
+                                                        .ofGloballyTerminated(testJobID)))
                         .setRequestJobStatusFunction(
                                 jobId -> CompletableFuture.completedFuture(JobStatus.FINISHED))
                         .setRequestJobResultFunction(
@@ -702,8 +702,8 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         .setSubmitFunction(
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
-                                                new DuplicateJobSubmissionException(
-                                                        testJobID, true)))
+                                                DuplicateJobSubmissionException
+                                                        .ofGloballyTerminated(testJobID)))
                         .setRequestJobStatusFunction(
                                 jobId ->
                                         FutureUtils.completedExceptionally(
@@ -737,8 +737,8 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         .setSubmitFunction(
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
-                                                new DuplicateJobSubmissionException(
-                                                        testJobID, true)))
+                                                DuplicateJobSubmissionException
+                                                        .ofGloballyTerminated(testJobID)))
                         .setRequestJobStatusFunction(
                                 jobId ->
                                         FutureUtils.completedExceptionally(
@@ -765,8 +765,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                         .setSubmitFunction(
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
-                                                new DuplicateJobSubmissionException(
-                                                        testJobID, false)));
+                                                DuplicateJobSubmissionException.of(testJobID)));
         final CompletableFuture<Void> applicationFuture =
                 runApplication(dispatcherBuilder, configurationUnderTest, 1);
         final ExecutionException executionException =
@@ -777,7 +776,7 @@ public class ApplicationDispatcherBootstrapTest extends TestLogger {
                 ExceptionUtils.findThrowable(
                         executionException, DuplicateJobSubmissionException.class);
         assertTrue(maybeDuplicate.isPresent());
-        assertFalse(maybeDuplicate.get().isTerminated());
+        assertFalse(maybeDuplicate.get().isGloballyTerminated());
     }
 
     private CompletableFuture<Void> runApplication(

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -72,7 +72,7 @@ public class FutureUtils {
 
     /**
      * Fakes asynchronous execution by immediately executing the operation and completing the
-     * supplied future either noramlly or exceptionally.
+     * supplied future either normally or exceptionally.
      *
      * @param operation to executed
      * @param <T> type of the result
@@ -1274,9 +1274,9 @@ public class FutureUtils {
      * @return completable future, that can recover from a specified exception
      */
     public static <T, E extends Throwable> CompletableFuture<T> handleException(
-            CompletableFuture<T> completableFuture,
+            CompletableFuture<? extends T> completableFuture,
             Class<E> exceptionClass,
-            Function<E, T> exceptionHandler) {
+            Function<? super E, ? extends T> exceptionHandler) {
         final CompletableFuture<T> handledFuture = new CompletableFuture<>();
         checkNotNull(completableFuture)
                 .whenComplete(
@@ -1284,8 +1284,7 @@ public class FutureUtils {
                             if (throwable == null) {
                                 handledFuture.complete(result);
                             } else if (exceptionClass.isAssignableFrom(throwable.getClass())) {
-                                @SuppressWarnings("unchecked")
-                                final E exception = (E) throwable;
+                                final E exception = exceptionClass.cast(throwable);
                                 try {
                                     handledFuture.complete(exceptionHandler.apply(exception));
                                 } catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/DuplicateJobSubmissionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/DuplicateJobSubmissionException.java
@@ -25,11 +25,19 @@ import org.apache.flink.api.common.JobID;
  */
 public class DuplicateJobSubmissionException extends JobSubmissionException {
 
-    private final boolean terminated;
+    public static DuplicateJobSubmissionException of(JobID jobId) {
+        return new DuplicateJobSubmissionException(jobId, false);
+    }
 
-    public DuplicateJobSubmissionException(JobID jobID, boolean terminated) {
+    public static DuplicateJobSubmissionException ofGloballyTerminated(JobID jobId) {
+        return new DuplicateJobSubmissionException(jobId, true);
+    }
+
+    private final boolean globallyTerminated;
+
+    private DuplicateJobSubmissionException(JobID jobID, boolean globallyTerminated) {
         super(jobID, "Job has already been submitted.");
-        this.terminated = terminated;
+        this.globallyTerminated = globallyTerminated;
     }
 
     /**
@@ -37,7 +45,7 @@ public class DuplicateJobSubmissionException extends JobSubmissionException {
      *
      * @return true if the job has already finished, either successfully or as a failure
      */
-    public boolean isTerminated() {
-        return terminated;
+    public boolean isGloballyTerminated() {
+        return globallyTerminated;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/DuplicateJobSubmissionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/DuplicateJobSubmissionException.java
@@ -25,7 +25,19 @@ import org.apache.flink.api.common.JobID;
  */
 public class DuplicateJobSubmissionException extends JobSubmissionException {
 
-    public DuplicateJobSubmissionException(JobID jobID) {
+    private final boolean terminated;
+
+    public DuplicateJobSubmissionException(JobID jobID, boolean terminated) {
         super(jobID, "Job has already been submitted.");
+        this.terminated = terminated;
+    }
+
+    /**
+     * Checks whether the duplicate job has already been finished.
+     *
+     * @return true if the job has already finished, either successfully or as a failure
+     */
+    public boolean isTerminated() {
+        return terminated;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -68,6 +68,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -822,6 +823,63 @@ public class FutureUtilsTest extends TestLogger {
 
         Assert.assertFalse(runWithExecutor.get());
         Assert.assertTrue(continuationFuture.isDone());
+    }
+
+    @Test
+    public void testHandleExceptionWithCompletedFuture() {
+        final CompletableFuture<String> future = CompletableFuture.completedFuture("foobar");
+        final CompletableFuture<String> handled =
+                FutureUtils.handleException(future, Exception.class, exception -> "handled");
+        assertEquals("foobar", handled.join());
+    }
+
+    @Test
+    public void testHandleExceptionWithNormalCompletion() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        final CompletableFuture<String> handled =
+                FutureUtils.handleException(future, Exception.class, exception -> "handled");
+        future.complete("foobar");
+        assertEquals("foobar", handled.join());
+    }
+
+    @Test
+    public void testHandleExceptionWithMatchingExceptionallyCompletedFuture() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        final CompletableFuture<String> handled =
+                FutureUtils.handleException(
+                        future, UnsupportedOperationException.class, exception -> "handled");
+        future.completeExceptionally(new UnsupportedOperationException("foobar"));
+        assertEquals("handled", handled.join());
+    }
+
+    @Test
+    public void testHandleExceptionWithNotMatchingExceptionallyCompletedFuture() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        final CompletableFuture<String> handled =
+                FutureUtils.handleException(
+                        future, UnsupportedOperationException.class, exception -> "handled");
+        future.completeExceptionally(new IllegalArgumentException("foobar"));
+        final CompletionException completionException =
+                assertThrows(CompletionException.class, handled::join);
+        assertTrue(completionException.getCause() instanceof IllegalArgumentException);
+        assertEquals("foobar", completionException.getCause().getMessage());
+    }
+
+    @Test
+    public void testHandleExceptionWithThrowingExceptionHandler() {
+        final CompletableFuture<String> future = new CompletableFuture<>();
+        final CompletableFuture<String> handled =
+                FutureUtils.handleException(
+                        future,
+                        UnsupportedOperationException.class,
+                        exception -> {
+                            throw new IllegalStateException("something went terribly wrong");
+                        });
+        future.completeExceptionally(new UnsupportedOperationException("foobar"));
+        final CompletionException completionException =
+                assertThrows(CompletionException.class, handled::join);
+        assertTrue(completionException.getCause() instanceof IllegalStateException);
+        assertEquals("something went terribly wrong", completionException.getCause().getMessage());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -858,28 +858,29 @@ public class FutureUtilsTest extends TestLogger {
         final CompletableFuture<String> handled =
                 FutureUtils.handleException(
                         future, UnsupportedOperationException.class, exception -> "handled");
-        future.completeExceptionally(new IllegalArgumentException("foobar"));
+        final IllegalArgumentException futureException = new IllegalArgumentException("foobar");
+        future.completeExceptionally(futureException);
         final CompletionException completionException =
                 assertThrows(CompletionException.class, handled::join);
-        assertTrue(completionException.getCause() instanceof IllegalArgumentException);
-        assertEquals("foobar", completionException.getCause().getMessage());
+        assertEquals(futureException, completionException.getCause());
     }
 
     @Test
     public void testHandleExceptionWithThrowingExceptionHandler() {
         final CompletableFuture<String> future = new CompletableFuture<>();
+        final IllegalStateException handlerException =
+                new IllegalStateException("something went terribly wrong");
         final CompletableFuture<String> handled =
                 FutureUtils.handleException(
                         future,
                         UnsupportedOperationException.class,
                         exception -> {
-                            throw new IllegalStateException("something went terribly wrong");
+                            throw handlerException;
                         });
         future.completeExceptionally(new UnsupportedOperationException("foobar"));
         final CompletionException completionException =
                 assertThrows(CompletionException.class, handled::join);
-        assertTrue(completionException.getCause() instanceof IllegalStateException);
-        assertEquals("something went terribly wrong", completionException.getCause().getMessage());
+        assertEquals(handlerException, completionException.getCause());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -285,7 +285,7 @@ public class DispatcherTest extends TestLogger {
         assertTrue(executionException.getCause() instanceof DuplicateJobSubmissionException);
         final DuplicateJobSubmissionException duplicateException =
                 (DuplicateJobSubmissionException) executionException.getCause();
-        assertTrue(duplicateException.isTerminated());
+        assertTrue(duplicateException.isGloballyTerminated());
     }
 
     @Test
@@ -307,7 +307,7 @@ public class DispatcherTest extends TestLogger {
         assertTrue(executionException.getCause() instanceof DuplicateJobSubmissionException);
         final DuplicateJobSubmissionException duplicateException =
                 (DuplicateJobSubmissionException) executionException.getCause();
-        assertFalse(duplicateException.isTerminated());
+        assertFalse(duplicateException.isGloballyTerminated());
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -571,7 +571,7 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
                                                 new DuplicateJobSubmissionException(
-                                                        jobGraph.getJobID())))
+                                                        jobGraph.getJobID(), false)))
                         .build();
 
         runOnAddedJobGraphTest(dispatcherGateway, this::verifyOnAddedJobGraphResultDidNotFail);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -570,8 +570,8 @@ public class SessionDispatcherLeaderProcessTest extends TestLogger {
                         .setSubmitFunction(
                                 jobGraph ->
                                         FutureUtils.completedExceptionally(
-                                                new DuplicateJobSubmissionException(
-                                                        jobGraph.getJobID(), false)))
+                                                DuplicateJobSubmissionException.of(
+                                                        jobGraph.getJobID())))
                         .build();
 
         runOnAddedJobGraphTest(dispatcherGateway, this::verifyOnAddedJobGraphResultDidNotFail);


### PR DESCRIPTION
## What is the purpose of the change

* https://issues.apache.org/jira/browse/FLINK-21928
* Success in case of DuplicateJobSubmission in application mode for already terminated job.

## Brief change log

- *DuplicateJobSubmissionException* knows whether duplicate is terminated or running
- Application mode treats DuplicateJobSubmissionException as sucess in HA mode, if duplicate is already terminated 

## Verifying this change

Added new tests for Dispatcher and ApplicationDispatcherBootstrap.

## Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
