### PR TITLE
[FLINK-22452][Connectors/Kafka] Support specifying custom transactional.id prefix in FlinkKafkaProducer

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -33,6 +33,7 @@ import kafka.server.KafkaServer;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,8 +49,12 @@ import java.util.stream.IntStream;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /** IT cases for the {@link FlinkKafkaProducer}. */
 public class FlinkKafkaProducerITCase extends KafkaTestBase {
@@ -595,6 +600,93 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
                 FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
         assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 43, 45, 46, 47));
         deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testCustomizeTransactionalIdPrefix() throws Exception {
+        String transactionalIdPrefix = "my-prefix";
+
+        Properties properties = createProperties();
+        String topic = "testCustomizeTransactionalIdPrefix";
+        FlinkKafkaProducer<Integer> kafkaProducer =
+                spy(
+                        new FlinkKafkaProducer<>(
+                                topic,
+                                integerKeyedSerializationSchema,
+                                properties,
+                                FlinkKafkaProducer.Semantic.EXACTLY_ONCE));
+        kafkaProducer.setTransactionalIdPrefix(transactionalIdPrefix);
+
+        try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(kafkaProducer), IntSerializer.INSTANCE)) {
+            testHarness.setup();
+            testHarness.open();
+            testHarness.processElement(1, 0);
+            testHarness.snapshot(0, 1);
+        }
+
+        ArgumentCaptor<FlinkKafkaProducer.KafkaTransactionState> stateCaptor =
+                ArgumentCaptor.forClass(FlinkKafkaProducer.KafkaTransactionState.class);
+        verify(kafkaProducer).invoke(stateCaptor.capture(), any(), any());
+
+        deleteTestTopic(topic);
+        checkProducerLeak();
+
+        FlinkKafkaProducer.KafkaTransactionState state = stateCaptor.getValue();
+        assertThat(state.transactionalId, startsWith(transactionalIdPrefix));
+    }
+
+    @Test
+    public void testRestoreUsingDifferentTransactionalIdPrefix() throws Exception {
+        String topic = "testCustomizeTransactionalIdPrefix";
+        Properties properties = createProperties();
+
+        final String transactionalIdPrefix1 = "my-prefix1";
+        FlinkKafkaProducer<Integer> kafkaProducer1 =
+                new FlinkKafkaProducer<>(
+                        topic,
+                        integerKeyedSerializationSchema,
+                        properties,
+                        FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+        kafkaProducer1.setTransactionalIdPrefix(transactionalIdPrefix1);
+        OperatorSubtaskState snapshot;
+        try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness1 =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(kafkaProducer1), IntSerializer.INSTANCE)) {
+            testHarness1.setup();
+            testHarness1.open();
+            testHarness1.processElement(42, 0);
+            snapshot = testHarness1.snapshot(0, 1);
+
+            testHarness1.processElement(43, 2);
+        }
+
+        final String transactionalIdPrefix2 = "my-prefix2";
+        FlinkKafkaProducer<Integer> kafkaProducer2 =
+                new FlinkKafkaProducer<>(
+                        topic,
+                        integerKeyedSerializationSchema,
+                        properties,
+                        FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
+        kafkaProducer2.setTransactionalIdPrefix(transactionalIdPrefix2);
+        try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness2 =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(kafkaProducer2), IntSerializer.INSTANCE)) {
+            testHarness2.setup();
+            // restore from the previous snapshot, transactions with records 43 should be aborted
+            testHarness2.initializeState(snapshot);
+            testHarness2.open();
+
+            testHarness2.processElement(44, 3);
+            testHarness2.snapshot(1, 4);
+            testHarness2.processElement(45, 5);
+            testHarness2.notifyOfCompletedCheckpoint(1);
+            testHarness2.processElement(46, 6);
+        }
+
+        assertExactlyOnceForTopic(createProperties(), topic, 0, Arrays.asList(42, 44));
+        checkProducerLeak();
     }
 
     private void testRecoverWithChangeSemantics(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerTest.java
@@ -110,6 +110,14 @@ public class FlinkKafkaProducerTest {
         assertThat(partitioner.openCalled, equalTo(true));
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testProvidedNullTransactionalIdPrefix() {
+        FlinkKafkaProducer<Integer> kafkaProducer =
+                new FlinkKafkaProducer<>(
+                        "localhost:9092", "test-topic", new OpenTestingSerializationSchema());
+        kafkaProducer.setTransactionalIdPrefix(null);
+    }
+
     private static class CustomPartitioner<T> extends FlinkKafkaPartitioner<T> {
         private boolean openCalled;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -238,6 +238,24 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
         this(operator, SimpleOperatorFactory.of(operator), env, false, new OperatorID());
     }
 
+    public AbstractStreamOperatorTestHarness(
+            StreamOperator<OUT> operator, String taskName, OperatorID operatorID) throws Exception {
+        this(
+                operator,
+                SimpleOperatorFactory.of(operator),
+                new MockEnvironmentBuilder()
+                        .setTaskName(taskName)
+                        .setManagedMemorySize(3 * 1024 * 1024)
+                        .setInputSplitProvider(new MockInputSplitProvider())
+                        .setBufferSize(1024)
+                        .setMaxParallelism(1)
+                        .setParallelism(1)
+                        .setSubtaskIndex(0)
+                        .build(),
+                false,
+                operatorID);
+    }
+
     private AbstractStreamOperatorTestHarness(
             StreamOperator<OUT> operator,
             StreamOperatorFactory<OUT> factory,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -175,6 +175,17 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
         super(factory, maxParallelism, parallelism, subtaskIndex, operatorID);
     }
 
+    public OneInputStreamOperatorTestHarness(
+            OneInputStreamOperator<IN, OUT> operator,
+            TypeSerializer<IN> typeSerializerIn,
+            String taskName,
+            OperatorID operatorID)
+            throws Exception {
+        super(operator, taskName, operatorID);
+
+        config.setupNetworkInputs(Preconditions.checkNotNull(typeSerializerIn));
+    }
+
     @Override
     public void setup(TypeSerializer<OUT> outputSerializer) {
         super.setup(outputSerializer);


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this pull request is to implement the feature that a FlinkKafkaProducer can have a customized `transactional.id` prefix instead of the default prefix generation behavior as described in [FLIP-172](https://cwiki.apache.org/confluence/display/FLINK/FLIP-172%3A+Support+custom+transactional.id+prefix+in+FlinkKafkaProducer) and [FLINK-22452](https://issues.apache.org/jira/browse/FLINK-22452).

## Brief change log

A new method `setTransactionalPrefix(String)` is introduced to the `FlinkKafkaProducer` class.


## Verifying this change

This change added tests and can be verified as follows:

  - Added an integration test for `FlinkKafkaProducer` which ensures the generated `transactional.id` starts with what has been specified.
  - Added an integration test for `FlinkKafkaProducer` which covers the case that state can also be restored after the `transactional.id` changes, while the previous uncommitted transaction is aborted.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
