### PR TITLE
[FLINK-23432][docs] Solve the Markdown header failure issue

### DIFF
--- a/docs/content.zh/docs/ops/state/checkpoints.md
+++ b/docs/content.zh/docs/ops/state/checkpoints.md
@@ -67,6 +67,7 @@ config.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CAN
 <div class="alert alert-warning">
   <strong>注意:</strong> Checkpoint 目录不是公共 API 的一部分，因此可能在未来的 Release 中进行改变。
 </div>
+
 #### 通过配置文件全局配置
 
 ```yaml


### PR DESCRIPTION


The page url ：https://ci.apache.org/projects/flink/flink-docs-master/zh/docs/ops/state/checkpoints/

markdown： docs/content.zh/docs/ops/state/checkpoints.md



- A blank line should be added between lines 69 and 70.

```txt
L67 <div class="alert alert-warning">
L68  				<strong>注意:</strong> Checkpoint 目录不是公共 API 的一部分，因此可能在未来的 Release 中进行改变。
L69 </div>
L70 #### 通过配置文件全局配置
```

- The modification is shown below

```txt
<div class="alert alert-warning">
  <strong>注意:</strong> Checkpoint 目录不是公共 API 的一部分，因此可能在未来的 Release 中进行改变。
</div>

#### 通过配置文件全局配置
```



