### PR TITLE
[FLINK-23373][task] Fully support object reuse in OperatorChain

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CopyingChainingOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CopyingChainingOutput.java
@@ -18,9 +18,13 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
+
+import javax.annotation.Nullable;
 
 final class CopyingChainingOutput<T> extends ChainingOutput<T> {
 
@@ -29,8 +33,17 @@ final class CopyingChainingOutput<T> extends ChainingOutput<T> {
     public CopyingChainingOutput(
             OneInputStreamOperator<T, ?> operator,
             TypeSerializer<T> serializer,
-            OutputTag<T> outputTag) {
+            @Nullable OutputTag<T> outputTag) {
         super(operator, outputTag);
+        this.serializer = serializer;
+    }
+
+    public CopyingChainingOutput(
+            Input<T> input,
+            TypeSerializer<T> serializer,
+            OperatorMetricGroup operatorMetricGroup,
+            @Nullable OutputTag<T> outputTag) {
+        super(input, operatorMetricGroup, outputTag);
         this.serializer = serializer;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -223,7 +223,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
                                         new MockSource(Boundedness.BOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
+                                        WatermarkStrategy.noWatermarks()),
+                                BasicTypeInfo.INT_TYPE_INFO)
                         .setupOutputForSingletonOperatorChain(
                                 new MapToStringMultipleInputOperatorFactory(1))
                         .build()) {
@@ -272,13 +273,15 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                                             new MultipleInputStreamTaskTest
                                                     .LifeCycleTrackingMockSource(
                                                     Boundedness.CONTINUOUS_UNBOUNDED, 1),
-                                            WatermarkStrategy.noWatermarks()))
+                                            WatermarkStrategy.noWatermarks()),
+                                    BasicTypeInfo.INT_TYPE_INFO)
                             .addSourceInput(
                                     new SourceOperatorFactory<>(
                                             new MultipleInputStreamTaskTest
                                                     .LifeCycleTrackingMockSource(
                                                     Boundedness.CONTINUOUS_UNBOUNDED, 1),
-                                            WatermarkStrategy.noWatermarks()))
+                                            WatermarkStrategy.noWatermarks()),
+                                    BasicTypeInfo.INT_TYPE_INFO)
                             .addAdditionalOutput(partitionWriters)
                             .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(4))
                             .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
@@ -356,13 +359,15 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                                 new SourceOperatorFactory<>(
                                         new SourceOperatorStreamTaskTest.LifeCycleMonitorSource(
                                                 Boundedness.CONTINUOUS_UNBOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
+                                        WatermarkStrategy.noWatermarks()),
+                                BasicTypeInfo.INT_TYPE_INFO)
                         .addSourceInput(
                                 secondSourceOperatorId,
                                 new SourceOperatorFactory<>(
                                         new SourceOperatorStreamTaskTest.LifeCycleMonitorSource(
                                                 Boundedness.CONTINUOUS_UNBOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
+                                        WatermarkStrategy.noWatermarks()),
+                                BasicTypeInfo.INT_TYPE_INFO)
                         .setTaskStateSnapshot(1, TaskStateSnapshot.FINISHED)
                         .setupOperatorChain(
                                 nonSourceOperatorId,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.TimestampAssigner;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -49,6 +48,10 @@ import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
 import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.MapToStringMultipleInputOperatorFactory;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -57,6 +60,7 @@ import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.addSourceRecords;
+import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.applyObjectReuse;
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.buildTestHarness;
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -73,8 +77,17 @@ import static org.junit.Assert.fail;
  * Tests for {@link MultipleInputStreamTask} combined with {@link
  * org.apache.flink.streaming.api.operators.SourceOperator} chaining.
  */
+@RunWith(Parameterized.class)
 public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
+
     private static final int MAX_STEPS = 100;
+
+    @Parameters(name = "objectReuse = {0}")
+    public static Boolean[] parameters() {
+        return new Boolean[] {true, false};
+    }
+
+    @Parameter public boolean objectReuse;
 
     private final CheckpointMetaData metaData =
             new CheckpointMetaData(1L, System.currentTimeMillis());
@@ -85,7 +98,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      */
     @Test
     public void testSourceCheckpointFirst() throws Exception {
-        try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness()) {
+        try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(objectReuse)) {
             testHarness.setAutoProcess(false);
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
             CheckpointBarrier barrier = createBarrier(testHarness);
@@ -117,7 +130,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      */
     @Test
     public void testSourceCheckpointFirstUnaligned() throws Exception {
-        try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(true)) {
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                buildTestHarness(true, objectReuse)) {
             testHarness.setAutoProcess(false);
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
             addRecords(testHarness);
@@ -152,7 +166,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      */
     @Test
     public void testSourceCheckpointLast() throws Exception {
-        try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness()) {
+        try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(objectReuse)) {
             testHarness.setAutoProcess(false);
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
             CheckpointBarrier barrier = createBarrier(testHarness);
@@ -192,7 +206,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
     @Test
     public void testSourceCheckpointLastUnaligned() throws Exception {
         boolean unaligned = true;
-        try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(unaligned)) {
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                buildTestHarness(unaligned, objectReuse)) {
             testHarness.setAutoProcess(false);
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
 
@@ -219,7 +234,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                        .modifyExecutionConfig(config -> config.enableObjectReuse())
+                        .modifyExecutionConfig(applyObjectReuse(objectReuse))
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
                                         new MockSource(Boundedness.BOUNDED, 1),
@@ -265,7 +280,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                     new StreamTaskMailboxTestHarnessBuilder<>(
                                     MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
                             .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
-                            .modifyExecutionConfig(ExecutionConfig::enableObjectReuse)
+                            .modifyExecutionConfig(applyObjectReuse(objectReuse))
                             .addInput(BasicTypeInfo.INT_TYPE_INFO)
                             .addInput(BasicTypeInfo.STRING_TYPE_INFO)
                             .addSourceInput(
@@ -352,7 +367,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
                         .modifyStreamConfig(config -> config.setCheckpointingEnabled(true))
-                        .modifyExecutionConfig(ExecutionConfig::enableObjectReuse)
+                        .modifyExecutionConfig(applyObjectReuse(objectReuse))
                         .addInput(BasicTypeInfo.INT_TYPE_INFO)
                         .addSourceInput(
                                 firstSourceOperatorId,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -24,6 +24,9 @@ import org.apache.flink.api.common.eventtime.WatermarkGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -32,6 +35,8 @@ import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
@@ -74,17 +79,21 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTest.WatermarkMetricOperator;
 import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.SerializedValue;
 
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -127,6 +136,8 @@ public class MultipleInputStreamTaskTest {
 
     @Parameter public boolean objectReuse;
 
+    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+
     @Before
     public void setUp() {
         LIFE_CYCLE_EVENTS.clear();
@@ -150,6 +161,39 @@ public class MultipleInputStreamTaskTest {
             testHarness.waitForTaskCompletion();
 
             assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+        }
+    }
+
+    @Test
+    public void testCopyForObjectReuse() throws Exception {
+        SharedReference<List<Integer>> copiedElementsRef = sharedObjects.add(new ArrayList<>());
+        CopyProxySerializer proxySerializer = new CopyProxySerializer(copiedElementsRef);
+
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .modifyExecutionConfig(applyObjectReuse(objectReuse))
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO)
+                        .addSourceInput(
+                                new SourceOperatorFactory<>(
+                                        new MockSource(Boundedness.BOUNDED, 1),
+                                        WatermarkStrategy.noWatermarks()),
+                                proxySerializer)
+                        .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
+                        .setupOutputForSingletonOperatorChain(
+                                new MapToStringMultipleInputOperatorFactory(3))
+                        .build()) {
+
+            addSourceRecords(testHarness, 1, 42, 43);
+
+            testHarness.endInput();
+            testHarness.waitForTaskCompletion();
+
+            if (objectReuse) {
+                assertTrue(copiedElementsRef.get().isEmpty());
+            } else {
+                assertThat(copiedElementsRef.get(), containsInAnyOrder(42, 43));
+            }
         }
     }
 
@@ -363,7 +407,7 @@ public class MultipleInputStreamTaskTest {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                        .modifyExecutionConfig(config -> config.enableObjectReuse())
+                        .modifyExecutionConfig(applyObjectReuse(objectReuse))
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO)
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
@@ -460,7 +504,7 @@ public class MultipleInputStreamTaskTest {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                        .modifyExecutionConfig(config -> config.enableObjectReuse())
+                        .modifyExecutionConfig(applyObjectReuse(objectReuse))
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO)
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
@@ -703,7 +747,7 @@ public class MultipleInputStreamTaskTest {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                        .modifyExecutionConfig(config -> config.enableObjectReuse())
+                        .modifyExecutionConfig(applyObjectReuse(objectReuse))
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO)
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
@@ -1093,11 +1137,11 @@ public class MultipleInputStreamTaskTest {
                 .dispatchOperatorEvent(sourceOperatorID, new SerializedValue<>(addSplitEvent));
     }
 
-    private static StreamTaskMailboxTestHarness<String> buildWatermarkTestHarness(
+    private StreamTaskMailboxTestHarness<String> buildWatermarkTestHarness(
             int inputChannels, boolean readerMarkIdleOnNoSplits) throws Exception {
         return new StreamTaskMailboxTestHarnessBuilder<>(
                         MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
-                .modifyExecutionConfig(config -> config.enableObjectReuse())
+                .modifyExecutionConfig(applyObjectReuse(objectReuse))
                 .addInput(BasicTypeInfo.STRING_TYPE_INFO, inputChannels)
                 .addSourceInput(
                         new SourceOperatorFactory<>(
@@ -1257,5 +1301,81 @@ public class MultipleInputStreamTaskTest {
 
         @Override
         public void onPeriodicEmit(WatermarkOutput output) {}
+    }
+
+    private static class CopyProxySerializer extends TypeSerializer<Integer> {
+
+        SharedReference<List<Integer>> copiedElementsRef;
+
+        public CopyProxySerializer(SharedReference<List<Integer>> copiedElementsRef) {
+            this.copiedElementsRef = copiedElementsRef;
+        }
+
+        @Override
+        public boolean isImmutableType() {
+            return false; // to force copy
+        }
+
+        @Override
+        public TypeSerializer<Integer> duplicate() {
+            return new CopyProxySerializer(copiedElementsRef);
+        }
+
+        @Override
+        public Integer createInstance() {
+            return IntSerializer.INSTANCE.createInstance();
+        }
+
+        @Override
+        public Integer copy(Integer from) {
+            copiedElementsRef.applySync(list -> list.add(from));
+            return IntSerializer.INSTANCE.copy(from);
+        }
+
+        @Override
+        public Integer copy(Integer from, Integer reuse) {
+            copiedElementsRef.applySync(list -> list.add(from));
+            return IntSerializer.INSTANCE.copy(from, reuse);
+        }
+
+        @Override
+        public int getLength() {
+            return IntSerializer.INSTANCE.getLength();
+        }
+
+        @Override
+        public void serialize(Integer record, DataOutputView target) throws IOException {
+            IntSerializer.INSTANCE.serialize(record, target);
+        }
+
+        @Override
+        public Integer deserialize(DataInputView source) throws IOException {
+            return IntSerializer.INSTANCE.deserialize(source);
+        }
+
+        @Override
+        public Integer deserialize(Integer reuse, DataInputView source) throws IOException {
+            return IntSerializer.INSTANCE.deserialize(reuse, source);
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int hashCode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TypeSerializerSnapshot<Integer> snapshotConfiguration() {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -354,7 +354,8 @@ public class MultipleInputStreamTaskTest {
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
                                         new LifeCycleTrackingMockSource(Boundedness.BOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
+                                        WatermarkStrategy.noWatermarks()),
+                                BasicTypeInfo.INT_TYPE_INFO)
                         .addInput(BasicTypeInfo.STRING_TYPE_INFO)
                         .setupOperatorChain(new MapToStringMultipleInputOperatorFactory(3))
                         .name(mainOperatorName)
@@ -450,7 +451,8 @@ public class MultipleInputStreamTaskTest {
                         .addSourceInput(
                                 new SourceOperatorFactory<>(
                                         new LifeCycleTrackingMockSource(Boundedness.BOUNDED, 1),
-                                        WatermarkStrategy.noWatermarks()))
+                                        WatermarkStrategy.noWatermarks()),
+                                BasicTypeInfo.INT_TYPE_INFO)
                         .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
                         .setupOperatorChain(
                                 new LifeCycleTrackingMapToStringMultipleInputOperatorFactory())
@@ -694,7 +696,8 @@ public class MultipleInputStreamTaskTest {
                                         new MockSource(
                                                 Boundedness.CONTINUOUS_UNBOUNDED, 2, true, false),
                                         WatermarkStrategy.forGenerator(
-                                                ctx -> new RecordToWatermarkGenerator())))
+                                                ctx -> new RecordToWatermarkGenerator())),
+                                BasicTypeInfo.INT_TYPE_INFO)
                         .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
                         .setupOperatorChain(
                                 mainOperatorId, new MapToStringMultipleInputOperatorFactory(3))
@@ -1036,7 +1039,8 @@ public class MultipleInputStreamTaskTest {
                 .addSourceInput(
                         new SourceOperatorFactory<>(
                                 new MockSource(Boundedness.BOUNDED, 1),
-                                WatermarkStrategy.noWatermarks()))
+                                WatermarkStrategy.noWatermarks()),
+                        BasicTypeInfo.INT_TYPE_INFO)
                 .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
                 .setupOutputForSingletonOperatorChain(
                         new MapToStringMultipleInputOperatorFactory(3))
@@ -1078,7 +1082,8 @@ public class MultipleInputStreamTaskTest {
                                         true,
                                         readerMarkIdleOnNoSplits),
                                 WatermarkStrategy.forGenerator(
-                                        ctx -> new RecordToWatermarkGenerator())))
+                                        ctx -> new RecordToWatermarkGenerator())),
+                        BasicTypeInfo.INT_TYPE_INFO)
                 .addInput(BasicTypeInfo.DOUBLE_TYPE_INFO, inputChannels)
                 .setupOutputForSingletonOperatorChain(
                         new MapToStringMultipleInputOperatorFactory(3))

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -139,14 +139,21 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         return this;
     }
 
-    public StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
-            SourceOperatorFactory<?> sourceOperatorFactory) {
-        return addSourceInput(new OperatorID(), sourceOperatorFactory);
+    public <SourceType> StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
+            SourceOperatorFactory<SourceType> sourceOperatorFactory,
+            TypeInformation<SourceType> sourceType) {
+        return addSourceInput(new OperatorID(), sourceOperatorFactory, sourceType);
     }
 
-    public StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
-            OperatorID operatorId, SourceOperatorFactory<?> sourceOperatorFactory) {
-        inputs.add(new SourceInputConfigPlaceHolder(operatorId, sourceOperatorFactory));
+    public <SourceType> StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
+            OperatorID operatorId,
+            SourceOperatorFactory<SourceType> sourceOperatorFactory,
+            TypeInformation<SourceType> sourceType) {
+        inputs.add(
+                new SourceInputConfigPlaceHolder<>(
+                        operatorId,
+                        sourceOperatorFactory,
+                        sourceType.createSerializer(executionConfig)));
         return this;
     }
 
@@ -296,7 +303,7 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         sourceConfig.setTimeCharacteristic(streamConfig.getTimeCharacteristic());
         sourceConfig.setOutEdgesInOrder(outEdgesInOrder);
         sourceConfig.setChainedOutputs(outEdgesInOrder);
-        sourceConfig.setTypeSerializerOut(outputSerializer);
+        sourceConfig.setTypeSerializerOut(sourceInput.getSourceSerializer());
         sourceConfig.setOperatorID(sourceInput.getOperatorId());
         sourceConfig.setStreamOperatorFactory(sourceInput.getSourceOperatorFactory());
 
@@ -383,22 +390,30 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
      * A place holder representation of a {@link SourceInputConfig}. When building the test harness
      * it is replaced with {@link SourceInputConfig}.
      */
-    public static class SourceInputConfigPlaceHolder implements InputConfig {
+    public static class SourceInputConfigPlaceHolder<SourceOut> implements InputConfig {
         private OperatorID operatorId;
-        private SourceOperatorFactory<?> sourceOperatorFactory;
+        private SourceOperatorFactory<SourceOut> sourceOperatorFactory;
+        private TypeSerializer<SourceOut> sourceSerializer;
 
         public SourceInputConfigPlaceHolder(
-                OperatorID operatorId, SourceOperatorFactory<?> sourceOperatorFactory) {
+                OperatorID operatorId,
+                SourceOperatorFactory<SourceOut> sourceOperatorFactory,
+                TypeSerializer<SourceOut> sourceSerializer) {
             this.operatorId = operatorId;
             this.sourceOperatorFactory = sourceOperatorFactory;
+            this.sourceSerializer = sourceSerializer;
         }
 
         public OperatorID getOperatorId() {
             return operatorId;
         }
 
-        public SourceOperatorFactory<?> getSourceOperatorFactory() {
+        public SourceOperatorFactory<SourceOut> getSourceOperatorFactory() {
             return sourceOperatorFactory;
+        }
+
+        public TypeSerializer<SourceOut> getSourceSerializer() {
+            return sourceSerializer;
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -149,11 +149,23 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
             OperatorID operatorId,
             SourceOperatorFactory<SourceType> sourceOperatorFactory,
             TypeInformation<SourceType> sourceType) {
+        return addSourceInput(
+                operatorId, sourceOperatorFactory, sourceType.createSerializer(executionConfig));
+    }
+
+    public <SourceType> StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
+            SourceOperatorFactory<SourceType> sourceOperatorFactory,
+            TypeSerializer<SourceType> sourceSerializer) {
+        return addSourceInput(new OperatorID(), sourceOperatorFactory, sourceSerializer);
+    }
+
+    public <SourceType> StreamTaskMailboxTestHarnessBuilder<OUT> addSourceInput(
+            OperatorID operatorId,
+            SourceOperatorFactory<SourceType> sourceOperatorFactory,
+            TypeSerializer<SourceType> sourceSerializer) {
         inputs.add(
                 new SourceInputConfigPlaceHolder<>(
-                        operatorId,
-                        sourceOperatorFactory,
-                        sourceType.createSerializer(executionConfig)));
+                        operatorId, sourceOperatorFactory, sourceSerializer));
         return this;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This adds the missing parts to make object reuse work in OperatorChain.

## Brief change log

See commit messages.

## Verifying this change

This change added tests and can be verified as follows:
`MultipleInputStreamTaskChainedSourcesCheckpointingTest` and `MultipleInputStreamTaskTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
