### PR TITLE
[FLINK-23368][python] Fix the wrong mapping of state cache in PyFlink

### DIFF
--- a/flink-python/pyflink/fn_execution/state_impl.py
+++ b/flink-python/pyflink/fn_execution/state_impl.py
@@ -1060,14 +1060,14 @@ class RemoteKeyedStateBackend(object):
         if key == self._current_key:
             return
         encoded_old_key = self._encoded_current_key
-        self._current_key = key
-        self._encoded_current_key = self._key_coder_impl.encode(self._current_key)
         for state_name, state_obj in self._all_states.items():
             if self._state_cache_size > 0:
                 # cache old internal state
                 self.cache_internal_state(encoded_old_key, state_obj)
             state_obj.namespace = None
             state_obj._internal_state = None
+        self._current_key = key
+        self._encoded_current_key = self._key_coder_impl.encode(self._current_key)
 
     def get_current_key(self):
         return self._current_key


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the wrong mapping of state cache in PyFlink. This kind of wrong mapping occurs when the key is switched, but the state is not used*

## Brief change log

  - *fix the wrong mapping in switching key*

## Verifying this change

This change added tests and can be verified as follows:

  - *The changed IT `test_key_by_map`*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
