### PR TITLE
[FLINK-22545][coordination] Fix check during creation of Source Coordinator thread

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 
+import javax.annotation.Nullable;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -85,13 +87,16 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
     }
 
     /** A thread factory class that provides some helper methods. */
-    public static class CoordinatorExecutorThreadFactory implements ThreadFactory {
+    public static class CoordinatorExecutorThreadFactory
+            implements ThreadFactory, Thread.UncaughtExceptionHandler {
 
         private final String coordinatorThreadName;
         private final ClassLoader cl;
         private final Thread.UncaughtExceptionHandler errorHandler;
 
-        private Thread t;
+        @Nullable private Thread t;
+
+        @Nullable private volatile Throwable previousFailureReason;
 
         CoordinatorExecutorThreadFactory(
                 final String coordinatorThreadName, final ClassLoader contextClassLoader) {
@@ -110,16 +115,30 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
 
         @Override
         public synchronized Thread newThread(Runnable r) {
-            if (t != null) {
+            if (t != null && t.isAlive()) {
                 throw new Error(
-                        "This indicates that a fatal error has happened and caused the "
-                                + "coordinator executor thread to exit. Check the earlier logs"
-                                + "to see the root cause of the problem.");
+                        "Source Coordinator Thread already exists. There should never be more than one "
+                                + "thread driving the actions of a Source Coordinator. Existing Thread: "
+                                + t);
+            }
+            if (t != null && previousFailureReason != null) {
+                throw new Error(
+                        "The following a fatal error has happened in a previously spawned "
+                                + "Source Coordinator thread. No new thread can be spawned.",
+                        previousFailureReason);
             }
             t = new Thread(r, coordinatorThreadName);
             t.setContextClassLoader(cl);
-            t.setUncaughtExceptionHandler(errorHandler);
+            t.setUncaughtExceptionHandler(this);
             return t;
+        }
+
+        @Override
+        public synchronized void uncaughtException(Thread t, Throwable e) {
+            if (previousFailureReason == null) {
+                previousFailureReason = e;
+            }
+            errorHandler.uncaughtException(t, e);
         }
 
         String getCoordinatorThreadName() {


### PR DESCRIPTION
## What is the purpose of the change

Fixed bug [FLINK-22545](https://issues.apache.org/jira/browse/FLINK-22545) leading to test instabilities, by changing a "safety net" sanity check during the creation of the Source Coordinator thread (which drives the Source's Split Enumerator).

The check was meant as a safeguard to prevent re-instantiation after fatal errors killed a previous thread.
But the check was susceptible to thread termination due to idleness in the executor.

This updates the check to only fail if there is in fact an instantiation next to a running thread, or after a
previously crashed thread.

## Verifying this change

This fixes a test instability, and is verified by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
