### PR TITLE
[FLINK-23069][table-api-java] Support schemaless #executeInsert(TableDescriptor)

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/bridge/java/internal/StreamTableEnvironmentImpl.java
@@ -39,12 +39,12 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.ExternalSchemaTranslator;
 import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.SchemaResolver;
+import org.apache.flink.table.catalog.SchemaTranslator;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.delegation.Executor;
@@ -299,8 +299,8 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
         final ObjectIdentifier objectIdentifier =
                 catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-        final ExternalSchemaTranslator.InputResult schemaTranslationResult =
-                ExternalSchemaTranslator.fromExternal(
+        final SchemaTranslator.ConsumingResult schemaTranslationResult =
+                SchemaTranslator.createConsumingResult(
                         catalogManager.getDataTypeFactory(), dataStream.getType(), schema);
 
         final ResolvedSchema resolvedSchema =
@@ -356,8 +356,8 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
         Preconditions.checkNotNull(table, "Table must not be null.");
         Preconditions.checkNotNull(targetDataType, "Target data type must not be null.");
 
-        final ExternalSchemaTranslator.OutputResult schemaTranslationResult =
-                ExternalSchemaTranslator.fromInternal(
+        final SchemaTranslator.ProducingResult schemaTranslationResult =
+                SchemaTranslator.createProducingResult(
                         getCatalogManager().getDataTypeFactory(),
                         table.getResolvedSchema(),
                         targetDataType);
@@ -369,8 +369,8 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
     public DataStream<Row> toChangelogStream(Table table) {
         Preconditions.checkNotNull(table, "Table must not be null.");
 
-        final ExternalSchemaTranslator.OutputResult schemaTranslationResult =
-                ExternalSchemaTranslator.fromInternal(table.getResolvedSchema(), null);
+        final SchemaTranslator.ProducingResult schemaTranslationResult =
+                SchemaTranslator.createProducingResult(table.getResolvedSchema(), null);
 
         return toStreamInternal(table, schemaTranslationResult, null);
     }
@@ -380,8 +380,8 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
         Preconditions.checkNotNull(table, "Table must not be null.");
         Preconditions.checkNotNull(targetSchema, "Target schema must not be null.");
 
-        final ExternalSchemaTranslator.OutputResult schemaTranslationResult =
-                ExternalSchemaTranslator.fromInternal(table.getResolvedSchema(), targetSchema);
+        final SchemaTranslator.ProducingResult schemaTranslationResult =
+                SchemaTranslator.createProducingResult(table.getResolvedSchema(), targetSchema);
 
         return toStreamInternal(table, schemaTranslationResult, null);
     }
@@ -393,15 +393,15 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl
         Preconditions.checkNotNull(targetSchema, "Target schema must not be null.");
         Preconditions.checkNotNull(changelogMode, "Changelog mode must not be null.");
 
-        final ExternalSchemaTranslator.OutputResult schemaTranslationResult =
-                ExternalSchemaTranslator.fromInternal(table.getResolvedSchema(), targetSchema);
+        final SchemaTranslator.ProducingResult schemaTranslationResult =
+                SchemaTranslator.createProducingResult(table.getResolvedSchema(), targetSchema);
 
         return toStreamInternal(table, schemaTranslationResult, changelogMode);
     }
 
     private <T> DataStream<T> toStreamInternal(
             Table table,
-            ExternalSchemaTranslator.OutputResult schemaTranslationResult,
+            SchemaTranslator.ProducingResult schemaTranslationResult,
             @Nullable ChangelogMode changelogMode) {
         final CatalogManager catalogManager = getCatalogManager();
         final SchemaResolver schemaResolver = catalogManager.getSchemaResolver();

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -92,6 +92,19 @@ public interface StatementSet {
      * TableDescriptor)}. Then a statement is added to the statement set that inserts the {@link
      * Table} object's pipeline into that temporary table.
      *
+     * <p>This method allows to declare a {@link Schema} for the sink descriptor. The declaration is
+     * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
+     *
+     * <ul>
+     *   <li>add computed or metadata columns next to the physical columns
+     *   <li>declare a watermark strategy
+     *   <li>declare a primary key
+     * </ul>
+     *
+     * <p>It is possible to declare a schema without physical/regular columns. In this case, those
+     * columns will be automatically derived and implicitly put at the beginning of the schema
+     * declaration.
+     *
      * <p>Examples:
      *
      * <pre>{@code

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.TemporalTableFunction;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.types.DataType;
 
 /**
  * The {@link Table} object is the core abstraction of the Table API. Similar to how the DataStream
@@ -1379,6 +1380,21 @@ public interface Table {
      * TableDescriptor)}) using a unique identifier. Note that calling this method multiple times,
      * even with the same descriptor, results in multiple sink tables being registered.
      *
+     * <p>This method allows to declare a {@link Schema} for the sink. The declaration is similar to
+     * a {@code CREATE TABLE} DDL in SQL and allows to:
+     *
+     * <ul>
+     *   <li>enrich or overwrite automatically derived columns with a custom {@link DataType}
+     *   <li>reorder columns
+     *   <li>add computed or metadata columns next to the physical columns
+     *   <li>declare a watermark strategy
+     *   <li>declare a primary key
+     * </ul>
+     *
+     * <p>It is possible to declare a schema without physical/regular columns. In this case, those
+     * columns will be automatically derived and implicitly put at the beginning of the schema
+     * declaration.
+     *
      * <p>Examples:
      *
      * <pre>{@code
@@ -1415,6 +1431,19 @@ public interface Table {
      * temporary catalog table (see {@link TableEnvironment#createTemporaryTable(String,
      * TableDescriptor)}) using a unique identifier. Note that calling this method multiple times,
      * even with the same descriptor, results in multiple sink tables being registered.
+     *
+     * <p>This method allows to declare a {@link Schema} for the sink descriptor. The declaration is
+     * similar to a {@code CREATE TABLE} DDL in SQL and allows to:
+     *
+     * <ul>
+     *   <li>add computed or metadata columns next to the physical columns
+     *   <li>declare a watermark strategy
+     *   <li>declare a primary key
+     * </ul>
+     *
+     * <p>It is possible to declare a schema without physical/regular columns. In this case, those
+     * columns will be automatically derived and implicitly put at the beginning of the schema
+     * declaration.
      *
      * <p>Examples:
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
@@ -492,14 +493,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     private void createTemporaryTableInternal(
             UnresolvedIdentifier path, TableDescriptor descriptor) {
         final ObjectIdentifier tableIdentifier = catalogManager.qualifyIdentifier(path);
-
-        final CatalogTable catalogTable =
-                CatalogTable.of(
-                        descriptor.getSchema(),
-                        descriptor.getComment().orElse(null),
-                        descriptor.getPartitionKeys(),
-                        descriptor.getOptions());
-
+        final CatalogTable catalogTable = convertTableDescriptor(descriptor);
         catalogManager.createTemporaryTable(catalogTable, tableIdentifier, false);
     }
 
@@ -510,15 +504,24 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
         final ObjectIdentifier tableIdentifier =
                 catalogManager.qualifyIdentifier(getParser().parseIdentifier(path));
-
-        final CatalogTable catalogTable =
-                CatalogTable.of(
-                        descriptor.getSchema(),
-                        descriptor.getComment().orElse(null),
-                        descriptor.getPartitionKeys(),
-                        descriptor.getOptions());
-
+        final CatalogTable catalogTable = convertTableDescriptor(descriptor);
         catalogManager.createTable(catalogTable, tableIdentifier, false);
+    }
+
+    private CatalogTable convertTableDescriptor(TableDescriptor descriptor) {
+        final Schema schema =
+                descriptor
+                        .getSchema()
+                        .orElseThrow(
+                                () ->
+                                        new ValidationException(
+                                                "Missing schema in TableDescriptor."));
+
+        return CatalogTable.of(
+                schema,
+                descriptor.getComment().orElse(null),
+                descriptor.getPartitionKeys(),
+                descriptor.getOptions());
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -34,10 +34,10 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.WindowGroupedTable;
-import org.apache.flink.table.catalog.ExternalSchemaTranslator;
 import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.SchemaTranslator;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ExpressionParser;
@@ -583,8 +583,8 @@ public class TableImpl implements Table {
     public TableResult executeInsert(TableDescriptor descriptor, boolean overwrite) {
         final String path = TableDescriptorUtil.getUniqueAnonymousPath();
 
-        final ExternalSchemaTranslator.InputResult schemaTranslationResult =
-                ExternalSchemaTranslator.fromExternal(
+        final SchemaTranslator.ConsumingResult schemaTranslationResult =
+                SchemaTranslator.createConsumingResult(
                         tableEnvironment.getCatalogManager().getDataTypeFactory(),
                         getResolvedSchema().toSourceRowDataType(),
                         descriptor.getSchema().orElse(null),

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableDescriptorTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableDescriptorTest.java
@@ -24,7 +24,9 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link TableDescriptor}. */
 public class TableDescriptorTest {
@@ -54,7 +56,8 @@ public class TableDescriptorTest {
                         .comment("Test Comment")
                         .build();
 
-        assertEquals(schema, descriptor.getSchema());
+        assertTrue(descriptor.getSchema().isPresent());
+        assertEquals(schema, descriptor.getSchema().get());
 
         assertEquals(1, descriptor.getPartitionKeys().size());
         assertEquals("f0", descriptor.getPartitionKeys().get(0));
@@ -63,6 +66,12 @@ public class TableDescriptorTest {
         assertEquals("test-connector", descriptor.getOptions().get("connector"));
 
         assertEquals("Test Comment", descriptor.getComment().orElse(null));
+    }
+
+    @Test
+    public void testNoSchema() {
+        final TableDescriptor descriptor = TableDescriptor.forConnector("test-connector").build();
+        assertFalse(descriptor.getSchema().isPresent());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

For `Table#executeInsert`, the schema can actually be inferred and thus is not required to be defined in the table descriptor, which simplifies the API usage in this case. However, we apply the same "merging" strategy between resolved and declared schema as we do during Table API <-> DataStream conversion.

## Brief change log

* Make the schema in `TableDescriptor` optional.
* Merge resolved and declared schema for `#executeInsert` and build a new descriptor.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

* `TableSinkITCase` (adjusted to use this new functionality)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
