### PR TITLE
[FLINK-23370][table-planner] Propagate Boundedness of ScanRuntimeProviders to Transformation

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecTableSourceScan.java
@@ -47,13 +47,14 @@ public class BatchExecTableSourceScan extends CommonExecTableSourceScan
             StreamExecutionEnvironment env,
             InputFormat<RowData, ?> inputFormat,
             InternalTypeInfo<RowData> outputTypeInfo,
-            String name) {
+            String operatorName) {
         // env.createInput will use ContinuousFileReaderOperator, but it do not support multiple
         // paths. If read partitioned source, after partition pruning, we need let InputFormat
         // to read multiple partitions which are multiple paths.
         // We can use InputFormatSourceFunction directly to support InputFormat.
-        InputFormatSourceFunction<RowData> func =
+        final InputFormatSourceFunction<RowData> function =
                 new InputFormatSourceFunction<>(inputFormat, outputTypeInfo);
-        return env.addSource(func, name, outputTypeInfo).getTransformation();
+        return createSourceFunctionTransformation(
+                env, function, true, operatorName, outputTypeInfo);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
@@ -60,9 +60,9 @@ public class StreamExecTableSourceScan extends CommonExecTableSourceScan
             StreamExecutionEnvironment env,
             InputFormat<RowData, ?> inputFormat,
             InternalTypeInfo<RowData> outputTypeInfo,
-            String name) {
+            String operatorName) {
         // It's better to use StreamExecutionEnvironment.createInput()
         // rather than addLegacySource() for streaming, because it take care of checkpoint.
-        return env.createInput(inputFormat, outputTypeInfo).name(name).getTransformation();
+        return env.createInput(inputFormat, outputTypeInfo).name(operatorName).getTransformation();
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.WithBoundedness;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.utils.JavaStreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Various tests to check {@link Transformation}s that have been generated from {@link ExecNode}s.
+ */
+public class TransformationsTest extends TableTestBase {
+
+    @Test
+    public void testLegacyBatchSource() {
+        final JavaStreamTableTestUtil util = javaStreamTestUtil();
+        final StreamTableEnvironment env = util.tableEnv();
+
+        final Table table =
+                env.from(
+                        TableDescriptor.forConnector("values")
+                                .option("bounded", "true")
+                                .schema(dummySchema())
+                                .build());
+
+        final LegacySourceTransformation<?> sourceTransform =
+                toLegacySourceTransformation(env, table);
+
+        assertBoundedness(Boundedness.BOUNDED, sourceTransform);
+    }
+
+    @Test
+    public void testLegacyStreamSource() {
+        final JavaStreamTableTestUtil util = javaStreamTestUtil();
+        final StreamTableEnvironment env = util.tableEnv();
+
+        final Table table =
+                env.from(
+                        TableDescriptor.forConnector("values")
+                                .option("bounded", "false")
+                                .schema(dummySchema())
+                                .build());
+
+        final LegacySourceTransformation<?> sourceTransform =
+                toLegacySourceTransformation(env, table);
+
+        assertBoundedness(Boundedness.CONTINUOUS_UNBOUNDED, sourceTransform);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper methods
+    // --------------------------------------------------------------------------------------------
+
+    private static LegacySourceTransformation<?> toLegacySourceTransformation(
+            StreamTableEnvironment env, Table table) {
+        final Transformation<?> transform = env.toChangelogStream(table).getTransformation();
+        assertTrue(transform.getInputs().size() > 0);
+
+        final Transformation<?> sourceTransform = transform.getInputs().get(0);
+        assertTrue(sourceTransform instanceof LegacySourceTransformation);
+        return (LegacySourceTransformation<?>) sourceTransform;
+    }
+
+    private static void assertBoundedness(Boundedness boundedness, Transformation<?> transform) {
+        assertTrue(transform instanceof WithBoundedness);
+        assertEquals(boundedness, ((WithBoundedness) transform).getBoundedness());
+    }
+
+    private static Schema dummySchema() {
+        return Schema.newBuilder().column("i", DataTypes.INT()).build();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Ensures that the `Boundedness` is set correctly in the stream graph for all `ScanRuntimeProvider`s.


## Brief change log

Create transformation manually for batch mode.

## Verifying this change

This change added tests and can be verified as follows: `TransformationsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
