### PR TITLE
[FLINK-10804] [Runtime/Coordination] Transfer suppressed exceptions with SerializedThrowable

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
@@ -93,7 +93,8 @@ public class SerializedThrowable extends Exception implements Serializable {
                     initCause(new SerializedThrowable(exception.getCause(), alreadySeen));
                 }
             }
-
+            // mimic suppressed exceptions
+            addAllSuppressed(exception.getSuppressed());
         } else {
             // copy from that serialized throwable
             SerializedThrowable other = (SerializedThrowable) exception;
@@ -103,6 +104,7 @@ public class SerializedThrowable extends Exception implements Serializable {
             this.cachedException = other.cachedException;
             this.setStackTrace(other.getStackTrace());
             this.initCause(other.getCause());
+            this.addAllSuppressed(other.getSuppressed());
         }
     }
 
@@ -137,6 +139,18 @@ public class SerializedThrowable extends Exception implements Serializable {
 
     public String getFullStringifiedStackTrace() {
         return fullStringifiedStackTrace;
+    }
+
+    private void addAllSuppressed(Throwable[] suppressed) {
+        for (Throwable s : suppressed) {
+            SerializedThrowable serializedThrowable;
+            if (s instanceof SerializedThrowable) {
+                serializedThrowable = (SerializedThrowable) s;
+            } else {
+                serializedThrowable = new SerializedThrowable(s);
+            }
+            this.addSuppressed(serializedThrowable);
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
@@ -29,8 +29,10 @@ import org.junit.Test;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/** Tests for {@link SerializedThrowable}. */
 public class SerializedThrowableTest {
 
     @Test
@@ -151,5 +153,34 @@ public class SerializedThrowableTest {
         assertEquals("parent message", copy.getMessage());
         assertNotNull(copy.getCause());
         assertEquals("original message", copy.getCause().getMessage());
+    }
+
+    @Test
+    public void testSuppressedTransferring() {
+        Exception root = new Exception("root");
+        Exception suppressed = new Exception("suppressed");
+        root.addSuppressed(suppressed);
+
+        SerializedThrowable serializedThrowable = new SerializedThrowable(root);
+
+        assertEquals(1, serializedThrowable.getSuppressed().length);
+        Throwable actualSuppressed = serializedThrowable.getSuppressed()[0];
+        assertTrue(actualSuppressed instanceof SerializedThrowable);
+        assertEquals("suppressed", actualSuppressed.getMessage());
+    }
+
+    @Test
+    public void testCopySuppressed() {
+        Exception root = new Exception("root");
+        Exception suppressed = new Exception("suppressed");
+        root.addSuppressed(suppressed);
+
+        SerializedThrowable serializedThrowable = new SerializedThrowable(root);
+        SerializedThrowable copy = new SerializedThrowable(serializedThrowable);
+
+        assertEquals(1, copy.getSuppressed().length);
+        Throwable actualSuppressed = copy.getSuppressed()[0];
+        assertTrue(actualSuppressed instanceof SerializedThrowable);
+        assertEquals("suppressed", actualSuppressed.getMessage());
     }
 }


### PR DESCRIPTION
### What is the purpose of the change
The goal of the PR is to transfer suppressed exceptions with `SerializedThrowable`.

### Brief change log
b960ccecd1d872d7a733a682013b4f2920cd8800 : new logic for transferring suppressed exceptions with unit tests added
ca42f1ed27b9b03e275d90bf73382d30988829de, 7247896f2c4d750bf2ae204b53c94a79e3794e6b : modifided `SerializedThrowableSerializerTest` to test suppressed exceptions serde.

### Verifying this change
This PR adds new unit tests `SerializedThrowableTest.testSuppressedTransferring()`, `SerializedThrowableTest.testCopySuppressed()`.

### Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (yes / **no**)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (yes / **no**)
- The serializers: (**yes** / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
- The S3 file system connector: (yes / **no** / don't know)

### Documentation
- Does this pull request introduce a new feature? (yes / **no**)
- If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
