### PR TITLE
[FLINK-23374][table-code-splitter] Clean up logs produced by code splitter

### DIFF
--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaLexer.g4
@@ -30,7 +30,7 @@
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
 //
-//  This Java grammar file is copied from the official Antlr repository
+//  This Java grammar file is copied from
 //  https://github.com/antlr/grammars-v4/tree/master/java/java
 //
 // ----------------------------------------------------------------------------

--- a/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
+++ b/flink-table/flink-table-code-splitter/src/main/antlr4/JavaParser.g4
@@ -30,8 +30,12 @@
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
 //
-//  This Java grammar file is copied from the official Antlr repository
+//  This Java grammar file is copied and modified from
 //  https://github.com/antlr/grammars-v4/tree/master/java/java
+//
+//  Modification:
+//    1. Add constructorCall
+//    2. Make constructorCall as a child of expression
 //
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
@@ -476,6 +480,10 @@ methodCall
     : IDENTIFIER '(' expressionList? ')'
     ;
 
+constructorCall
+    : (THIS | SUPER) '(' expressionList? ')'
+    ;
+
 expression
     : primary
     | expression bop='.'
@@ -488,6 +496,7 @@ expression
       )
     | expression '[' expression ']'
     | methodCall
+    | constructorCall
     | NEW creator
     | '(' typeType ')' expression
     | expression postfix=('++' | '--')

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaParserTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/JavaParserTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.codesplit;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link JavaParser}. */
+public class JavaParserTest {
+
+    @Test
+    public void testConstructorCall() {
+        String code =
+                "public class A extends B {\n"
+                        + "  private final int a, b;\n"
+                        + "  public A(int a) {\n"
+                        + "    this(a, 0);\n"
+                        + "  }\n"
+                        + "  public A(int a, int b) {\n"
+                        + "    super(a, b);\n"
+                        + "    this.a = a;\n"
+                        + "    this.b = b;\n"
+                        + "  }\n"
+                        + "}";
+        CommonTokenStream tokenStream =
+                new CommonTokenStream(new JavaLexer(CharStreams.fromString(code)));
+        JavaParser parser = new JavaParser(tokenStream);
+        TestConstructorCallVisitor visitor = new TestConstructorCallVisitor();
+        visitor.visit(parser.compilationUnit());
+        Assert.assertEquals(1, visitor.thisCount);
+        Assert.assertEquals(1, visitor.superCount);
+    }
+
+    private static class TestConstructorCallVisitor extends JavaParserBaseVisitor<Void> {
+        private int thisCount = 0;
+        private int superCount = 0;
+
+        @Override
+        public Void visitConstructorCall(JavaParser.ConstructorCallContext ctx) {
+            if (ctx.THIS() != null) {
+                thisCount++;
+            } else if (ctx.SUPER() != null) {
+                superCount++;
+            }
+            return visitChildren(ctx);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedCollectorWrapper.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedCollectorWrapper.java
@@ -30,7 +30,7 @@ public class GeneratedCollectorWrapper<C extends Collector<?>> extends Generated
     private final Class<C> clazz;
 
     public GeneratedCollectorWrapper(C collector) {
-        super(collector.getClass().getSimpleName(), "N/A", new Object[0]);
+        super(collector.getClass().getSimpleName(), "", new Object[0]);
         //noinspection unchecked
         this.clazz = (Class<C>) collector.getClass();
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedFunctionWrapper.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedFunctionWrapper.java
@@ -30,7 +30,7 @@ public class GeneratedFunctionWrapper<F extends Function> extends GeneratedFunct
     private final Class<F> clazz;
 
     public GeneratedFunctionWrapper(F function) {
-        super(function.getClass().getSimpleName(), "N/A", new Object[0]);
+        super(function.getClass().getSimpleName(), "", new Object[0]);
         //noinspection unchecked
         this.clazz = (Class<F>) function.getClass();
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedResultFutureWrapper.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedResultFutureWrapper.java
@@ -31,7 +31,7 @@ public class GeneratedResultFutureWrapper<T extends ResultFuture<?>>
     private final Class<T> clazz;
 
     public GeneratedResultFutureWrapper(T resultFuture) {
-        super(resultFuture.getClass().getSimpleName(), "N/A", new Object[0]);
+        super(resultFuture.getClass().getSimpleName(), "", new Object[0]);
         //noinspection unchecked
         this.clazz = (Class<T>) resultFuture.getClass();
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -804,7 +804,7 @@ public class SlicingWindowAggOperatorTest {
 
     private static GeneratedNamespaceAggsHandleFunction<Long> wrapGenerated(
             NamespaceAggsHandleFunction<Long> aggsFunction) {
-        return new GeneratedNamespaceAggsHandleFunction<Long>("N/A", "N/A", new Object[0]) {
+        return new GeneratedNamespaceAggsHandleFunction<Long>("N/A", "", new Object[0]) {
             private static final long serialVersionUID = 1L;
 
             @Override

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorTest.java
@@ -2054,7 +2054,7 @@ public class WindowOperatorTest {
                         .countWindow(windowSize)
                         .aggregate(
                                 new GeneratedNamespaceTableAggsHandleFunction<>(
-                                        "MockClass", "MockCode", new Object[] {}),
+                                        "MockClass", "", new Object[] {}),
                                 accTypes,
                                 aggResultTypes,
                                 windowTypes)


### PR DESCRIPTION
(When merging this PR, please keep the two commits separated.)

## What is the purpose of the change

Currently due to the logic of code splitter, logs are full of errors like
```
2021-07-12T20:44:24.0059271Z line 221:17 missing ';' at '('
2021-07-12T20:44:24.0063922Z line 221:59 mismatched input ',' expecting ')'
2021-07-12T20:44:24.0070238Z line 221:80 mismatched input ',' expecting ';'
2021-07-12T20:44:24.0076791Z line 223:69 mismatched input ',' expecting ';'
2021-07-12T20:44:24.0079044Z line 224:33 mismatched input ',' expecting ';'
2021-07-12T20:44:24.0081798Z line 225:65 mismatched input ',' expecting ';'
2021-07-12T20:44:24.0088060Z line 226:16 mismatched input ',' expecting ';'
2021-07-12T20:44:24.0089917Z line 227:76 extraneous input ')' expecting ';'
2021-07-12T20:44:24.0792855Z line 385:17 missing ';' at '('
```

This is because Java grammar files currently does not deal with constructor calls like `this(a, b)` and `super(a, b)`. This PR fixes this issue along with cleaning up other unnecessary output.

## Brief change log

 - Add support for constructor call in `JavaParser`
 - Clean up unnecessary output in tests due to code splitting and compiling logic

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable