### PR TITLE
[FLINK-22910][runtime] Refine ShuffleMaster lifecycle management for pluggable shuffle service framework

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobMasterServiceLeadershipRunnerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobMasterServiceLeadershipRunnerFactory.java
@@ -38,8 +38,6 @@ import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFact
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.shuffle.ShuffleMaster;
-import org.apache.flink.runtime.shuffle.ShuffleServiceLoader;
 import org.apache.flink.util.Preconditions;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -83,10 +81,6 @@ public enum JobMasterServiceLeadershipRunnerFactory implements JobManagerRunnerF
                     "Adaptive Scheduler is required for reactive mode");
         }
 
-        final ShuffleMaster<?> shuffleMaster =
-                ShuffleServiceLoader.loadShuffleServiceFactory(configuration)
-                        .createShuffleMaster(configuration);
-
         final LibraryCacheManager.ClassLoaderLease classLoaderLease =
                 jobManagerServices
                         .getLibraryCacheManager()
@@ -111,7 +105,6 @@ public enum JobMasterServiceLeadershipRunnerFactory implements JobManagerRunnerF
                         jobManagerJobMetricGroupFactory,
                         fatalErrorHandler,
                         userCodeClassLoader,
-                        shuffleMaster,
                         initializationTimestamp);
 
         final DefaultJobMasterServiceProcessFactory jobMasterServiceProcessFactory =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -460,7 +460,8 @@ public class Execution
             CompletableFuture<? extends ShuffleDescriptor> shuffleDescriptorFuture =
                     vertex.getExecutionGraphAccessor()
                             .getShuffleMaster()
-                            .registerPartitionWithProducer(partitionDescriptor, producerDescriptor);
+                            .registerPartitionWithProducer(
+                                    vertex.getJobId(), partitionDescriptor, producerDescriptor);
 
             CompletableFuture<ResultPartitionDeploymentDescriptor> partitionRegistration =
                     shuffleDescriptorFuture.thenApply(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
@@ -36,6 +35,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFac
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
 import org.apache.flink.runtime.util.Hardware;
@@ -55,8 +55,8 @@ public class NettyShuffleServiceFactory
     private static final String DIR_NAME_PREFIX = "netty-shuffle";
 
     @Override
-    public NettyShuffleMaster createShuffleMaster(Configuration configuration) {
-        return new NettyShuffleMaster(configuration);
+    public NettyShuffleMaster createShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
+        return new NettyShuffleMaster(shuffleMasterContext.getConfiguration());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTracker.java
@@ -39,7 +39,18 @@ public interface JobMasterPartitionTracker
             ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor);
 
     /** Releases the given partitions and stop the tracking of partitions that were released. */
-    void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds);
+    default void stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> resultPartitionIds) {
+        stopTrackingAndReleasePartitions(resultPartitionIds, true);
+    }
+
+    /**
+     * Releases the given partitions and stop the tracking of partitions that were released. The
+     * boolean flag indicates whether we need to notify the ShuffleMaster to release all external
+     * resources or not.
+     */
+    void stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> resultPartitionIds, boolean releaseOnShuffleMaster);
 
     /**
      * Releases the job partitions and promotes the cluster partitions, and stops the tracking of

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImpl.java
@@ -99,10 +99,12 @@ public class JobMasterPartitionTrackerImpl
     }
 
     @Override
-    public void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds) {
+    public void stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> resultPartitionIds, boolean releaseOnShuffleMaster) {
         stopTrackingAndHandlePartitions(
                 resultPartitionIds,
-                (tmID, partitionDescs) -> internalReleasePartitions(tmID, partitionDescs));
+                (tmID, partitionDescs) ->
+                        internalReleasePartitions(tmID, partitionDescs, releaseOnShuffleMaster));
     }
 
     @Override
@@ -138,11 +140,14 @@ public class JobMasterPartitionTrackerImpl
 
     private void internalReleasePartitions(
             ResourceID potentialPartitionLocation,
-            Collection<ResultPartitionDeploymentDescriptor> partitionDeploymentDescriptors) {
+            Collection<ResultPartitionDeploymentDescriptor> partitionDeploymentDescriptors,
+            boolean releaseOnShuffleMaster) {
 
         internalReleasePartitionsOnTaskExecutor(
                 potentialPartitionLocation, partitionDeploymentDescriptors);
-        internalReleasePartitionsOnShuffleMaster(partitionDeploymentDescriptors.stream());
+        if (releaseOnShuffleMaster) {
+            internalReleasePartitionsOnShuffleMaster(partitionDeploymentDescriptors.stream());
+        }
     }
 
     private void internalReleaseOrPromotePartitions(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
+import org.apache.flink.runtime.shuffle.ShuffleMasterContextImpl;
 import org.apache.flink.runtime.shuffle.ShuffleServiceLoader;
 import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.util.ExceptionUtils;
@@ -144,8 +146,11 @@ public class JobManagerSharedServices {
                         Hardware.getNumberCPUCores(),
                         new ExecutorThreadFactory("jobmanager-future"));
 
+        final ShuffleMasterContext shuffleMasterContext =
+                new ShuffleMasterContextImpl(config, fatalErrorHandler);
         final ShuffleMaster<?> shuffleMaster =
-                ShuffleServiceLoader.loadShuffleServiceFactory(config).createShuffleMaster(config);
+                ShuffleServiceLoader.loadShuffleServiceFactory(config)
+                        .createShuffleMaster(shuffleMasterContext);
 
         return new JobManagerSharedServices(
                 futureExecutor, libraryCacheManager, shuffleMaster, blobServer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
@@ -102,6 +102,12 @@ public class JobManagerSharedServices {
             firstException = t;
         }
 
+        try {
+            shuffleMaster.close();
+        } catch (Throwable t) {
+            firstException = firstException == null ? t : firstException;
+        }
+
         libraryCacheManager.shutdown();
 
         if (firstException != null) {
@@ -151,6 +157,7 @@ public class JobManagerSharedServices {
         final ShuffleMaster<?> shuffleMaster =
                 ShuffleServiceLoader.loadShuffleServiceFactory(config)
                         .createShuffleMaster(shuffleMasterContext);
+        shuffleMaster.start();
 
         return new JobManagerSharedServices(
                 futureExecutor, libraryCacheManager, shuffleMaster, blobServer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -291,4 +291,12 @@ public interface JobMasterGateway
             OperatorID operatorId,
             SerializedValue<CoordinationRequest> serializedRequest,
             @RpcTimeout Time timeout);
+
+    /**
+     * Notifies the {@link org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker}
+     * to stop tracking the target result partitions and release the locally occupied resources on
+     * {@link org.apache.flink.runtime.taskexecutor.TaskExecutor}s if any.
+     */
+    CompletableFuture<?> stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> partitionIds);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -69,7 +69,6 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
             JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
             FatalErrorHandler fatalErrorHandler,
             ClassLoader userCodeClassloader,
-            ShuffleMaster<?> shuffleMaster,
             long initializationTimestamp) {
         this.executor = executor;
         this.rpcService = rpcService;
@@ -82,7 +81,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
         this.jobManagerJobMetricGroupFactory = jobManagerJobMetricGroupFactory;
         this.fatalErrorHandler = fatalErrorHandler;
         this.userCodeClassloader = userCodeClassloader;
-        this.shuffleMaster = shuffleMaster;
+        this.shuffleMaster = jobManagerSharedServices.getShuffleMaster();
         this.initializationTimestamp = initializationTimestamp;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/JobShuffleContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/JobShuffleContext.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Job level shuffle context which can offer some job information like job ID and through it, the
+ * shuffle plugin notify the job to stop tracking the lost result partitions.
+ */
+public interface JobShuffleContext {
+
+    /** @return the corresponding {@link JobID}. */
+    JobID getJobId();
+
+    /**
+     * Notifies the job to stop tracking and release the target result partitions, which means these
+     * partitions will be removed and will be reproduced if used afterwards.
+     */
+    CompletableFuture<?> stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> partitionIds);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/JobShuffleContextImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/JobShuffleContextImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The default implementation of {@link JobShuffleContext}. */
+public class JobShuffleContextImpl implements JobShuffleContext {
+
+    private final JobID jobId;
+
+    private final JobMasterGateway jobMasterGateway;
+
+    public JobShuffleContextImpl(JobID jobId, JobMasterGateway jobMasterGateway) {
+        this.jobId = checkNotNull(jobId);
+        this.jobMasterGateway = checkNotNull(jobMasterGateway);
+    }
+
+    @Override
+    public JobID getJobId() {
+        return jobId;
+    }
+
+    @Override
+    public CompletableFuture<?> stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> partitionIds) {
+        return jobMasterGateway.stopTrackingAndReleasePartitions(partitionIds);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
@@ -60,7 +61,9 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
 
     @Override
     public CompletableFuture<NettyShuffleDescriptor> registerPartitionWithProducer(
-            PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+            JobID jobID,
+            PartitionDescriptor partitionDescriptor,
+            ProducerDescriptor producerDescriptor) {
 
         ResultPartitionID resultPartitionID =
                 new ResultPartitionID(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.MemorySize;
 
 import java.util.Collection;
@@ -39,6 +40,7 @@ public interface ShuffleMaster<T extends ShuffleDescriptor> {
      * internally within the shuffle service. The descriptor should provide enough information to
      * read from or write data to the partition.
      *
+     * @param jobID job ID of the corresponding job which registered the partition
      * @param partitionDescriptor general job graph information about the partition
      * @param producerDescriptor general producer information (location, execution id, connection
      *     info)
@@ -46,7 +48,9 @@ public interface ShuffleMaster<T extends ShuffleDescriptor> {
      *     and their data exchange.
      */
     CompletableFuture<T> registerPartitionWithProducer(
-            PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor);
+            JobID jobID,
+            PartitionDescriptor partitionDescriptor,
+            ProducerDescriptor producerDescriptor);
 
     /**
      * Release any external resources occupied by the given partition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMaster.java
@@ -31,7 +31,39 @@ import java.util.concurrent.CompletableFuture;
  * @param <T> partition shuffle descriptor used for producer/consumer deployment and their data
  *     exchange.
  */
-public interface ShuffleMaster<T extends ShuffleDescriptor> {
+public interface ShuffleMaster<T extends ShuffleDescriptor> extends AutoCloseable {
+
+    /**
+     * Starts this shuffle master as a service. One can do some initialization here, for example
+     * getting access and connecting to the external system.
+     */
+    default void start() throws Exception {}
+
+    /**
+     * Closes this shuffle master service which should release all resources. A shuffle master will
+     * only be closed when the cluster is shut down.
+     */
+    @Override
+    default void close() throws Exception {}
+
+    /**
+     * Registers the target job together with the corresponding {@link JobShuffleContext} to this
+     * shuffle master. Through the shuffle context, one can obtain some basic information like job
+     * ID, job configuration. It enables ShuffleMaster to notify JobMaster about lost result
+     * partitions, so that JobMaster can identify and reproduce unavailable partitions earlier.
+     *
+     * @param context the corresponding shuffle context of the target job.
+     */
+    default void registerJob(JobShuffleContext context) {}
+
+    /**
+     * Unregisters the target job from this shuffle master, which means the corresponding job has
+     * reached a global termination state and all the allocated resources except for the cluster
+     * partitions can be cleared.
+     *
+     * @param jobID ID of the target job to be unregistered.
+     */
+    default void unregisterJob(JobID jobID) {}
 
     /**
      * Asynchronously register a partition and its producer with the shuffle service.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContext.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Shuffle context used to create {@link ShuffleMaster}. It can work as a proxy to other cluster
+ * components and hide these components from users. For example, the customized shuffle master can
+ * access the cluster fatal error handler through this context and in the future, more components
+ * like the resource manager partition tracker will be accessible.
+ */
+public interface ShuffleMasterContext {
+
+    /** @return the cluster configuration. */
+    Configuration getConfiguration();
+
+    /** Handles the fatal error if any. */
+    void onFatalError(Throwable throwable);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContextImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleMasterContextImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The default implementation of {@link ShuffleMasterContext}. */
+public class ShuffleMasterContextImpl implements ShuffleMasterContext {
+
+    private final Configuration configuration;
+
+    private final FatalErrorHandler fatalErrorHandler;
+
+    public ShuffleMasterContextImpl(
+            Configuration configuration, FatalErrorHandler fatalErrorHandler) {
+        this.configuration = checkNotNull(configuration);
+        this.fatalErrorHandler = checkNotNull(fatalErrorHandler);
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void onFatalError(Throwable throwable) {
+        fatalErrorHandler.onFatalError(throwable);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.shuffle;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 
@@ -39,10 +38,10 @@ public interface ShuffleServiceFactory<
     /**
      * Factory method to create a specific {@link ShuffleMaster} implementation.
      *
-     * @param configuration Flink configuration
+     * @param shuffleMasterContext shuffle context for shuffle master.
      * @return shuffle manager implementation
      */
-    ShuffleMaster<SD> createShuffleMaster(Configuration configuration);
+    ShuffleMaster<SD> createShuffleMaster(ShuffleMasterContext shuffleMasterContext);
 
     /**
      * Factory method to create a specific local {@link ShuffleEnvironment} implementation.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionPartitionLifecycleTest.java
@@ -322,7 +322,9 @@ public class ExecutionPartitionLifecycleTest extends TestLogger {
 
         @Override
         public CompletableFuture<ShuffleDescriptor> registerPartitionWithProducer(
-                PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+                JobID jobID,
+                PartitionDescriptor partitionDescriptor,
+                ProducerDescriptor producerDescriptor) {
             return CompletableFuture.completedFuture(
                     new TestingShuffleDescriptor(
                             partitionDescriptor.getPartitionId(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/JobMasterPartitionTrackerImplTest.java
@@ -317,7 +317,9 @@ public class JobMasterPartitionTrackerImplTest extends TestLogger {
 
         @Override
         public CompletableFuture<ShuffleDescriptor> registerPartitionWithProducer(
-                PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+                JobID jobID,
+                PartitionDescriptor partitionDescriptor,
+                ProducerDescriptor producerDescriptor) {
             return null;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpJobMasterPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpJobMasterPartitionTracker.java
@@ -42,7 +42,7 @@ public enum NoOpJobMasterPartitionTracker implements JobMasterPartitionTracker {
 
     @Override
     public void stopTrackingAndReleasePartitions(
-            Collection<ResultPartitionID> resultPartitionIds) {}
+            Collection<ResultPartitionID> resultPartitionIds, boolean releaseOnShuffleMaster) {}
 
     @Override
     public void stopTrackingAndReleaseOrPromotePartitions(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingJobMasterPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TestingJobMasterPartitionTracker.java
@@ -103,7 +103,8 @@ public class TestingJobMasterPartitionTracker implements JobMasterPartitionTrack
     }
 
     @Override
-    public void stopTrackingAndReleasePartitions(Collection<ResultPartitionID> resultPartitionIds) {
+    public void stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> resultPartitionIds, boolean releaseOnShuffleMaster) {
         stopTrackingAndReleasePartitionsConsumer.accept(resultPartitionIds);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerSharedServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerSharedServicesBuilder.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blob.VoidBlobWriter;
 import org.apache.flink.runtime.execution.librarycache.ContextClassLoaderLibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.runtime.shuffle.ShuffleTestUtils;
 import org.apache.flink.runtime.testutils.TestingUtils;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -33,17 +35,25 @@ public class TestingJobManagerSharedServicesBuilder {
 
     private LibraryCacheManager libraryCacheManager;
 
+    private ShuffleMaster<?> shuffleMaster;
+
     private BlobWriter blobWriter;
 
     public TestingJobManagerSharedServicesBuilder() {
         scheduledExecutorService = TestingUtils.defaultExecutor();
         libraryCacheManager = ContextClassLoaderLibraryCacheManager.INSTANCE;
+        shuffleMaster = ShuffleTestUtils.DEFAULT_SHUFFLE_MASTER;
         blobWriter = VoidBlobWriter.getInstance();
     }
 
     public TestingJobManagerSharedServicesBuilder setScheduledExecutorService(
             ScheduledExecutorService scheduledExecutorService) {
         this.scheduledExecutorService = scheduledExecutorService;
+        return this;
+    }
+
+    public TestingJobManagerSharedServicesBuilder setShuffleMaster(ShuffleMaster<?> shuffleMaster) {
+        this.shuffleMaster = shuffleMaster;
         return this;
     }
 
@@ -59,6 +69,6 @@ public class TestingJobManagerSharedServicesBuilder {
 
     public JobManagerSharedServices build() {
         return new JobManagerSharedServices(
-                scheduledExecutorService, libraryCacheManager, blobWriter);
+                scheduledExecutorService, libraryCacheManager, shuffleMaster, blobWriter);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -517,4 +517,10 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             Time timeout) {
         return deliverCoordinationRequestFunction.apply(operatorId, serializedRequest);
     }
+
+    @Override
+    public CompletableFuture<?> stopTrackingAndReleasePartitions(
+            Collection<ResultPartitionID> partitionIds) {
+        return CompletableFuture.completedFuture(null);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -130,7 +131,9 @@ public class SsgNetworkMemoryCalculationUtilsTest {
     private static class TestShuffleMaster implements ShuffleMaster<ShuffleDescriptor> {
         @Override
         public CompletableFuture<ShuffleDescriptor> registerPartitionWithProducer(
-                PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+                JobID jobID,
+                PartitionDescriptor partitionDescriptor,
+                ProducerDescriptor producerDescriptor) {
             return null;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleMasterTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.shuffle;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.io.network.NettyShuffleServiceFactory;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.flink.api.common.restartstrategy.RestartStrategies.fixedDelayRestart;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link ShuffleMaster}. */
+public class ShuffleMasterTest extends TestLogger {
+
+    private static final String STOP_TRACKING_PARTITION_KEY = "stop_tracking_partition_key";
+
+    private static final String PARTITION_REGISTRATION_EVENT = "registerPartitionWithProducer";
+
+    private static final String EXTERNAL_PARTITION_RELEASE_EVENT = "releasePartitionExternally";
+
+    @Before
+    public void before() {
+        TestShuffleMaster.partitionEvents.clear();
+    }
+
+    @Test
+    public void testShuffleMasterLifeCycle() throws Exception {
+        try (MiniCluster cluster = new MiniCluster(createClusterConfiguration(false))) {
+            cluster.start();
+            cluster.executeJobBlocking(createJobGraph());
+        }
+        assertTrue(TestShuffleMaster.currentInstance.get().closed.get());
+
+        String[] expectedPartitionEvents =
+                new String[] {
+                    PARTITION_REGISTRATION_EVENT,
+                    PARTITION_REGISTRATION_EVENT,
+                    EXTERNAL_PARTITION_RELEASE_EVENT,
+                    EXTERNAL_PARTITION_RELEASE_EVENT,
+                };
+        assertArrayEquals(expectedPartitionEvents, TestShuffleMaster.partitionEvents.toArray());
+    }
+
+    @Test
+    public void testStopTrackingPartition() throws Exception {
+        try (MiniCluster cluster = new MiniCluster(createClusterConfiguration(true))) {
+            cluster.start();
+            cluster.executeJobBlocking(createJobGraph());
+        }
+        assertTrue(TestShuffleMaster.currentInstance.get().closed.get());
+
+        String[] expectedPartitionEvents =
+                new String[] {
+                    PARTITION_REGISTRATION_EVENT,
+                    PARTITION_REGISTRATION_EVENT,
+                    PARTITION_REGISTRATION_EVENT,
+                    PARTITION_REGISTRATION_EVENT,
+                    EXTERNAL_PARTITION_RELEASE_EVENT,
+                    EXTERNAL_PARTITION_RELEASE_EVENT,
+                };
+        assertArrayEquals(expectedPartitionEvents, TestShuffleMaster.partitionEvents.toArray());
+    }
+
+    private MiniClusterConfiguration createClusterConfiguration(boolean stopTrackingPartition) {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ShuffleServiceOptions.SHUFFLE_SERVICE_FACTORY_CLASS,
+                TestShuffleServiceFactory.class.getName());
+        configuration.setString(RestOptions.BIND_PORT, "0");
+        configuration.setBoolean(STOP_TRACKING_PARTITION_KEY, stopTrackingPartition);
+        return new MiniClusterConfiguration.Builder()
+                .setNumTaskManagers(1)
+                .setNumSlotsPerTaskManager(1)
+                .setConfiguration(configuration)
+                .build();
+    }
+
+    private JobGraph createJobGraph() throws Exception {
+        JobVertex source = new JobVertex("source");
+        source.setParallelism(2);
+        source.setInvokableClass(NoOpInvokable.class);
+
+        JobVertex sink = new JobVertex("sink");
+        sink.setParallelism(2);
+        sink.setInvokableClass(NoOpInvokable.class);
+
+        sink.connectNewDataSetAsInput(
+                source, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        JobGraph jobGraph = JobGraphTestUtils.batchJobGraph(source, sink);
+        ExecutionConfig config = new ExecutionConfig();
+        config.setRestartStrategy(fixedDelayRestart(2, Time.seconds(2)));
+        jobGraph.setExecutionConfig(config);
+        return jobGraph;
+    }
+
+    /** An {@link TestShuffleServiceFactory} implementation for testing. */
+    public static class TestShuffleServiceFactory extends NettyShuffleServiceFactory {
+        @Override
+        public NettyShuffleMaster createShuffleMaster(ShuffleMasterContext shuffleMasterContext) {
+            return new TestShuffleMaster(shuffleMasterContext.getConfiguration());
+        }
+    }
+
+    /** An {@link ShuffleMaster} implementation for testing. */
+    private static class TestShuffleMaster extends NettyShuffleMaster {
+
+        private static final AtomicReference<TestShuffleMaster> currentInstance =
+                new AtomicReference<>();
+
+        private static final BlockingQueue<String> partitionEvents = new LinkedBlockingQueue<>();
+
+        private final AtomicBoolean started = new AtomicBoolean();
+
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private final BlockingQueue<ResultPartitionID> partitions = new LinkedBlockingQueue<>();
+
+        private final AtomicReference<JobShuffleContext> jobContext = new AtomicReference<>();
+
+        private final boolean stopTrackingPartition;
+
+        public TestShuffleMaster(Configuration conf) {
+            super(conf);
+            this.stopTrackingPartition = conf.getBoolean(STOP_TRACKING_PARTITION_KEY, false);
+            currentInstance.set(this);
+        }
+
+        @Override
+        public void start() throws Exception {
+            assertFalse(started.get());
+            assertFalse(closed.get());
+            started.set(true);
+            super.start();
+        }
+
+        @Override
+        public void close() throws Exception {
+            assertShuffleMasterAlive();
+            closed.set(true);
+            super.close();
+        }
+
+        @Override
+        public void registerJob(JobShuffleContext context) {
+            assertShuffleMasterAlive();
+            assertTrue(jobContext.compareAndSet(null, context));
+            super.registerJob(context);
+        }
+
+        @Override
+        public void unregisterJob(JobID jobID) {
+            assertJobRegistered();
+            jobContext.set(null);
+            super.unregisterJob(jobID);
+        }
+
+        @Override
+        public CompletableFuture<NettyShuffleDescriptor> registerPartitionWithProducer(
+                JobID jobID,
+                PartitionDescriptor partitionDescriptor,
+                ProducerDescriptor producerDescriptor) {
+            assertJobRegistered();
+            partitionEvents.add(PARTITION_REGISTRATION_EVENT);
+
+            CompletableFuture<NettyShuffleDescriptor> future = new CompletableFuture<>();
+            try {
+                NettyShuffleDescriptor shuffleDescriptor =
+                        super.registerPartitionWithProducer(
+                                        jobID, partitionDescriptor, producerDescriptor)
+                                .get();
+                // stop tracking the first registered partition when registering the second
+                // partition and trigger the failure of the second task, it is expected that
+                // the first partition will be reproduced
+                if (partitions.size() == 1 && stopTrackingPartition) {
+                    jobContext
+                            .get()
+                            .stopTrackingAndReleasePartitions(
+                                    Collections.singletonList(partitions.peek()))
+                            .thenRun(() -> future.completeExceptionally(new Exception("Test")));
+                } else {
+                    future.complete(shuffleDescriptor);
+                }
+                partitions.add(shuffleDescriptor.getResultPartitionID());
+            } catch (Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+            return future;
+        }
+
+        @Override
+        public void releasePartitionExternally(ShuffleDescriptor shuffleDescriptor) {
+            assertJobRegistered();
+            partitionEvents.add(EXTERNAL_PARTITION_RELEASE_EVENT);
+
+            super.releasePartitionExternally(shuffleDescriptor);
+        }
+
+        private void assertShuffleMasterAlive() {
+            assertFalse(closed.get());
+            assertTrue(started.get());
+        }
+
+        private void assertJobRegistered() {
+            assertShuffleMasterAlive();
+            assertNotNull(jobContext.get());
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
@@ -76,7 +76,8 @@ public class ShuffleServiceLoaderTest extends TestLogger {
             implements ShuffleServiceFactory<
                     ShuffleDescriptor, ResultPartitionWriter, IndexedInputGate> {
         @Override
-        public ShuffleMaster<ShuffleDescriptor> createShuffleMaster(Configuration configuration) {
+        public ShuffleMaster<ShuffleDescriptor> createShuffleMaster(
+                ShuffleMasterContext shuffleMasterContext) {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/TestingShuffleMaster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/TestingShuffleMaster.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.shuffle;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -48,7 +49,9 @@ public class TestingShuffleMaster implements ShuffleMaster<ShuffleDescriptor> {
 
     @Override
     public CompletableFuture<ShuffleDescriptor> registerPartitionWithProducer(
-            PartitionDescriptor partitionDescriptor, ProducerDescriptor producerDescriptor) {
+            JobID jobID,
+            PartitionDescriptor partitionDescriptor,
+            ProducerDescriptor producerDescriptor) {
         if (throwExceptionalOnRegistration) {
             throw new RuntimeException("Forced partition registration failure");
         } else if (autoCompleteRegistration) {


### PR DESCRIPTION
## What is the purpose of the change

This PR refines ShuffleMaster lifecycle management for pluggable shuffle service framework which includes:
1. [FLINK-23214][runtime] Make ShuffleMaster a cluster level shared service;
2. [FLINK-22674][runtime] Provide JobID when applying for shuffle resources by ShuffleMaster#registerPartitionWithProducer;
3. [FLINK-23249][runtime] Introduce ShuffleMasterContext to ShuffleMaster;
4. [FLINK-22910][runtime] Add lifecycle methods to ShuffleMaster including open, close, registerJob and unregisterJob.


## Brief change log

  - Make ShuffleMaster a cluster level shared service;
  - Provide JobID when applying for shuffle resources by ShuffleMaster#registerPartitionWithProducer;
  - Introduce ShuffleMasterContext to ShuffleMaster;
  - Add lifecycle methods to ShuffleMaster including open, close, registerJob and unregisterJob.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
