### PR TITLE
[FLINK-23309][python] Optimize the finish bundle logic in PyFlink

### DIFF
--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_fast.pxd
@@ -24,6 +24,7 @@ from apache_beam.coders.coder_impl cimport OutputStream as BOutputStream
 from apache_beam.coders.coder_impl cimport StreamCoderImpl
 
 from pyflink.fn_execution.coder_impl_fast cimport LengthPrefixBaseCoderImpl, FieldCoderImpl
+from pyflink.fn_execution.beam.beam_stream_fast cimport BeamTimeBasedOutputStream
 from pyflink.fn_execution.stream_fast cimport OutputStream
 
 cdef class PassThroughLengthPrefixCoderImpl(StreamCoderImpl):
@@ -37,3 +38,4 @@ cdef class FlinkFieldCoderBeamWrapper(StreamCoderImpl):
 
 cdef class FlinkLengthPrefixCoderBeamWrapper(StreamCoderImpl):
     cdef readonly LengthPrefixBaseCoderImpl _value_coder
+    cdef BeamTimeBasedOutputStream _output_stream

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_fast.pyx
@@ -94,12 +94,10 @@ cdef class FlinkLengthPrefixCoderBeamWrapper(StreamCoderImpl):
     """
     def __cinit__(self, value_coder):
         self._value_coder = value_coder
-        self._output_stream = None
+        self._output_stream = BeamTimeBasedOutputStream()
 
     cpdef encode_to_stream(self, value, BOutputStream out_stream, bint nested):
-        if not self._output_stream:
-            self._output_stream = BeamTimeBasedOutputStream()
-        self._output_stream.parse_output_stream(out_stream)
+        self._output_stream.reset_output_stream(out_stream)
         self._value_coder.encode_to_stream(value, self._output_stream)
 
     cpdef decode_from_stream(self, BInputStream in_stream, bint nested):

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_fast.pyx
@@ -26,7 +26,7 @@ from apache_beam.coders.coder_impl cimport OutputStream as BOutputStream
 from apache_beam.coders.coder_impl cimport StreamCoderImpl
 
 from pyflink.fn_execution.beam.beam_stream_fast cimport BeamInputStream
-from pyflink.fn_execution.beam.beam_stream_fast import BeamOutputStream
+from pyflink.fn_execution.beam.beam_stream_fast cimport BeamTimeBasedOutputStream
 from pyflink.fn_execution.stream_fast cimport InputStream
 
 cdef class PassThroughLengthPrefixCoderImpl(StreamCoderImpl):
@@ -94,10 +94,13 @@ cdef class FlinkLengthPrefixCoderBeamWrapper(StreamCoderImpl):
     """
     def __cinit__(self, value_coder):
         self._value_coder = value_coder
+        self._output_stream = None
 
     cpdef encode_to_stream(self, value, BOutputStream out_stream, bint nested):
-        output_stream = BeamOutputStream(out_stream)
-        self._value_coder.encode_to_stream(value, output_stream)
+        if not self._output_stream:
+            self._output_stream = BeamTimeBasedOutputStream()
+        self._output_stream.parse_output_stream(out_stream)
+        self._value_coder.encode_to_stream(value, self._output_stream)
 
     cpdef decode_from_stream(self, BInputStream in_stream, bint nested):
         cdef BeamInputStream input_stream = BeamInputStream(in_stream, in_stream.size())

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -67,12 +67,10 @@ class FlinkLengthPrefixCoderBeamWrapper(FlinkFieldCoderBeamWrapper):
     """
     def __init__(self, value_coder):
         super(FlinkLengthPrefixCoderBeamWrapper, self).__init__(value_coder)
-        self._output_stream = None
+        self._output_stream = BeamTimeBasedOutputStream()
 
     def encode_to_stream(self, value, out_stream: create_OutputStream, nested):
-        if not self._output_stream:
-            self._output_stream = BeamTimeBasedOutputStream()
-        self._output_stream.parse_output_stream(out_stream)
+        self._output_stream.reset_output_stream(out_stream)
 
         self._value_coder.encode_to_stream(value, self._data_output_stream)
         self._output_stream.write(self._data_output_stream.get())

--- a/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coder_impl_slow.py
@@ -20,7 +20,7 @@ from typing import Any
 from apache_beam.coders.coder_impl import StreamCoderImpl, create_InputStream, create_OutputStream
 
 from pyflink.fn_execution.stream_slow import OutputStream
-from pyflink.fn_execution.beam.beam_stream_slow import BeamInputStream
+from pyflink.fn_execution.beam.beam_stream_slow import BeamInputStream, BeamTimeBasedOutputStream
 
 
 class PassThroughLengthPrefixCoderImpl(StreamCoderImpl):
@@ -40,9 +40,9 @@ class PassThroughLengthPrefixCoderImpl(StreamCoderImpl):
         return 'PassThroughLengthPrefixCoderImpl[%s]' % self._value_coder
 
 
-class FlinkCoderBeamWrapper(StreamCoderImpl):
+class FlinkFieldCoderBeamWrapper(StreamCoderImpl):
     """
-    Bridge between Beam coder and Flink coder.
+    Bridge between Beam coder and Flink coder for the low-level FieldCoder.
     """
     def __init__(self, value_coder):
         self._value_coder = value_coder
@@ -58,4 +58,25 @@ class FlinkCoderBeamWrapper(StreamCoderImpl):
         return self._value_coder.decode_from_stream(data_input_stream)
 
     def __repr__(self):
-        return 'FlinkCoderBeamWrapper[%s]' % self._value_coder
+        return 'FlinkFieldCoderBeamWrapper[%s]' % self._value_coder
+
+
+class FlinkLengthPrefixCoderBeamWrapper(FlinkFieldCoderBeamWrapper):
+    """
+    Bridge between Beam coder and Flink coder for the top-level LengthPrefixCoder.
+    """
+    def __init__(self, value_coder):
+        super(FlinkLengthPrefixCoderBeamWrapper, self).__init__(value_coder)
+        self._output_stream = None
+
+    def encode_to_stream(self, value, out_stream: create_OutputStream, nested):
+        if not self._output_stream:
+            self._output_stream = BeamTimeBasedOutputStream()
+        self._output_stream.parse_output_stream(out_stream)
+
+        self._value_coder.encode_to_stream(value, self._data_output_stream)
+        self._output_stream.write(self._data_output_stream.get())
+        self._data_output_stream.clear()
+
+    def __repr__(self):
+        return 'FlinkLengthPrefixCoderBeamWrapper[%s]' % self._value_coder

--- a/flink-python/pyflink/fn_execution/beam/beam_coders.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coders.py
@@ -20,8 +20,7 @@ from apache_beam.coders.coders import FastCoder, LengthPrefixCoder
 from apache_beam.portability import common_urns
 from apache_beam.typehints import typehints
 
-from pyflink.fn_execution.coders import (
-    ArrowCoder, OverWindowArrowCoder, LengthPrefixBaseCoder)
+from pyflink.fn_execution.coders import LengthPrefixBaseCoder
 from pyflink.fn_execution.flink_fn_execution_pb2 import CoderInfoDescriptor
 
 try:
@@ -30,8 +29,8 @@ try:
     from pyflink.fn_execution.beam.beam_coder_impl_fast import FlinkLengthPrefixCoderBeamWrapper
 except ImportError:
     from pyflink.fn_execution.beam import beam_coder_impl_slow as beam_coder_impl
-    FlinkFieldCoderBeamWrapper = beam_coder_impl.FlinkCoderBeamWrapper
-    FlinkLengthPrefixCoderBeamWrapper = beam_coder_impl.FlinkCoderBeamWrapper
+    from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkFieldCoderBeamWrapper
+    from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkLengthPrefixCoderBeamWrapper
 
 FLINK_CODER_URN = "flink:coder:v1"
 
@@ -66,11 +65,7 @@ class FlinkCoder(FastCoder):
 
     def get_impl(self):
         if isinstance(self._internal_coder, LengthPrefixBaseCoder):
-            if isinstance(self._internal_coder._field_coder, (ArrowCoder, OverWindowArrowCoder)):
-                from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkCoderBeamWrapper
-                return FlinkCoderBeamWrapper(self._create_impl())
-            else:
-                return FlinkLengthPrefixCoderBeamWrapper(self._create_impl())
+            return FlinkLengthPrefixCoderBeamWrapper(self._create_impl())
         else:
             return FlinkFieldCoderBeamWrapper(self._create_impl())
 

--- a/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations_fast.pxd
@@ -17,10 +17,10 @@
 ################################################################################
 # cython: language_level=3
 
-from apache_beam.coders.coder_impl cimport StreamCoderImpl
 from apache_beam.runners.worker.operations cimport Operation
 from apache_beam.utils.windowed_value cimport WindowedValue
 
+from pyflink.fn_execution.beam.beam_coder_impl_fast cimport FlinkLengthPrefixCoderBeamWrapper
 from pyflink.fn_execution.coder_impl_fast cimport InputStreamWrapper
 
 cdef class InputProcessor:
@@ -37,9 +37,10 @@ cdef class IntermediateInputProcessor(InputProcessor):
 cdef class OutputProcessor:
     cdef Operation _consumer
     cpdef process_outputs(self, WindowedValue windowed_value, results)
+    cpdef close(self)
 
 cdef class NetworkOutputProcessor(OutputProcessor):
-    cdef StreamCoderImpl _value_coder_impl
+    cdef FlinkLengthPrefixCoderBeamWrapper _value_coder_impl
 
 cdef class IntermediateOutputProcessor(OutputProcessor):
     pass

--- a/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pxd
@@ -29,10 +29,17 @@ cdef class BeamInputStream(LengthPrefixInputStream):
     cdef BInputStream _input_stream
     cdef void _parse_input_stream(self, BInputStream input_stream)
 
-cdef class BeamOutputStream(LengthPrefixOutputStream):
+cdef class BeamSizeBasedOutputStream(LengthPrefixOutputStream):
     cdef char*_output_data
     cdef size_t _output_pos
     cdef size_t _output_buffer_size
     cdef BOutputStream _output_stream
+
+    cdef void parse_output_stream(self, BOutputStream output_stream)
     cdef void _maybe_flush(self)
-    cdef void _parse_output_stream(self, BOutputStream output_stream)
+
+cdef class BeamTimeBasedOutputStream(BeamSizeBasedOutputStream):
+    cdef bint _flush_event
+    cdef object _periodic_flusher
+
+    cpdef void notify_flush(self)

--- a/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pxd
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pxd
@@ -35,8 +35,8 @@ cdef class BeamSizeBasedOutputStream(LengthPrefixOutputStream):
     cdef size_t _output_buffer_size
     cdef BOutputStream _output_stream
 
-    cdef void parse_output_stream(self, BOutputStream output_stream)
-    cdef void _maybe_flush(self)
+    cdef void reset_output_stream(self, BOutputStream output_stream)
+    cdef bint _maybe_flush(self)
 
 cdef class BeamTimeBasedOutputStream(BeamSizeBasedOutputStream):
     cdef bint _flush_event

--- a/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pyx
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_fast.pyx
@@ -23,6 +23,8 @@
 from libc.stdlib cimport realloc
 from libc.string cimport memcpy
 
+from apache_beam.runners.worker.data_plane import PeriodicThread
+
 cdef class BeamInputStream(LengthPrefixInputStream):
     def __cinit__(self, input_stream, size):
         self._input_buffer_size = size
@@ -54,14 +56,11 @@ cdef class BeamInputStream(LengthPrefixInputStream):
         self._input_data = input_stream.allc
         self._input_pos = input_stream.pos
 
-cdef class BeamOutputStream(LengthPrefixOutputStream):
-    def __cinit__(self, output_stream):
-        self._output_stream = output_stream
-        self._parse_output_stream(output_stream)
-
+cdef class BeamSizeBasedOutputStream(LengthPrefixOutputStream):
     cdef void write(self, char*data, size_t length):
         cdef char bits
         cdef size_t size = length
+        cdef size_t i
         # the length of the variable prefix length will be less than 9 bytes
         if self._output_buffer_size < self._output_pos + length + 9:
             self._output_buffer_size += length + 9
@@ -91,12 +90,33 @@ cdef class BeamOutputStream(LengthPrefixOutputStream):
         self._output_stream.flush()
         self._output_pos = 0
 
-    cdef void _parse_output_stream(self, BOutputStream output_stream):
+    cdef void parse_output_stream(self, BOutputStream output_stream):
+        self._output_stream = output_stream
         self._output_data = output_stream.data
         self._output_pos = output_stream.pos
         self._output_buffer_size = output_stream.buffer_size
 
     cdef void _maybe_flush(self):
         if self._output_pos > 10_000_000:
-            self._output_stream.flush()
-            self._output_pos = 0
+            self.flush()
+
+cdef class BeamTimeBasedOutputStream(BeamSizeBasedOutputStream):
+    def __init__(self, *args, **kwargs):
+        self._flush_event = False
+        self._periodic_flusher = PeriodicThread(1, self.notify_flush)
+        self._periodic_flusher.daemon = True
+        self._periodic_flusher.start()
+
+    cpdef void notify_flush(self):
+        if not self._flush_event:
+            self._flush_event = True
+
+    cdef void _maybe_flush(self):
+        if self._flush_event or self._output_pos > 10_000_000:
+            self.flush()
+            self._flush_event = False
+
+    cpdef void close(self):
+        if self._periodic_flusher:
+            self._periodic_flusher.cancel()
+            self._periodic_flusher = None

--- a/flink-python/pyflink/fn_execution/beam/beam_stream_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_slow.py
@@ -15,7 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from apache_beam.coders.coder_impl import create_InputStream
+from apache_beam.coders.coder_impl import create_InputStream, create_OutputStream
+from apache_beam.runners.worker.data_plane import PeriodicThread
 
 from pyflink.fn_execution.stream_slow import InputStream
 
@@ -33,3 +34,31 @@ class BeamInputStream(InputStream):
 
     def size(self):
         return self._input_stream.size()
+
+
+class BeamTimeBasedOutputStream(create_OutputStream):
+    def __init__(self):
+        super(BeamTimeBasedOutputStream).__init__()
+        self._flush_event = False
+        self._periodic_flusher = PeriodicThread(1, self.notify_flush)
+        self._periodic_flusher.daemon = True
+        self._periodic_flusher.start()
+        self._output_stream = None
+
+    def write(self, b: bytes):
+        self._output_stream.write(b)
+        if self._flush_event:
+            self._output_stream.flush()
+            self._flush_event = False
+
+    def parse_output_stream(self, output_stream: create_OutputStream):
+        self._output_stream = output_stream
+
+    def notify_flush(self):
+        if not self._flush_event:
+            self._flush_event = True
+
+    def close(self):
+        if self._periodic_flusher:
+            self._periodic_flusher.cancel()
+            self._periodic_flusher = None

--- a/flink-python/pyflink/fn_execution/beam/beam_stream_slow.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_stream_slow.py
@@ -51,12 +51,11 @@ class BeamTimeBasedOutputStream(create_OutputStream):
             self._output_stream.flush()
             self._flush_event = False
 
-    def parse_output_stream(self, output_stream: create_OutputStream):
+    def reset_output_stream(self, output_stream: create_OutputStream):
         self._output_stream = output_stream
 
     def notify_flush(self):
-        if not self._flush_event:
-            self._flush_event = True
+        self._flush_event = True
 
     def close(self):
         if self._periodic_flusher:

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -89,6 +89,19 @@ cdef class RowCoderImpl(FieldCoderImpl):
     cdef list _field_names
     cdef MaskUtils _mask_utils
 
+cdef class ArrowCoderImpl(FieldCoderImpl):
+    cdef object _schema
+    cdef list _field_types
+    cdef object _timezone
+    cdef object _resettable_io
+    cdef object _batch_reader
+
+    cdef list decode_one_batch_from_stream(self, InputStream in_stream, size_t size)
+
+cdef class OverWindowArrowCoderImpl(FieldCoderImpl):
+    cdef ArrowCoderImpl _arrow_coder
+    cdef IntCoderImpl _int_coder
+
 cdef class TinyIntCoderImpl(FieldCoderImpl):
     pass
 

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -28,10 +28,13 @@ import pickle
 from typing import List, Union
 
 from cloudpickle import cloudpickle
+import pyarrow as pa
 
 from pyflink.common import Row, RowKind
 from pyflink.common.time import Instant
 from pyflink.datastream.window import CountWindow, TimeWindow
+from pyflink.fn_execution.ResettableIO import ResettableIO
+from pyflink.table.utils import pandas_to_arrow, arrow_to_pandas
 
 ROW_KIND_BIT_SIZE = 2
 
@@ -420,6 +423,73 @@ cdef class RowCoderImpl(FieldCoderImpl):
     def __repr__(self):
         return 'RowCoderImpl[%s, %s]' % \
                (', '.join(str(c) for c in self._field_coders), self._field_names)
+
+cdef class ArrowCoderImpl(FieldCoderImpl):
+    """
+    A coder for arrow format data.
+    """
+
+    def __init__(self, schema, row_type, timezone):
+        self._schema = schema
+        self._field_types = row_type.field_types()
+        self._timezone = timezone
+        self._resettable_io = ResettableIO()
+        self._batch_reader = self._load_from_stream(self._resettable_io)
+
+    cpdef encode_to_stream(self, cols, OutputStream out_stream):
+        self._resettable_io.set_output_stream(out_stream)
+        batch_writer = pa.RecordBatchStreamWriter(self._resettable_io, self._schema)
+        batch_writer.write_batch(
+            pandas_to_arrow(self._schema, self._timezone, self._field_types, cols))
+
+    cpdef decode_from_stream(self, InputStream in_stream, size_t size):
+        return self.decode_one_batch_from_stream(in_stream, size)
+
+    cdef list decode_one_batch_from_stream(self, InputStream in_stream, size_t size):
+        self._resettable_io.set_input_bytes(in_stream.read(size))
+        # there is only one arrow batch in the underlying input stream
+        return arrow_to_pandas(self._timezone, self._field_types, [next(self._batch_reader)])
+
+    def _load_from_stream(self, stream):
+        while stream.readable():
+            reader = pa.ipc.open_stream(stream)
+            yield reader.read_next_batch()
+
+    def __repr__(self):
+        return 'ArrowCoderImpl[%s]' % self._schema
+
+cdef class OverWindowArrowCoderImpl(FieldCoderImpl):
+    """
+    A coder for over window with arrow format data.
+    The data structure: [window data][arrow format data].
+    """
+    def __init__(self, arrow_coder_impl: ArrowCoderImpl):
+        self._arrow_coder = arrow_coder_impl
+        self._int_coder = IntCoderImpl()
+
+    cpdef encode_to_stream(self, cols, OutputStream out_stream):
+        self._arrow_coder.encode_to_stream(cols, out_stream)
+
+    cpdef decode_from_stream(self, InputStream in_stream, size_t size):
+        cdef int32_t window_num, window_size
+        cdef list window_boundaries_and_arrow_data
+        window_num = self._int_coder.decode_from_stream(in_stream, 0)
+        size -= 4
+        window_boundaries_and_arrow_data = []
+        for _ in range(window_num):
+            window_size = self._int_coder.decode_from_stream(in_stream, 0)
+            size -= 4
+            window_boundaries_and_arrow_data.append(
+                [self._int_coder.decode_from_stream(in_stream, 0)
+                 for _ in range(window_size)])
+            size -= 4 * window_size
+        window_boundaries_and_arrow_data.append(
+            self._arrow_coder.decode_one_batch_from_stream(in_stream, size))
+        return window_boundaries_and_arrow_data
+
+    def __repr__(self):
+        return 'OverWindowArrowCoderImpl[%s]' % self._arrow_coder
+
 
 cdef class TinyIntCoderImpl(FieldCoderImpl):
     """

--- a/flink-python/pyflink/fn_execution/coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/coder_impl_slow.py
@@ -289,16 +289,16 @@ class ArrowCoderImpl(FieldCoderImpl):
     def decode_from_stream(self, in_stream: InputStream, length=0):
         return self.decode_one_batch_from_stream(in_stream, length)
 
+    def decode_one_batch_from_stream(self, in_stream: InputStream, size: int) -> List:
+        self._resettable_io.set_input_bytes(in_stream.read(size))
+        # there is only one arrow batch in the underlying input stream
+        return arrow_to_pandas(self._timezone, self._field_types, [next(self._batch_reader)])
+
     @staticmethod
     def _load_from_stream(stream):
         while stream.readable():
             reader = pa.ipc.open_stream(stream)
             yield reader.read_next_batch()
-
-    def decode_one_batch_from_stream(self, in_stream: InputStream, size: int) -> List:
-        self._resettable_io.set_input_bytes(in_stream.read(size))
-        # there is only one arrow batch in the underlying input stream
-        return arrow_to_pandas(self._timezone, self._field_types, [next(self._batch_reader)])
 
     def __repr__(self):
         return 'ArrowCoderImpl[%s]' % self._schema

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -160,14 +160,8 @@ class IterableCoder(LengthPrefixBaseCoder):
         self._separated_with_end_message = separated_with_end_message
 
     def get_impl(self):
-        if isinstance(self._field_coder, (ArrowCoder, OverWindowArrowCoder)):
-            # ArrowCoder and OverWindowArrowCoder doesn't support fast coder currently.
-            from pyflink.fn_execution import coder_impl_slow
-            return coder_impl_slow.IterableCoderImpl(self._field_coder.get_impl(),
-                                                     self._separated_with_end_message)
-        else:
-            return coder_impl.IterableCoderImpl(self._field_coder.get_impl(),
-                                                self._separated_with_end_message)
+        return coder_impl.IterableCoderImpl(self._field_coder.get_impl(),
+                                            self._separated_with_end_message)
 
 
 class ValueCoder(LengthPrefixBaseCoder):
@@ -179,12 +173,7 @@ class ValueCoder(LengthPrefixBaseCoder):
         super(ValueCoder, self).__init__(field_coder)
 
     def get_impl(self):
-        if isinstance(self._field_coder, (ArrowCoder, OverWindowArrowCoder)):
-            # ArrowCoder and OverWindowArrowCoder doesn't support fast coder currently.
-            from pyflink.fn_execution import coder_impl_slow
-            return coder_impl_slow.ValueCoderImpl(self._field_coder.get_impl())
-        else:
-            return coder_impl.ValueCoderImpl(self._field_coder.get_impl())
+        return coder_impl.ValueCoderImpl(self._field_coder.get_impl())
 
 
 #########################################################################
@@ -240,9 +229,7 @@ class ArrowCoder(FieldCoder):
         self._timezone = timezone
 
     def get_impl(self):
-        # ArrowCoder doesn't support fast coder implementation currently.
-        from pyflink.fn_execution import coder_impl_slow
-        return coder_impl_slow.ArrowCoderImpl(self._schema, self._row_type, self._timezone)
+        return coder_impl.ArrowCoderImpl(self._schema, self._row_type, self._timezone)
 
     def __repr__(self):
         return 'ArrowCoder[%s]' % self._schema
@@ -257,9 +244,7 @@ class OverWindowArrowCoder(FieldCoder):
         self._arrow_coder = ArrowCoder(schema, row_type, timezone)
 
     def get_impl(self):
-        # OverWindowArrowCoder doesn't support fast coder implementation currently.
-        from pyflink.fn_execution import coder_impl_slow
-        return coder_impl_slow.OverWindowArrowCoderImpl(self._arrow_coder.get_impl())
+        return coder_impl.OverWindowArrowCoderImpl(self._arrow_coder.get_impl())
 
     def __repr__(self):
         return 'OverWindowArrowCoder[%s]' % self._arrow_coder

--- a/flink-python/pyflink/fn_execution/stream_fast.pxd
+++ b/flink-python/pyflink/fn_execution/stream_fast.pxd
@@ -25,11 +25,13 @@ cdef class LengthPrefixInputStream:
 cdef class LengthPrefixOutputStream:
     cdef void write(self, char*data, size_t length)
     cpdef void flush(self)
+    cpdef void close(self)
 
 cdef class InputStream:
     cdef char*_input_data
     cdef size_t _input_pos
 
+    cpdef bytes read(self, size_t size)
     cdef long read_byte(self) except? -1
     cdef int8_t read_int8(self) except? -1
     cdef int16_t read_int16(self) except? -1
@@ -44,6 +46,7 @@ cdef class OutputStream:
     cdef size_t buffer_size
     cdef size_t pos
 
+    cpdef void write(self, bytes v)
     cdef void write_byte(self, unsigned char val)
     cdef void write_int8(self, int8_t v)
     cdef void write_int16(self, int16_t v)

--- a/flink-python/src/main/java/org/apache/flink/python/PythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonFunctionRunner.java
@@ -53,6 +53,16 @@ public interface PythonFunctionRunner {
     Tuple2<byte[], Integer> pollResult() throws Exception;
 
     /**
+     * Retrieves the Python function result, waiting if necessary until an element becomes
+     * available.
+     *
+     * @return the head of he Python function result buffer. f0 means the byte array buffer which
+     *     stores the Python function result. f1 means the length of the Python function result byte
+     *     array.
+     */
+    Tuple2<byte[], Integer> takeResult() throws Exception;
+
+    /**
      * Forces to finish the processing of the current bundle of elements. It will flush the data
      * cached in the data buffer for processing and retrieves the state mutations (if exists) made
      * by the Python function. The call blocks until all of the outputs produced by this bundle have

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -347,6 +347,14 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
     }
 
     @Override
+    public Tuple2<byte[], Integer> takeResult() throws Exception {
+        byte[] result = resultBuffer.take();
+        this.reusableResultTuple.f0 = result;
+        this.reusableResultTuple.f1 = result.length;
+        return this.reusableResultTuple;
+    }
+
+    @Override
     public void flush() throws Exception {
         if (bundleStarted) {
             try {
@@ -355,6 +363,11 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
                 bundleStarted = false;
             }
         }
+    }
+
+    /** Interrupts the progress of takeResult. */
+    public void noEmptySignal() {
+        resultBuffer.add(new byte[0]);
     }
 
     private void finishBundle() {

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/runners/python/beam/BeamPythonFunctionRunner.java
@@ -366,7 +366,7 @@ public abstract class BeamPythonFunctionRunner implements PythonFunctionRunner {
     }
 
     /** Interrupts the progress of takeResult. */
-    public void noEmptySignal() {
+    public void notifyNoMoreResults() {
         resultBuffer.add(new byte[0]);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will optimize the finish bundle logic in PyFlink so that we can solve following three problems*
    - *OutputStream can not receive any data in checkpointing*
    - *Small data is hard to processed in pipeline*
    - *Python UDTF output unbounded data*

## Brief change log

  - *Move the blocking logic of finish bundle to async thread in Java Operator*
  - *Use Schedule Task to flush data to in Python Side*


## Verifying this change

- *Manual Test to cover*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
