### PR TITLE
[FLINK-23115][python] Expose new APIs about TableDescriptor in PyFlink

### DIFF
--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -23,6 +23,7 @@ Important classes used by both Flink Streaming and Batch API:
       A config to define the behavior of the program execution.
 """
 from pyflink.common.completable_future import CompletableFuture
+from pyflink.common.config_options import ConfigOption, ConfigOptions
 from pyflink.common.configuration import Configuration
 from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.execution_mode import ExecutionMode
@@ -40,6 +41,8 @@ from pyflink.common.watermark_strategy import WatermarkStrategy
 __all__ = [
     'CompletableFuture',
     'Configuration',
+    'ConfigOption',
+    'ConfigOptions',
     'ExecutionConfig',
     'ExecutionMode',
     'InputDependencyConstraint',

--- a/flink-python/pyflink/common/config_options.py
+++ b/flink-python/pyflink/common/config_options.py
@@ -26,7 +26,7 @@ __all__ = ['ConfigOptions', 'ConfigOption']
 
 class ConfigOptions(object):
     """
-    {@code ConfigOptions} are used to build a :class:`~pyflink.table.ConfigOption`. The option is
+    {@code ConfigOptions} are used to build a :class:`~pyflink.common.ConfigOption`. The option is
     typically built in one of the following patterns:
 
     Example:

--- a/flink-python/pyflink/common/config_options.py
+++ b/flink-python/pyflink/common/config_options.py
@@ -27,7 +27,7 @@ __all__ = ['ConfigOptions', 'ConfigOption']
 class ConfigOptions(object):
     """
     {@code ConfigOptions} are used to build a :class:`~pyflink.table.ConfigOption`. The option is
-    typically built in one of the following pattern:
+    typically built in one of the following patterns:
 
     Example:
     ::

--- a/flink-python/pyflink/common/config_options.py
+++ b/flink-python/pyflink/common/config_options.py
@@ -1,0 +1,125 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import TypeVar, Generic
+
+from pyflink.java_gateway import get_gateway
+
+T = TypeVar('T')
+
+__all__ = ['ConfigOptions', 'ConfigOption']
+
+
+class ConfigOptions(object):
+    """
+    {@code ConfigOptions} are used to build a :class:`~pyflink.table.ConfigOption`. The option is
+    typically built in one of the following pattern:
+
+    Example:
+    ::
+
+        # simple string-valued option with a default value
+        >>> ConfigOptions.key("tmp.dir").string_type().default_value("/tmp")
+        # simple integer-valued option with a default value
+        >>> ConfigOptions.key("application.parallelism").int_type().default_value(100)
+        # option with no default value
+        >>> ConfigOptions.key("user.name").string_type().no_default_value()
+    """
+
+    def __init__(self, j_config_options):
+        self._j_config_options = j_config_options
+
+    @staticmethod
+    def key(key: str):
+        """
+        Starts building a new ConfigOption.
+
+        :param key: The key for the config option.
+        :return: The builder for the config option with the given key.
+        """
+        gateway = get_gateway()
+        j_option_builder = gateway.jvm.org.apache.flink.configuration.ConfigOptions.key(key)
+        return ConfigOptions.OptionBuilder(j_option_builder)
+
+    class OptionBuilder(object):
+        def __init__(self, j_option_builder):
+            self._j_option_builder = j_option_builder
+
+        def boolean_type(self) -> 'ConfigOptions.TypedConfigOptionBuilder[bool]':
+            """
+            Defines that the value of the option should be of bool type.
+            """
+            return ConfigOptions.TypedConfigOptionBuilder(self._j_option_builder.booleanType())
+
+        def int_type(self) -> 'ConfigOptions.TypedConfigOptionBuilder[int]':
+            """
+            Defines that the value of the option should be of int type
+            (from -2,147,483,648 to 2,147,483,647).
+            """
+            return ConfigOptions.TypedConfigOptionBuilder(self._j_option_builder.intType())
+
+        def long_type(self) -> 'ConfigOptions.TypedConfigOptionBuilder[int]':
+            """
+            Defines that the value of the option should be of int type
+            (from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807).
+            """
+            return ConfigOptions.TypedConfigOptionBuilder(self._j_option_builder.longType())
+
+        def float_type(self) -> 'ConfigOptions.TypedConfigOptionBuilder[float]':
+            """
+            Defines that the value of the option should be of float type
+            (4-byte single precision floating point number).
+            :return:
+            """
+            return ConfigOptions.TypedConfigOptionBuilder(self._j_option_builder.floatType())
+
+        def double_type(self) -> 'ConfigOptions.TypedConfigOptionBuilder[float]':
+            """
+            Defines that the value of the option should be of float Double} type
+            (8-byte double precision floating point number).
+            """
+            return ConfigOptions.TypedConfigOptionBuilder(self._j_option_builder.doubleType())
+
+        def string_type(self) -> 'ConfigOptions.TypedConfigOptionBuilder[str]':
+            """
+            Defines that the value of the option should be of str type.
+            """
+            return ConfigOptions.TypedConfigOptionBuilder(self._j_option_builder.stringType())
+
+    class TypedConfigOptionBuilder(Generic[T]):
+        def __init__(self, j_typed_config_option_builder):
+            self._j_typed_config_option_builder = j_typed_config_option_builder
+
+        def default_value(self, value: T) -> 'ConfigOption[T]':
+            return ConfigOption(self._j_typed_config_option_builder.defaultValue(value))
+
+        def no_default_value(self) -> 'ConfigOption[str]':
+            return ConfigOption(self._j_typed_config_option_builder.noDefaultValue())
+
+
+class ConfigOption(Generic[T]):
+    """
+    A {@code ConfigOption} describes a configuration parameter. It encapsulates the configuration
+    key, deprecated older versions of the key, and an optional default value for the configuration
+    parameter.
+
+    {@code ConfigOptions} are built via the ConfigOptions class. Once created, a config
+    option is immutable.
+    """
+
+    def __init__(self, j_config_option):
+        self._j_config_option = j_config_option

--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -74,6 +74,7 @@ from pyflink.table.explain_detail import ExplainDetail
 from pyflink.table.expression import Expression
 from pyflink.table.module import Module, ModuleEntry
 from pyflink.table.result_kind import ResultKind
+from pyflink.table.schema import Schema
 from pyflink.table.sinks import CsvTableSink, TableSink, WriteMode
 from pyflink.table.sources import CsvTableSource, TableSource
 from pyflink.table.sql_dialect import SqlDialect
@@ -109,6 +110,7 @@ __all__ = [
     'Row',
     'RowKind',
     'ScalarFunction',
+    'Schema',
     'SqlDialect',
     'StatementSet',
     'StreamTableEnvironment',

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional
 from py4j.java_gateway import java_import
 
 from pyflink.java_gateway import get_gateway
+from pyflink.table.schema import Schema
 from pyflink.table.table_schema import TableSchema
 
 __all__ = ['Catalog', 'CatalogDatabase', 'CatalogBaseTable', 'CatalogPartition', 'CatalogFunction',
@@ -733,8 +734,21 @@ class CatalogBaseTable(object):
         Get the schema of the table.
 
         :return: Schema of the table/view.
+
+        . note:: Deprecated in 1.14. This method returns the deprecated ableSchema class. The old
+        class was a hybrid of resolved and unresolved schema information. It has been replaced by
+        the new Schema which is always unresolved and will be resolved by the framework later.
         """
         return TableSchema(j_table_schema=self._j_catalog_base_table.getSchema())
+
+    def get_unresolved_schema(self) -> Schema:
+        """
+        Returns the schema of the table or view.
+
+        The schema can reference objects from other catalogs and will be resolved and validated by
+        the framework when accessing the table or view.
+        """
+        return Schema(self._j_catalog_base_table.getUnresolvedSchema())
 
     def get_comment(self) -> str:
         """

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -735,7 +735,7 @@ class CatalogBaseTable(object):
 
         :return: Schema of the table/view.
 
-        . note:: Deprecated in 1.14. This method returns the deprecated ableSchema class. The old
+        . note:: Deprecated in 1.14. This method returns the deprecated TableSchema class. The old
         class was a hybrid of resolved and unresolved schema information. It has been replaced by
         the new Schema which is always unresolved and will be resolved by the framework later.
         """

--- a/flink-python/pyflink/table/schema.py
+++ b/flink-python/pyflink/table/schema.py
@@ -74,14 +74,14 @@ class Schema(object):
             """
             Adopts all members from the given unresolved schema.
             """
-            self._j_builder.fromSchema(unresolved_schema)
+            self._j_builder.fromSchema(unresolved_schema._j_schema)
             return self
 
         def from_row_data_type(self, data_type: DataType) -> 'Schema.Builder':
             """
             Adopts all fields of the given row as physical columns of the schema.
             """
-            self._j_builder.fromRowDataType(data_type)
+            self._j_builder.fromRowDataType(_to_java_data_type(data_type))
             return self
 
         def from_fields(self,

--- a/flink-python/pyflink/table/schema.py
+++ b/flink-python/pyflink/table/schema.py
@@ -1,0 +1,266 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import Union, List
+
+from pyflink.java_gateway import get_gateway
+from pyflink.table import Expression
+from pyflink.table.expression import _get_java_expression
+from pyflink.table.types import DataType, _to_java_data_type
+from pyflink.util.java_utils import to_jarray
+
+__all__ = ['Schema']
+
+
+class Schema(object):
+    """
+    Schema of a table or view.
+
+    A schema represents the schema part of a {@code CREATE TABLE (schema) WITH (options)} DDL
+    statement in SQL. It defines columns of different kind, constraints, time attributes, and
+    watermark strategies. It is possible to reference objects (such as functions or types) across
+    different catalogs.
+
+    This class is used in the API and catalogs to define an unresolved schema that will be
+    translated to ResolvedSchema. Some methods of this class perform basic validation, however, the
+    main validation happens during the resolution. Thus, an unresolved schema can be incomplete and
+    might be enriched or merged with a different schema at a later stage.
+
+    Since an instance of this class is unresolved, it should not be directly persisted. The str()
+    shows only a summary of the contained objects.
+    """
+
+    def __init__(self, j_schema):
+        self._j_schema = j_schema
+
+    @staticmethod
+    def new_builder() -> 'Schema.Builder':
+        gateway = get_gateway()
+        j_builder = gateway.jvm.Schema.newBuilder()
+        return Schema.Builder(j_builder)
+
+    def __str__(self):
+        return self._j_schema.toString()
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__ and self._j_schema.equals(other._j_schema)
+
+    def __hash__(self):
+        return self._j_schema.hashCode()
+
+    class Builder(object):
+        """
+        A builder for constructing an immutable but still unresolved Schema.
+        """
+
+        def __init__(self, j_builder):
+            self._j_builder = j_builder
+
+        def from_schema(self, unresolved_schema: 'Schema') -> 'Schema.Builder':
+            """
+            Adopts all members from the given unresolved schema.
+            """
+            self._j_builder.fromSchema(unresolved_schema)
+            return self
+
+        def from_row_data_type(self, data_type: DataType) -> 'Schema.Builder':
+            """
+            Adopts all fields of the given row as physical columns of the schema.
+            """
+            self._j_builder.fromRowDataType(data_type)
+            return self
+
+        def from_fields(self,
+                        field_names: List[str],
+                        field_data_types: List[DataType]) -> 'Schema.Builder':
+            """
+            Adopts the given field names and field data types as physical columns of the schema.
+            """
+            gateway = get_gateway()
+            j_field_names = to_jarray(gateway.jvm.String, field_names)
+            j_field_data_types = to_jarray(
+                gateway.jvm.AbstractDataType,
+                [_to_java_data_type(field_data_type) for field_data_type in field_data_types])
+            self._j_builder.fromFields(j_field_names, j_field_data_types)
+            return self
+
+        def column(self,
+                   column_name: str,
+                   data_type: Union[str, DataType]) -> 'Schema.Builder':
+            """
+            Declares a physical column that is appended to this schema.
+
+            Physical columns are regular columns known from databases. They define the names, the
+            types, and the order of fields in the physical data. Thus, physical columns represent
+            the payload that is read from and written to an external system. Connectors and formats
+            use these columns (in the defined order) to configure themselves. Other kinds of columns
+            can be declared between physical columns but will not influence the final physical
+            schema.
+
+            :param column_name: Column name
+            :param data_type: Data type of the column
+            """
+            if isinstance(data_type, str):
+                self._j_builder.column(column_name, data_type)
+            else:
+                self._j_builder.column(column_name, _to_java_data_type(data_type))
+            return self
+
+        def column_by_expression(self,
+                                 column_name: str,
+                                 expr: Union[str, Expression]) -> 'Schema.Builder':
+            """
+            Declares a computed column that is appended to this schema.
+
+            Computed columns are virtual columns that are generated by evaluating an expression
+            that can reference other columns declared in the same table. Both physical columns and
+            metadata columns can be accessed. The column itself is not physically stored within the
+            table. The column’s data type is derived automatically from the given expression and
+            does not have to be declared manually.
+
+            Computed columns are commonly used for defining time attributes. For example, the
+            computed column can be used if the original field is not TIMESTAMP(3) type or is nested
+            in a JSON string.
+
+            Example:
+            ::
+
+                >>> Schema.new_builder().
+                ...  column_by_expression("ts", "orig_ts - INTERVAL '60' MINUTE").
+                ...  column_by_metadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp")
+
+            :param column_name: Column name
+            :param expr: Computation of the column
+            """
+            self._j_builder.columnByExpression(column_name, _get_java_expression(expr))
+            return self
+
+        def column_by_metadata(self,
+                               column_name: str,
+                               data_type: Union[DataType, str],
+                               metadata_key: str = None,
+                               is_virtual: bool = False) -> 'Schema.Builder':
+            """
+            Declares a metadata column that is appended to this schema.
+
+            Metadata columns allow to access connector and/or format specific fields for every row
+            of a table. For example, a metadata column can be used to read and write the timestamp
+            from and to Kafka records for time-based operations. The connector and format
+            documentation lists the available metadata fields for every component.
+
+            Every metadata field is identified by a string-based key and has a documented data
+            type. The metadata key can be omitted if the column name should be used as the
+            identifying metadata key. For convenience, the runtime will perform an explicit cast if
+            the data type of the column differs from the data type of the metadata field. Of course,
+            this requires that the two data types are compatible.
+
+            By default, a metadata column can be used for both reading and writing. However, in
+            many cases an external system provides more read-only metadata fields than writable
+            fields. Therefore, it is possible to exclude metadata columns from persisting by setting
+            the {@code is_virtual} flag to {@code true}.
+
+            :param column_name: Column name
+            :param data_type: Data type of the column
+            :param metadata_key: Identifying metadata key, if null the column name will be used as
+                metadata key
+            :param is_virtual: Whether the column should be persisted or not
+            """
+            if isinstance(data_type, DataType):
+                self._j_builder.columnByMetadata(
+                    column_name,
+                    _to_java_data_type(data_type),
+                    metadata_key, is_virtual)
+            else:
+                self._j_builder.columnByMetadata(
+                    column_name,
+                    data_type,
+                    metadata_key,
+                    is_virtual)
+            return self
+
+        def watermark(self,
+                      column_name: str,
+                      watermark_expr: Union[str, Expression]) -> 'Schema.Builder':
+            """
+            Declares that the given column should serve as an event-time (i.e. rowtime) attribute
+            and specifies a corresponding watermark strategy as an expression.
+
+            The column must be of type {@code TIMESTAMP(3)} or {@code TIMESTAMP_LTZ(3)} and be a
+            top-level column in the schema. It may be a computed column.
+
+            The watermark generation expression is evaluated by the framework for every record
+            during runtime. The framework will periodically emit the largest generated watermark. If
+            the current watermark is still identical to the previous one, or is null, or the value
+            of the returned watermark is smaller than that of the last emitted one, then no new
+            watermark will be emitted. A watermark is emitted in an interval defined by the
+            configuration.
+
+            Any scalar expression can be used for declaring a watermark strategy for
+            in-memory/temporary tables. However, currently, only SQL expressions can be persisted in
+            a catalog. The expression's return data type must be {@code TIMESTAMP(3)}. User-defined
+            functions (also defined in different catalogs) are supported.
+
+            Example:
+            ::
+
+                >>> Schema.new_builder().watermark("ts", "ts - INTERVAL '5' SECOND")
+
+            :param column_name: The column name used as a rowtime attribute
+            :param watermark_expr: The expression used for watermark generation
+            """
+            self._j_builder.watermark(column_name, _get_java_expression(watermark_expr))
+            return self
+
+        def primary_key(self, *column_names: str) -> 'Schema.Builder':
+            """
+            Declares a primary key constraint for a set of given columns. Primary key uniquely
+            identify a row in a table. Neither of columns in a primary can be nullable. The primary
+            key is informational only. It will not be enforced. It can be used for optimizations. It
+            is the data owner's responsibility to ensure uniqueness of the data.
+
+            The primary key will be assigned a generated name in the format {@code PK_col1_col2}.
+
+            :param column_names: Columns that form a unique primary key
+            """
+            gateway = get_gateway()
+            self._j_builder.primaryKey(to_jarray(gateway.jvm.java.lang.String, column_names))
+            return self
+
+        def primary_key_named(self,
+                              constraint_name: str,
+                              *column_names: str) -> 'Schema.Builder':
+            """
+            Declares a primary key constraint for a set of given columns. Primary key uniquely
+            identify a row in a table. Neither of columns in a primary can be nullable. The primary
+            key is informational only. It will not be enforced. It can be used for optimizations. It
+            is the data owner's responsibility to ensure uniqueness of the data.
+
+            :param constraint_name: Name for the primary key, can be used to reference the
+                constraint
+            :param column_names: Columns that form a unique primary key
+            """
+            gateway = get_gateway()
+            self._j_builder.primaryKeyNamed(
+                constraint_name,
+                to_jarray(gateway.jvm.java.lang.String, column_names))
+            return self
+
+        def build(self) -> 'Schema':
+            """
+            Returns an instance of an unresolved Schema.
+            """
+            return Schema(self._j_builder.build())

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -15,7 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+from typing import Union
+
 from pyflink.table import ExplainDetail
+from pyflink.table.table_descriptor import TableDescriptor
 from pyflink.table.table_result import TableResult
 from pyflink.util.java_utils import to_j_explain_detail_arr
 
@@ -52,21 +55,68 @@ class StatementSet(object):
         self._j_statement_set.addInsertSql(stmt)
         return self
 
-    def add_insert(self, target_path: str, table, overwrite: bool = False) -> 'StatementSet':
+    def add_insert(self,
+                   target_path_or_descriptor: Union[str, TableDescriptor],
+                   table,
+                   overwrite: bool = False) -> 'StatementSet':
         """
-        add Table with the given sink table name to the set.
+        Adds a statement that the pipeline defined by the given Table object should be written to a
+        table (backed by a DynamicTableSink) that was registered under the specified path or
+        expressed via the given TableDescriptor.
 
-        :param target_path: The path of the registered :class:`~pyflink.table.TableSink` to which
-                            the :class:`~pyflink.table.Table` is written.
+        1. When target_path_or_descriptor is a tale path:
+
+            See the documentation of :func:`~TableEnvironment.use_database` or
+            :func:`~TableEnvironment.use_catalog` for the rules on the path resolution.
+
+        2. When target_path_or_descriptor is a table descriptor:
+
+            The given TableDescriptor is registered as an inline (i.e. anonymous) temporary catalog
+            table (see :func:`~TableEnvironment.create_temporary_table`).
+
+            Then a statement is added to the statement set that inserts the Table object's pipeline
+            into that temporary table.
+
+            This method allows to declare a Schema for the sink descriptor. The declaration is
+            similar to a {@code CREATE TABLE} DDL in SQL and allows to:
+
+                1. overwrite automatically derived columns with a custom DataType
+                2. add metadata columns next to the physical columns
+                3. declare a primary key
+
+            It is possible to declare a schema without physical/regular columns. In this case, those
+            columns will be automatically derived and implicitly put at the beginning of the schema
+            declaration.
+
+            Examples:
+            ::
+
+                >>>stmt_set = table_env.create_statement_set()
+                >>>source_table = table_env.from_path("SourceTable")
+                >>>sink_descriptor = TableDescriptor.for_connector("blackhole")
+                ...     .schema(Schema.new_builder()
+                ...         .build())
+                ...     .build()
+                >>>stmt_set.add_insert(sink_descriptor, source_table)
+
+            .. note:: add_insert for a table descriptor (case 2.) was added from
+                flink 1.14.0.
+
+        :param target_path_or_descriptor: The path of the registered
+            :class:`~pyflink.table.TableSink` or the descriptor describing the sink table into which
+            data should be inserted to which the :class:`~pyflink.table.Table` is written.
         :param table: The Table to add.
         :type table: pyflink.table.Table
-        :param overwrite: The flag that indicates whether the insert
-                          should overwrite existing data or not.
+        :param overwrite: Indicates whether the insert should overwrite existing data or not.
         :return: current StatementSet instance.
 
         .. versionadded:: 1.11.0
         """
-        self._j_statement_set.addInsert(target_path, table._j_table, overwrite)
+        if isinstance(target_path_or_descriptor, str):
+            self._j_statement_set.addInsert(target_path_or_descriptor, table._j_table, overwrite)
+        else:
+            self._j_statement_set.addInsert(
+                target_path_or_descriptor._j_table_descriptor, table._j_table, overwrite)
         return self
 
     def explain(self, *extra_details: ExplainDetail) -> str:

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -91,13 +91,13 @@ class StatementSet(object):
             Examples:
             ::
 
-                >>>stmt_set = table_env.create_statement_set()
-                >>>source_table = table_env.from_path("SourceTable")
-                >>>sink_descriptor = TableDescriptor.for_connector("blackhole")
+                >>> stmt_set = table_env.create_statement_set()
+                >>> source_table = table_env.from_path("SourceTable")
+                >>> sink_descriptor = TableDescriptor.for_connector("blackhole")
                 ...     .schema(Schema.new_builder()
                 ...         .build())
                 ...     .build()
-                >>>stmt_set.add_insert(sink_descriptor, source_table)
+                >>> stmt_set.add_insert(sink_descriptor, source_table)
 
             .. note:: add_insert for a table descriptor (case 2.) was added from
                 flink 1.14.0.

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1074,15 +1074,15 @@ class Table(object):
             Examples:
             ::
 
-                >>>schema = Schema.new_builder()
-                ...     .column("f0", DataTypes.STRING())
-                ...     .build()
-                >>>table = table_env.from_descriptor(TableDescriptor.for_connector("datagen")
-                ...     .schema(schema)
-                ...     .build())
-                >>>table.execute_insert(TableDescriptor.for_connector("blackhole")
-                ...     .schema(schema)
-                ...     .build())
+                >>> schema = Schema.new_builder()
+                ...      .column("f0", DataTypes.STRING())
+                ...      .build()
+                >>> table = table_env.from_descriptor(TableDescriptor.for_connector("datagen")
+                ...      .schema(schema)
+                ...      .build())
+                >>> table.execute_insert(TableDescriptor.for_connector("blackhole")
+                ...      .schema(schema)
+                ...      .build())
 
             If multiple pipelines should insert data into one or more sink tables as part of a
             single execution, use a :class:`~pyflink.table.StatementSet`

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -26,6 +26,7 @@ from pyflink.table import ExplainDetail
 from pyflink.table.expression import Expression, _get_java_expression
 from pyflink.table.expressions import col, with_columns, without_columns
 from pyflink.table.serializers import ArrowSerializer
+from pyflink.table.table_descriptor import TableDescriptor
 from pyflink.table.table_result import TableResult
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.types import create_arrow_schema
@@ -1033,27 +1034,81 @@ class Table(object):
         """
         self._j_table.printSchema()
 
-    def execute_insert(self, table_path: str, overwrite: bool = False) -> TableResult:
+    def execute_insert(self,
+                       table_path_or_descriptor: Union[str, TableDescriptor],
+                       overwrite: bool = False) -> TableResult:
         """
-        Writes the :class:`~pyflink.table.Table` to a :class:`~pyflink.table.TableSink` that was
-        registered under the specified name, and then execute the insert operation.
-        For the path resolution algorithm see :func:`~TableEnvironment.use_database`.
+        1. When target_path_or_descriptor is a tale path:
 
-        Example:
-        ::
+            Writes the :class:`~pyflink.table.Table` to a :class:`~pyflink.table.TableSink` that was
+            registered under the specified name, and then execute the insert operation. For the path
+            resolution algorithm see :func:`~TableEnvironment.use_database`.
 
-            >>> tab.execute_insert("sink")
+            Example:
+            ::
 
-        :param table_path: The path of the registered :class:`~pyflink.table.TableSink` to which
-               the :class:`~pyflink.table.Table` is written.
-        :param overwrite: The flag that indicates whether the insert should overwrite
-               existing data or not.
+                >>> tab.execute_insert("sink")
+
+        2. When target_path_or_descriptor is a table descriptor:
+
+            Declares that the pipeline defined by the given Table object should be written to a
+            table (backed by a DynamicTableSink) expressed via the given TableDescriptor. It
+            executes the insert operation.
+
+            TableDescriptor is registered as an inline (i.e. anonymous) temporary catalog table
+            (see :func:`~TableEnvironment.create_temporary_table`) using a unique identifier.
+            Note that calling this method multiple times, even with the same descriptor, results
+            in multiple sink tables being registered.
+
+            This method allows to declare a :class:`~pyflink.table.Schema` for the sink descriptor.
+            The declaration is similar to a {@code CREATE TABLE} DDL in SQL and allows to:
+
+                1. overwrite automatically derived columns with a custom DataType
+                2. add metadata columns next to the physical columns
+                3. declare a primary key
+
+            It is possible to declare a schema without physical/regular columns. In this case, those
+            columns will be automatically derived and implicitly put at the beginning of the schema
+            declaration.
+
+            Examples:
+            ::
+
+                >>>schema = Schema.new_builder()
+                ...     .column("f0", DataTypes.STRING())
+                ...     .build()
+                >>>table = table_env.from_descriptor(TableDescriptor.for_connector("datagen")
+                ...     .schema(schema)
+                ...     .build())
+                >>>table.execute_insert(TableDescriptor.for_connector("blackhole")
+                ...     .schema(schema)
+                ...     .build())
+
+            If multiple pipelines should insert data into one or more sink tables as part of a
+            single execution, use a :class:`~pyflink.table.StatementSet`
+            (see :func:`~TableEnvironment.create_statement_set`).
+
+            By default, all insertion operations are executed asynchronously. Use
+            :func:`~TableResult.await` or :func:`~TableResult.get_job_client` to monitor the
+            execution.
+
+            .. note:: execute_insert for a table descriptor (case 2.) was added from
+                flink 1.14.0.
+
+        :param table_path_or_descriptor: The path of the registered
+            :class:`~pyflink.table.TableSink` or the descriptor describing the sink table into which
+            data should be inserted to which the :class:`~pyflink.table.Table` is written.
+        :param overwrite: Indicates whether the insert should overwrite existing data or not.
         :return: The table result.
 
         .. versionadded:: 1.11.0
         """
         self._t_env._before_execute()
-        return TableResult(self._j_table.executeInsert(table_path, overwrite))
+        if isinstance(table_path_or_descriptor, str):
+            return TableResult(self._j_table.executeInsert(table_path_or_descriptor, overwrite))
+        else:
+            return TableResult(self._j_table.executeInsert(
+                table_path_or_descriptor._j_table_descriptor, overwrite))
 
     def execute(self) -> TableResult:
         """

--- a/flink-python/pyflink/table/table_descriptor.py
+++ b/flink-python/pyflink/table/table_descriptor.py
@@ -1,0 +1,257 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import Dict, Union, List, Optional
+
+from pyflink.common.config_options import ConfigOption
+from pyflink.java_gateway import get_gateway
+from pyflink.table.schema import Schema
+from pyflink.util.java_utils import to_jarray
+
+__all__ = ['TableDescriptor', 'FormatDescriptor']
+
+
+class TableDescriptor(object):
+    """
+    Describes a CatalogTable representing a source or sink.
+
+    TableDescriptor is a template for creating a CatalogTable} instance. It closely resembles the
+    "CREATE TABLE" SQL DDL statement, containing schema, connector options, and other
+    characteristics. Since tables in Flink are typically backed by external systems, the
+    descriptor describes how a connector (and possibly its format) are configured.
+
+    This can be used to register a table in the Table API, see :func:`create_temporary_table` in
+    TableEnvironment.
+    """
+
+    def __init__(self, j_table_descriptor):
+        self._j_table_descriptor = j_table_descriptor
+
+    @staticmethod
+    def for_connector(connector: str) -> 'TableDescriptor.Builder':
+        """
+        Creates a new :class:`~pyflink.table.TableDescriptor.Builder` for a table using the given
+        connector.
+
+        :param connector: The factory identifier for the connector.
+        """
+        gateway = get_gateway()
+        j_builder = gateway.jvm.TableDescriptor.forConnector(connector)
+        return TableDescriptor.Builder(j_builder)
+
+    def get_schema(self) -> Optional[Schema]:
+        j_schema = self._j_table_descriptor.getSchema()
+        if j_schema.isPresent():
+            return Schema(j_schema.get())
+        else:
+            return None
+
+    def get_options(self) -> Dict[str, str]:
+        return self._j_table_descriptor.getOptions()
+
+    def get_partition_keys(self) -> List[str]:
+        return self._j_table_descriptor.getPartitionKeys()
+
+    def get_comment(self) -> Optional[str]:
+        j_comment = self._j_table_descriptor.getComment()
+        if j_comment.isPresent():
+            return j_comment.get()
+        else:
+            return None
+
+    def __str__(self):
+        return self._j_table_descriptor.toString()
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__ and
+                self._j_table_descriptor.equals(other._j_table_descriptor))
+
+    def __hash__(self):
+        return self._j_table_descriptor.hashCode()
+
+    class Builder(object):
+        """
+        Builder for TableDescriptor.
+        """
+
+        def __init__(self, j_builder):
+            self._j_builder = j_builder
+
+        def schema(self, schema: Schema) -> 'TableDescriptor.Builder':
+            """
+            Define the schema of the TableDescriptor.
+            """
+            self._j_builder.schema(schema._j_schema)
+            return self
+
+        def option(self, key: Union[str, ConfigOption], value) -> 'TableDescriptor.Builder':
+            """
+            Sets the given option on the table.
+
+            Option keys must be fully specified. When defining options for a Format, use
+            format(FormatDescriptor) instead.
+
+            Example:
+            ::
+
+                >>> TableDescriptor.for_connector("kafka") \
+                ...     .option("scan.startup.mode", "latest-offset") \
+                ...     .build()
+
+            """
+            if isinstance(key, str):
+                self._j_builder.option(key, value)
+            else:
+                self._j_builder.option(key._j_config_option, value)
+            return self
+
+        def format(self,
+                   format: Union[str, 'FormatDescriptor'],
+                   format_option: ConfigOption[str] = None) -> 'TableDescriptor.Builder':
+            """
+            Defines the format to be used for this table.
+
+            Note that not every connector requires a format to be specified, while others may use
+            multiple formats.
+
+            Example:
+            ::
+
+                >>> TableDescriptor.for_connector("kafka") \
+                ...     .format(FormatDescriptor.for_format("json")
+                ...                 .option("ignore-parse-errors", "true")
+                ...                 .build())
+
+                will result in the options:
+
+                    'format' = 'json'
+                    'json.ignore-parse-errors' = 'true'
+
+            """
+            if format_option is None:
+                if isinstance(format, str):
+                    self._j_builder.format(format)
+                else:
+                    self._j_builder.format(format._j_format_descriptor)
+            else:
+                if isinstance(format, str):
+                    self._j_builder.format(format_option._j_config_option, format)
+                else:
+                    self._j_builder.format(
+                        format_option._j_config_option, format._j_format_descriptor)
+            return self
+
+        def partitioned_by(self, *partition_keys: str) -> 'TableDescriptor.Builder':
+            """
+            Define which columns this table is partitioned by.
+            """
+            gateway = get_gateway()
+            self._j_builder.partitionedBy(to_jarray(gateway.jvm.java.lang.String, partition_keys))
+            return self
+
+        def comment(self, comment: str) -> 'TableDescriptor.Builder':
+            """
+            Define the comment for this table.
+            """
+            self._j_builder.comment(comment)
+            return self
+
+        def build(self) -> 'TableDescriptor':
+            """
+            Returns an immutable instance of :class:`~pyflink.table.TableDescriptor`.
+            """
+            return TableDescriptor(self._j_builder.build())
+
+
+class FormatDescriptor(object):
+    """
+    Describes a Format and its options for use with :class:`~pyflink.table.TableDescriptor`.
+
+    Formats are responsible for encoding and decoding data in table connectors. Note that not
+    every connector has a format, while others may have multiple formats (e.g. the Kafka connector
+    has separate formats for keys and values). Common formats are "json", "csv", "avro", etc.
+    """
+
+    def __init__(self, j_format_descriptor):
+        self._j_format_descriptor = j_format_descriptor
+
+    @staticmethod
+    def for_format(format: str) -> 'FormatDescriptor.Builder':
+        """
+        Creates a new :class:`~pyflink.table.FormatDescriptor.Builder` describing a format with the
+        given format identifier.
+
+        :param format: The factory identifier for the format.
+        """
+        gateway = get_gateway()
+        j_builder = gateway.jvm.FormatDescriptor.forFormat(format)
+        return FormatDescriptor.Builder(j_builder)
+
+    def get_format(self) -> str:
+        return self._j_format_descriptor.getFormat()
+
+    def get_options(self) -> Dict[str, str]:
+        return self._j_format_descriptor.getOptions()
+
+    def __str__(self):
+        return self._j_format_descriptor.toString()
+
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__ and
+                self._j_format_descriptor.equals(other._j_format_descriptor))
+
+    def __hash__(self):
+        return self._j_format_descriptor.hashCode()
+
+    class Builder(object):
+        """
+        Builder for FormatDescriptor.
+        """
+
+        def __init__(self, j_builder):
+            self._j_builder = j_builder
+
+        def option(self, key: Union[str, ConfigOption], value) -> 'FormatDescriptor.Builder':
+            """
+            Sets the given option on the format.
+
+            Note that format options must not be prefixed with the format identifier itself here.
+
+            Example:
+            ::
+
+                >>> FormatDescriptor.for_format("json") \
+                ...     .option("ignore-parse-errors", "true") \
+                ...     .build()
+
+                will automatically be converted into its prefixed form:
+
+                    'format' = 'json'
+                    'json.ignore-parse-errors' = 'true'
+
+            """
+            if isinstance(key, str):
+                self._j_builder.option(key, value)
+            else:
+                self._j_builder.option(key._j_config_option, value)
+            return self
+
+        def build(self) -> 'FormatDescriptor':
+            """
+            Returns an immutable instance of :class:`~pyflink.table.FormatDescriptor`.
+            """
+            return FormatDescriptor(self._j_builder.build())

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -40,15 +40,7 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTest
         return {
             'getCompletionHints',
             'fromValues',
-            'create',
-            'createTemporaryTable',
-            'createTable',
-            'createTemporarySystemFunction',
-            'dropTemporarySystemFunction',
-            'createFunction',
-            'dropFunction',
-            'createTemporaryFunction',
-            'dropTemporaryFunction'}
+            'create'}
 
     @classmethod
     def java_method_name(cls, python_method_name):
@@ -59,7 +51,10 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, PyFlinkTest
         :param python_method_name:
         :return:
         """
-        return {'from_path': 'from'}.get(python_method_name, python_method_name)
+        py_func_to_java_method_dict = {'from_path': 'from',
+                                       "from_descriptor": "from",
+                                       "create_java_function": "create_function"}
+        return py_func_to_java_method_dict.get(python_method_name, python_method_name)
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/table/tests/test_schema.py
+++ b/flink-python/pyflink/table/tests/test_schema.py
@@ -1,0 +1,59 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.table import DataTypes
+from pyflink.table.expressions import call_sql
+from pyflink.table.schema import Schema
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class SchemaTest(PyFlinkTestCase):
+    def test_schema_basic(self):
+        self.schema = Schema.new_builder() \
+            .primary_key_named("primary_constraint", "id") \
+            .column("id", DataTypes.INT().not_null()) \
+            .column("counter", DataTypes.INT().not_null()) \
+            .column("payload", "ROW<name STRING, age INT, flag BOOLEAN>") \
+            .column_by_metadata("topic", DataTypes.STRING(), None, True) \
+            .column_by_expression("ts", call_sql("orig_ts - INTERVAL '60' MINUTE")) \
+            .column_by_metadata("orig_ts", DataTypes.TIMESTAMP(3), "timestamp") \
+            .watermark("ts", "ts - INTERVAL '5' SECOND") \
+            .column_by_expression("proctime", "PROCTIME()") \
+            .build()
+        self.assertEqual("""(
+  `id` INT NOT NULL,
+  `counter` INT NOT NULL,
+  `payload` [ROW<name STRING, age INT, flag BOOLEAN>],
+  `topic` METADATA VIRTUAL,
+  `ts` AS [orig_ts - INTERVAL '60' MINUTE],
+  `orig_ts` METADATA FROM 'timestamp',
+  `proctime` AS [PROCTIME()],
+  WATERMARK FOR `ts` AS [ts - INTERVAL '5' SECOND],
+  CONSTRAINT `primary_constraint` PRIMARY KEY (`id`) NOT ENFORCED
+)""", str(self.schema))
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_schema.py
+++ b/flink-python/pyflink/table/tests/test_schema.py
@@ -23,7 +23,15 @@ from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 class SchemaTest(PyFlinkTestCase):
     def test_schema_basic(self):
+        old_schema = Schema.new_builder() \
+            .from_row_data_type(DataTypes.ROW(
+                [DataTypes.FIELD("a", DataTypes.TINYINT()),
+                 DataTypes.FIELD("b", DataTypes.SMALLINT()),
+                 DataTypes.FIELD("c", DataTypes.INT())])) \
+            .from_fields(["d", "e"], [DataTypes.STRING(), DataTypes.BOOLEAN()]) \
+            .build()
         self.schema = Schema.new_builder() \
+            .from_schema(old_schema) \
             .primary_key_named("primary_constraint", "id") \
             .column("id", DataTypes.INT().not_null()) \
             .column("counter", DataTypes.INT().not_null()) \
@@ -35,6 +43,11 @@ class SchemaTest(PyFlinkTestCase):
             .column_by_expression("proctime", "PROCTIME()") \
             .build()
         self.assertEqual("""(
+  `a` TINYINT,
+  `b` SMALLINT,
+  `c` INT,
+  `d` STRING,
+  `e` BOOLEAN,
   `id` INT NOT NULL,
   `counter` INT NOT NULL,
   `payload` [ROW<name STRING, age INT, flag BOOLEAN>],

--- a/flink-python/pyflink/table/tests/test_table_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_table_descriptor.py
@@ -1,0 +1,134 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.common.config_options import ConfigOptions
+from pyflink.table import DataTypes
+from pyflink.table.schema import Schema
+from pyflink.table.table_descriptor import TableDescriptor, FormatDescriptor
+from pyflink.testing.test_case_utils import PyFlinkTestCase
+
+
+class TableDescriptorTest(PyFlinkTestCase):
+
+    def setUp(self):
+        self.option_a = ConfigOptions.key("a").boolean_type().no_default_value()
+        self.option_b = ConfigOptions.key("b").int_type().no_default_value()
+        self.key_format = ConfigOptions.key("key.format").string_type().no_default_value()
+
+    def test_basic(self):
+        schema = Schema.new_builder() \
+            .column("f0", DataTypes.STRING()) \
+            .column("f1", DataTypes.BIGINT()) \
+            .primary_key("f0") \
+            .build()
+
+        descriptor = TableDescriptor.for_connector("test-connector") \
+            .schema(schema) \
+            .partitioned_by("f0") \
+            .comment("Test Comment") \
+            .build()
+
+        self.assertIsNotNone(descriptor.get_schema())
+
+        self.assertEqual(1, len(descriptor.get_partition_keys()))
+        self.assertEqual("f0", descriptor.get_partition_keys()[0])
+
+        self.assertEqual(1, len(descriptor.get_options()))
+        self.assertEqual("test-connector", descriptor.get_options().get("connector"))
+
+        self.assertEqual("Test Comment", descriptor.get_comment())
+
+    def test_no_schema(self):
+        descriptor = TableDescriptor.for_connector("test-connector").build()
+        self.assertIsNone(descriptor.get_schema())
+
+    def test_options(self):
+        descriptor = TableDescriptor.for_connector("test-connector") \
+            .schema(Schema.new_builder().build()) \
+            .option(self.option_a, False) \
+            .option(self.option_b, 42) \
+            .option("c", "C") \
+            .build()
+        self.assertEqual(4, len(descriptor.get_options()))
+        self.assertEqual("test-connector", descriptor.get_options().get("connector"))
+        self.assertEqual("false", descriptor.get_options().get("a"))
+        self.assertEqual("42", descriptor.get_options().get("b"))
+        self.assertEqual("C", descriptor.get_options().get("c"))
+
+    def test_format_basic(self):
+        descriptor = TableDescriptor.for_connector("test-connector") \
+            .schema(Schema.new_builder().build()) \
+            .format("json") \
+            .build()
+        self.assertEqual(2, len(descriptor.get_options()))
+        self.assertEqual("test-connector", descriptor.get_options().get("connector"))
+        self.assertEqual("json", descriptor.get_options().get("format"))
+
+    def test_format_with_format_descriptor(self):
+        descriptor = TableDescriptor.for_connector("test-connector") \
+            .schema(Schema.new_builder().build()) \
+            .format(FormatDescriptor.for_format("test-format")
+                    .option(self.option_a, True)
+                    .option(self.option_b, 42)
+                    .option("c", "C")
+                    .build(),
+                    self.key_format) \
+            .build()
+        self.assertEqual(5, len(descriptor.get_options()))
+        self.assertEqual("test-connector", descriptor.get_options().get("connector"))
+        self.assertEqual("test-format", descriptor.get_options().get("key.format"))
+        self.assertEqual("true", descriptor.get_options().get("key.test-format.a"))
+        self.assertEqual("42", descriptor.get_options().get("key.test-format.b"))
+        self.assertEqual("C", descriptor.get_options().get("key.test-format.c"))
+
+    def test_to_string(self):
+        schema = Schema.new_builder().column("f0", DataTypes.STRING()).build()
+        format_descriptor = FormatDescriptor \
+            .for_format("test-format") \
+            .option(self.option_a, False) \
+            .build()
+        table_descriptor = TableDescriptor.for_connector("test-connector") \
+            .schema(schema) \
+            .partitioned_by("f0") \
+            .option(self.option_a, True) \
+            .format(format_descriptor) \
+            .comment("Test Comment") \
+            .build()
+        self.assertEqual("test-format[{a=false}]", str(format_descriptor))
+        self.assertEqual("""(
+  `f0` STRING
+)
+COMMENT 'Test Comment'
+PARTITIONED BY (`f0`)
+WITH (
+  'a' = 'true',
+  'connector' = 'test-connector',
+  'test-format.a' = 'false',
+  'format' = 'test-format'
+)""", str(table_descriptor))
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -20,7 +20,6 @@ import decimal
 import os
 import sys
 from py4j.protocol import Py4JJavaError
-from pyflink.table.udf import udf
 
 from pyflink.common import RowKind
 from pyflink.common.typeinfo import Types
@@ -28,10 +27,13 @@ from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
 from pyflink.table import DataTypes, CsvTableSink, StreamTableEnvironment, EnvironmentSettings, \
     Module, ResultKind, ModuleEntry
-from pyflink.table.descriptors import FileSystem, OldCsv, Schema
+from pyflink.table.catalog import ObjectPath, CatalogBaseTable
+from pyflink.table.descriptors import FileSystem, OldCsv
 from pyflink.table.explain_detail import ExplainDetail
 from pyflink.table.expressions import col
+from pyflink.table.table_descriptor import TableDescriptor
 from pyflink.table.types import RowType, Row
+from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import \
     PyFlinkBatchTableTestCase, PyFlinkStreamTableTestCase, \
@@ -163,6 +165,8 @@ class TableEnvironmentTest(object):
         self.assert_equals(t_env.list_user_defined_functions(), [])
 
     def test_temporary_tables(self):
+        from pyflink.table.descriptors import Schema
+
         t_env = self.t_env
         t_env.connect(FileSystem().path(os.path.join(self.tempdir + '/temp_1.csv'))) \
             .with_format(OldCsv()
@@ -192,6 +196,71 @@ class TableEnvironmentTest(object):
         actual = t_env.list_temporary_tables()
         expected = ['temporary_table_2']
         self.assert_equals(actual, expected)
+
+    def test_create_temporary_table_from_descriptor(self):
+        from pyflink.table.schema import Schema
+
+        t_env = self.t_env
+        catalog = t_env.get_current_catalog()
+        database = t_env.get_current_database()
+        schema = Schema.new_builder().column("f0", DataTypes.INT()).build()
+        t_env.create_temporary_table(
+            "T",
+            TableDescriptor.for_connector("fake")
+             .schema(schema)
+             .option("a", "Test")
+             .build())
+
+        self.assertFalse(t_env.get_catalog(catalog).table_exists(ObjectPath(database, "T")))
+        gateway = get_gateway()
+
+        catalog_table = CatalogBaseTable(
+            t_env._j_tenv.getCatalogManager()
+                 .getTable(gateway.jvm.ObjectIdentifier.of(catalog, database, "T"))
+                 .get()
+                 .getTable())
+        self.assertEqual(schema, catalog_table.get_unresolved_schema())
+        self.assertEqual("fake", catalog_table.get_options().get("connector"))
+        self.assertEqual("Test", catalog_table.get_options().get("a"))
+
+    def test_create_table_from_descriptor(self):
+        from pyflink.table.schema import Schema
+
+        catalog = self.t_env.get_current_catalog()
+        database = self.t_env.get_current_database()
+        schema = Schema.new_builder().column("f0", DataTypes.INT()).build()
+        self.t_env.create_table(
+            "T",
+            TableDescriptor.for_connector("fake")
+                  .schema(schema)
+                  .option("a", "Test")
+                  .build())
+        object_path = ObjectPath(database, "T")
+        self.assertTrue(self.t_env.get_catalog(catalog).table_exists(object_path))
+
+        catalog_table = self.t_env.get_catalog(catalog).get_table(object_path)
+        self.assertEqual(schema, catalog_table.get_unresolved_schema())
+        self.assertEqual("fake", catalog_table.get_options().get("connector"))
+        self.assertEqual("Test", catalog_table.get_options().get("a"))
+
+    def test_table_from_descriptor(self):
+        from pyflink.table.schema import Schema
+
+        schema = Schema.new_builder().column("f0", DataTypes.INT()).build()
+        descriptor = TableDescriptor.for_connector("fake").schema(schema).build()
+
+        table = self.t_env.from_descriptor(descriptor)
+        self.assertEqual(schema,
+                         Schema(Schema.new_builder()._j_builder
+                                .fromResolvedSchema(table._j_table.getResolvedSchema()).build()))
+        table = CatalogBaseTable(self.t_env._j_tenv
+                                 .getCatalogManager()
+                                 .getTable(table._j_table
+                                           .getQueryOperation()
+                                           .getTableIdentifier())
+                                 .get()
+                                 .getTable())
+        self.assertEqual("fake", table.get_options().get("connector"))
 
 
 class DataStreamConversionTestCases(object):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will expose new APIs about TableDescriptor in PyFlink*

## Brief change log

  - *Add ConfigOptions/TableDescriptor/FormatDescriptor/Schema*
  - *Expose create_table/create_temporary_table/from_descriptor of TableEnvironment*
  - *Expose Table#execute_insert and StatementSet#add_insert in Python Table API*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_schema.py` , `test_table_descriptor.py`, `test_table_environment_api.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
