### PR TITLE
[FLINK-23183][connectors/rabbitmq] Fix ACKs for redelivered messages in RMQSource

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -410,10 +410,16 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
                 if (usesCorrelationId) {
                     Preconditions.checkNotNull(
                             correlationId,
-                            "RabbitMQ source was instantiated "
-                                    + "with usesCorrelationId set to true yet we couldn't extract the correlation id from it !");
+                            "RabbitMQ source was instantiated with usesCorrelationId set to "
+                                    + "true yet we couldn't extract the correlation id from it!");
                     if (!addId(correlationId)) {
                         // we have already processed this message
+                        try {
+                            channel.basicReject(deliveryTag, false);
+                        } catch (IOException e) {
+                            throw new RuntimeException(
+                                    "Message could not be acknowledged with basicReject.", e);
+                        }
                         return false;
                     }
                 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the issue described in FLINK-23183. Currently the redelivered messages are not acknowledged properly upon connection failure (only applicable when autoAck is disabled). When used with a prefetch count in the consumer it may even lead to blocking the source from consuming any more messages.
In the suggested fix, all successfully consumed RMQ messages are be acknowledged, regardless of whether the message is ignored or processed further in the pipeline. In case of redelivered messages, `basicReject` is invoked to acknowledge the message immediately after it's received.

## Brief change log

  - `channel.basicReject` in `RMQSource` is called in case of already processed (and checkpointed) but redelivered messages (e.g. after the job failover)

## Verifying this change

This change added tests and can be verified as follows:

  - `RMQSourceTest#testRedeliveredSessionIDsAck` which tests whether redelivered messages are acknowledged properly
  - `RMQSourceITCase#testMessageDelivery` which tests if the source actually consumes the messages 
  - `RMQSourceITCase#testAckFailure` which reproduces the issue described in FLINK-23183. Exactly-once mode is enabled here (checkpointing and correlationIds) and the source always fails on acknowledgement (but after a successful checkpoint)

The change was also tested on a Flink 1.12 cluster on live data.
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
