### PR TITLE
[FLINK-20323][table/planner] CorrelateSortToRankRule supports dealing…

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
@@ -118,10 +118,7 @@ class CorrelateSortToRankRule extends RelOptRule(
       return false
     }
     val variable = fieldAccess.getReferenceExpr.asInstanceOf[RexCorrelVariable]
-    if (!variable.id.equals(correlate.getCorrelationId)) {
-      return false
-    }
-    true
+    variable.id.equals(correlate.getCorrelationId)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRule.scala
@@ -19,11 +19,10 @@
 package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.table.planner.calcite.{FlinkRelBuilder, FlinkRelFactories}
-import org.apache.flink.table.planner.plan.utils.SortUtil
 import org.apache.flink.table.runtime.operators.rank.{ConstantRankRange, RankType}
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
-import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
 import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Aggregate, Correlate, Filter, JoinRelType, Project, Sort}
@@ -82,10 +81,7 @@ class CorrelateSortToRankRule extends RelOptRule(
       return false
     }
     val agg: Aggregate = call.rel(1)
-    if (agg.getAggCallList.size() > 0
-      || agg.getGroupSets.size() > 1
-      || agg.getGroupSet.cardinality() != 1) {
-      // only one group field is supported now
+    if (agg.getAggCallList.size() > 0 || agg.getGroupSets.size() > 1) {
       return false
     }
     val aggInput: Project = call.rel(2)
@@ -103,11 +99,20 @@ class CorrelateSortToRankRule extends RelOptRule(
       return false
     }
     val filter: Filter = call.rel(5)
-    val condition = filter.getCondition
+
+    val cnfCond = RelOptUtil.conjunctions(filter.getCondition)
+    if (cnfCond.exists(c => !isValidCondition(c, correlate))) {
+      return false
+    }
+
+    aggInput.getInput.getDigest.equals(filter.getInput.getDigest)
+  }
+
+  private def isValidCondition(condition: RexNode, correlate: Correlate): Boolean = {
+    // must be equiv condition
     if (condition.getKind != SqlKind.EQUALS) {
       return false
     }
-    // only support one partition key
     val (inputRef, fieldAccess) = resolveFilterCondition(condition)
     if (inputRef == null) {
       return false
@@ -116,7 +121,7 @@ class CorrelateSortToRankRule extends RelOptRule(
     if (!variable.id.equals(correlate.getCorrelationId)) {
       return false
     }
-    aggInput.getInput.getDigest.equals(filter.getInput.getDigest)
+    true
   }
 
   /**
@@ -126,7 +131,7 @@ class CorrelateSortToRankRule extends RelOptRule(
    * @return tuple of operands (RexInputRef, RexFieldAccess),
    *         or null if the pattern does not match
    */
-  def resolveFilterCondition(condition: RexNode): (RexInputRef, RexFieldAccess) = {
+  private def resolveFilterCondition(condition: RexNode): (RexInputRef, RexFieldAccess) = {
     val condCall = condition.asInstanceOf[RexCall]
     val operand0 = condCall.getOperands.get(0)
     val operand1 = condCall.getOperands.get(1)
@@ -146,8 +151,9 @@ class CorrelateSortToRankRule extends RelOptRule(
     val sortInput: Project = call.rel(4)
     val filter: Filter = call.rel(5)
 
-    val partitionKey: ImmutableBitSet =
-      ImmutableBitSet.of(resolveFilterCondition(filter.getCondition)._1.getIndex)
+    val cnfCond = RelOptUtil.conjunctions(filter.getCondition)
+    val partitionKey: ImmutableBitSet = ImmutableBitSet.of(
+      cnfCond.map(c => resolveFilterCondition(c)._1.getIndex): _*)
 
     val baseType: RelDataType = sortInput.getInput().getRowType
     val projects = new util.ArrayList[RexNode]()

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.xml
@@ -221,7 +221,7 @@ LogicalProject(f0=[$0], f1=[$1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testMultipleGroupingsNotSupported">
+  <TestCase name="testCorrelateSortToRankWithMultipleGroupKeys">
     <Resource name="sql">
       <![CDATA[
 SELECT f0, f2
@@ -252,14 +252,8 @@ LogicalProject(f0=[$0], f2=[$2])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(f0=[$0], f2=[$2])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
-   :- LogicalAggregate(group=[{0, 1}])
-   :  +- LogicalProject(f0=[$0], f1=[$1])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
-   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
-      +- LogicalProject(f2=[$2])
-         +- LogicalFilter(condition=[AND(=($0, $cor0.f0), =($1, $cor0.f1))])
-            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
++- LogicalRank(rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[$0,$1], orderBy=[$2 DESC], select=[f0=$0, f1=$1, f2=$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.xml
@@ -342,4 +342,88 @@ LogicalProject(f0=[$0], f1=[$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testMultipleGroupingsWithConstantNotSupported1">
+    <Resource name="sql">
+	  <![CDATA[
+SELECT f0, f2
+FROM
+  (SELECT DISTINCT f0, f1 FROM t1) t2,
+  LATERAL (
+    SELECT f2
+    FROM t1
+    WHERE f0 = 1 AND f1 = t2.f1
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+	</Resource>
+    <Resource name="ast">
+	  <![CDATA[
+LogicalProject(f0=[$0], f2=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(f0=[$0], f1=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f2=[$2])
+         +- LogicalFilter(condition=[AND(=($0, 1), =($1, $cor0.f1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(f0=[$0], f2=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(f0=[$0], f1=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f2=[$2])
+         +- LogicalFilter(condition=[AND(=($0, 1), =($1, $cor0.f1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultipleGroupingsWithConstantNotSupported2">
+    <Resource name="sql">
+    <![CDATA[
+SELECT f0, f2
+FROM
+  (SELECT DISTINCT f0, f1 FROM t1) t2,
+  LATERAL (
+    SELECT f2
+    FROM t1
+    WHERE 1 = t2.f0 AND f1 = t2.f1
+    ORDER BY f2
+    DESC LIMIT 3
+  )
+      ]]>
+  </Resource>
+    <Resource name="ast">
+    <![CDATA[
+LogicalProject(f0=[$0], f2=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(f0=[$0], f1=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f2=[$2])
+         +- LogicalFilter(condition=[AND(=(1, $cor0.f0), =($1, $cor0.f1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(f0=[$0], f2=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(f0=[$0], f1=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+   +- LogicalSort(sort0=[$0], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(f2=[$2])
+         +- LogicalFilter(condition=[AND(=(1, $cor0.f0), =($1, $cor0.f1))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -54,6 +54,44 @@ Calc(select=[a, b])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelateSortToRankWithMultipleGroupKeys">
+    <Resource name="sql">
+      <![CDATA[
+SELECT a, b, c
+FROM
+  (SELECT DISTINCT a, b FROM T) T1,
+  LATERAL (
+    SELECT c, d
+    FROM T
+    WHERE a = T1.a and b = T1.b
+    ORDER BY d
+    DESC LIMIT 3
+  )
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+   :- LogicalAggregate(group=[{0, 1}])
+   :  +- LogicalProject(a=[$0], b=[$1])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+   +- LogicalSort(sort0=[$1], dir0=[DESC-nulls-last], fetch=[3])
+      +- LogicalProject(c=[$2], d=[$3])
+         +- LogicalFilter(condition=[AND(=($0, $cor0.a), =($1, $cor0.b))])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=3], partitionBy=[a, b], orderBy=[d DESC], select=[a, b, c, d])
+   +- Exchange(distribution=[hash[a, b]])
+      +- Calc(select=[a, b, c, d])
+         +- DataStreamScan(table=[[default_catalog, default_database, T]], fields=[a, b, c, d, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCreateViewWithRowNumber">
     <Resource name="sql">
       <![CDATA[insert into sink select name, eat, cnt

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.scala
@@ -76,24 +76,6 @@ class CorrelateSortToRankRuleTest extends TableTestBase {
   }
 
   @Test
-  def testCorrelateSortToRankWithMultipleGroupKeys(): Unit = {
-    val query =
-      s"""
-         |SELECT f0, f2
-         |FROM
-         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
-         |  LATERAL (
-         |    SELECT f2
-         |    FROM t1
-         |    WHERE f0 = t2.f0 AND f1 = t2.f1
-         |    ORDER BY f2
-         |    DESC LIMIT 3
-         |  )
-      """.stripMargin
-    util.verifyRelPlan(query)
-  }
-
-  @Test
   def testNonInnerJoinNotSupported(): Unit = {
     val query =
       s"""
@@ -123,6 +105,24 @@ class CorrelateSortToRankRuleTest extends TableTestBase {
          |    SELECT f1, f2
          |    FROM t1
          |    WHERE f0 = t2.mf0
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyRelPlan(query)
+  }
+
+  @Test
+  def testCorrelateSortToRankWithMultipleGroupKeys(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f2
+         |FROM
+         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0 AND f1 = t2.f1
          |    ORDER BY f2
          |    DESC LIMIT 3
          |  )
@@ -196,6 +196,42 @@ class CorrelateSortToRankRuleTest extends TableTestBase {
          |    SELECT f1, f2
          |    FROM t1
          |    WHERE t2.f0 = f0 + 1
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyRelPlan(query)
+  }
+
+  @Test
+  def testMultipleGroupingsWithConstantNotSupported1(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f2
+         |FROM
+         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f2
+         |    FROM t1
+         |    WHERE f0 = 1 AND f1 = t2.f1
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyRelPlan(query)
+  }
+
+  @Test
+  def testMultipleGroupingsWithConstantNotSupported2(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f2
+         |FROM
+         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f2
+         |    FROM t1
+         |    WHERE 1 = t2.f0 AND f1 = t2.f1
          |    ORDER BY f2
          |    DESC LIMIT 3
          |  )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/CorrelateSortToRankRuleTest.scala
@@ -76,6 +76,24 @@ class CorrelateSortToRankRuleTest extends TableTestBase {
   }
 
   @Test
+  def testCorrelateSortToRankWithMultipleGroupKeys(): Unit = {
+    val query =
+      s"""
+         |SELECT f0, f2
+         |FROM
+         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
+         |  LATERAL (
+         |    SELECT f2
+         |    FROM t1
+         |    WHERE f0 = t2.f0 AND f1 = t2.f1
+         |    ORDER BY f2
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyRelPlan(query)
+  }
+
+  @Test
   def testNonInnerJoinNotSupported(): Unit = {
     val query =
       s"""
@@ -105,24 +123,6 @@ class CorrelateSortToRankRuleTest extends TableTestBase {
          |    SELECT f1, f2
          |    FROM t1
          |    WHERE f0 = t2.mf0
-         |    ORDER BY f2
-         |    DESC LIMIT 3
-         |  )
-      """.stripMargin
-    util.verifyRelPlan(query)
-  }
-
-  @Test // TODO: this is a valid case to support
-  def testMultipleGroupingsNotSupported(): Unit = {
-    val query =
-      s"""
-         |SELECT f0, f2
-         |FROM
-         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
-         |  LATERAL (
-         |    SELECT f2
-         |    FROM t1
-         |    WHERE f0 = t2.f0 AND f1 = t2.f1
          |    ORDER BY f2
          |    DESC LIMIT 3
          |  )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/RankTest.scala
@@ -689,6 +689,26 @@ class RankTest extends TableTestBase {
   }
 
   @Test
+  def testCorrelateSortToRankWithMultipleGroupKeys(): Unit = {
+    util.addDataStream[(Int, String, Long, Long)](
+      "T", 'a, 'b, 'c, 'd, 'proctime.proctime, 'rowtime.rowtime)
+    val query =
+      s"""
+         |SELECT a, b, c
+         |FROM
+         |  (SELECT DISTINCT a, b FROM T) T1,
+         |  LATERAL (
+         |    SELECT c, d
+         |    FROM T
+         |    WHERE a = T1.a and b = T1.b
+         |    ORDER BY d
+         |    DESC LIMIT 3
+         |  )
+      """.stripMargin
+    util.verifyExecPlan(query)
+  }
+
+  @Test
   def testRankWithAnotherRankAsInput(): Unit = {
     val sql =
       """


### PR DESCRIPTION
… with multiple group keys

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

## Brief change log

Currently, `CorrelateSortToRankRule` cannot deal with multiple group keys, e.g., 
```
  def testMultipleGroupingsNotSupported(): Unit = {
    val query =
      s"""
         |SELECT f0, f2
         |FROM
         |  (SELECT DISTINCT f0, f1 FROM t1) t2,
         |  LATERAL (
         |    SELECT f2
         |    FROM t1
         |    WHERE f0 = t2.f0 AND f1 = t2.f1
         |    ORDER BY f2
         |    DESC LIMIT 3
         |  )
      """.stripMargin
    util.verifyPlan(query)
  }
```
This pr will solve this problem.



## Verifying this change
* Unit test in `CorrelateSortToRankRuleTest`
* IT test in `RankITTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
