### PR TITLE
[FLINK-23372][streaming-java] Disable AllVerticesInSameSlotSharingGroupByDefault in batch mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -361,6 +361,7 @@ public class StreamGraphGenerator {
                 checkpointConfig.disableCheckpointing();
             }
 
+            graph.setAllVerticesInSameSlotSharingGroupByDefault(false);
             graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED);
             setDefaultBufferTimeout(-1);
             setBatchStateBackendAndTimerService(graph);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
@@ -75,7 +75,8 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
 
         assertThat(
                 environment.getStreamGraph(),
-                hasProperties(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, true));
+                hasProperties(
+                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, true, true));
     }
 
     @Test
@@ -93,7 +94,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 environment.getStreamGraph(),
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, false));
+                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        JobType.STREAMING,
+                        false,
+                        true));
     }
 
     @Test
@@ -120,7 +124,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 streamGraph,
                 hasProperties(
-                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED, JobType.BATCH, false));
+                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
+                        JobType.BATCH,
+                        false,
+                        false));
     }
 
     @Test
@@ -170,7 +177,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, false));
+                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        JobType.STREAMING,
+                        false,
+                        true));
     }
 
     @Test
@@ -183,7 +193,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED, JobType.BATCH, false));
+                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
+                        JobType.BATCH,
+                        false,
+                        false));
     }
 
     @Test
@@ -196,7 +209,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, false));
+                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        JobType.STREAMING,
+                        false,
+                        true));
     }
 
     @Test
@@ -213,7 +229,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, false));
+                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        JobType.STREAMING,
+                        false,
+                        true));
     }
 
     @Test
@@ -226,14 +245,20 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED, JobType.BATCH, false));
+                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
+                        JobType.BATCH,
+                        false,
+                        false));
 
         final StreamGraph streamingGraph =
                 generateStreamGraph(RuntimeExecutionMode.STREAMING, bounded);
         assertThat(
                 streamingGraph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, false));
+                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        JobType.STREAMING,
+                        false,
+                        true));
     }
 
     private StreamGraph generateStreamGraph(
@@ -262,7 +287,8 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
     private static TypeSafeMatcher<StreamGraph> hasProperties(
             final GlobalDataExchangeMode exchangeMode,
             final JobType jobType,
-            final boolean isCheckpointingEnable) {
+            final boolean isCheckpointingEnabled,
+            final boolean isAllVerticesInSameSlotSharingGroupByDefault) {
 
         return new TypeSafeMatcher<StreamGraph>() {
             @Override
@@ -270,17 +296,22 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
                 return exchangeMode == actualStreamGraph.getGlobalDataExchangeMode()
                         && jobType == actualStreamGraph.getJobType()
                         && actualStreamGraph.getCheckpointConfig().isCheckpointingEnabled()
-                                == isCheckpointingEnable;
+                                == isCheckpointingEnabled
+                        && actualStreamGraph.isAllVerticesInSameSlotSharingGroupByDefault()
+                                == isAllVerticesInSameSlotSharingGroupByDefault;
             }
 
             @Override
             public void describeTo(Description description) {
                 description
-                        .appendText("a StreamGraph with exchangeMode='")
+                        .appendText("a StreamGraph with exchangeMode=")
                         .appendValue(exchangeMode)
-                        .appendText("' and jobType='")
+                        .appendText(", jobType=")
                         .appendValue(jobType)
-                        .appendText("'");
+                        .appendText(", isCheckpointingEnabled=")
+                        .appendValue(isCheckpointingEnabled)
+                        .appendText(", isAllVerticesInSameSlotSharingGroupByDefault=")
+                        .appendValue(isAllVerticesInSameSlotSharingGroupByDefault);
             }
 
             @Override
@@ -288,11 +319,14 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
                     StreamGraph item, Description mismatchDescription) {
                 mismatchDescription
                         .appendText("was ")
-                        .appendText("a StreamGraph with exchangeMode='")
-                        .appendValue(item.getGlobalDataExchangeMode())
-                        .appendText("' and scheduleMode='")
-                        .appendValue(item.getJobType())
-                        .appendText("'");
+                        .appendText("a StreamGraph with exchangeMode=")
+                        .appendValue(exchangeMode)
+                        .appendText(", jobType=")
+                        .appendValue(jobType)
+                        .appendText(", isCheckpointingEnabled=")
+                        .appendValue(isCheckpointingEnabled)
+                        .appendText(", isAllVerticesInSameSlotSharingGroupByDefault=")
+                        .appendValue(isAllVerticesInSameSlotSharingGroupByDefault);
             }
         };
     }


### PR DESCRIPTION
## What is the purpose of the change

This reverts FLINK-20001 and thus ensures that batch modes in both DataStream API and Table API behave the same regarding slot assignment. See the JIRA issue for more information.

## Brief change log

`graph.setAllVerticesInSameSlotSharingGroupByDefault(false);` added to `StreamGraphGenerator`

## Verifying this change

This change added tests and can be verified as follows: `StreamGraphGeneratorExecutionModeDetectionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
