### PR TITLE
[FLINK-23356][hbase] Do not use delegation token in case of keytab

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -92,11 +92,13 @@ public class HadoopModule implements SecurityModule {
                     // and does not fallback to using Kerberos tickets
                     Credentials credentialsToBeAdded = new Credentials();
                     final Text hdfsDelegationTokenKind = new Text("HDFS_DELEGATION_TOKEN");
+                    final Text hbaseDelegationTokenKind = new Text("HBASE_AUTH_TOKEN");
                     Collection<Token<? extends TokenIdentifier>> usrTok =
                             credentialsFromTokenStorageFile.getAllTokens();
-                    // If UGI use keytab for login, do not load HDFS delegation token.
+                    // If UGI use keytab for login, do not load HDFS/HBase delegation token.
                     for (Token<? extends TokenIdentifier> token : usrTok) {
-                        if (!token.getKind().equals(hdfsDelegationTokenKind)) {
+                        if (!token.getKind().equals(hdfsDelegationTokenKind)
+                                && !token.getKind().equals(hbaseDelegationTokenKind)) {
                             credentialsToBeAdded.addToken(token.getService(), token);
                         }
                     }


### PR DESCRIPTION
## What is the purpose of the change

HBase delegation token expired after 7 days because Flink never re-obtains delegation tokens. This is basically a big issue in Flink which needs to be resolved later on. This has been realized in FLINK-6376 and hacked around for HDFS but HBase still suffers from the mentioned issue. In this PR I've done the same fix for HBase just like HDFS.

## Brief change log

HBase delegation token is now not used in case of keytab.

## Verifying this change

Manually verified by me on YARN cluster:
* HBase delegation token expiration deducted to 1 hour
* Flink obtained DT
* Double checked that Flink not used DT
* Double checked that Flink workload still worked after 1 hour

User verified it on YARN cluster within PROD like circumstances.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes, now YARN deployment is not using delegation token in case of keytab
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
