### PR TITLE
[FLINK-23395] Bump Okhttp to 3.14.9

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -39,7 +39,6 @@ under the License.
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -47,7 +47,6 @@ under the License.
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.7.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -35,17 +35,6 @@ under the License.
 		<kubernetes.client.version>4.9.2</kubernetes.client.version>
 	</properties>
 
-	<!-- Set dependency version for transitive dependencies -->
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.squareup.okhttp3</groupId>
-				<artifactId>okhttp</artifactId>
-				<version>3.12.1</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<dependencies>
 
 		<!-- core dependencies  -->
@@ -179,6 +168,13 @@ under the License.
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.kubernetes.shaded.com.fasterxml.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>okhttp3/internal/publicsuffix</pattern>
+									<shadedPattern>META-INF</shadedPattern>
+									<includes>
+										<include>**/NOTICE</include>
+									</includes>
 								</relocation>
 								<relocation>
 									<pattern>okhttp3</pattern>

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -12,8 +12,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1
 - com.squareup.okhttp3:logging-interceptor:3.12.6
-- com.squareup.okhttp3:okhttp:3.12.1
-- com.squareup.okio:okio:1.15.0
+- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okio:okio:1.17.2
 - io.fabric8:kubernetes-client:4.9.2
 - io.fabric8:kubernetes-model:4.9.2
 - io.fabric8:kubernetes-model-common:4.9.2

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.12.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.1
-- com.squareup.okhttp3:logging-interceptor:3.12.6
+- com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2
 - io.fabric8:kubernetes-client:4.9.2

--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -56,7 +56,6 @@ under the License.
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.7.0</version>
 		</dependency>
 
 		<dependency>
@@ -93,6 +92,15 @@ under the License.
 									<include>com.squareup.okio:*</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>okhttp3/internal/publicsuffix</pattern>
+									<shadedPattern>META-INF</shadedPattern>
+									<includes>
+										<include>**/NOTICE</include>
+									</includes>
+								</relocation>
+							</relocations>
 							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 						</configuration>
 					</execution>

--- a/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
@@ -6,5 +6,5 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.squareup.okhttp3:okhttp:3.7.0
-- com.squareup.okio:okio:1.12.0
+- com.squareup.okhttp3:okhttp:3.14.9
+- com.squareup.okio:okio:1.17.2

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -7,8 +7,8 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.squareup.moshi:moshi:1.8.0
-- com.squareup.okhttp3:logging-interceptor:3.14.4
-- com.squareup.okhttp3:okhttp:3.14.4
+- com.squareup.okhttp3:logging-interceptor:3.14.9
+- com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2
 - com.squareup.retrofit2:converter-moshi:2.6.2
 - com.squareup.retrofit2:retrofit:2.6.2

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@ under the License.
 		<beam.version>2.27.0</beam.version>
 		<protoc.version>3.11.1</protoc.version>
 		<arrow.version>0.16.0</arrow.version>
+		<okhttp.version>3.14.9</okhttp.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
 		<!--
@@ -526,6 +527,17 @@ under the License.
 				<type>pom</type>
 				<scope>import</scope>
 				<version>2.12.1</version>
+			</dependency>
+			
+			<dependency>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>okhttp</artifactId>
+				<version>${okhttp.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.squareup.okhttp3</groupId>
+				<artifactId>logging-interceptor</artifactId>
+				<version>${okhttp.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
This is the latest (and last) version for Okhttp 3.x .

Long-term we need to look into Okhttp 4 to avoid some IPv6 issues, but v4 unfortunately relies on the kotlin standard library which we haven't had to deal with so far.