### PR TITLE
[FLINK-23365][filesystems]flink-azure-fs-hadoop compile error because of json-smart

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -69,10 +69,6 @@ under the License.
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-common</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>net.minidev</groupId>
-					<artifactId>json-smart</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -69,6 +69,10 @@ under the License.
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-common</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -78,6 +82,12 @@ under the License.
 			<artifactId>azure</artifactId>
 			<version>${fs.azure.sdk.version}</version>
 			<scope>test</scope>
+        <exclusions>
+			<exclusion>
+				<groupId>net.minidev</groupId>
+				<artifactId>json-smart</artifactId>
+			</exclusion>
+		</exclusions>
 		</dependency>
 
 		<!-- for the behavior test suite -->


### PR DESCRIPTION

## What is the purpose of the change

This pull request fixes the issue described in FLINK-23365. 


## Brief change log

update flink-fs-hadoop-shaded/pom.xml  exclusion  json-smart


## Verifying this change
     

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
