### PR TITLE
[FLINK-23367][state] Ensure InternalPriorityQueue#iterator could be closed for changelog state-backend

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyGroupedPriorityQueue.java
@@ -129,9 +129,8 @@ public class ChangelogKeyGroupedPriorityQueue<T>
     @Override
     @Nonnull
     public CloseableIterator<T> iterator() {
-        return CloseableIterator.adapterForIterator(
-                StateChangeLoggingIterator.create(
-                        delegatedPriorityQueue.iterator(), logger, serializer::serialize, null));
+        return StateChangeLoggingIterator.create(
+                delegatedPriorityQueue.iterator(), logger, serializer::serialize, null);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

 Ensure InternalPriorityQueue#iterator could be closed for changelog state-backend


## Brief change log

Make `StateChangeLoggingIterator.java` as `CloseableIterator`.


## Verifying this change

This change is already covered by existing tests, such as `ChangelogDelegateEmbeddedRocksDBStateBackendTest#testKeyGroupedInternalPriorityQueue `


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
