### PR TITLE
[FLINK-23369][core][docs] Mechanism to document enums used in ConfigOptions

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -17,8 +17,8 @@
         <tr>
             <td><h5>cluster.intercept-user-system-exit</h5></td>
             <td style="word-wrap: break-word;">DISABLED</td>
-            <td><p>Enum</p>Possible values: [DISABLED, LOG, THROW]</td>
-            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit())<ul><li>DISABLED - Flink is not monitoring or intercepting calls to System.exit()</li><li>LOG - Log exit attempt with stack trace but still allowing exit to be performed</li><li>THROW - Throw exception when exit is attempted disallowing JVM termination</li></ul><br />Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.</td>
+            <td><p>Enum</p></td>
+            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit())<ul><li>DISABLED - Flink is not monitoring or intercepting calls to System.exit()</li><li>LOG - Log exit attempt with stack trace but still allowing exit to be performed</li><li>THROW - Throw exception when exit is attempted disallowing JVM termination</li></ul><br />Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br><br>Possible values:<ul><li>"DISABLED"</li><li>"LOG"</li><li>"THROW"</li></ul></td>
         </tr>
         <tr>
             <td><h5>cluster.io-pool.size</h5></td>
@@ -65,8 +65,8 @@
         <tr>
             <td><h5>cluster.uncaught-exception-handling</h5></td>
             <td style="word-wrap: break-word;">LOG</td>
-            <td><p>Enum</p>Possible values: [LOG, FAIL]</td>
-            <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)</td>
+            <td><p>Enum</p></td>
+            <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)<br><br>Possible values:<ul><li>"LOG"</li><li>"FAIL"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>cluster.intercept-user-system-exit</h5></td>
             <td style="word-wrap: break-word;">DISABLED</td>
             <td><p>Enum</p></td>
-            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit())<ul><li>DISABLED - Flink is not monitoring or intercepting calls to System.exit()</li><li>LOG - Log exit attempt with stack trace but still allowing exit to be performed</li><li>THROW - Throw exception when exit is attempted disallowing JVM termination</li></ul><br />Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br><br>Possible values:<ul><li>"DISABLED"</li><li>"LOG"</li><li>"THROW"</li></ul></td>
+            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit()). Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br><br>Possible values:<ul><li>"DISABLED": Flink is not monitoring or intercepting calls to System.exit()</li><li>"LOG": Log exit attempt with stack trace but still allowing exit to be performed</li><li>"THROW": Throw exception when exit is attempted disallowing JVM termination</li></ul></td>
         </tr>
         <tr>
             <td><h5>cluster.io-pool.size</h5></td>

--- a/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
@@ -17,8 +17,8 @@
         <tr>
             <td><h5>execution.checkpointing.externalized-checkpoint-retention</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td><p>Enum</p>Possible values: [DELETE_ON_CANCELLATION, RETAIN_ON_CANCELLATION]</td>
-            <td>Externalized checkpoints write their meta data out to persistent storage and are not automatically cleaned up when the owning job fails or is suspended (terminating with job status <code class="highlighter-rouge">JobStatus#FAILED</code> or <code class="highlighter-rouge">JobStatus#SUSPENDED</code>. In this case, you have to manually clean up the checkpoint state, both the meta data and actual program state.<br /><br />The mode defines how an externalized checkpoint should be cleaned up on job cancellation. If you choose to retain externalized checkpoints on cancellation you have to handle checkpoint clean up manually when you cancel the job as well (terminating with job status <code class="highlighter-rouge">JobStatus#CANCELED</code>).<br /><br />The target directory for externalized checkpoints is configured via <code class="highlighter-rouge">state.checkpoints.dir</code>.</td>
+            <td><p>Enum</p></td>
+            <td>Externalized checkpoints write their meta data out to persistent storage and are not automatically cleaned up when the owning job fails or is suspended (terminating with job status <code class="highlighter-rouge">JobStatus#FAILED</code> or <code class="highlighter-rouge">JobStatus#SUSPENDED</code>. In this case, you have to manually clean up the checkpoint state, both the meta data and actual program state.<br /><br />The mode defines how an externalized checkpoint should be cleaned up on job cancellation. If you choose to retain externalized checkpoints on cancellation you have to handle checkpoint clean up manually when you cancel the job as well (terminating with job status <code class="highlighter-rouge">JobStatus#CANCELED</code>).<br /><br />The target directory for externalized checkpoints is configured via <code class="highlighter-rouge">state.checkpoints.dir</code>.<br><br>Possible values:<ul><li>"DELETE_ON_CANCELLATION"</li><li>"RETAIN_ON_CANCELLATION"</li></ul></td>
         </tr>
         <tr>
             <td><h5>execution.checkpointing.interval</h5></td>
@@ -41,8 +41,8 @@
         <tr>
             <td><h5>execution.checkpointing.mode</h5></td>
             <td style="word-wrap: break-word;">EXACTLY_ONCE</td>
-            <td><p>Enum</p>Possible values: [EXACTLY_ONCE, AT_LEAST_ONCE]</td>
-            <td>The checkpointing mode (exactly-once vs. at-least-once).</td>
+            <td><p>Enum</p></td>
+            <td>The checkpointing mode (exactly-once vs. at-least-once).<br><br>Possible values:<ul><li>"EXACTLY_ONCE"</li><li>"AT_LEAST_ONCE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>execution.checkpointing.prefer-checkpoint-for-recovery</h5></td>

--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -61,14 +61,14 @@ By default no operator is disabled.</td>
         <tr>
             <td><h5>table.exec.sink.not-null-enforcer</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">ERROR</td>
-            <td><p>Enum</p>Possible values: [ERROR, DROP]</td>
-            <td>The NOT NULL column constraint on a table enforces that null values can't be inserted into the table. Flink supports 'error' (default) and 'drop' enforcement behavior. By default, Flink will check values and throw runtime exception when null values writing into NOT NULL columns. Users can change the behavior to 'drop' to silently drop such records without throwing exception.</td>
+            <td><p>Enum</p></td>
+            <td>The NOT NULL column constraint on a table enforces that null values can't be inserted into the table. Flink supports 'error' (default) and 'drop' enforcement behavior. By default, Flink will check values and throw runtime exception when null values writing into NOT NULL columns. Users can change the behavior to 'drop' to silently drop such records without throwing exception.<br><br>Possible values:<ul><li>"ERROR"</li><li>"DROP"</li></ul></td>
         </tr>
         <tr>
             <td><h5>table.exec.sink.upsert-materialize</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">AUTO</td>
-            <td><p>Enum</p>Possible values: [NONE, AUTO, FORCE]</td>
-            <td>Because of the disorder of ChangeLog data caused by Shuffle in distributed system, the data received by Sink may not be the order of global upsert. So add upsert materialize operator before upsert sink. It receives the upstream changelog records and generate an upsert view for the downstream.<br />By default, the materialize operator will be added when a distributed disorder occurs on unique keys. You can also choose no materialization(NONE) or force materialization(FORCE).</td>
+            <td><p>Enum</p></td>
+            <td>Because of the disorder of ChangeLog data caused by Shuffle in distributed system, the data received by Sink may not be the order of global upsert. So add upsert materialize operator before upsert sink. It receives the upstream changelog records and generate an upsert view for the downstream.<br />By default, the materialize operator will be added when a distributed disorder occurs on unique keys. You can also choose no materialization(NONE) or force materialization(FORCE).<br><br>Possible values:<ul><li>"NONE"</li><li>"AUTO"</li><li>"FORCE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>table.exec.sort.async-merge-enabled</h5><br> <span class="label label-primary">Batch</span></td>

--- a/docs/layouts/shortcodes/generated/execution_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_configuration.html
@@ -23,8 +23,8 @@
         <tr>
             <td><h5>execution.runtime-mode</h5></td>
             <td style="word-wrap: break-word;">STREAMING</td>
-            <td><p>Enum</p>Possible values: [STREAMING, BATCH, AUTOMATIC]</td>
-            <td>Runtime execution mode of DataStream programs. Among other things, this controls task scheduling, network shuffle behavior, and time semantics.</td>
+            <td><p>Enum</p></td>
+            <td>Runtime execution mode of DataStream programs. Among other things, this controls task scheduling, network shuffle behavior, and time semantics.<br><br>Possible values:<ul><li>"STREAMING"</li><li>"BATCH"</li><li>"AUTOMATIC"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -11,8 +11,8 @@
         <tr>
             <td><h5>cluster.intercept-user-system-exit</h5></td>
             <td style="word-wrap: break-word;">DISABLED</td>
-            <td><p>Enum</p>Possible values: [DISABLED, LOG, THROW]</td>
-            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit())<ul><li>DISABLED - Flink is not monitoring or intercepting calls to System.exit()</li><li>LOG - Log exit attempt with stack trace but still allowing exit to be performed</li><li>THROW - Throw exception when exit is attempted disallowing JVM termination</li></ul><br />Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.</td>
+            <td><p>Enum</p></td>
+            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit())<ul><li>DISABLED - Flink is not monitoring or intercepting calls to System.exit()</li><li>LOG - Log exit attempt with stack trace but still allowing exit to be performed</li><li>THROW - Throw exception when exit is attempted disallowing JVM termination</li></ul><br />Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br><br>Possible values:<ul><li>"DISABLED"</li><li>"LOG"</li><li>"THROW"</li></ul></td>
         </tr>
         <tr>
             <td><h5>cluster.processes.halt-on-fatal-error</h5></td>
@@ -23,8 +23,8 @@
         <tr>
             <td><h5>cluster.uncaught-exception-handling</h5></td>
             <td style="word-wrap: break-word;">LOG</td>
-            <td><p>Enum</p>Possible values: [LOG, FAIL]</td>
-            <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)</td>
+            <td><p>Enum</p></td>
+            <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)<br><br>Possible values:<ul><li>"LOG"</li><li>"FAIL"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -12,7 +12,7 @@
             <td><h5>cluster.intercept-user-system-exit</h5></td>
             <td style="word-wrap: break-word;">DISABLED</td>
             <td><p>Enum</p></td>
-            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit())<ul><li>DISABLED - Flink is not monitoring or intercepting calls to System.exit()</li><li>LOG - Log exit attempt with stack trace but still allowing exit to be performed</li><li>THROW - Throw exception when exit is attempted disallowing JVM termination</li></ul><br />Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br><br>Possible values:<ul><li>"DISABLED"</li><li>"LOG"</li><li>"THROW"</li></ul></td>
+            <td>Flag to check user code exiting system by terminating JVM (e.g., System.exit()). Note that this configuration option can interfere with <code class="highlighter-rouge">cluster.processes.halt-on-fatal-error</code>: In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when <code class="highlighter-rouge">THROW</code> is configured.<br><br>Possible values:<ul><li>"DISABLED": Flink is not monitoring or intercepting calls to System.exit()</li><li>"LOG": Log exit attempt with stack trace but still allowing exit to be performed</li><li>"THROW": Throw exception when exit is attempted disallowing JVM termination</li></ul></td>
         </tr>
         <tr>
             <td><h5>cluster.processes.halt-on-fatal-error</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -35,8 +35,8 @@
         <tr>
             <td><h5>scheduler-mode</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td><p>Enum</p>Possible values: [REACTIVE]</td>
-            <td>Determines the mode of the scheduler. Note that <code class="highlighter-rouge">scheduler-mode</code>=<code class="highlighter-rouge">REACTIVE</code> is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.</td>
+            <td><p>Enum</p></td>
+            <td>Determines the mode of the scheduler. Note that <code class="highlighter-rouge">scheduler-mode</code>=<code class="highlighter-rouge">REACTIVE</code> is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.<br><br>Possible values:<ul><li>"REACTIVE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>slot.idle.timeout</h5></td>

--- a/docs/layouts/shortcodes/generated/influxdb_reporter_configuration.html
+++ b/docs/layouts/shortcodes/generated/influxdb_reporter_configuration.html
@@ -17,8 +17,8 @@
         <tr>
             <td><h5>consistency</h5></td>
             <td style="word-wrap: break-word;">ONE</td>
-            <td><p>Enum</p>Possible values: [ALL, ANY, ONE, QUORUM]</td>
-            <td>(optional) the InfluxDB consistency level for metrics</td>
+            <td><p>Enum</p></td>
+            <td>(optional) the InfluxDB consistency level for metrics<br><br>Possible values:<ul><li>"ALL"</li><li>"ANY"</li><li>"ONE"</li><li>"QUORUM"</li></ul></td>
         </tr>
         <tr>
             <td><h5>db</h5></td>
@@ -53,8 +53,8 @@
         <tr>
             <td><h5>scheme</h5></td>
             <td style="word-wrap: break-word;">http</td>
-            <td><p>Enum</p>Possible values: [http, https]</td>
-            <td>the InfluxDB schema</td>
+            <td><p>Enum</p></td>
+            <td>the InfluxDB schema<br><br>Possible values:<ul><li>"http"</li><li>"https"</li></ul></td>
         </tr>
         <tr>
             <td><h5>username</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -149,8 +149,8 @@
         <tr>
             <td><h5>scheduler-mode</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td><p>Enum</p>Possible values: [REACTIVE]</td>
-            <td>Determines the mode of the scheduler. Note that <code class="highlighter-rouge">scheduler-mode</code>=<code class="highlighter-rouge">REACTIVE</code> is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.</td>
+            <td><p>Enum</p></td>
+            <td>Determines the mode of the scheduler. Note that <code class="highlighter-rouge">scheduler-mode</code>=<code class="highlighter-rouge">REACTIVE</code> is only supported by standalone application deployments, not by active resource managers (YARN, Kubernetes) or session clusters.<br><br>Possible values:<ul><li>"REACTIVE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>slot.idle.timeout</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -41,8 +41,8 @@
         <tr>
             <td><h5>kubernetes.container.image.pull-policy</h5></td>
             <td style="word-wrap: break-word;">IfNotPresent</td>
-            <td><p>Enum</p>Possible values: [IfNotPresent, Always, Never]</td>
-            <td>The Kubernetes container image pull policy (IfNotPresent or Always or Never). The default policy is IfNotPresent to avoid putting pressure to image repository.</td>
+            <td><p>Enum</p></td>
+            <td>The Kubernetes container image pull policy (IfNotPresent or Always or Never). The default policy is IfNotPresent to avoid putting pressure to image repository.<br><br>Possible values:<ul><li>"IfNotPresent"</li><li>"Always"</li><li>"Never"</li></ul></td>
         </tr>
         <tr>
             <td><h5>kubernetes.container.image.pull-secrets</h5></td>
@@ -167,8 +167,8 @@
         <tr>
             <td><h5>kubernetes.rest-service.exposed.type</h5></td>
             <td style="word-wrap: break-word;">LoadBalancer</td>
-            <td><p>Enum</p>Possible values: [ClusterIP, NodePort, LoadBalancer]</td>
-            <td>The exposed type of the rest service (ClusterIP or NodePort or LoadBalancer). The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.</td>
+            <td><p>Enum</p></td>
+            <td>The exposed type of the rest service (ClusterIP or NodePort or LoadBalancer). The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.<br><br>Possible values:<ul><li>"ClusterIP"</li><li>"NodePort"</li><li>"LoadBalancer"</li></ul></td>
         </tr>
         <tr>
             <td><h5>kubernetes.secrets</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -42,7 +42,7 @@
             <td><h5>kubernetes.container.image.pull-policy</h5></td>
             <td style="word-wrap: break-word;">IfNotPresent</td>
             <td><p>Enum</p></td>
-            <td>The Kubernetes container image pull policy (IfNotPresent or Always or Never). The default policy is IfNotPresent to avoid putting pressure to image repository.<br><br>Possible values:<ul><li>"IfNotPresent"</li><li>"Always"</li><li>"Never"</li></ul></td>
+            <td>The Kubernetes container image pull policy. The default policy is IfNotPresent to avoid putting pressure to image repository.<br><br>Possible values:<ul><li>"IfNotPresent"</li><li>"Always"</li><li>"Never"</li></ul></td>
         </tr>
         <tr>
             <td><h5>kubernetes.container.image.pull-secrets</h5></td>
@@ -168,7 +168,7 @@
             <td><h5>kubernetes.rest-service.exposed.type</h5></td>
             <td style="word-wrap: break-word;">LoadBalancer</td>
             <td><p>Enum</p></td>
-            <td>The exposed type of the rest service (ClusterIP or NodePort or LoadBalancer). The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.<br><br>Possible values:<ul><li>"ClusterIP"</li><li>"NodePort"</li><li>"LoadBalancer"</li></ul></td>
+            <td>The exposed type of the rest service. The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.<br><br>Possible values:<ul><li>"ClusterIP"</li><li>"NodePort"</li><li>"LoadBalancer"</li></ul></td>
         </tr>
         <tr>
             <td><h5>kubernetes.secrets</h5></td>

--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -41,8 +41,8 @@
         <tr>
             <td><h5>pipeline.closure-cleaner-level</h5></td>
             <td style="word-wrap: break-word;">RECURSIVE</td>
-            <td><p>Enum</p>Possible values: [NONE, TOP_LEVEL, RECURSIVE]</td>
-            <td>Configures the mode in which the closure cleaner works<ul><li><code class="highlighter-rouge">NONE</code> - disables the closure cleaner completely</li><li><code class="highlighter-rouge">TOP_LEVEL</code> - cleans only the top-level class without recursing into fields</li><li><code class="highlighter-rouge">RECURSIVE</code> - cleans all the fields recursively</li></ul></td>
+            <td><p>Enum</p></td>
+            <td>Configures the mode in which the closure cleaner works<ul><li><code class="highlighter-rouge">NONE</code> - disables the closure cleaner completely</li><li><code class="highlighter-rouge">TOP_LEVEL</code> - cleans only the top-level class without recursing into fields</li><li><code class="highlighter-rouge">RECURSIVE</code> - cleans all the fields recursively</li></ul><br><br>Possible values:<ul><li>"NONE"</li><li>"TOP_LEVEL"</li><li>"RECURSIVE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>pipeline.default-kryo-serializers</h5></td>

--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -42,7 +42,7 @@
             <td><h5>pipeline.closure-cleaner-level</h5></td>
             <td style="word-wrap: break-word;">RECURSIVE</td>
             <td><p>Enum</p></td>
-            <td>Configures the mode in which the closure cleaner works<ul><li><code class="highlighter-rouge">NONE</code> - disables the closure cleaner completely</li><li><code class="highlighter-rouge">TOP_LEVEL</code> - cleans only the top-level class without recursing into fields</li><li><code class="highlighter-rouge">RECURSIVE</code> - cleans all the fields recursively</li></ul><br><br>Possible values:<ul><li>"NONE"</li><li>"TOP_LEVEL"</li><li>"RECURSIVE"</li></ul></td>
+            <td>Configures the mode in which the closure cleaner works.<br><br>Possible values:<ul><li>"NONE": Disables the closure cleaner completely.</li><li>"TOP_LEVEL": Cleans only the top-level class without recursing into fields.</li><li>"RECURSIVE": Cleans all fields recursively.</li></ul></td>
         </tr>
         <tr>
             <td><h5>pipeline.default-kryo-serializers</h5></td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -47,8 +47,8 @@
         <tr>
             <td><h5>state.backend.rocksdb.compaction.style</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td><p>Enum</p>Possible values: [LEVEL, UNIVERSAL, FIFO]</td>
-            <td>The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO or UNIVERSAL, and RocksDB choose 'LEVEL' as default style.</td>
+            <td><p>Enum</p></td>
+            <td>The specified compaction style for DB. Candidate compaction style is LEVEL, FIFO or UNIVERSAL, and RocksDB choose 'LEVEL' as default style.<br><br>Possible values:<ul><li>"LEVEL"</li><li>"UNIVERSAL"</li><li>"FIFO"</li></ul></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.files.open</h5></td>
@@ -59,8 +59,8 @@
         <tr>
             <td><h5>state.backend.rocksdb.log.level</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
-            <td><p>Enum</p>Possible values: [DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL, NUM_INFO_LOG_LEVELS]</td>
-            <td>The specified log level for DB. Candidate log level is DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL or NUM_INFO_LOG_LEVELS, and Flink choose 'HEADER_LEVEL' as default style. Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.</td>
+            <td><p>Enum</p></td>
+            <td>The specified log level for DB. Candidate log level is DEBUG_LEVEL, INFO_LEVEL, WARN_LEVEL, ERROR_LEVEL, FATAL_LEVEL, HEADER_LEVEL or NUM_INFO_LOG_LEVELS, and Flink choose 'HEADER_LEVEL' as default style. Note: RocksDB logs will not be output to TaskManager logs, and there is no rolling strategy. If the Flink task runs for a long time, it may lead to uncontrolled disk space usage. There is no need to modify the RocksDB log level, unless troubleshooting RocksDB.<br><br>Possible values:<ul><li>"DEBUG_LEVEL"</li><li>"INFO_LEVEL"</li><li>"WARN_LEVEL"</li><li>"ERROR_LEVEL"</li><li>"FATAL_LEVEL"</li><li>"HEADER_LEVEL"</li><li>"NUM_INFO_LOG_LEVELS"</li></ul></td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.thread.num</h5></td>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -65,8 +65,8 @@
         <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">ROCKSDB</td>
-            <td><p>Enum</p>Possible values: [HEAP, ROCKSDB]</td>
-            <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based) or ROCKSDB for an implementation based on RocksDB.</td>
+            <td><p>Enum</p></td>
+            <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based) or ROCKSDB for an implementation based on RocksDB.<br><br>Possible values:<ul><li>"HEAP"</li><li>"ROCKSDB"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/rocksdb_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configuration.html
@@ -66,7 +66,7 @@
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">ROCKSDB</td>
             <td><p>Enum</p></td>
-            <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based) or ROCKSDB for an implementation based on RocksDB.<br><br>Possible values:<ul><li>"HEAP"</li><li>"ROCKSDB"</li></ul></td>
+            <td>This determines the factory for timer service state implementation.<br><br>Possible values:<ul><li>"HEAP": Heap-based</li><li>"ROCKSDB": Implementation based on RocksDB</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/sql_client_configuration.html
+++ b/docs/layouts/shortcodes/generated/sql_client_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>sql-client.execution.result-mode</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">TABLE</td>
             <td><p>Enum</p></td>
-            <td>Determine the mode when display the query result. The available values are ['table', 'tableau', 'changelog']. The 'table' mode materializes results in memory and visualizes them in a regular, paginated table representation. The 'changelog' mode does not materialize results and visualizes the result stream that is produced by a continuous query. The 'tableau' mode is more like a traditional way which will display the results in the screen directly with a tableau format. <br><br>Possible values:<ul><li>"TABLE"</li><li>"CHANGELOG"</li><li>"TABLEAU"</li></ul></td>
+            <td>Determines how the query result should be displayed.<br><br>Possible values:<ul><li>"TABLE": Materializes results in memory and visualizes them in a regular, paginated table representation.</li><li>"CHANGELOG": Visualizes the result stream that is produced by a continuous query.</li><li>"TABLEAU": Display results in the screen directly in a tableau format.</li></ul></td>
         </tr>
         <tr>
             <td><h5>sql-client.verbose</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>

--- a/docs/layouts/shortcodes/generated/sql_client_configuration.html
+++ b/docs/layouts/shortcodes/generated/sql_client_configuration.html
@@ -23,8 +23,8 @@
         <tr>
             <td><h5>sql-client.execution.result-mode</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">TABLE</td>
-            <td><p>Enum</p>Possible values: [TABLE, CHANGELOG, TABLEAU]</td>
-            <td>Determine the mode when display the query result. The available values are ['table', 'tableau', 'changelog']. The 'table' mode materializes results in memory and visualizes them in a regular, paginated table representation. The 'changelog' mode does not materialize results and visualizes the result stream that is produced by a continuous query. The 'tableau' mode is more like a traditional way which will display the results in the screen directly with a tableau format. </td>
+            <td><p>Enum</p></td>
+            <td>Determine the mode when display the query result. The available values are ['table', 'tableau', 'changelog']. The 'table' mode materializes results in memory and visualizes them in a regular, paginated table representation. The 'changelog' mode does not materialize results and visualizes the result stream that is produced by a continuous query. The 'tableau' mode is more like a traditional way which will display the results in the screen directly with a tableau format. <br><br>Possible values:<ul><li>"TABLE"</li><li>"CHANGELOG"</li><li>"TABLEAU"</li></ul></td>
         </tr>
         <tr>
             <td><h5>sql-client.verbose</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>

--- a/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
@@ -41,8 +41,8 @@
         <tr>
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">ROCKSDB</td>
-            <td><p>Enum</p>Possible values: [HEAP, ROCKSDB]</td>
-            <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based) or ROCKSDB for an implementation based on RocksDB.</td>
+            <td><p>Enum</p></td>
+            <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based) or ROCKSDB for an implementation based on RocksDB.<br><br>Possible values:<ul><li>"HEAP"</li><li>"ROCKSDB"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
+++ b/docs/layouts/shortcodes/generated/state_backend_rocksdb_section.html
@@ -42,7 +42,7 @@
             <td><h5>state.backend.rocksdb.timer-service.factory</h5></td>
             <td style="word-wrap: break-word;">ROCKSDB</td>
             <td><p>Enum</p></td>
-            <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based) or ROCKSDB for an implementation based on RocksDB.<br><br>Possible values:<ul><li>"HEAP"</li><li>"ROCKSDB"</li></ul></td>
+            <td>This determines the factory for timer service state implementation.<br><br>Possible values:<ul><li>"HEAP": Heap-based</li><li>"ROCKSDB": Implementation based on RocksDB</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/stream_pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/stream_pipeline_configuration.html
@@ -11,8 +11,8 @@
         <tr>
             <td><h5>pipeline.time-characteristic</h5></td>
             <td style="word-wrap: break-word;">ProcessingTime</td>
-            <td><p>Enum</p>Possible values: [ProcessingTime, IngestionTime, EventTime]</td>
-            <td>The time characteristic for all created streams, e.g., processingtime, event time, or ingestion time.<br /><br />If you set the characteristic to IngestionTime or EventTime this will set a default watermark update interval of 200 ms. If this is not applicable for your application you should change it using <code class="highlighter-rouge">pipeline.auto-watermark-interval</code>.</td>
+            <td><p>Enum</p></td>
+            <td>The time characteristic for all created streams, e.g., processingtime, event time, or ingestion time.<br /><br />If you set the characteristic to IngestionTime or EventTime this will set a default watermark update interval of 200 ms. If this is not applicable for your application you should change it using <code class="highlighter-rouge">pipeline.auto-watermark-interval</code>.<br><br>Possible values:<ul><li>"ProcessingTime"</li><li>"IngestionTime"</li><li>"EventTime"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -120,7 +120,7 @@
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
             <td style="word-wrap: break-word;">ORDER</td>
             <td><p>Enum</p></td>
-            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning (FIRST), at the end (LAST), or be positioned based on their name (ORDER). DISABLED means the user-jars are excluded from the system class path.<br><br>Possible values:<ul><li>"DISABLED"</li><li>"FIRST"</li><li>"LAST"</li><li>"ORDER"</li></ul></td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path.<br><br>Possible values:<ul><li>"DISABLED": Exclude user jars from the system class path</li><li>"FIRST": Position at the beginning</li><li>"LAST": Position at the end</li><li>"ORDER": Position based on the name of the jar</li></ul></td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>

--- a/docs/layouts/shortcodes/generated/yarn_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/yarn_config_configuration.html
@@ -119,8 +119,8 @@
         <tr>
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
             <td style="word-wrap: break-word;">ORDER</td>
-            <td><p>Enum</p>Possible values: [DISABLED, FIRST, LAST, ORDER]</td>
-            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning (FIRST), at the end (LAST), or be positioned based on their name (ORDER). DISABLED means the user-jars are excluded from the system class path.</td>
+            <td><p>Enum</p></td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning (FIRST), at the end (LAST), or be positioned based on their name (ORDER). DISABLED means the user-jars are excluded from the system class path.<br><br>Possible values:<ul><li>"DISABLED"</li><li>"FIRST"</li><li>"LAST"</li><li>"ORDER"</li></ul></td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -24,11 +24,13 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.util.Preconditions;
 
 import com.esotericsoftware.kryo.Serializer;
@@ -42,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.configuration.description.TextElement.text;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
@@ -1052,15 +1055,23 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     }
 
     /** Configuration settings for the closure cleaner. */
-    public enum ClosureCleanerLevel {
-        /** Disable the closure cleaner completely. */
-        NONE,
+    public enum ClosureCleanerLevel implements DescribedEnum {
+        NONE(text("Disables the closure cleaner completely.")),
 
-        /** Clean only the top-level class without recursing into fields. */
-        TOP_LEVEL,
+        TOP_LEVEL(text("Cleans only the top-level class without recursing into fields.")),
 
-        /** Clean all the fields recursively. */
-        RECURSIVE
+        RECURSIVE(text("Cleans all fields recursively."));
+
+        private final InlineElement description;
+
+        ClosureCleanerLevel(InlineElement description) {
+            this.description = description;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
     }
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -21,11 +21,9 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
-import org.apache.flink.configuration.description.TextElement;
+import org.apache.flink.configuration.description.InlineElement;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import static org.apache.flink.configuration.ClusterOptions.UserSystemExitMode.THROW;
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
@@ -113,7 +111,15 @@ public class ClusterOptions {
             key("cluster.intercept-user-system-exit")
                     .enumType(UserSystemExitMode.class)
                     .defaultValue(UserSystemExitMode.DISABLED)
-                    .withDescription(UserSystemExitMode.getConfigDescription());
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Flag to check user code exiting system by terminating JVM (e.g., System.exit()). ")
+                                    .text(
+                                            "Note that this configuration option can interfere with %s: "
+                                                    + "In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when %s is configured.",
+                                            code(HALT_ON_FATAL_ERROR.key()), code(THROW.name()))
+                                    .build());
 
     @Documentation.ExcludeFromDocumentation
     public static final ConfigOption<Boolean> ENABLE_FINE_GRAINED_RESOURCE_MANAGEMENT =
@@ -174,37 +180,19 @@ public class ClusterOptions {
     }
 
     /** The mode of how to handle user code attempting to exit JVM. */
-    public enum UserSystemExitMode {
-        DISABLED("Flink is not monitoring or intercepting calls to System.exit()"),
-        LOG("Log exit attempt with stack trace but still allowing exit to be performed"),
-        THROW("Throw exception when exit is attempted disallowing JVM termination");
+    public enum UserSystemExitMode implements DescribedEnum {
+        DISABLED(text("Flink is not monitoring or intercepting calls to System.exit()")),
+        LOG(text("Log exit attempt with stack trace but still allowing exit to be performed")),
+        THROW(text("Throw exception when exit is attempted disallowing JVM termination"));
 
-        private final String description;
+        private final InlineElement description;
 
-        UserSystemExitMode(String description) {
+        UserSystemExitMode(InlineElement description) {
             this.description = description;
         }
 
-        public static Description getConfigDescription() {
-            Description.DescriptionBuilder builder = Description.builder();
-            List<TextElement> modeDescriptions =
-                    new ArrayList<>(UserSystemExitMode.values().length);
-            builder.text(
-                    "Flag to check user code exiting system by terminating JVM (e.g., System.exit())");
-            for (UserSystemExitMode mode : UserSystemExitMode.values()) {
-                modeDescriptions.add(
-                        text(String.format("%s - %s", mode.name(), mode.getDescription())));
-            }
-            builder.list(modeDescriptions.toArray(new TextElement[modeDescriptions.size()]));
-            builder.linebreak();
-            builder.text(
-                    "Note that this configuration option can interfere with %s: "
-                            + "In intercepted user-code, a call to System.exit() will not cause the JVM to halt, when %s is configured.",
-                    code(HALT_ON_FATAL_ERROR.key()), code(THROW.name()));
-            return builder.build();
-        }
-
-        public String getDescription() {
+        @Override
+        public InlineElement getDescription() {
             return description;
         }
     }

--- a/flink-core/src/main/java/org/apache/flink/configuration/DescribedEnum.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DescribedEnum.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.InlineElement;
+import org.apache.flink.configuration.description.TextElement;
+
+import java.util.List;
+
+/**
+ * Describe enum constants used in {@link ConfigOption}s.
+ *
+ * <p>For enums used as config options, this interface can be implemented to provide a {@link
+ * Description} for each enum constant. This will be used when generating documentation for config
+ * options to include a list of available values alongside their respective descriptions.
+ *
+ * <p>More precisely, only a {@link InlineElement}s can be returned as block elements cannot be
+ * nested into a list.
+ */
+@PublicEvolving
+public interface DescribedEnum {
+
+    /**
+     * Returns the description for the enum constant.
+     *
+     * <p>If you want to include links or code blocks, use {@link TextElement#wrap(List)} to wrap
+     * multiple inline elements into a single one.
+     */
+    InlineElement getDescription();
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.code;
-import static org.apache.flink.configuration.description.TextElement.text;
 
 /** The {@link ConfigOption configuration options} for job execution. */
 @PublicEvolving
@@ -106,20 +105,7 @@ public class PipelineOptions {
             key("pipeline.closure-cleaner-level")
                     .enumType(ClosureCleanerLevel.class)
                     .defaultValue(ClosureCleanerLevel.RECURSIVE)
-                    .withDescription(
-                            Description.builder()
-                                    .text("Configures the mode in which the closure cleaner works")
-                                    .list(
-                                            text(
-                                                    "%s - disables the closure cleaner completely",
-                                                    code(ClosureCleanerLevel.NONE.toString())),
-                                            text(
-                                                    "%s - cleans only the top-level class without recursing into fields",
-                                                    code(ClosureCleanerLevel.TOP_LEVEL.toString())),
-                                            text(
-                                                    "%s - cleans all the fields recursively",
-                                                    code(ClosureCleanerLevel.RECURSIVE.toString())))
-                                    .build());
+                    .withDescription("Configures the mode in which the closure cleaner works.");
 
     public static final ConfigOption<Boolean> FORCE_AVRO =
             key("pipeline.force-avro")

--- a/flink-core/src/main/java/org/apache/flink/configuration/description/TextElement.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/description/TextElement.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.configuration.description;
 
+import org.apache.flink.shaded.guava18.com.google.common.base.Strings;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -51,6 +53,11 @@ public class TextElement implements BlockElement, InlineElement {
      */
     public static TextElement text(String text) {
         return new TextElement(text, Collections.emptyList());
+    }
+
+    /** Wraps a list of {@link InlineElement}s into a single {@link TextElement}. */
+    public static InlineElement wrap(InlineElement... elements) {
+        return text(Strings.repeat("%s", elements.length), elements);
     }
 
     /**

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -24,13 +24,19 @@ import org.apache.flink.annotation.docs.ConfigGroups;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.Formatter;
 import org.apache.flink.configuration.description.HtmlFormatter;
+import org.apache.flink.configuration.description.InlineElement;
+import org.apache.flink.configuration.description.TextElement;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -48,13 +54,16 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.configuration.description.TextElement.text;
 import static org.apache.flink.docs.util.Utils.escapeCharacters;
 
 /** Class used for generating code based documentation of configuration parameters. */
@@ -454,9 +463,61 @@ public class ConfigOptionsDocGenerator {
                 + type
                 + "</td>\n"
                 + "            <td>"
-                + formatter.format(option.description())
+                + getDescription(optionWithMetaInfo)
                 + "</td>\n"
                 + "        </tr>\n";
+    }
+
+    @VisibleForTesting
+    static String getDescription(OptionWithMetaInfo optionWithMetaInfo) {
+        final String enumValuesSection =
+                Optional.ofNullable(getEnumOptionsDescription(optionWithMetaInfo))
+                        .map(formatter::format)
+                        .map(desc -> String.format("<br /><br />%s", desc))
+                        .orElse("");
+
+        return formatter.format(optionWithMetaInfo.option.description()) + enumValuesSection;
+    }
+
+    /**
+     * Returns a {@link Description} for the enum constants of the given option in case it is
+     * enum-based, and {@code null} otherwise.
+     */
+    private static @Nullable Description getEnumOptionsDescription(
+            OptionWithMetaInfo optionWithMetaInfo) {
+        Class<?> clazz = getClazz(optionWithMetaInfo.option);
+        if (!clazz.isEnum()) {
+            return null;
+        }
+
+        InlineElement[] optionDescriptions =
+                Arrays.stream(clazz.getEnumConstants())
+                        .map(ConfigOptionsDocGenerator::formatEnumOption)
+                        .map(
+                                elements ->
+                                        TextElement.wrap(
+                                                elements.stream().toArray(InlineElement[]::new)))
+                        .toArray(InlineElement[]::new);
+
+        return Description.builder().text("Possible values:").list(optionDescriptions).build();
+    }
+
+    /**
+     * Formats a single enum constant.
+     *
+     * <p>If the enum implements {@link DescribedEnum}, this includes the given description for each
+     * constant. Otherwise, only the constant itself is printed.
+     */
+    private static List<InlineElement> formatEnumOption(Object e) {
+        final List<InlineElement> elements = new LinkedList<>();
+        elements.add(text("\"%s\"", text(escapeCharacters(e.toString()))));
+
+        if (DescribedEnum.class.isAssignableFrom(e.getClass())) {
+            elements.add(text(": "));
+            elements.add(((DescribedEnum) e).getDescription());
+        }
+
+        return elements;
     }
 
     private static Class<?> getClazz(ConfigOption<?> option) {
@@ -490,7 +551,7 @@ public class ConfigOptionsDocGenerator {
         boolean isList = isList(option);
 
         if (clazz.isEnum()) {
-            return enumTypeToHtml(clazz, isList);
+            return enumTypeToHtml(isList);
         }
 
         return atomicTypeToHtml(clazz, isList);
@@ -509,7 +570,7 @@ public class ConfigOptionsDocGenerator {
         return escapeCharacters(type);
     }
 
-    private static String enumTypeToHtml(Class<?> enumClazz, boolean isList) {
+    private static String enumTypeToHtml(boolean isList) {
         final String type;
         if (isList) {
             type = "List<Enum>";
@@ -517,10 +578,7 @@ public class ConfigOptionsDocGenerator {
             type = "Enum";
         }
 
-        return String.format(
-                "<p>%s</p>Possible values: %s",
-                escapeCharacters(type),
-                escapeCharacters(Arrays.toString(enumClazz.getEnumConstants())));
+        return String.format("<p>%s</p>", escapeCharacters(type));
     }
 
     @VisibleForTesting

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -24,9 +24,11 @@ import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Formatter;
 import org.apache.flink.configuration.description.HtmlFormatter;
+import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.docs.configuration.data.TestCommonOptions;
 import org.apache.flink.util.FileUtils;
 
@@ -43,6 +45,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.configuration.description.TextElement.text;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -75,6 +78,22 @@ public class ConfigOptionsDocGeneratorTest {
         VALUE_3
     }
 
+    private enum DescribedTestEnum implements DescribedEnum {
+        A(text("First letter of the alphabet")),
+        B(text("Second letter of the alphabet"));
+
+        private final InlineElement description;
+
+        DescribedTestEnum(InlineElement description) {
+            this.description = description;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
+    }
+
     static class TypeTestConfigGroup {
         public static ConfigOption<TestEnum> enumOption =
                 ConfigOptions.key("option.enum")
@@ -87,6 +106,12 @@ public class ConfigOptionsDocGeneratorTest {
                         .enumType(TestEnum.class)
                         .asList()
                         .defaultValues(TestEnum.VALUE_1, TestEnum.VALUE_2)
+                        .withDescription("Description");
+
+        public static ConfigOption<DescribedTestEnum> describedEnum =
+                ConfigOptions.key("option.enum.described")
+                        .enumType(DescribedTestEnum.class)
+                        .noDefaultValue()
                         .withDescription("Description");
 
         public static ConfigOption<MemorySize> memoryOption =
@@ -139,14 +164,20 @@ public class ConfigOptionsDocGeneratorTest {
                         + "        <tr>\n"
                         + "            <td><h5>option.enum</h5></td>\n"
                         + "            <td style=\"word-wrap: break-word;\">VALUE_1</td>\n"
-                        + "            <td><p>Enum</p>Possible values: [VALUE_1, VALUE_2, VALUE_3]</td>\n"
-                        + "            <td>Description</td>\n"
+                        + "            <td><p>Enum</p></td>\n"
+                        + "            <td>Description<br /><br />Possible values:<ul><li>\"VALUE_1\"</li><li>\"VALUE_2\"</li><li>\"VALUE_3\"</li></ul></td>\n"
+                        + "        </tr>\n"
+                        + "        <tr>\n"
+                        + "            <td><h5>option.enum.described</h5></td>\n"
+                        + "            <td style=\"word-wrap: break-word;\">(none)</td>\n"
+                        + "            <td><p>Enum</p></td>\n"
+                        + "            <td>Description<br /><br />Possible values:<ul><li>\"A\": First letter of the alphabet</li><li>\"B\": Second letter of the alphabet</li></ul></td>\n"
                         + "        </tr>\n"
                         + "        <tr>\n"
                         + "            <td><h5>option.enum.list</h5></td>\n"
                         + "            <td style=\"word-wrap: break-word;\">VALUE_1;<wbr>VALUE_2</td>\n"
-                        + "            <td><p>List&lt;Enum&gt;</p>Possible values: [VALUE_1, VALUE_2, VALUE_3]</td>\n"
-                        + "            <td>Description</td>\n"
+                        + "            <td><p>List&lt;Enum&gt;</p></td>\n"
+                        + "            <td>Description<br /><br />Possible values:<ul><li>\"VALUE_1\"</li><li>\"VALUE_2\"</li><li>\"VALUE_3\"</li></ul></td>\n"
                         + "        </tr>\n"
                         + "        <tr>\n"
                         + "            <td><h5>option.map</h5></td>\n"

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
@@ -21,8 +21,6 @@ package org.apache.flink.docs.configuration;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.description.Formatter;
-import org.apache.flink.configuration.description.HtmlFormatter;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -50,6 +48,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.DEFAULT_PATH_PREFIX;
 import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.LOCATIONS;
 import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.extractConfigOptions;
+import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.getDescription;
 import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.processConfigOptions;
 import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.stringifyDefault;
 import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.typeToHtml;
@@ -61,8 +60,6 @@ import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.type
  * does not refer to non-existent options.
  */
 public class ConfigOptionsDocsCompletenessITCase {
-
-    private static final Formatter htmlFormatter = new HtmlFormatter();
 
     @Test
     public void testCompleteness() throws IOException, ClassNotFoundException {
@@ -257,7 +254,7 @@ public class ConfigOptionsDocsCompletenessITCase {
                             // Use split to exclude document key tag.
                             String key = tableRow.child(0).text().split(" ")[0];
                             String defaultValue = tableRow.child(1).text();
-                            String typeValue = tableRow.child(2).text();
+                            String typeValue = tableRow.child(2).html();
                             String description =
                                     tableRow.child(3).childNodes().stream()
                                             .map(Object::toString)
@@ -304,7 +301,7 @@ public class ConfigOptionsDocsCompletenessITCase {
         String key = optionWithMetaInfo.option.key();
         String defaultValue = stringifyDefault(optionWithMetaInfo);
         String typeValue = typeToHtml(optionWithMetaInfo);
-        String description = htmlFormatter.format(optionWithMetaInfo.option.description());
+        String description = getDescription(optionWithMetaInfo);
         boolean isSuffixOption = isSuffixOption(optionWithMetaInfo.field);
         return new ExistingOption(
                 key, defaultValue, typeValue, description, optionsClass, isSuffixOption);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -56,7 +56,7 @@ public class KubernetesConfigOptions {
                     .enumType(ServiceExposedType.class)
                     .defaultValue(ServiceExposedType.LoadBalancer)
                     .withDescription(
-                            "The exposed type of the rest service (ClusterIP or NodePort or LoadBalancer). "
+                            "The exposed type of the rest service. "
                                     + "The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.");
 
     public static final ConfigOption<String> JOB_MANAGER_SERVICE_ACCOUNT =
@@ -134,7 +134,7 @@ public class KubernetesConfigOptions {
                     .enumType(ImagePullPolicy.class)
                     .defaultValue(ImagePullPolicy.IfNotPresent)
                     .withDescription(
-                            "The Kubernetes container image pull policy (IfNotPresent or Always or Never). "
+                            "The Kubernetes container image pull policy. "
                                     + "The default policy is IfNotPresent to avoid putting pressure to image repository.");
 
     public static final ConfigOption<List<String>> CONTAINER_IMAGE_PULL_SECRETS =

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -22,9 +22,7 @@ import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
 
-import static org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP;
 import static org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB;
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.DEFAULT;
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.FLASH_SSD_OPTIMIZED;
@@ -46,15 +44,13 @@ public class RocksDBOptions {
 
     /** Choice of timer service implementation. */
     @Documentation.Section(Documentation.Sections.STATE_BACKEND_ROCKSDB)
-    public static final ConfigOption<PriorityQueueStateType> TIMER_SERVICE_FACTORY =
-            ConfigOptions.key("state.backend.rocksdb.timer-service.factory")
-                    .enumType(PriorityQueueStateType.class)
-                    .defaultValue(ROCKSDB)
-                    .withDescription(
-                            String.format(
-                                    "This determines the factory for timer service state implementation. Options "
-                                            + "are either %s (heap-based) or %s for an implementation based on RocksDB.",
-                                    HEAP.name(), ROCKSDB.name()));
+    public static final ConfigOption<EmbeddedRocksDBStateBackend.PriorityQueueStateType>
+            TIMER_SERVICE_FACTORY =
+                    ConfigOptions.key("state.backend.rocksdb.timer-service.factory")
+                            .enumType(EmbeddedRocksDBStateBackend.PriorityQueueStateType.class)
+                            .defaultValue(ROCKSDB)
+                            .withDescription(
+                                    "This determines the factory for timer service state implementation.");
 
     /**
      * The number of threads used to transfer (download and upload) files in RocksDBStateBackend.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/ResultMode.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/ResultMode.java
@@ -18,17 +18,29 @@
 
 package org.apache.flink.table.client.config;
 
-import org.apache.flink.types.RowKind;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.InlineElement;
+
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /** The mode when display the result of the query in the sql client. */
-public enum ResultMode {
+public enum ResultMode implements DescribedEnum {
+    TABLE(
+            text(
+                    "Materializes results in memory and visualizes them in a regular, paginated table representation.")),
 
-    /** Collects results and returns them as table snapshots. */
-    TABLE,
+    CHANGELOG(text("Visualizes the result stream that is produced by a continuous query.")),
 
-    /** A result that is represented as a changelog consisting of records with {@link RowKind}. */
-    CHANGELOG,
+    TABLEAU(text("Display results in the screen directly in a tableau format."));
 
-    /** Print result in tableau mode. */
-    TABLEAU
+    private final InlineElement description;
+
+    ResultMode(InlineElement description) {
+        this.description = description;
+    }
+
+    @Override
+    public InlineElement getDescription() {
+        return description;
+    }
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
@@ -42,11 +42,7 @@ public class SqlClientOptions {
             ConfigOptions.key("sql-client.execution.result-mode")
                     .enumType(ResultMode.class)
                     .defaultValue(ResultMode.TABLE)
-                    .withDescription(
-                            "Determine the mode when display the query result. The available values are ['table', 'tableau', 'changelog']. "
-                                    + "The 'table' mode materializes results in memory and visualizes them in a regular, paginated table representation. "
-                                    + "The 'changelog' mode does not materialize results and visualizes the result stream that is produced by a continuous query. "
-                                    + "The 'tableau' mode is more like a traditional way which will display the results in the screen directly with a tableau format. ");
+                    .withDescription("Determines how the query result should be displayed.");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Boolean> VERBOSE =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/TimersSavepointITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
 import org.apache.flink.contrib.streaming.state.RocksDBOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -110,14 +111,14 @@ public class TimersSavepointITCase {
             throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
         JobGraph jobGraph;
 
-        jobGraph = getJobGraph(PriorityQueueStateType.HEAP);
+        jobGraph = getJobGraph(EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP);
         jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
         client.submitJob(jobGraph).get();
         resultLatch.await();
     }
 
     private void takeSavepoint(String savepointPath, ClusterClient<?> client) throws Exception {
-        JobGraph jobGraph = getJobGraph(PriorityQueueStateType.ROCKSDB);
+        JobGraph jobGraph = getJobGraph(EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
         client.submitJob(jobGraph).get();
         waitForAllTaskRunning(miniClusterResource.getMiniCluster(), jobGraph.getJobID());
         CompletableFuture<String> savepointPathFuture =

--- a/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/BackendSwitchSpecs.java
@@ -21,6 +21,7 @@ package org.apache.flink.test.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend;
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend.PriorityQueueStateType;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackendBuilder;
@@ -67,10 +68,12 @@ public final class BackendSwitchSpecs {
     }
 
     /** Specification for a {@link RocksDBKeyedStateBackend}. */
-    static final BackendSwitchSpec ROCKS = new RocksSpec(PriorityQueueStateType.ROCKSDB);
+    static final BackendSwitchSpec ROCKS =
+            new RocksSpec(EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB);
 
     /** Specification for a {@link RocksDBKeyedStateBackend} which stores its timers on heap. */
-    static final BackendSwitchSpec ROCKS_HEAP_TIMERS = new RocksSpec(PriorityQueueStateType.HEAP);
+    static final BackendSwitchSpec ROCKS_HEAP_TIMERS =
+            new RocksSpec(EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP);
 
     /** Specification for a {@link HeapKeyedStateBackend}. */
     static final BackendSwitchSpec HEAP = new HeapSpec();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -19,9 +19,11 @@
 package org.apache.flink.yarn.configuration;
 
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.ExternalResourceOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.InlineElement;
 
 import java.util.List;
 
@@ -29,9 +31,6 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.configuration.description.TextElement.text;
-import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.DISABLED;
-import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.FIRST;
-import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.LAST;
 import static org.apache.flink.yarn.configuration.YarnConfigOptions.UserJarInclusion.ORDER;
 
 /**
@@ -60,12 +59,8 @@ public class YarnConfigOptions {
                     .enumType(UserJarInclusion.class)
                     .defaultValue(ORDER)
                     .withDescription(
-                            String.format(
-                                    "Defines whether user-jars are included in the system class path for per-job-clusters as"
-                                            + " well as their positioning in the path. They can be positioned at the beginning (%s), at the"
-                                            + " end (%s), or be positioned based on their name (%s). %s means the user-jars"
-                                            + " are excluded from the system class path.",
-                                    FIRST.name(), LAST.name(), ORDER.name(), DISABLED.name()));
+                            "Defines whether user-jars are included in the system class path for per-job-clusters "
+                                    + "as well as their positioning in the path.");
 
     /** The vcores exposed by YARN. */
     public static final ConfigOption<Integer> VCORES =
@@ -407,10 +402,21 @@ public class YarnConfigOptions {
     private YarnConfigOptions() {}
 
     /** @see YarnConfigOptions#CLASSPATH_INCLUDE_USER_JAR */
-    public enum UserJarInclusion {
-        DISABLED,
-        FIRST,
-        LAST,
-        ORDER
+    public enum UserJarInclusion implements DescribedEnum {
+        DISABLED(text("Exclude user jars from the system class path")),
+        FIRST(text("Position at the beginning")),
+        LAST(text("Position at the end")),
+        ORDER(text("Position based on the name of the jar"));
+
+        private final InlineElement description;
+
+        UserJarInclusion(InlineElement description) {
+            this.description = description;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This introduces a new interface which can be implemented for enums which are used in (enum-based) `ConfigOption`s. It allows providing documentation about the individual values. This is then used in `ConfigOptionsDocGenerator`: the list of available values is moved from "Type" to "Description", and if the interface is implemented, the provided documentation is added to each listed value.

One note: `DescribedEnum#getDescription` cannot return an actual `Description` because those cannot be nested into a list, only inline elements can.

This PR also goes through the enum options currently covered by the docs generator and applies this change there. In #16482 this will be used to convert some string-based connector options into enum-based ones as well.

## Brief change log

* `DescribedEnum` interface for enums used in options
* `ConfigOptionsDocGenerator` to make use of this new interface
* Cleaned up some options to use this new feature

## Verifying this change

This change added tests and can be verified as follows:
* `ConfigOptionsDocGeneratorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
