### PR TITLE
[FLINK-21979] Cleanup completed checkpoint store after dispatcher cleans up HA services

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -380,8 +380,7 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
         return persistAndRunFuture.handleAsync(
                 (acknowledge, throwable) -> {
                     if (throwable != null) {
-                        cleanUpJobData(jobGraph.getJobID(), true);
-
+                        cleanUpHighAvailabilityJobData(jobGraph.getJobID());
                         ClusterEntryPointExceptionUtils.tryEnrichClusterEntryPointError(throwable);
                         final Throwable strippedThrowable =
                                 ExceptionUtils.stripCompletionException(throwable);
@@ -437,7 +436,9 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                         .thenApply(cleanupJobState -> removeJob(jobId, cleanupJobState))
                         .thenCompose(Function.identity());
 
-        FutureUtils.assertNoException(jobTerminationFuture);
+        FutureUtils.handleUncaughtException(
+                jobTerminationFuture,
+                (thread, throwable) -> fatalErrorHandler.onFatalError(throwable));
         registerJobManagerRunnerTerminationFuture(jobId, jobTerminationFuture);
     }
 
@@ -743,31 +744,48 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 
     private CompletableFuture<Void> removeJob(JobID jobId, CleanupJobState cleanupJobState) {
         final JobManagerRunner job = checkNotNull(runningJobs.remove(jobId));
-
-        final CompletableFuture<Void> jobTerminationFuture = job.closeAsync();
-
-        return jobTerminationFuture.thenRunAsync(
-                () -> cleanUpJobData(jobId, cleanupJobState.cleanupHAData), ioExecutor);
+        return CompletableFuture.supplyAsync(
+                        () -> cleanUpJobGraph(jobId, cleanupJobState.cleanupHAData), ioExecutor)
+                .thenCompose(
+                        jobGraphRemoved -> job.closeAsync().thenApply(ignored -> jobGraphRemoved))
+                .thenAcceptAsync(
+                        jobGraphRemoved -> cleanUpRemainingJobData(jobId, jobGraphRemoved),
+                        ioExecutor);
     }
 
-    private void cleanUpJobData(JobID jobId, boolean cleanupHA) {
-        jobManagerMetricGroup.removeJob(jobId);
-
-        boolean jobGraphRemoved = false;
+    /**
+     * Clean up job graph from {@link org.apache.flink.runtime.jobmanager.JobGraphStore}.
+     *
+     * @param jobId Reference to the job that we want to clean.
+     * @param cleanupHA Flag signalling whether we should remove (we're done with the job) or just
+     *     release the job graph.
+     * @return True if we have removed the job graph. This means we can clean other HA-related
+     *     services as well.
+     */
+    private boolean cleanUpJobGraph(JobID jobId, boolean cleanupHA) {
         if (cleanupHA) {
             try {
                 jobGraphWriter.removeJobGraph(jobId);
-
-                // only clean up the HA blobs and ha service data for the particular job
-                // if we could remove the job from HA storage
-                jobGraphRemoved = true;
+                return true;
             } catch (Exception e) {
                 log.warn(
                         "Could not properly remove job {} from submitted job graph store.",
                         jobId,
                         e);
+                return false;
             }
+        }
+        try {
+            jobGraphWriter.releaseJobGraph(jobId);
+        } catch (Exception e) {
+            log.warn("Could not properly release job {} from submitted job graph store.", jobId, e);
+        }
+        return false;
+    }
 
+    private void cleanUpRemainingJobData(JobID jobId, boolean jobGraphRemoved) {
+        jobManagerMetricGroup.removeJob(jobId);
+        if (jobGraphRemoved) {
             try {
                 runningJobsRegistry.clearJob(jobId);
             } catch (IOException e) {
@@ -776,29 +794,19 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
                         jobId,
                         e);
             }
-
-            if (jobGraphRemoved) {
-                try {
-                    highAvailabilityServices.cleanupJobData(jobId);
-                } catch (Exception e) {
-                    log.warn(
-                            "Could not properly clean data for job {} stored by ha services",
-                            jobId,
-                            e);
-                }
-            }
-        } else {
             try {
-                jobGraphWriter.releaseJobGraph(jobId);
+                highAvailabilityServices.cleanupJobData(jobId);
             } catch (Exception e) {
                 log.warn(
-                        "Could not properly release job {} from submitted job graph store.",
-                        jobId,
-                        e);
+                        "Could not properly clean data for job {} stored by ha services", jobId, e);
             }
         }
-
         blobServer.cleanupJob(jobId, jobGraphRemoved);
+    }
+
+    private void cleanUpHighAvailabilityJobData(JobID jobId) {
+        final boolean jobGraphRemoved = cleanUpJobGraph(jobId, true);
+        cleanUpRemainingJobData(jobId, jobGraphRemoved);
     }
 
     /** Terminate all currently running {@link JobManagerRunner}s. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/AbstractDispatcherTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmanager.JobGraphWriter;
+import org.apache.flink.runtime.jobmanager.StandaloneJobGraphStore;
+import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TimeUtils;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
+
+/** Abstract test for the {@link Dispatcher} component. */
+public class AbstractDispatcherTest extends TestLogger {
+
+    static TestingRpcService rpcService;
+
+    static final Time TIMEOUT = Time.minutes(1L);
+
+    @BeforeClass
+    public static void setupClass() {
+        rpcService = new TestingRpcService();
+    }
+
+    @AfterClass
+    public static void teardownClass() throws Exception {
+        if (rpcService != null) {
+            RpcUtils.terminateRpcService(rpcService, TIMEOUT);
+            rpcService = null;
+        }
+    }
+
+    static void awaitStatus(DispatcherGateway dispatcherGateway, JobID jobId, JobStatus status)
+            throws Exception {
+        CommonTestUtils.waitUntilCondition(
+                () -> status.equals(dispatcherGateway.requestJobStatus(jobId, TIMEOUT).get()),
+                Deadline.fromNow(TimeUtils.toDuration(TIMEOUT)));
+    }
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public final TestingFatalErrorHandlerResource testingFatalErrorHandlerResource =
+            new TestingFatalErrorHandlerResource();
+
+    @Rule public TestName name = new TestName();
+
+    Configuration configuration;
+
+    BlobServer blobServer;
+
+    TestingHighAvailabilityServices haServices;
+
+    HeartbeatServices heartbeatServices;
+
+    @Before
+    public void setUp() throws Exception {
+        heartbeatServices = new HeartbeatServices(1000L, 10000L);
+
+        haServices = new TestingHighAvailabilityServices();
+        haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
+        haServices.setResourceManagerLeaderRetriever(new SettableLeaderRetrievalService());
+        haServices.setJobGraphStore(new StandaloneJobGraphStore());
+
+        configuration = new Configuration();
+        configuration.setString(
+                BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+        blobServer = new BlobServer(configuration, new VoidBlobStore());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (haServices != null) {
+            haServices.closeAndCleanupAllData();
+        }
+        if (blobServer != null) {
+            blobServer.close();
+        }
+    }
+
+    /** A convenient builder for the {@link TestingDispatcher}. */
+    public class TestingDispatcherBuilder {
+
+        private Collection<JobGraph> initialJobGraphs = Collections.emptyList();
+
+        private final DispatcherBootstrapFactory dispatcherBootstrapFactory =
+                (dispatcher, scheduledExecutor, errorHandler) -> new NoOpDispatcherBootstrap();
+
+        private HeartbeatServices heartbeatServices = AbstractDispatcherTest.this.heartbeatServices;
+
+        private HighAvailabilityServices haServices = AbstractDispatcherTest.this.haServices;
+
+        private JobManagerRunnerFactory jobManagerRunnerFactory =
+                JobMasterServiceLeadershipRunnerFactory.INSTANCE;
+
+        private JobGraphWriter jobGraphWriter = NoOpJobGraphWriter.INSTANCE;
+
+        private FatalErrorHandler fatalErrorHandler =
+                testingFatalErrorHandlerResource.getFatalErrorHandler();
+
+        TestingDispatcherBuilder setHeartbeatServices(HeartbeatServices heartbeatServices) {
+            this.heartbeatServices = heartbeatServices;
+            return this;
+        }
+
+        TestingDispatcherBuilder setHaServices(HighAvailabilityServices haServices) {
+            this.haServices = haServices;
+            return this;
+        }
+
+        TestingDispatcherBuilder setInitialJobGraphs(Collection<JobGraph> initialJobGraphs) {
+            this.initialJobGraphs = initialJobGraphs;
+            return this;
+        }
+
+        TestingDispatcherBuilder setJobManagerRunnerFactory(
+                JobManagerRunnerFactory jobManagerRunnerFactory) {
+            this.jobManagerRunnerFactory = jobManagerRunnerFactory;
+            return this;
+        }
+
+        TestingDispatcherBuilder setJobGraphWriter(JobGraphWriter jobGraphWriter) {
+            this.jobGraphWriter = jobGraphWriter;
+            return this;
+        }
+
+        public TestingDispatcherBuilder setFatalErrorHandler(FatalErrorHandler fatalErrorHandler) {
+            this.fatalErrorHandler = fatalErrorHandler;
+            return this;
+        }
+
+        TestingDispatcher build() throws Exception {
+            TestingResourceManagerGateway resourceManagerGateway =
+                    new TestingResourceManagerGateway();
+
+            final MemoryExecutionGraphInfoStore executionGraphInfoStore =
+                    new MemoryExecutionGraphInfoStore();
+
+            return new TestingDispatcher(
+                    rpcService,
+                    DispatcherId.generate(),
+                    initialJobGraphs,
+                    dispatcherBootstrapFactory,
+                    new DispatcherServices(
+                            configuration,
+                            haServices,
+                            () -> CompletableFuture.completedFuture(resourceManagerGateway),
+                            blobServer,
+                            heartbeatServices,
+                            executionGraphInfoStore,
+                            fatalErrorHandler,
+                            VoidHistoryServerArchivist.INSTANCE,
+                            null,
+                            UnregisteredMetricGroups.createUnregisteredJobManagerMetricGroup(),
+                            jobGraphWriter,
+                            jobManagerRunnerFactory,
+                            ForkJoinPool.commonPool()));
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherFailoverITCase.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.EmbeddedCompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
+import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneRunningJobsRegistry;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.TestingJobGraphStore;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertTrue;
+
+/** An integration test for various fail-over scenarios of the {@link Dispatcher} component. */
+public class DispatcherFailoverITCase extends AbstractDispatcherTest {
+
+    private static final Time TIMEOUT = Time.seconds(1);
+
+    private final BlockingQueue<RpcEndpoint> toTerminate = new LinkedBlockingQueue<>();
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        final CompletedCheckpointStore completedCheckpointStore =
+                new EmbeddedCompletedCheckpointStore();
+        haServices.setCheckpointRecoveryFactory(
+                PerJobCheckpointRecoveryFactory.useSameServicesForAllJobs(
+                        completedCheckpointStore, new StandaloneCheckpointIDCounter()));
+    }
+
+    @After
+    public void tearDown() {
+        while (!toTerminate.isEmpty()) {
+            final RpcEndpoint endpoint = toTerminate.poll();
+            try {
+                RpcUtils.terminateRpcEndpoint(endpoint, TIMEOUT);
+            } catch (Exception e) {
+                // Ignore.
+            }
+        }
+    }
+
+    @Test
+    public void testRecoverFromCheckpointAfterJobGraphRemovalOfTerminatedJobFailed()
+            throws Exception {
+        final JobGraph jobGraph = createJobGraph();
+        final JobID jobId = jobGraph.getJobID();
+
+        // Construct job graph store.
+        final Error jobGraphRemovalError = new Error("Unable to remove job graph.");
+        final TestingJobGraphStore jobGraphStore =
+                TestingJobGraphStore.newBuilder()
+                        .setRemoveJobGraphConsumer(
+                                graph -> {
+                                    throw jobGraphRemovalError;
+                                })
+                        .build();
+        jobGraphStore.start(null);
+        haServices.setJobGraphStore(jobGraphStore);
+
+        // Construct leader election service.
+        final TestingLeaderElectionService leaderElectionService =
+                new TestingLeaderElectionService();
+        haServices.setJobMasterLeaderElectionService(jobId, leaderElectionService);
+
+        // Start the first dispatcher and submit the job.
+        final CountDownLatch jobGraphRemovalErrorReceived = new CountDownLatch(1);
+        final Dispatcher dispatcher =
+                createRecoveredDispatcher(
+                        throwable -> {
+                            final Optional<Error> maybeError =
+                                    ExceptionUtils.findThrowable(throwable, Error.class);
+                            if (maybeError.isPresent()
+                                    && jobGraphRemovalError.equals(maybeError.get())) {
+                                jobGraphRemovalErrorReceived.countDown();
+                            } else {
+                                testingFatalErrorHandlerResource
+                                        .getFatalErrorHandler()
+                                        .onFatalError(throwable);
+                            }
+                        });
+        toTerminate.add(dispatcher);
+        leaderElectionService.isLeader(UUID.randomUUID());
+        final DispatcherGateway dispatcherGateway =
+                dispatcher.getSelfGateway(DispatcherGateway.class);
+        dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
+        awaitStatus(dispatcherGateway, jobId, JobStatus.RUNNING);
+
+        // Run vertices, checkpoint and finish.
+        final JobMasterGateway jobMasterGateway =
+                connectToLeadingJobMaster(leaderElectionService).get();
+        try (final JobMasterTester tester =
+                new JobMasterTester(rpcService, jobId, jobMasterGateway)) {
+            final List<TaskDeploymentDescriptor> descriptors = tester.deployVertices(2).get();
+            tester.transitionTo(descriptors, ExecutionState.INITIALIZING).get();
+            tester.transitionTo(descriptors, ExecutionState.RUNNING).get();
+            tester.getCheckpointFuture(1L).get();
+            tester.transitionTo(descriptors, ExecutionState.FINISHED).get();
+        }
+        awaitStatus(dispatcherGateway, jobId, JobStatus.FINISHED);
+        jobGraphRemovalErrorReceived.await();
+
+        // Remove job master leadership.
+        leaderElectionService.notLeader();
+
+        // This will clear internal state of election service, so a new contender can register.
+        leaderElectionService.stop();
+
+        // Run a second dispatcher, that restores our finished job.
+        final Dispatcher secondDispatcher = createRecoveredDispatcher(null);
+        toTerminate.add(secondDispatcher);
+        final DispatcherGateway secondDispatcherGateway =
+                secondDispatcher.getSelfGateway(DispatcherGateway.class);
+        UUID uuid = UUID.randomUUID();
+        leaderElectionService.isLeader(uuid);
+        awaitStatus(secondDispatcherGateway, jobId, JobStatus.RUNNING);
+
+        // Now make sure that restored job started from checkpoint.
+        final JobMasterGateway secondJobMasterGateway =
+                connectToLeadingJobMaster(leaderElectionService).get();
+        try (final JobMasterTester tester =
+                new JobMasterTester(rpcService, jobId, secondJobMasterGateway)) {
+            final List<TaskDeploymentDescriptor> descriptors = tester.deployVertices(2).get();
+            final Optional<JobManagerTaskRestore> maybeRestore =
+                    descriptors.stream()
+                            .map(TaskDeploymentDescriptor::getTaskRestore)
+                            .filter(Objects::nonNull)
+                            .findAny();
+            assertTrue("Job has recovered from checkpoint.", maybeRestore.isPresent());
+        }
+    }
+
+    private JobGraph createJobGraph() {
+        final JobVertex firstVertex = new JobVertex("first");
+        firstVertex.setInvokableClass(NoOpInvokable.class);
+        firstVertex.setParallelism(1);
+
+        final JobVertex secondVertex = new JobVertex("second");
+        secondVertex.setInvokableClass(NoOpInvokable.class);
+        secondVertex.setParallelism(1);
+
+        final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
+                CheckpointCoordinatorConfiguration.builder()
+                        .setCheckpointInterval(20L)
+                        .setMinPauseBetweenCheckpoints(20L)
+                        .setCheckpointTimeout(10_000L)
+                        .build();
+        final JobCheckpointingSettings checkpointingSettings =
+                new JobCheckpointingSettings(checkpointCoordinatorConfiguration, null);
+        return JobGraphBuilder.newStreamingJobGraphBuilder()
+                .addJobVertex(firstVertex)
+                .addJobVertex(secondVertex)
+                .setJobCheckpointingSettings(checkpointingSettings)
+                .build();
+    }
+
+    private TestingDispatcher createRecoveredDispatcher(
+            @Nullable FatalErrorHandler fatalErrorHandler) throws Exception {
+        final List<JobGraph> jobGraphs = new ArrayList<>();
+        for (JobID jobId : haServices.getJobGraphStore().getJobIds()) {
+            jobGraphs.add(haServices.getJobGraphStore().recoverJobGraph(jobId));
+        }
+        haServices.setRunningJobsRegistry(new StandaloneRunningJobsRegistry());
+        final TestingDispatcher dispatcher =
+                new TestingDispatcherBuilder()
+                        .setJobManagerRunnerFactory(
+                                JobMasterServiceLeadershipRunnerFactory.INSTANCE)
+                        .setJobGraphWriter(haServices.getJobGraphStore())
+                        .setInitialJobGraphs(jobGraphs)
+                        .setFatalErrorHandler(
+                                fatalErrorHandler == null
+                                        ? testingFatalErrorHandlerResource.getFatalErrorHandler()
+                                        : fatalErrorHandler)
+                        .build();
+        dispatcher.start();
+        return dispatcher;
+    }
+
+    private static CompletableFuture<JobMasterGateway> connectToLeadingJobMaster(
+            TestingLeaderElectionService leaderElectionService) {
+        return leaderElectionService
+                .getConfirmationFuture()
+                .thenCompose(
+                        leaderConnectionInfo ->
+                                rpcService.connect(
+                                        leaderConnectionInfo.getAddress(),
+                                        JobMasterId.fromUuidOrNull(
+                                                leaderConnectionInfo.getLeaderSessionId()),
+                                        JobMasterGateway.class));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -332,7 +332,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
     @Test
     public void testHACleanupWhenJobFinishedWhileClosingDispatcher() throws Exception {
         final TestingJobManagerRunner testingJobManagerRunner =
-                new TestingJobManagerRunner.Builder()
+                TestingJobManagerRunner.newBuilder()
                         .setBlockingTermination(true)
                         .setJobId(jobId)
                         .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/JobMasterTester.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/JobMasterTester.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
+import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * A testing utility, that simulates the desired interactions with {@link JobMasterGateway} RPC.
+ * This is useful for light-weight e2e tests, eg. simulating specific fail-over scenario.
+ */
+public class JobMasterTester implements Closeable {
+
+    private static final Time TIMEOUT = Time.minutes(1);
+
+    private static TaskStateSnapshot createNonEmptyStateSnapshot(TaskInformation taskInformation) {
+        final TaskStateSnapshot checkpointStateHandles = new TaskStateSnapshot();
+        checkpointStateHandles.putSubtaskStateByOperatorID(
+                OperatorID.fromJobVertexID(taskInformation.getJobVertexId()),
+                OperatorSubtaskState.builder()
+                        .setManagedOperatorState(
+                                new OperatorStreamStateHandle(
+                                        Collections.emptyMap(),
+                                        new ByteStreamStateHandle("foobar", new byte[0])))
+                        .build());
+        return checkpointStateHandles;
+    }
+
+    private static class CheckpointCompletionHandler {
+
+        private final Map<ExecutionAttemptID, CompletableFuture<Void>> completedAttemptFutures;
+        private final CompletableFuture<Void> completedFuture;
+
+        public CheckpointCompletionHandler(List<TaskDeploymentDescriptor> descriptors) {
+            this.completedAttemptFutures =
+                    descriptors.stream()
+                            .map(TaskDeploymentDescriptor::getExecutionAttemptId)
+                            .collect(
+                                    Collectors.toMap(
+                                            Function.identity(),
+                                            ignored -> new CompletableFuture<>()));
+            this.completedFuture = FutureUtils.completeAll(completedAttemptFutures.values());
+        }
+
+        void completeAttempt(ExecutionAttemptID executionAttemptId) {
+            completedAttemptFutures.get(executionAttemptId).complete(null);
+        }
+
+        CompletableFuture<Void> getCompletedFuture() {
+            return completedFuture;
+        }
+    }
+
+    private final UnresolvedTaskManagerLocation taskManagerLocation =
+            new LocalUnresolvedTaskManagerLocation();
+    private final ConcurrentMap<ExecutionAttemptID, TaskDeploymentDescriptor> descriptors =
+            new ConcurrentHashMap<>();
+
+    private final TestingRpcService rpcService;
+    private final JobID jobId;
+    private final JobMasterGateway jobMasterGateway;
+    private final TaskExecutorGateway taskExecutorGateway;
+
+    private final CompletableFuture<ExecutionGraphInfo> executionGraphInfoFuture;
+
+    private final CompletableFuture<List<TaskDeploymentDescriptor>> descriptorsFuture =
+            new CompletableFuture<>();
+
+    private final ConcurrentMap<Long, CheckpointCompletionHandler> checkpoints =
+            new ConcurrentHashMap<>();
+
+    public JobMasterTester(
+            TestingRpcService rpcService, JobID jobId, JobMasterGateway jobMasterGateway) {
+        this.rpcService = rpcService;
+        this.jobId = jobId;
+        this.jobMasterGateway = jobMasterGateway;
+        this.taskExecutorGateway = createTaskExecutorGateway();
+        executionGraphInfoFuture = jobMasterGateway.requestJob(TIMEOUT);
+    }
+
+    public CompletableFuture<Acknowledge> transitionTo(
+            List<TaskDeploymentDescriptor> descriptors, ExecutionState state) {
+        final List<CompletableFuture<Acknowledge>> futures =
+                descriptors.stream()
+                        .map(TaskDeploymentDescriptor::getExecutionAttemptId)
+                        .map(
+                                attemptId ->
+                                        jobMasterGateway.updateTaskExecutionState(
+                                                new TaskExecutionState(attemptId, state)))
+                        .collect(Collectors.toList());
+        return FutureUtils.completeAll(futures).thenApply(ignored -> Acknowledge.get());
+    }
+
+    public CompletableFuture<List<TaskDeploymentDescriptor>> deployVertices(int numSlots) {
+        return jobMasterGateway
+                .registerTaskManager(
+                        taskExecutorGateway.getAddress(), taskManagerLocation, jobId, TIMEOUT)
+                .thenCompose(ignored -> offerSlots(numSlots))
+                .thenCompose(ignored -> descriptorsFuture);
+    }
+
+    public CompletableFuture<Void> getCheckpointFuture(long checkpointId) {
+        return descriptorsFuture.thenCompose(
+                descriptors ->
+                        checkpoints
+                                .computeIfAbsent(
+                                        checkpointId,
+                                        key -> new CheckpointCompletionHandler(descriptors))
+                                .getCompletedFuture());
+    }
+
+    @Override
+    public void close() throws IOException {
+        rpcService.unregisterGateway(taskExecutorGateway.getAddress());
+    }
+
+    private TaskExecutorGateway createTaskExecutorGateway() {
+        final TestingTaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setSubmitTaskConsumer(this::onSubmitTaskConsumer)
+                        .setTriggerCheckpointFunction(this::onTriggerCheckpoint)
+                        .setConfirmCheckpointFunction(this::onConfirmCheckpoint)
+                        .createTestingTaskExecutorGateway();
+        rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
+        return taskExecutorGateway;
+    }
+
+    private CompletableFuture<TaskInformation> getTaskInformation(
+            ExecutionAttemptID executionAttemptId) {
+        return descriptorsFuture.thenApply(
+                descriptors -> {
+                    final TaskDeploymentDescriptor descriptor =
+                            descriptors.stream()
+                                    .filter(
+                                            desc ->
+                                                    executionAttemptId.equals(
+                                                            desc.getExecutionAttemptId()))
+                                    .findAny()
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            String.format(
+                                                                    "Task descriptor for %s not found.",
+                                                                    executionAttemptId)));
+                    try {
+                        return descriptor
+                                .getSerializedTaskInformation()
+                                .deserializeValue(Thread.currentThread().getContextClassLoader());
+                    } catch (Exception e) {
+                        throw new IllegalStateException(
+                                String.format(
+                                        "Unable to deserialize task information of %s.",
+                                        executionAttemptId));
+                    }
+                });
+    }
+
+    private CompletableFuture<Acknowledge> onTriggerCheckpoint(
+            ExecutionAttemptID executionAttemptId,
+            long checkpointId,
+            long checkpointTimestamp,
+            CheckpointOptions checkpointOptions) {
+        return getTaskInformation(executionAttemptId)
+                .thenCompose(
+                        taskInformation -> {
+                            jobMasterGateway.acknowledgeCheckpoint(
+                                    jobId,
+                                    executionAttemptId,
+                                    checkpointId,
+                                    new CheckpointMetrics(),
+                                    createNonEmptyStateSnapshot(taskInformation));
+                            return CompletableFuture.completedFuture(Acknowledge.get());
+                        });
+    }
+
+    private CompletableFuture<Acknowledge> onConfirmCheckpoint(
+            ExecutionAttemptID executionAttemptId, long checkpointId, long checkpointTimestamp) {
+        return getTaskInformation(executionAttemptId)
+                .thenCompose(
+                        taskInformation ->
+                                completeAttemptCheckpoint(checkpointId, executionAttemptId));
+    }
+
+    private CompletableFuture<Acknowledge> onSubmitTaskConsumer(
+            TaskDeploymentDescriptor taskDeploymentDescriptor, JobMasterId jobMasterId) {
+        return executionGraphInfoFuture.thenCompose(
+                executionGraphInfo -> {
+                    final int numVertices =
+                            Iterables.size(
+                                    executionGraphInfo
+                                            .getArchivedExecutionGraph()
+                                            .getAllExecutionVertices());
+                    descriptors.put(
+                            taskDeploymentDescriptor.getExecutionAttemptId(),
+                            taskDeploymentDescriptor);
+                    if (descriptors.size() == numVertices) {
+                        descriptorsFuture.complete(new ArrayList<>(descriptors.values()));
+                    }
+                    return CompletableFuture.completedFuture(Acknowledge.get());
+                });
+    }
+
+    private CompletableFuture<Acknowledge> completeAttemptCheckpoint(
+            long checkpointId, ExecutionAttemptID executionAttemptId) {
+        return descriptorsFuture
+                .thenAccept(
+                        descriptors ->
+                                checkpoints
+                                        .computeIfAbsent(
+                                                checkpointId,
+                                                key -> new CheckpointCompletionHandler(descriptors))
+                                        .completeAttempt(executionAttemptId))
+                .thenApply(ignored -> Acknowledge.get());
+    }
+
+    private CompletableFuture<Collection<SlotOffer>> offerSlots(int numSlots) {
+        final List<SlotOffer> offers = new ArrayList<>();
+        for (int idx = 0; idx < numSlots; idx++) {
+            offers.add(new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY));
+        }
+        return jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), offers, TIMEOUT);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerFactory.java
@@ -77,7 +77,7 @@ public class TestingJobManagerRunnerFactory implements JobManagerRunnerFactory {
     @Nonnull
     private TestingJobManagerRunner createTestingJobManagerRunner(JobGraph jobGraph) {
         final boolean blockingTermination = numBlockingJobManagerRunners.getAndDecrement() > 0;
-        return new TestingJobManagerRunner.Builder()
+        return TestingJobManagerRunner.newBuilder()
                 .setJobId(jobGraph.getJobID())
                 .setBlockingTermination(blockingTermination)
                 .build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestUtils.java
@@ -93,7 +93,7 @@ public class TestUtils {
             SavepointRestoreSettings savepointRestoreSettings, JobVertex... jobVertices) {
 
         // enable checkpointing which is required to resume from a savepoint
-        final CheckpointCoordinatorConfiguration checkpoinCoordinatorConfiguration =
+        final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration =
                 CheckpointCoordinatorConfiguration.builder()
                         .setCheckpointInterval(1000L)
                         .setCheckpointTimeout(1000L)
@@ -107,7 +107,7 @@ public class TestUtils {
                         .setTolerableCheckpointFailureNumber(0)
                         .build();
         final JobCheckpointingSettings checkpointingSettings =
-                new JobCheckpointingSettings(checkpoinCoordinatorConfiguration, null);
+                new JobCheckpointingSettings(checkpointCoordinatorConfiguration, null);
 
         return JobGraphBuilder.newStreamingJobGraphBuilder()
                 .addJobVertices(Arrays.asList(jobVertices))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobManagerRunner.java
@@ -33,6 +33,10 @@ import java.util.concurrent.CompletableFuture;
 /** Testing implementation of the {@link JobManagerRunner}. */
 public class TestingJobManagerRunner implements JobManagerRunner {
 
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
     private final JobID jobId;
 
     private final boolean blockingTermination;
@@ -156,11 +160,16 @@ public class TestingJobManagerRunner implements JobManagerRunner {
 
     /** {@code Builder} for instantiating {@link TestingJobManagerRunner} instances. */
     public static class Builder {
+
         private JobID jobId = null;
         private boolean blockingTermination = false;
         private CompletableFuture<JobMasterGateway> jobMasterGatewayFuture =
                 new CompletableFuture<>();
         private CompletableFuture<JobManagerRunnerResult> resultFuture = new CompletableFuture<>();
+
+        private Builder() {
+            // No-op.
+        }
 
         public Builder setJobId(JobID jobId) {
             this.jobId = jobId;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -119,7 +119,7 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
     @After
     public void shutdownScheduler() throws Exception {
         if (createdScheduler != null) {
-            createdScheduler.close();
+            closeScheduler(createdScheduler);
         }
     }
 
@@ -140,7 +140,7 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
         final DefaultScheduler scheduler = createAndStartScheduler();
         final TestingOperatorCoordinator coordinator = getCoordinator(scheduler);
 
-        scheduler.close();
+        closeScheduler(scheduler);
 
         assertTrue(coordinator.isClosed());
     }
@@ -866,6 +866,12 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
         }
 
         return checkpointId;
+    }
+
+    private void closeScheduler(DefaultScheduler scheduler) throws Exception {
+        final CompletableFuture<Void> closeFuture = scheduler.closeAsync();
+        executor.triggerAll();
+        closeFuture.get();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -108,6 +108,13 @@ public class TestingRpcService implements RpcService {
         }
     }
 
+    public void unregisterGateway(String address) {
+        checkNotNull(address);
+        if (registeredConnections.remove(address) == null) {
+            throw new IllegalStateException("no gateway is registered under " + address);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private <C extends RpcGateway> CompletableFuture<C> getRpcGatewayFuture(C gateway) {
         return (CompletableFuture<C>) rpcGatewayFutureFunction.apply(gateway);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -129,7 +129,7 @@ public class DefaultSchedulerTest extends TestLogger {
 
     @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
 
-    private ManuallyTriggeredScheduledExecutor taskRestartExecutor =
+    private final ManuallyTriggeredScheduledExecutor taskRestartExecutor =
             new ManuallyTriggeredScheduledExecutor();
 
     private ExecutorService executor;
@@ -1071,7 +1071,6 @@ public class DefaultSchedulerTest extends TestLogger {
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(attemptId, ExecutionState.CANCELED, expectedException));
         taskRestartExecutor.triggerScheduledTasks();
-        final long end = System.currentTimeMillis();
 
         final Iterable<RootExceptionHistoryEntry> actualExceptionHistory =
                 scheduler.getExceptionHistory();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -46,6 +46,7 @@ import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.function.QuadFunction;
 import org.apache.flink.util.function.TriConsumer;
 import org.apache.flink.util.function.TriFunction;
 
@@ -108,6 +109,17 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
     private final Supplier<CompletableFuture<TaskThreadInfoResponse>>
             requestThreadInfoSamplesSupplier;
 
+    private final QuadFunction<
+                    ExecutionAttemptID,
+                    Long,
+                    Long,
+                    CheckpointOptions,
+                    CompletableFuture<Acknowledge>>
+            triggerCheckpointFunction;
+
+    private final TriFunction<ExecutionAttemptID, Long, Long, CompletableFuture<Acknowledge>>
+            confirmCheckpointFunction;
+
     TestingTaskExecutorGateway(
             String address,
             String hostname,
@@ -142,7 +154,16 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
                             CompletableFuture<Acknowledge>>
                     operatorEventHandler,
             Supplier<CompletableFuture<ThreadDumpInfo>> requestThreadDumpSupplier,
-            Supplier<CompletableFuture<TaskThreadInfoResponse>> requestThreadInfoSamplesSupplier) {
+            Supplier<CompletableFuture<TaskThreadInfoResponse>> requestThreadInfoSamplesSupplier,
+            QuadFunction<
+                            ExecutionAttemptID,
+                            Long,
+                            Long,
+                            CheckpointOptions,
+                            CompletableFuture<Acknowledge>>
+                    triggerCheckpointFunction,
+            TriFunction<ExecutionAttemptID, Long, Long, CompletableFuture<Acknowledge>>
+                    confirmCheckpointFunction) {
 
         this.address = Preconditions.checkNotNull(address);
         this.hostname = Preconditions.checkNotNull(hostname);
@@ -162,6 +183,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
         this.operatorEventHandler = operatorEventHandler;
         this.requestThreadDumpSupplier = requestThreadDumpSupplier;
         this.requestThreadInfoSamplesSupplier = requestThreadInfoSamplesSupplier;
+        this.triggerCheckpointFunction = triggerCheckpointFunction;
+        this.confirmCheckpointFunction = confirmCheckpointFunction;
     }
 
     @Override
@@ -218,13 +241,15 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
             long checkpointID,
             long checkpointTimestamp,
             CheckpointOptions checkpointOptions) {
-        return CompletableFuture.completedFuture(Acknowledge.get());
+        return triggerCheckpointFunction.apply(
+                executionAttemptID, checkpointID, checkpointTimestamp, checkpointOptions);
     }
 
     @Override
     public CompletableFuture<Acknowledge> confirmCheckpoint(
             ExecutionAttemptID executionAttemptID, long checkpointId, long checkpointTimestamp) {
-        return CompletableFuture.completedFuture(Acknowledge.get());
+        return confirmCheckpointFunction.apply(
+                executionAttemptID, checkpointId, checkpointTimestamp);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

* Cleaning up HA services before CompletedCheckpointStore

## Brief change log

*(for example:)*
  - CompletedCheckpointStore is cleaned in scheduler's `closeAsync`, instead of on execution graph termination.

## Verifying this change

This change added tests and can be verified as follows:

- Integration test for a failover scenario described in JIRA.
- 
## Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
