### PR TITLE
[hotfix] Finalize SeqNo for Change Log 

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -320,7 +320,7 @@ public class ChangelogKeyedStateBackend<K>
         // have to split it somehow for the former option, so the latter is used.
         lastCheckpointId = checkpointId;
         lastUploadedFrom = materializedTo;
-        lastUploadedTo = stateChangelogWriter.lastAppendedSequenceNumber().next();
+        lastUploadedTo = stateChangelogWriter.lastAppendedSequenceNumber();
 
         LOG.debug(
                 "snapshot for checkpoint {}, change range: {}..{}",


### PR DESCRIPTION
Without this PR, the current Log will always start recording from seq # 1;

while the `materilizedTo` is initialized to 0;  so the persist stream is from 0 -> the current position
