### PR TITLE
[FLINK-23402][streaming-java] Refactor enums for shuffle modes

### DIFF
--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.tpcds;
 
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
@@ -145,7 +145,7 @@ public class TpcdsTestProgram {
                 .getConfiguration()
                 .setString(
                         ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                        GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
+                        GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
         tEnv.getConfig()
                 .getConfiguration()
                 .setLong(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -93,7 +93,7 @@ import org.apache.flink.streaming.api.functions.source.SocketTextStreamFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
@@ -2110,7 +2110,8 @@ public class StreamExecutionEnvironment {
         if (configuration.get(ExecutionOptions.RUNTIME_MODE) == RuntimeExecutionMode.BATCH
                 && streamGraph.hasFineGrainedResource()) {
             if (configuration.get(ClusterOptions.FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING)) {
-                streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
+                streamGraph.setGlobalStreamExchangeMode(
+                        GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
             } else {
                 throw new IllegalConfigurationException(
                         "At the moment, fine-grained resource management requires batch workloads to "

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalDataExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalDataExchangeMode.java
@@ -19,13 +19,13 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 
 /**
  * This mode decides the default {@link ResultPartitionType} of job edges. Note that this only
- * affects job edges which are {@link ShuffleMode#UNDEFINED}.
+ * affects job edges which are {@link StreamExchangeMode#UNDEFINED}.
  */
 public enum GlobalDataExchangeMode {
     /** Set all job edges to be {@link ResultPartitionType#BLOCKING}. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalStreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalStreamExchangeMode.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.graph;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
@@ -27,6 +28,7 @@ import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
  * This mode decides the default {@link ResultPartitionType} of job edges. Note that this only
  * affects job edges which are {@link StreamExchangeMode#UNDEFINED}.
  */
+@Internal
 public enum GlobalStreamExchangeMode {
     /** Set all job edges to be {@link ResultPartitionType#BLOCKING}. */
     ALL_EDGES_BLOCKING,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalStreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/GlobalStreamExchangeMode.java
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
  * This mode decides the default {@link ResultPartitionType} of job edges. Note that this only
  * affects job edges which are {@link StreamExchangeMode#UNDEFINED}.
  */
-public enum GlobalDataExchangeMode {
+public enum GlobalStreamExchangeMode {
     /** Set all job edges to be {@link ResultPartitionType#BLOCKING}. */
     ALL_EDGES_BLOCKING,
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.util.OutputTag;
 
@@ -58,7 +58,7 @@ public class StreamEdge implements Serializable {
     /** The name of the operator in the target vertex. */
     private final String targetOperatorName;
 
-    private final ShuffleMode shuffleMode;
+    private final StreamExchangeMode exchangeMode;
 
     private long bufferTimeout;
 
@@ -78,7 +78,7 @@ public class StreamEdge implements Serializable {
                 ALWAYS_FLUSH_BUFFER_TIMEOUT,
                 outputPartitioner,
                 outputTag,
-                ShuffleMode.UNDEFINED);
+                StreamExchangeMode.UNDEFINED);
     }
 
     public StreamEdge(
@@ -87,7 +87,7 @@ public class StreamEdge implements Serializable {
             int typeNumber,
             StreamPartitioner<?> outputPartitioner,
             OutputTag outputTag,
-            ShuffleMode shuffleMode) {
+            StreamExchangeMode exchangeMode) {
 
         this(
                 sourceVertex,
@@ -96,7 +96,7 @@ public class StreamEdge implements Serializable {
                 sourceVertex.getBufferTimeout(),
                 outputPartitioner,
                 outputTag,
-                shuffleMode);
+                exchangeMode);
     }
 
     public StreamEdge(
@@ -106,7 +106,7 @@ public class StreamEdge implements Serializable {
             long bufferTimeout,
             StreamPartitioner<?> outputPartitioner,
             OutputTag outputTag,
-            ShuffleMode shuffleMode) {
+            StreamExchangeMode exchangeMode) {
 
         this.sourceId = sourceVertex.getId();
         this.targetId = targetVertex.getId();
@@ -116,7 +116,7 @@ public class StreamEdge implements Serializable {
         this.outputTag = outputTag;
         this.sourceOperatorName = sourceVertex.getOperatorName();
         this.targetOperatorName = targetVertex.getOperatorName();
-        this.shuffleMode = checkNotNull(shuffleMode);
+        this.exchangeMode = checkNotNull(exchangeMode);
         this.edgeId =
                 sourceVertex + "_" + targetVertex + "_" + typeNumber + "_" + outputPartitioner;
     }
@@ -141,8 +141,8 @@ public class StreamEdge implements Serializable {
         return outputPartitioner;
     }
 
-    public ShuffleMode getShuffleMode() {
-        return shuffleMode;
+    public StreamExchangeMode getExchangeMode() {
+        return exchangeMode;
     }
 
     public void setPartitioner(StreamPartitioner<?> partitioner) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -194,6 +194,8 @@ public class StreamEdge implements Serializable {
                 + typeNumber
                 + ", outputPartitioner="
                 + outputPartitioner
+                + ", exchangeMode="
+                + exchangeMode
                 + ", bufferTimeout="
                 + bufferTimeout
                 + ", outputTag="

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -104,7 +104,7 @@ public class StreamGraph implements Pipeline {
 
     private TimeCharacteristic timeCharacteristic;
 
-    private GlobalDataExchangeMode globalDataExchangeMode;
+    private GlobalStreamExchangeMode globalExchangeMode;
 
     /** Flag to indicate whether to put all vertices into the same slot sharing group by default. */
     private boolean allVerticesInSameSlotSharingGroupByDefault = true;
@@ -237,12 +237,12 @@ public class StreamGraph implements Pipeline {
         this.timeCharacteristic = timeCharacteristic;
     }
 
-    public GlobalDataExchangeMode getGlobalDataExchangeMode() {
-        return globalDataExchangeMode;
+    public GlobalStreamExchangeMode getGlobalStreamExchangeMode() {
+        return globalExchangeMode;
     }
 
-    public void setGlobalDataExchangeMode(GlobalDataExchangeMode globalDataExchangeMode) {
-        this.globalDataExchangeMode = globalDataExchangeMode;
+    public void setGlobalStreamExchangeMode(GlobalStreamExchangeMode globalExchangeMode) {
+        this.globalExchangeMode = globalExchangeMode;
     }
 
     public void setSlotSharingGroupResource(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -362,7 +362,7 @@ public class StreamGraphGenerator {
             }
 
             graph.setAllVerticesInSameSlotSharingGroupByDefault(false);
-            graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED);
+            graph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED);
             setDefaultBufferTimeout(-1);
             setBatchStateBackendAndTimerService(graph);
         } else {
@@ -373,10 +373,10 @@ public class StreamGraphGenerator {
 
             if (checkpointConfig.isApproximateLocalRecoveryEnabled()) {
                 checkApproximateLocalRecoveryCompatibility();
-                graph.setGlobalDataExchangeMode(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED_APPROXIMATE);
+                graph.setGlobalStreamExchangeMode(
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED_APPROXIMATE);
             } else {
-                graph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED);
+                graph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
             }
         }
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -62,7 +62,7 @@ import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.UdfStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.CustomPartitionerWrapper;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
@@ -780,7 +780,7 @@ public class StreamingJobGraphGenerator {
         StreamPartitioner<?> partitioner = edge.getPartitioner();
 
         ResultPartitionType resultPartitionType;
-        switch (edge.getShuffleMode()) {
+        switch (edge.getExchangeMode()) {
             case PIPELINED:
                 resultPartitionType = ResultPartitionType.PIPELINED_BOUNDED;
                 break;
@@ -792,7 +792,7 @@ public class StreamingJobGraphGenerator {
                 break;
             default:
                 throw new UnsupportedOperationException(
-                        "Data exchange mode " + edge.getShuffleMode() + " is not supported yet.");
+                        "Data exchange mode " + edge.getExchangeMode() + " is not supported yet.");
         }
 
         checkAndResetBufferTimeout(resultPartitionType, edge);
@@ -877,7 +877,7 @@ public class StreamingJobGraphGenerator {
         if (!(upStreamVertex.isSameSlotSharingGroup(downStreamVertex)
                 && areOperatorsChainable(upStreamVertex, downStreamVertex, streamGraph)
                 && (edge.getPartitioner() instanceof ForwardPartitioner)
-                && edge.getShuffleMode() != ShuffleMode.BATCH
+                && edge.getExchangeMode() != StreamExchangeMode.BATCH
                 && upStreamVertex.getParallelism() == downStreamVertex.getParallelism()
                 && streamGraph.isChainingEnabled())) {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -838,7 +838,7 @@ public class StreamingJobGraphGenerator {
     }
 
     private ResultPartitionType determineResultPartitionType(StreamPartitioner<?> partitioner) {
-        switch (streamGraph.getGlobalDataExchangeMode()) {
+        switch (streamGraph.getGlobalStreamExchangeMode()) {
             case ALL_EDGES_BLOCKING:
                 return ResultPartitionType.BLOCKING;
             case FORWARD_EDGES_PIPELINED:
@@ -860,7 +860,7 @@ public class StreamingJobGraphGenerator {
             default:
                 throw new RuntimeException(
                         "Unrecognized global data exchange mode "
-                                + streamGraph.getGlobalDataExchangeMode());
+                                + streamGraph.getGlobalStreamExchangeMode());
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -44,7 +44,7 @@ public class PartitionTransformation<T> extends Transformation<T> {
 
     private final StreamPartitioner<T> partitioner;
 
-    private final ShuffleMode shuffleMode;
+    private final StreamExchangeMode exchangeMode;
 
     /**
      * Creates a new {@code PartitionTransformation} from the given input and {@link
@@ -54,7 +54,7 @@ public class PartitionTransformation<T> extends Transformation<T> {
      * @param partitioner The {@code StreamPartitioner}
      */
     public PartitionTransformation(Transformation<T> input, StreamPartitioner<T> partitioner) {
-        this(input, partitioner, ShuffleMode.UNDEFINED);
+        this(input, partitioner, StreamExchangeMode.UNDEFINED);
     }
 
     /**
@@ -63,14 +63,16 @@ public class PartitionTransformation<T> extends Transformation<T> {
      *
      * @param input The input {@code Transformation}
      * @param partitioner The {@code StreamPartitioner}
-     * @param shuffleMode The {@code ShuffleMode}
+     * @param exchangeMode The {@code ShuffleMode}
      */
     public PartitionTransformation(
-            Transformation<T> input, StreamPartitioner<T> partitioner, ShuffleMode shuffleMode) {
+            Transformation<T> input,
+            StreamPartitioner<T> partitioner,
+            StreamExchangeMode exchangeMode) {
         super("Partition", input.getOutputType(), input.getParallelism());
         this.input = input;
         this.partitioner = partitioner;
-        this.shuffleMode = checkNotNull(shuffleMode);
+        this.exchangeMode = checkNotNull(exchangeMode);
     }
 
     /**
@@ -81,9 +83,9 @@ public class PartitionTransformation<T> extends Transformation<T> {
         return partitioner;
     }
 
-    /** Returns the {@link ShuffleMode} of this {@link PartitionTransformation}. */
-    public ShuffleMode getShuffleMode() {
-        return shuffleMode;
+    /** Returns the {@link StreamExchangeMode} of this {@link PartitionTransformation}. */
+    public StreamExchangeMode getExchangeMode() {
+        return exchangeMode;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -35,7 +35,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>This does not create a physical operation, it only affects how upstream operations are
  * connected to downstream operations.
  *
- * @param <T> The type of the elements that result from this {@code PartitionTransformation}
+ * @param <T> The type of the elements that result from this {@link PartitionTransformation}
  */
 @Internal
 public class PartitionTransformation<T> extends Transformation<T> {
@@ -47,23 +47,23 @@ public class PartitionTransformation<T> extends Transformation<T> {
     private final StreamExchangeMode exchangeMode;
 
     /**
-     * Creates a new {@code PartitionTransformation} from the given input and {@link
+     * Creates a new {@link PartitionTransformation} from the given input and {@link
      * StreamPartitioner}.
      *
-     * @param input The input {@code Transformation}
-     * @param partitioner The {@code StreamPartitioner}
+     * @param input The input {@link Transformation}
+     * @param partitioner The {@link StreamPartitioner}
      */
     public PartitionTransformation(Transformation<T> input, StreamPartitioner<T> partitioner) {
         this(input, partitioner, StreamExchangeMode.UNDEFINED);
     }
 
     /**
-     * Creates a new {@code PartitionTransformation} from the given input and {@link
+     * Creates a new {@link PartitionTransformation} from the given input and {@link
      * StreamPartitioner}.
      *
-     * @param input The input {@code Transformation}
-     * @param partitioner The {@code StreamPartitioner}
-     * @param exchangeMode The {@code ShuffleMode}
+     * @param input The input {@link Transformation}
+     * @param partitioner The {@link StreamPartitioner}
+     * @param exchangeMode The {@link StreamExchangeMode}
      */
     public PartitionTransformation(
             Transformation<T> input,
@@ -76,8 +76,8 @@ public class PartitionTransformation<T> extends Transformation<T> {
     }
 
     /**
-     * Returns the {@code StreamPartitioner} that must be used for partitioning the elements of the
-     * input {@code Transformation}.
+     * Returns the {@link StreamPartitioner} that must be used for partitioning the elements of the
+     * input {@link Transformation}.
      */
     public StreamPartitioner<T> getPartitioner() {
         return partitioner;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 
 /** The shuffle mode defines the data exchange mode between operators. */
 @PublicEvolving
-public enum ShuffleMode {
+public enum StreamExchangeMode {
     /**
      * Producer and consumer are online at the same time. Produced data is received by consumer
      * immediately.
@@ -37,8 +37,8 @@ public enum ShuffleMode {
 
     /**
      * The shuffle mode is undefined. It leaves it up to the framework to decide the shuffle mode.
-     * The framework will pick one of {@link ShuffleMode#BATCH} or {@link ShuffleMode#PIPELINED} in
-     * the end.
+     * The framework will pick one of {@link StreamExchangeMode#BATCH} or {@link
+     * StreamExchangeMode#PIPELINED} in the end.
      */
     UNDEFINED
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
@@ -18,10 +18,11 @@
 
 package org.apache.flink.streaming.api.transformations;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 
-/** The shuffle mode defines the data exchange mode between operators. */
-@PublicEvolving
+/** The data exchange mode between operators during {@link StreamGraph} generation. */
+@Internal
 public enum StreamExchangeMode {
     /**
      * Producer and consumer are online at the same time. Produced data is received by consumer
@@ -36,7 +37,7 @@ public enum StreamExchangeMode {
     BATCH,
 
     /**
-     * The shuffle mode is undefined. It leaves it up to the framework to decide the shuffle mode.
+     * The exchange mode is undefined. It leaves it up to the framework to decide the exchange mode.
      * The framework will pick one of {@link StreamExchangeMode#BATCH} or {@link
      * StreamExchangeMode#PIPELINED} in the end.
      */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/PartitionTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/PartitionTransformationTranslator.java
@@ -76,7 +76,7 @@ public class PartitionTransformationTranslator<OUT>
                     inputId,
                     virtualId,
                     transformation.getPartitioner(),
-                    transformation.getShuffleMode());
+                    transformation.getExchangeMode());
             resultIds.add(virtualId);
         }
         return resultIds;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorExecutionModeDetectionTest.java
@@ -76,7 +76,10 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 environment.getStreamGraph(),
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED, JobType.STREAMING, true, true));
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
+                        JobType.STREAMING,
+                        true,
+                        true));
     }
 
     @Test
@@ -94,7 +97,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 environment.getStreamGraph(),
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
                         JobType.STREAMING,
                         false,
                         true));
@@ -124,7 +127,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 streamGraph,
                 hasProperties(
-                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED,
                         JobType.BATCH,
                         false,
                         false));
@@ -177,7 +180,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
                         JobType.STREAMING,
                         false,
                         true));
@@ -193,7 +196,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED,
                         JobType.BATCH,
                         false,
                         false));
@@ -209,7 +212,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
                         JobType.STREAMING,
                         false,
                         true));
@@ -229,7 +232,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
                         JobType.STREAMING,
                         false,
                         true));
@@ -245,7 +248,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 graph,
                 hasProperties(
-                        GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED,
                         JobType.BATCH,
                         false,
                         false));
@@ -255,7 +258,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         assertThat(
                 streamingGraph,
                 hasProperties(
-                        GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
+                        GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
                         JobType.STREAMING,
                         false,
                         true));
@@ -285,7 +288,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
     }
 
     private static TypeSafeMatcher<StreamGraph> hasProperties(
-            final GlobalDataExchangeMode exchangeMode,
+            final GlobalStreamExchangeMode exchangeMode,
             final JobType jobType,
             final boolean isCheckpointingEnabled,
             final boolean isAllVerticesInSameSlotSharingGroupByDefault) {
@@ -293,7 +296,7 @@ public class StreamGraphGeneratorExecutionModeDetectionTest extends TestLogger {
         return new TypeSafeMatcher<StreamGraph>() {
             @Override
             protected boolean matchesSafely(StreamGraph actualStreamGraph) {
-                return exchangeMode == actualStreamGraph.getGlobalDataExchangeMode()
+                return exchangeMode == actualStreamGraph.getGlobalStreamExchangeMode()
                         && jobType == actualStreamGraph.getJobType()
                         && actualStreamGraph.getCheckpointConfig().isCheckpointingEnabled()
                                 == isCheckpointingEnabled

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -82,7 +82,7 @@ import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
@@ -593,7 +593,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         assertTrue(operatorFactory instanceof SourceOperatorFactory);
     }
 
-    /** Test setting shuffle mode to {@link ShuffleMode#PIPELINED}. */
+    /** Test setting shuffle mode to {@link StreamExchangeMode#PIPELINED}. */
     @Test
     public void testShuffleModePipelined() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -606,7 +606,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 sourceDataStream.getTransformation(),
                                 new ForwardPartitioner<>(),
-                                ShuffleMode.PIPELINED));
+                                StreamExchangeMode.PIPELINED));
         DataStream<Integer> mapDataStream =
                 partitionAfterSourceDataStream.map(value -> value).setParallelism(1);
 
@@ -616,7 +616,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 mapDataStream.getTransformation(),
                                 new RescalePartitioner<>(),
-                                ShuffleMode.PIPELINED));
+                                StreamExchangeMode.PIPELINED));
         partitionAfterMapDataStream.print().setParallelism(2);
 
         JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
@@ -633,7 +633,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 sourceAndMapVertex.getProducedDataSets().get(0).getResultType());
     }
 
-    /** Test setting shuffle mode to {@link ShuffleMode#BATCH}. */
+    /** Test setting shuffle mode to {@link StreamExchangeMode#BATCH}. */
     @Test
     public void testShuffleModeBatch() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -646,7 +646,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 sourceDataStream.getTransformation(),
                                 new ForwardPartitioner<>(),
-                                ShuffleMode.BATCH));
+                                StreamExchangeMode.BATCH));
         DataStream<Integer> mapDataStream =
                 partitionAfterSourceDataStream.map(value -> value).setParallelism(1);
 
@@ -656,7 +656,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 mapDataStream.getTransformation(),
                                 new RescalePartitioner<>(),
-                                ShuffleMode.BATCH));
+                                StreamExchangeMode.BATCH));
         partitionAfterMapDataStream.print().setParallelism(2);
 
         JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
@@ -677,7 +677,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 mapVertex.getProducedDataSets().get(0).getResultType());
     }
 
-    /** Test setting shuffle mode to {@link ShuffleMode#UNDEFINED}. */
+    /** Test setting shuffle mode to {@link StreamExchangeMode#UNDEFINED}. */
     @Test
     public void testShuffleModeUndefined() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -690,7 +690,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 sourceDataStream.getTransformation(),
                                 new ForwardPartitioner<>(),
-                                ShuffleMode.UNDEFINED));
+                                StreamExchangeMode.UNDEFINED));
         DataStream<Integer> mapDataStream =
                 partitionAfterSourceDataStream.map(value -> value).setParallelism(1);
 
@@ -700,7 +700,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 mapDataStream.getTransformation(),
                                 new RescalePartitioner<>(),
-                                ShuffleMode.UNDEFINED));
+                                StreamExchangeMode.UNDEFINED));
         partitionAfterMapDataStream.print().setParallelism(2);
 
         JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph());
@@ -784,15 +784,15 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testConflictShuffleModeWithBufferTimeout() {
-        testCompatibleShuffleModeWithBufferTimeout(ShuffleMode.BATCH);
+        testCompatibleShuffleModeWithBufferTimeout(StreamExchangeMode.BATCH);
     }
 
     @Test
     public void testNormalShuffleModeWithBufferTimeout() {
-        testCompatibleShuffleModeWithBufferTimeout(ShuffleMode.PIPELINED);
+        testCompatibleShuffleModeWithBufferTimeout(StreamExchangeMode.PIPELINED);
     }
 
-    private void testCompatibleShuffleModeWithBufferTimeout(ShuffleMode shuffleMode) {
+    private void testCompatibleShuffleModeWithBufferTimeout(StreamExchangeMode exchangeMode) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setBufferTimeout(100);
 
@@ -801,7 +801,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 new PartitionTransformation<>(
                         sourceDataStream.getTransformation(),
                         new RebalancePartitioner<>(),
-                        shuffleMode);
+                        exchangeMode);
 
         DataStream<Integer> partitionStream = new DataStream<>(env, transformation);
         partitionStream.map(value -> value).print();
@@ -1396,7 +1396,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                         new PartitionTransformation<>(
                                 source2.getTransformation(),
                                 new RebalancePartitioner<>(),
-                                ShuffleMode.BATCH));
+                                StreamExchangeMode.BATCH));
         partitioned.map(v -> v).name("map2");
 
         return env.getStreamGraph();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -593,9 +593,9 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         assertTrue(operatorFactory instanceof SourceOperatorFactory);
     }
 
-    /** Test setting shuffle mode to {@link StreamExchangeMode#PIPELINED}. */
+    /** Test setting exchange mode to {@link StreamExchangeMode#PIPELINED}. */
     @Test
-    public void testShuffleModePipelined() {
+    public void testExchangeModePipelined() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         // fromElements -> Map -> Print
         DataStream<Integer> sourceDataStream = env.fromElements(1, 2, 3);
@@ -624,18 +624,18 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
         assertEquals(2, verticesSorted.size());
 
-        // it can be chained with PIPELINED shuffle mode
+        // it can be chained with PIPELINED exchange mode
         JobVertex sourceAndMapVertex = verticesSorted.get(0);
 
-        // PIPELINED shuffle mode is translated into PIPELINED_BOUNDED result partition
+        // PIPELINED exchange mode is translated into PIPELINED_BOUNDED result partition
         assertEquals(
                 ResultPartitionType.PIPELINED_BOUNDED,
                 sourceAndMapVertex.getProducedDataSets().get(0).getResultType());
     }
 
-    /** Test setting shuffle mode to {@link StreamExchangeMode#BATCH}. */
+    /** Test setting exchange mode to {@link StreamExchangeMode#BATCH}. */
     @Test
-    public void testShuffleModeBatch() {
+    public void testExchangeModeBatch() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         // fromElements -> Map -> Print
         DataStream<Integer> sourceDataStream = env.fromElements(1, 2, 3);
@@ -664,11 +664,11 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
         assertEquals(3, verticesSorted.size());
 
-        // it can not be chained with BATCH shuffle mode
+        // it can not be chained with BATCH exchange mode
         JobVertex sourceVertex = verticesSorted.get(0);
         JobVertex mapVertex = verticesSorted.get(1);
 
-        // BATCH shuffle mode is translated into BLOCKING result partition
+        // BATCH exchange mode is translated into BLOCKING result partition
         assertEquals(
                 ResultPartitionType.BLOCKING,
                 sourceVertex.getProducedDataSets().get(0).getResultType());
@@ -677,9 +677,9 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
                 mapVertex.getProducedDataSets().get(0).getResultType());
     }
 
-    /** Test setting shuffle mode to {@link StreamExchangeMode#UNDEFINED}. */
+    /** Test setting exchange mode to {@link StreamExchangeMode#UNDEFINED}. */
     @Test
-    public void testShuffleModeUndefined() {
+    public void testExchangeModeUndefined() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         // fromElements -> Map -> Print
         DataStream<Integer> sourceDataStream = env.fromElements(1, 2, 3);
@@ -708,10 +708,10 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
         assertEquals(2, verticesSorted.size());
 
-        // it can be chained with UNDEFINED shuffle mode
+        // it can be chained with UNDEFINED exchange mode
         JobVertex sourceAndMapVertex = verticesSorted.get(0);
 
-        // UNDEFINED shuffle mode is translated into PIPELINED_BOUNDED result partition by default
+        // UNDEFINED exchange mode is translated into PIPELINED_BOUNDED result partition by default
         assertEquals(
                 ResultPartitionType.PIPELINED_BOUNDED,
                 sourceAndMapVertex.getProducedDataSets().get(0).getResultType());
@@ -742,7 +742,7 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
         env.disableOperatorChaining();
         DataStream<Integer> source = env.fromElements(1);
         source
-                // set the same parallelism as the source to make it a FORWARD SHUFFLE
+                // set the same parallelism as the source to make it a FORWARD exchange
                 .map(value -> value)
                 .setParallelism(1)
                 .rescale()
@@ -783,16 +783,16 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testConflictShuffleModeWithBufferTimeout() {
-        testCompatibleShuffleModeWithBufferTimeout(StreamExchangeMode.BATCH);
+    public void testConflictExchangeModeWithBufferTimeout() {
+        testCompatibleExchangeModeWithBufferTimeout(StreamExchangeMode.BATCH);
     }
 
     @Test
-    public void testNormalShuffleModeWithBufferTimeout() {
-        testCompatibleShuffleModeWithBufferTimeout(StreamExchangeMode.PIPELINED);
+    public void testNormalExchangeModeWithBufferTimeout() {
+        testCompatibleExchangeModeWithBufferTimeout(StreamExchangeMode.PIPELINED);
     }
 
-    private void testCompatibleShuffleModeWithBufferTimeout(StreamExchangeMode exchangeMode) {
+    private void testCompatibleExchangeModeWithBufferTimeout(StreamExchangeMode exchangeMode) {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setBufferTimeout(100);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RescalePartitioner;
 import org.apache.flink.util.TestLogger;
@@ -148,7 +148,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
                         new PartitionTransformation<>(
                                 source.getTransformation(),
                                 new ForwardPartitioner<>(),
-                                ShuffleMode.PIPELINED));
+                                StreamExchangeMode.PIPELINED));
         forward.map(i -> i).startNewChain().setParallelism(1);
         final StreamGraph streamGraph = env.getStreamGraph();
         streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
@@ -178,7 +178,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
                         new PartitionTransformation<>(
                                 source.getTransformation(),
                                 new ForwardPartitioner<>(),
-                                ShuffleMode.UNDEFINED));
+                                StreamExchangeMode.UNDEFINED));
         final DataStream<Integer> map1 = forward.map(i -> i).startNewChain().setParallelism(1);
 
         final DataStream<Integer> rescale =
@@ -187,7 +187,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
                         new PartitionTransformation<>(
                                 map1.getTransformation(),
                                 new RescalePartitioner<>(),
-                                ShuffleMode.UNDEFINED));
+                                StreamExchangeMode.UNDEFINED));
         final DataStream<Integer> map2 = rescale.map(i -> i).setParallelism(2);
 
         map2.rebalance().print().setParallelism(2);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest.java
@@ -139,7 +139,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
     }
 
     @Test
-    public void testGlobalDataExchangeModeDoesNotOverrideSpecifiedShuffleMode() {
+    public void testGlobalDataExchangeModeDoesNotOverrideSpecifiedExchangeMode() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final DataStream<Integer> source = env.fromElements(1, 2, 3).setParallelism(1);
         final DataStream<Integer> forward =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithGlobalStreamExchangeModeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithGlobalStreamExchangeModeTest.java
@@ -37,23 +37,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /**
- * Tests for {@link StreamingJobGraphGenerator} on different {@link GlobalDataExchangeMode}
+ * Tests for {@link StreamingJobGraphGenerator} on different {@link GlobalStreamExchangeMode}
  * settings.
  */
-public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends TestLogger {
+public class StreamingJobGraphGeneratorWithGlobalStreamExchangeModeTest extends TestLogger {
 
     @Test
-    public void testDefaultGlobalDataExchangeModeIsAllEdgesPipelined() {
+    public void testDefaultGlobalExchangeModeIsAllEdgesPipelined() {
         final StreamGraph streamGraph = createStreamGraph();
         assertThat(
-                streamGraph.getGlobalDataExchangeMode(),
-                is(GlobalDataExchangeMode.ALL_EDGES_PIPELINED));
+                streamGraph.getGlobalStreamExchangeMode(),
+                is(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED));
     }
 
     @Test
     public void testAllEdgesBlockingMode() {
         final StreamGraph streamGraph = createStreamGraph();
-        streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
         final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
         final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -75,7 +75,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
     @Test
     public void testAllEdgesPipelinedMode() {
         final StreamGraph streamGraph = createStreamGraph();
-        streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_PIPELINED);
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
         final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
         final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -97,7 +97,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
     @Test
     public void testForwardEdgesPipelinedMode() {
         final StreamGraph streamGraph = createStreamGraph();
-        streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED);
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED);
         final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
         final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -119,7 +119,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
     @Test
     public void testPointwiseEdgesPipelinedMode() {
         final StreamGraph streamGraph = createStreamGraph();
-        streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED);
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED);
         final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 
         final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
@@ -139,7 +139,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
     }
 
     @Test
-    public void testGlobalDataExchangeModeDoesNotOverrideSpecifiedExchangeMode() {
+    public void testGlobalExchangeModeDoesNotOverrideSpecifiedExchangeMode() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final DataStream<Integer> source = env.fromElements(1, 2, 3).setParallelism(1);
         final DataStream<Integer> forward =
@@ -151,7 +151,7 @@ public class StreamingJobGraphGeneratorWithGlobalDataExchangeModeTest extends Te
                                 StreamExchangeMode.PIPELINED));
         forward.map(i -> i).startNewChain().setParallelism(1);
         final StreamGraph streamGraph = env.getStreamGraph();
-        streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
 
         final JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
@@ -156,7 +156,7 @@ public class BatchExecExchange extends CommonExecExchange implements BatchExecNo
             return StreamExchangeMode.BATCH;
         }
         if (config.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE)
-                .equalsIgnoreCase(GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString())) {
+                .equalsIgnoreCase(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString())) {
             return StreamExchangeMode.BATCH;
         } else {
             return StreamExchangeMode.UNDEFINED;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecExchange.java
@@ -56,7 +56,7 @@ import java.util.Optional;
  * <p>TODO Remove this class once FLINK-21224 is finished.
  */
 public class BatchExecExchange extends CommonExecExchange implements BatchExecNode<RowData> {
-    // the required shuffle mode for reusable BatchExecExchange
+    // the required exchange mode for reusable BatchExecExchange
     // if it's None, use value from configuration
     @Nullable private StreamExchangeMode requiredExchangeMode;
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DeadlockBreakupProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DeadlockBreakupProcessor.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.processor;
 
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -43,7 +43,7 @@ public class DeadlockBreakupProcessor implements ExecNodeGraphProcessor {
                 new InputPriorityConflictResolver(
                         execGraph.getRootNodes(),
                         InputProperty.DamBehavior.END_INPUT,
-                        ShuffleMode.BATCH,
+                        StreamExchangeMode.BATCH,
                         context.getPlanner().getTableConfig().getConfiguration());
         resolver.detectAndResolve();
         return execGraph;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessor.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.planner.plan.nodes.exec.processor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.streaming.api.transformations.SourceTransformation;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
@@ -78,7 +78,7 @@ public class MultipleInputNodeCreationProcessor implements ExecNodeGraphProcesso
                     new InputPriorityConflictResolver(
                             execGraph.getRootNodes(),
                             InputProperty.DamBehavior.BLOCKING,
-                            ShuffleMode.PIPELINED,
+                            StreamExchangeMode.PIPELINED,
                             context.getPlanner().getTableConfig().getConfiguration());
             resolver.detectAndResolve();
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.processor.utils;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -40,7 +40,7 @@ import java.util.List;
 @Internal
 public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
 
-    private final ShuffleMode shuffleMode;
+    private final StreamExchangeMode exchangeMode;
     private final Configuration configuration;
 
     /**
@@ -49,16 +49,16 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
      * @param roots the first layer of nodes on the output side of the graph
      * @param safeDamBehavior when checking for conflicts we'll ignore the edges with {@link
      *     InputProperty.DamBehavior} stricter or equal than this
-     * @param shuffleMode when a conflict occurs we'll insert an {@link BatchExecExchange} node with
-     *     this shuffleMode to resolve conflict
+     * @param exchangeMode when a conflict occurs we'll insert an {@link BatchExecExchange} node
+     *     with this shuffleMode to resolve conflict
      */
     public InputPriorityConflictResolver(
             List<ExecNode<?>> roots,
             InputProperty.DamBehavior safeDamBehavior,
-            ShuffleMode shuffleMode,
+            StreamExchangeMode exchangeMode,
             Configuration configuration) {
         super(roots, Collections.emptySet(), safeDamBehavior);
-        this.shuffleMode = shuffleMode;
+        this.exchangeMode = exchangeMode;
         this.configuration = configuration;
     }
 
@@ -86,7 +86,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
                 BatchExecExchange newExchange =
                         new BatchExecExchange(
                                 inputProperty, (RowType) exchange.getOutputType(), "Exchange");
-                newExchange.setRequiredShuffleMode(shuffleMode);
+                newExchange.setRequiredExchangeMode(exchangeMode);
                 newExchange.setInputEdges(exchange.getInputEdges());
                 newNode = newExchange;
             } else {
@@ -96,7 +96,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
                                 inputProperty,
                                 (RowType) exchange.getOutputType(),
                                 exchange.getDescription());
-                newExchange.setRequiredShuffleMode(shuffleMode);
+                newExchange.setRequiredExchangeMode(exchangeMode);
                 newExchange.setInputEdges(exchange.getInputEdges());
                 newNode = newExchange;
             }
@@ -137,7 +137,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
         BatchExecExchange exchange =
                 new BatchExecExchange(
                         newInputProperty, (RowType) inputNode.getOutputType(), "Exchange");
-        exchange.setRequiredShuffleMode(shuffleMode);
+        exchange.setRequiredExchangeMode(exchangeMode);
         ExecEdge execEdge = ExecEdge.builder().source(inputNode).target(exchange).build();
         exchange.setInputEdges(Collections.singletonList(execEdge));
         return exchange;
@@ -168,7 +168,8 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
     }
 
     private InputProperty.DamBehavior getDamBehavior() {
-        if (BatchExecExchange.getShuffleMode(configuration, shuffleMode) == ShuffleMode.BATCH) {
+        if (BatchExecExchange.getExchangeMode(configuration, exchangeMode)
+                == StreamExchangeMode.BATCH) {
             return InputProperty.DamBehavior.BLOCKING;
         } else {
             return InputProperty.DamBehavior.PIPELINED;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolver.java
@@ -50,7 +50,7 @@ public class InputPriorityConflictResolver extends InputPriorityGraphGenerator {
      * @param safeDamBehavior when checking for conflicts we'll ignore the edges with {@link
      *     InputProperty.DamBehavior} stricter or equal than this
      * @param exchangeMode when a conflict occurs we'll insert an {@link BatchExecExchange} node
-     *     with this shuffleMode to resolve conflict
+     *     with this exchange mode to resolve conflict
      */
     public InputPriorityConflictResolver(
             List<ExecNode<?>> roots,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/ExecNodeGraphJsonPlanGenerator.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.serde;
 
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
@@ -293,7 +293,7 @@ public class ExecNodeGraphJsonPlanGenerator {
                                 .source(source)
                                 .target(target)
                                 .shuffle(edge.getShuffle())
-                                .shuffleMode(edge.getShuffleMode())
+                                .exchangeMode(edge.getExchangeMode())
                                 .build();
                 idToInputEdges
                         .computeIfAbsent(target.getId(), n -> new ArrayList<>())
@@ -343,20 +343,20 @@ public class ExecNodeGraphJsonPlanGenerator {
         @JsonSerialize(using = ShuffleJsonSerializer.class)
         @JsonDeserialize(using = ShuffleJsonDeserializer.class)
         private final ExecEdge.Shuffle shuffle;
-        /** The {@link ShuffleMode} defines the data exchange mode on this edge. */
+        /** The {@link StreamExchangeMode} on this edge. */
         @JsonProperty(FIELD_NAME_SHUFFLE_MODE)
-        private final ShuffleMode shuffleMode;
+        private final StreamExchangeMode exchangeMode;
 
         @JsonCreator
         public JsonPlanEdge(
                 @JsonProperty(FIELD_NAME_SOURCE) int sourceId,
                 @JsonProperty(FIELD_NAME_TARGET) int targetId,
                 @JsonProperty(FIELD_NAME_SHUFFLE) ExecEdge.Shuffle shuffle,
-                @JsonProperty(FIELD_NAME_SHUFFLE_MODE) ShuffleMode shuffleMode) {
+                @JsonProperty(FIELD_NAME_SHUFFLE_MODE) StreamExchangeMode exchangeMode) {
             this.sourceId = sourceId;
             this.targetId = targetId;
             this.shuffle = shuffle;
-            this.shuffleMode = shuffleMode;
+            this.exchangeMode = exchangeMode;
         }
 
         @JsonIgnore
@@ -375,8 +375,8 @@ public class ExecNodeGraphJsonPlanGenerator {
         }
 
         @JsonIgnore
-        public ShuffleMode getShuffleMode() {
-            return shuffleMode;
+        public StreamExchangeMode getExchangeMode() {
+            return exchangeMode;
         }
 
         /** Build {@link JsonPlanEdge} from an {@link ExecEdge}. */
@@ -385,7 +385,7 @@ public class ExecNodeGraphJsonPlanGenerator {
                     execEdge.getSource().getId(),
                     execEdge.getTarget().getId(),
                     execEdge.getShuffle(),
-                    execEdge.getShuffleMode());
+                    execEdge.getExchangeMode());
         }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.table.api.TableConfig;
@@ -80,11 +80,11 @@ public class ExecutorUtils {
         if (streamGraph.getCheckpointConfig().isCheckpointingEnabled()) {
             throw new IllegalArgumentException("Checkpoint is not supported for batch jobs.");
         }
-        streamGraph.setGlobalDataExchangeMode(getGlobalDataExchangeMode(tableConfig));
+        streamGraph.setGlobalStreamExchangeMode(getGlobalStreamExchangeMode(tableConfig));
     }
 
-    private static GlobalDataExchangeMode getGlobalDataExchangeMode(TableConfig tableConfig) {
-        return StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(
+    private static GlobalStreamExchangeMode getGlobalStreamExchangeMode(TableConfig tableConfig) {
+        return StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(
                 tableConfig.getConfiguration());
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/ExecutorUtils.java
@@ -84,7 +84,7 @@ public class ExecutorUtils {
     }
 
     private static GlobalDataExchangeMode getGlobalDataExchangeMode(TableConfig tableConfig) {
-        return ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(
+        return StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(
                 tableConfig.getConfiguration());
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
-/** Utility class to load job-wide shuffle mode. */
+/** Utility class to load job-wide exchange mode. */
 public class StreamExchangeModeUtils {
 
     static final String ALL_EDGES_BLOCKING_LEGACY = "batch";

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
@@ -23,7 +23,7 @@ import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
 /** Utility class to load job-wide shuffle mode. */
-public class ShuffleModeUtils {
+public class StreamExchangeModeUtils {
 
     static final String ALL_EDGES_BLOCKING_LEGACY = "batch";
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtils.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 
 /** Utility class to load job-wide exchange mode. */
@@ -29,13 +29,13 @@ public class StreamExchangeModeUtils {
 
     static final String ALL_EDGES_PIPELINED_LEGACY = "pipelined";
 
-    static GlobalDataExchangeMode getShuffleModeAsGlobalDataExchangeMode(
+    static GlobalStreamExchangeMode getShuffleModeAsGlobalStreamExchangeMode(
             final Configuration configuration) {
         final String value =
                 configuration.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE);
 
         try {
-            return GlobalDataExchangeMode.valueOf(convertLegacyShuffleMode(value).toUpperCase());
+            return GlobalStreamExchangeMode.valueOf(convertLegacyShuffleMode(value).toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
                     String.format(
@@ -47,9 +47,9 @@ public class StreamExchangeModeUtils {
     private static String convertLegacyShuffleMode(final String shuffleMode) {
         switch (shuffleMode.toLowerCase()) {
             case ALL_EDGES_BLOCKING_LEGACY:
-                return GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString();
+                return GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString();
             case ALL_EDGES_PIPELINED_LEGACY:
-                return GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString();
+                return GlobalStreamExchangeMode.ALL_EDGES_PIPELINED.toString();
             default:
                 return shuffleMode;
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
@@ -75,7 +75,7 @@ class BatchPhysicalExchange(
   private def getExchangeMode: StreamExchangeMode = {
     val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
     if (tableConfig.getConfiguration.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE)
-      .equalsIgnoreCase(GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString)) {
+      .equalsIgnoreCase(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString)) {
       StreamExchangeMode.BATCH
     } else {
       StreamExchangeMode.UNDEFINED

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalExchange.scala
@@ -19,11 +19,11 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
-import org.apache.flink.streaming.api.transformations.ShuffleMode
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange
-import org.apache.flink.table.planner.plan.nodes.exec.{InputProperty, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalExchange
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 
@@ -60,7 +60,7 @@ class BatchPhysicalExchange(
       throw new UnsupportedOperationException("Range sort is not supported.")
     }
 
-    val damBehavior = if (getShuffleMode eq ShuffleMode.BATCH) {
+    val damBehavior = if (getExchangeMode eq StreamExchangeMode.BATCH) {
       InputProperty.DamBehavior.BLOCKING
     } else {
       InputProperty.DamBehavior.PIPELINED
@@ -72,13 +72,13 @@ class BatchPhysicalExchange(
       .build
   }
 
-  private def getShuffleMode: ShuffleMode = {
+  private def getExchangeMode: StreamExchangeMode = {
     val tableConfig = FlinkRelOptUtil.getTableConfigFromContext(this)
     if (tableConfig.getConfiguration.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE)
       .equalsIgnoreCase(GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString)) {
-      ShuffleMode.BATCH
+      StreamExchangeMode.BATCH
     } else {
-      ShuffleMode.UNDEFINED
+      StreamExchangeMode.UNDEFINED
     }
   }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.processor.utils;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -78,21 +78,21 @@ public class InputPriorityConflictResolverTest {
                 new InputPriorityConflictResolver(
                         Collections.singletonList(nodes[7]),
                         InputProperty.DamBehavior.END_INPUT,
-                        ShuffleMode.BATCH,
+                        StreamExchangeMode.BATCH,
                         new Configuration());
         resolver.detectAndResolve();
         Assert.assertEquals(nodes[1], nodes[7].getInputNodes().get(0));
         Assert.assertEquals(nodes[2], nodes[7].getInputNodes().get(1));
         Assert.assertTrue(nodes[7].getInputNodes().get(2) instanceof BatchExecExchange);
         Assert.assertEquals(
-                Optional.of(ShuffleMode.BATCH),
-                ((BatchExecExchange) nodes[7].getInputNodes().get(2)).getRequiredShuffleMode());
+                Optional.of(StreamExchangeMode.BATCH),
+                ((BatchExecExchange) nodes[7].getInputNodes().get(2)).getRequiredExchangeMode());
         Assert.assertEquals(
                 nodes[3], nodes[7].getInputNodes().get(2).getInputEdges().get(0).getSource());
         Assert.assertTrue(nodes[7].getInputNodes().get(3) instanceof BatchExecExchange);
         Assert.assertEquals(
-                Optional.of(ShuffleMode.BATCH),
-                ((BatchExecExchange) nodes[7].getInputNodes().get(3)).getRequiredShuffleMode());
+                Optional.of(StreamExchangeMode.BATCH),
+                ((BatchExecExchange) nodes[7].getInputNodes().get(3)).getRequiredExchangeMode());
         Assert.assertEquals(
                 nodes[4], nodes[7].getInputNodes().get(3).getInputEdges().get(0).getSource());
         Assert.assertEquals(nodes[5], nodes[7].getInputNodes().get(4));
@@ -117,7 +117,7 @@ public class InputPriorityConflictResolverTest {
                                 .build(),
                         (RowType) nodes[0].getOutputType(),
                         "Exchange");
-        exchange.setRequiredShuffleMode(ShuffleMode.BATCH);
+        exchange.setRequiredExchangeMode(StreamExchangeMode.BATCH);
         ExecEdge execEdge = ExecEdge.builder().source(nodes[0]).target(exchange).build();
         exchange.setInputEdges(Collections.singletonList(execEdge));
 
@@ -128,7 +128,7 @@ public class InputPriorityConflictResolverTest {
                 new InputPriorityConflictResolver(
                         Collections.singletonList(nodes[1]),
                         InputProperty.DamBehavior.END_INPUT,
-                        ShuffleMode.BATCH,
+                        StreamExchangeMode.BATCH,
                         new Configuration());
         resolver.detectAndResolve();
 
@@ -140,7 +140,8 @@ public class InputPriorityConflictResolverTest {
                 execNode -> {
                     Assert.assertTrue(execNode instanceof BatchExecExchange);
                     BatchExecExchange e = (BatchExecExchange) execNode;
-                    Assert.assertEquals(Optional.of(ShuffleMode.BATCH), e.getRequiredShuffleMode());
+                    Assert.assertEquals(
+                            Optional.of(StreamExchangeMode.BATCH), e.getRequiredExchangeMode());
                     Assert.assertEquals(nodes[0], e.getInputEdges().get(0).getSource());
                 };
         checkExchange.accept(input0);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
@@ -27,8 +27,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/** Tests for {@link ShuffleModeUtils}. */
-public class ShuffleModeUtilsTest extends TestLogger {
+/** Tests for {@link StreamExchangeModeUtils}. */
+public class StreamExchangeModeUtilsTest extends TestLogger {
 
     @Test
     public void testGetValidShuffleMode() {
@@ -39,28 +39,28 @@ public class ShuffleModeUtilsTest extends TestLogger {
                 GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString());
         assertEquals(
                 GlobalDataExchangeMode.ALL_EDGES_BLOCKING,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED.toString());
         assertEquals(
                 GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
         assertEquals(
                 GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString());
         assertEquals(
                 GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
     }
 
     @Test
@@ -69,17 +69,17 @@ public class ShuffleModeUtilsTest extends TestLogger {
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                ShuffleModeUtils.ALL_EDGES_BLOCKING_LEGACY);
+                StreamExchangeModeUtils.ALL_EDGES_BLOCKING_LEGACY);
         assertEquals(
                 GlobalDataExchangeMode.ALL_EDGES_BLOCKING,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                ShuffleModeUtils.ALL_EDGES_PIPELINED_LEGACY);
+                StreamExchangeModeUtils.ALL_EDGES_PIPELINED_LEGACY);
         assertEquals(
                 GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
     }
 
     @Test
@@ -90,12 +90,12 @@ public class ShuffleModeUtilsTest extends TestLogger {
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Forward_edges_PIPELINED");
         assertEquals(
                 GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
 
         configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Pipelined");
         assertEquals(
                 GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
     }
 
     @Test
@@ -103,13 +103,13 @@ public class ShuffleModeUtilsTest extends TestLogger {
         final Configuration configuration = new Configuration();
         assertEquals(
                 GlobalDataExchangeMode.ALL_EDGES_BLOCKING,
-                ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testGetInvalidShuffleMode() {
         final Configuration configuration = new Configuration();
         configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "invalid-value");
-        ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration);
+        StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.util.TestLogger;
 
@@ -36,31 +36,31 @@ public class StreamExchangeModeUtilsTest extends TestLogger {
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString());
+                GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString());
         assertEquals(
-                GlobalDataExchangeMode.ALL_EDGES_BLOCKING,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.ALL_EDGES_BLOCKING,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED.toString());
+                GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED.toString());
         assertEquals(
-                GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
+                GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
         assertEquals(
-                GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-                GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString());
+                GlobalStreamExchangeMode.ALL_EDGES_PIPELINED.toString());
         assertEquals(
-                GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
     }
 
     @Test
@@ -71,15 +71,15 @@ public class StreamExchangeModeUtilsTest extends TestLogger {
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 StreamExchangeModeUtils.ALL_EDGES_BLOCKING_LEGACY);
         assertEquals(
-                GlobalDataExchangeMode.ALL_EDGES_BLOCKING,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.ALL_EDGES_BLOCKING,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
 
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 StreamExchangeModeUtils.ALL_EDGES_PIPELINED_LEGACY);
         assertEquals(
-                GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
     }
 
     @Test
@@ -89,27 +89,27 @@ public class StreamExchangeModeUtilsTest extends TestLogger {
         configuration.setString(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Forward_edges_PIPELINED");
         assertEquals(
-                GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
 
         configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Pipelined");
         assertEquals(
-                GlobalDataExchangeMode.ALL_EDGES_PIPELINED,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.ALL_EDGES_PIPELINED,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
     }
 
     @Test
     public void testGetDefaultShuffleMode() {
         final Configuration configuration = new Configuration();
         assertEquals(
-                GlobalDataExchangeMode.ALL_EDGES_BLOCKING,
-                StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+                GlobalStreamExchangeMode.ALL_EDGES_BLOCKING,
+                StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testGetInvalidShuffleMode() {
         final Configuration configuration = new Configuration();
         configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "invalid-value");
-        StreamExchangeModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration);
+        StreamExchangeModeUtils.getShuffleModeAsGlobalStreamExchangeMode(configuration);
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.Tuple
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.ExecutionConfigOptions._
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
@@ -521,6 +521,6 @@ object BatchTestBase {
     conf.getConfiguration.setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, DEFAULT_PARALLELISM)
     conf.getConfiguration.setString(
       TABLE_EXEC_SHUFFLE_MODE,
-      GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString)
+      GlobalStreamExchangeMode.ALL_EDGES_PIPELINED.toString)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -22,7 +22,7 @@ import org.apache.flink.api.java.typeutils.{PojoTypeInfo, RowTypeInfo, TupleType
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment}
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecEnv}
 import org.apache.flink.streaming.api.{TimeCharacteristic, environment}
 import org.apache.flink.table.api._
@@ -997,7 +997,7 @@ abstract class TableTestUtil(
   val tableEnv: TableEnvironment = testingTableEnv
   tableEnv.getConfig.getConfiguration.setString(
     ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
-    GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString)
+    GlobalStreamExchangeMode.ALL_EDGES_PIPELINED.toString)
 
   private val env: StreamExecutionEnvironment = getPlanner.getExecEnv
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
@@ -27,7 +27,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
-import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.streaming.api.graph.GlobalStreamExchangeMode;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
 
@@ -92,7 +92,7 @@ public class BlockingShuffleITCase {
                 .addSink(new VerifySink());
 
         StreamGraph streamGraph = env.getStreamGraph();
-        streamGraph.setGlobalDataExchangeMode(GlobalDataExchangeMode.ALL_EDGES_BLOCKING);
+        streamGraph.setGlobalStreamExchangeMode(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
         // a scheduler supporting batch jobs is required for this job graph, because it contains
         // blocking data exchanges.
         // The scheduler is selected based on the JobType.


### PR DESCRIPTION
## What is the purpose of the change

This refactors some enum classes that are used for more or less the same purpose but in different parts of the stack with different values. It should reduce confusion and collisions with API classes.

The new naming is as follows:

```
DataExchangeMode (for network stack, remains as it is)

ShuffleMode -> StreamExchangeMode (belongs to *stream* graph and influences the data *exchange*)

GlobalDataExchangeMode -> GlobalStreamExchangeMode (belongs to *stream* graph and influences the data *exchange* but globally)
```

In docs and API we will expose the word "shuffle" also for shuffle service etc. Thus, we will add a new `ShuffleMode` enum according to FLIP-134 for the API. The API enum class will follow in the next PR.

The word "exchange" is used internally for declaring shuffles in graphs.

## Brief change log

Use the term "exchange mode" consistently.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
