### PR TITLE
[FLINK-23416][runtime] Don't log NoResourceAvailableException stacktrace

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.OptionalFailure;
 import org.apache.flink.util.Preconditions;
@@ -1430,17 +1431,15 @@ public class Execution
                         getAttemptId(),
                         currentState,
                         targetState);
-            } else {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info(
-                            "{} ({}) switched from {} to {} on {}.",
-                            getVertex().getTaskNameWithSubtaskIndex(),
-                            getAttemptId(),
-                            currentState,
-                            targetState,
-                            getLocationInformation(),
-                            error);
-                }
+            } else if (LOG.isInfoEnabled()) {
+                LOG.info(
+                        "{} ({}) switched from {} to {} on {}.",
+                        getVertex().getTaskNameWithSubtaskIndex(),
+                        getAttemptId(),
+                        currentState,
+                        targetState,
+                        getLocationInformation(),
+                        ExceptionUtils.stripCompletionException(error));
             }
 
             if (targetState == INITIALIZING || targetState == RUNNING) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/NoResourceAvailableException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/NoResourceAvailableException.java
@@ -41,6 +41,12 @@ public class NoResourceAvailableException extends JobException {
         super(message, cause);
     }
 
+    public static NoResourceAvailableException withoutStackTrace(String message) {
+        NoResourceAvailableException exception = new NoResourceAvailableException(message);
+        exception.setStackTrace(new StackTraceElement[0]);
+        return exception;
+    }
+
     // --------------------------------------------------------------------------------------------
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DeclarativeSlotPoolBridge.java
@@ -354,7 +354,7 @@ public class DeclarativeSlotPoolBridge extends DeclarativeSlotPoolService implem
                     getSlotServiceStatus());
             cancelPendingRequests(
                     predicate,
-                    new NoResourceAvailableException(
+                    NoResourceAvailableException.withoutStackTrace(
                             "Could not acquire the minimum required resources."));
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Please see FLINK-23416 for more details.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no

