### PR TITLE
[FLINK-21117][connector/kafka] Set checkpoint timeout to Long.MAX to reveal thread dump on CI if test get stuck

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -373,6 +373,11 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
                         BasicTypeInfo.INT_TYPE_INFO, new ExecutionConfig());
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // Never let checkpoint expire so that we can get thread dump on CI if the test get stuck
+        // See FLINK-21117
+        env.getCheckpointConfig().setCheckpointTimeout(Long.MAX_VALUE);
+
         env.enableCheckpointing(500);
         env.setParallelism(1);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));


### PR DESCRIPTION
## What is the purpose of the change

This pull request sets checkpoint timeout to Long.MAX_VALUE for Kafka producer IT case so that the CI could print thread dump if the test get stuck at some place. 


## Brief change log

- Set checkpoint timeout to Long.MAX_VALUE for Kafka producer's exactly once test. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
