### PR TITLE
[FLINK-23371] Disable progressive watermarks for bounded SourceFunctions

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -313,7 +313,8 @@ public class ContinuousFileReaderOperator<OUT, T extends TimestampedInputSplit>
                         new Object(), // no actual locking needed
                         output,
                         getRuntimeContext().getExecutionConfig().getAutoWatermarkInterval(),
-                        -1);
+                        -1,
+                        true);
 
         this.reusedRecord = serializer.createInstance();
         this.completedSplitsCounter = getMetricGroup().counter("numSplitsProcessed");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -44,16 +45,29 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 
     private static final long serialVersionUID = 1L;
 
+    /** Whether to emit intermediate watermarks or only one final watermark at the end of input. */
+    private final boolean emitProgressiveWatermarks;
+
     private transient SourceFunction.SourceContext<OUT> ctx;
 
     private transient volatile boolean canceledOrStopped = false;
 
     private transient volatile boolean hasSentMaxWatermark = false;
 
-    public StreamSource(SRC sourceFunction) {
+    public StreamSource(SRC sourceFunction, boolean emitProgressiveWatermarks) {
         super(sourceFunction);
 
         this.chainingStrategy = ChainingStrategy.HEAD;
+        this.emitProgressiveWatermarks = emitProgressiveWatermarks;
+    }
+
+    public StreamSource(SRC sourceFunction) {
+        this(sourceFunction, true);
+    }
+
+    @VisibleForTesting
+    public boolean emitsProgressiveWatermarks() {
+        return emitProgressiveWatermarks;
     }
 
     public void run(final Object lockingObject, final OperatorChain<?, ?> operatorChain)
@@ -98,7 +112,8 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
                         lockingObject,
                         collector,
                         watermarkInterval,
-                        -1);
+                        -1,
+                        emitProgressiveWatermarks);
 
         try {
             userFunction.run(ctx);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSourceContextIdleDetectionTests.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSourceContextIdleDetectionTests.java
@@ -97,7 +97,8 @@ public class StreamSourceContextIdleDetectionTests {
                         new Object(),
                         new CollectorOutput<>(output),
                         0,
-                        idleTimeout);
+                        idleTimeout,
+                        true);
 
         // -------------------------- begin test scenario --------------------------
 
@@ -196,7 +197,8 @@ public class StreamSourceContextIdleDetectionTests {
                         new Object(),
                         new CollectorOutput<String>(output),
                         watermarkInterval,
-                        idleTimeout);
+                        idleTimeout,
+                        true);
 
         // -------------------------- begin test scenario --------------------------
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -144,7 +144,7 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
             boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
         }
 
-        final StreamSource<RowData, ?> sourceOperator = new StreamSource<>(function);
+        final StreamSource<RowData, ?> sourceOperator = new StreamSource<>(function, !isBounded);
         return new LegacySourceTransformation<>(
                 operatorName, sourceOperator, outputTypeInfo, parallelism, boundedness);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/TransformationsTest.java
@@ -57,6 +57,7 @@ public class TransformationsTest extends TableTestBase {
                 toLegacySourceTransformation(env, table);
 
         assertBoundedness(Boundedness.BOUNDED, sourceTransform);
+        assertFalse(sourceTransform.getOperator().emitsProgressiveWatermarks());
     }
 
     @Test
@@ -75,6 +76,7 @@ public class TransformationsTest extends TableTestBase {
                 toLegacySourceTransformation(env, table);
 
         assertBoundedness(Boundedness.CONTINUOUS_UNBOUNDED, sourceTransform);
+        assertTrue(sourceTransform.getOperator().emitsProgressiveWatermarks());
     }
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This prevents that `SourceFunction`s emit progressive watermarks in bounded `SourceFunctionProvider`s.

It might be a rare use case but since `SourceFunction` is still widely used, it ensures correctness and consistency with the FLIP-27 stack when used in a `DynamicTableSource`.

## Brief change log

- Add an internal flag for `StreamSource` to disable emitting progressive watermarks
- Set this flag for bounded `SourceFunctionProvider` in planner

## Verifying this change

This change added tests and can be verified as follows: `StreamSourceOperatorWatermarksTest` and `TransformationsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
