### PR TITLE
[FLINK-23218][coordination] Distribute the ShuffleDescriptors via blob server

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/CompressedSerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CompressedSerializedValue.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/** An extension of {@link SerializedValue} that compresses the value after the serialization. */
+@Internal
+public class CompressedSerializedValue<T> extends SerializedValue<T> {
+
+    private static final long serialVersionUID = -4358765382738374654L;
+
+    private CompressedSerializedValue(T value) throws IOException {
+        super(InstantiationUtil.serializeObjectAndCompress(value));
+    }
+
+    /**
+     * Decompress and deserialize the data to get the original object.
+     *
+     * @param loader the classloader to deserialize
+     * @return the deserialized object
+     * @throws IOException exception during decompression and deserialization
+     * @throws ClassNotFoundException if class is not found in the classloader
+     */
+    @Override
+    public T deserializeValue(ClassLoader loader) throws IOException, ClassNotFoundException {
+        Preconditions.checkNotNull(loader, "No classloader has been passed");
+        return InstantiationUtil.decompressAndDeserializeObject(getByteArray(), loader);
+    }
+
+    /** Returns the size of the compressed serialized data. */
+    public int getSize() {
+        return getByteArray().length;
+    }
+
+    /**
+     * Constructs a compressed serialized value for the given object.
+     *
+     * @param object the object to serialize and compress
+     * @throws NullPointerException if object is null
+     * @throws IOException exception during serialization and compression
+     */
+    public static <T> CompressedSerializedValue<T> fromObject(T object) throws IOException {
+        Preconditions.checkNotNull(object, "Value must not be null");
+        return new CompressedSerializedValue<>(object);
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public String toString() {
+        return String.format("Compressed Serialized Value [byte array length: %d]", getSize());
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/util/CompressedSerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/util/CompressedSerializedValue.java
@@ -28,6 +28,10 @@ public class CompressedSerializedValue<T> extends SerializedValue<T> {
 
     private static final long serialVersionUID = -4358765382738374654L;
 
+    private CompressedSerializedValue(byte[] compressedSerializedData) {
+        super(compressedSerializedData);
+    }
+
     private CompressedSerializedValue(T value) throws IOException {
         super(InstantiationUtil.serializeObjectAndCompress(value));
     }
@@ -61,6 +65,20 @@ public class CompressedSerializedValue<T> extends SerializedValue<T> {
     public static <T> CompressedSerializedValue<T> fromObject(T object) throws IOException {
         Preconditions.checkNotNull(object, "Value must not be null");
         return new CompressedSerializedValue<>(object);
+    }
+
+    /**
+     * Construct a compressed serialized value with a serialized byte array.
+     *
+     * <p>The byte array must be the result of serialization and compression with {@link
+     * InstantiationUtil#serializeObjectAndCompress}.
+     *
+     * @param compressedSerializedData the compressed serialized byte array
+     * @param <T> type of the object
+     * @return {@link CompressedSerializedValue} that can be deserialized as the object
+     */
+    public static <T> CompressedSerializedValue<T> fromBytes(byte[] compressedSerializedData) {
+        return new CompressedSerializedValue<>(compressedSerializedData);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -49,6 +49,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
 
 /** Utility class to create instances from class objects and checking failure reasons. */
 @Internal
@@ -618,6 +620,12 @@ public final class InstantiationUtil {
         }
     }
 
+    public static <T> T decompressAndDeserializeObject(byte[] bytes, ClassLoader cl)
+            throws IOException, ClassNotFoundException {
+        return deserializeObject(
+                new InflaterInputStream(new ByteArrayInputStream(bytes)), cl, false);
+    }
+
     public static byte[] serializeObject(Object o) throws IOException {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 ObjectOutputStream oos = new ObjectOutputStream(baos)) {
@@ -633,6 +641,17 @@ public final class InstantiationUtil {
                         ? (ObjectOutputStream) out
                         : new ObjectOutputStream(out);
         oos.writeObject(o);
+    }
+
+    public static byte[] serializeObjectAndCompress(Object o) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DeflaterOutputStream dos = new DeflaterOutputStream(baos);
+                ObjectOutputStream oos = new ObjectOutputStream(dos)) {
+            oos.writeObject(o);
+            oos.flush();
+            dos.close();
+            return baos.toByteArray();
+        }
     }
 
     public static boolean isSerializable(Object o) {

--- a/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedValue.java
@@ -43,7 +43,7 @@ public class SerializedValue<T> implements java.io.Serializable {
     /** The serialized data. */
     private final byte[] serializedData;
 
-    private SerializedValue(byte[] serializedData) {
+    protected SerializedValue(byte[] serializedData) {
         Preconditions.checkNotNull(serializedData, "Serialized data must not be null");
         Preconditions.checkArgument(
                 serializedData.length != 0, "Serialized data must not be empty");

--- a/flink-core/src/test/java/org/apache/flink/util/CompressedSerializedValueTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CompressedSerializedValueTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.core.testutils.CommonTestUtils;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -31,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 public class CompressedSerializedValueTest {
     @Test
     public void testSimpleValue() throws Exception {
+
         final String value = "teststring";
 
         CompressedSerializedValue<String> v = CompressedSerializedValue.fromObject(value);
@@ -47,10 +50,26 @@ public class CompressedSerializedValueTest {
 
         assertNotEquals(0, v.getSize());
         assertArrayEquals(v.getByteArray(), copy.getByteArray());
+
+        byte[] bytes = v.getByteArray();
+        CompressedSerializedValue<String> saved =
+                CompressedSerializedValue.fromBytes(Arrays.copyOf(bytes, bytes.length));
+        assertEquals(v, saved);
+        assertArrayEquals(v.getByteArray(), saved.getByteArray());
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullValue() throws Exception {
         CompressedSerializedValue.fromObject(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testFromNullBytes() {
+        CompressedSerializedValue.fromBytes(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromEmptyBytes() {
+        CompressedSerializedValue.fromBytes(new byte[0]);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/util/CompressedSerializedValueTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/CompressedSerializedValueTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+/** Tests for {@link CompressedSerializedValue}. */
+public class CompressedSerializedValueTest {
+    @Test
+    public void testSimpleValue() throws Exception {
+        final String value = "teststring";
+
+        CompressedSerializedValue<String> v = CompressedSerializedValue.fromObject(value);
+        CompressedSerializedValue<String> copy = CommonTestUtils.createCopySerializable(v);
+
+        assertEquals(value, v.deserializeValue(getClass().getClassLoader()));
+        assertEquals(value, copy.deserializeValue(getClass().getClassLoader()));
+
+        assertEquals(v, copy);
+        assertEquals(v.hashCode(), copy.hashCode());
+
+        assertNotNull(v.toString());
+        assertNotNull(copy.toString());
+
+        assertNotEquals(0, v.getSize());
+        assertArrayEquals(v.getByteArray(), copy.getByteArray());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullValue() throws Exception {
+        CompressedSerializedValue.fromObject(null);
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/util/InstantiationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/InstantiationUtilTest.java
@@ -145,6 +145,18 @@ public class InstantiationUtilTest extends TestLogger {
     }
 
     @Test
+    public void testCompressionAndSerializationAlongWithDecompressionAndDeserialization()
+            throws IOException, ClassNotFoundException {
+        final String value = "teststring";
+
+        assertEquals(
+                value,
+                InstantiationUtil.decompressAndDeserializeObject(
+                        InstantiationUtil.serializeObjectAndCompress(value),
+                        getClass().getClassLoader()));
+    }
+
+    @Test
     public void testWriteToConfigFailingSerialization() {
         try {
             final String key1 = "testkey1";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobWriter.java
@@ -59,6 +59,14 @@ public interface BlobWriter {
     PermanentBlobKey putPermanent(JobID jobId, InputStream inputStream) throws IOException;
 
     /**
+     * Delete the uploaded data with the given {@link JobID} and {@link PermanentBlobKey}.
+     *
+     * @param jobId ID of the job this blob belongs to
+     * @param permanentBlobKey the key of this blob
+     */
+    boolean deletePermanent(JobID jobId, PermanentBlobKey permanentBlobKey);
+
+    /**
      * Returns the min size before data will be offloaded to the BLOB store.
      *
      * @return minimum offloading size
@@ -79,10 +87,17 @@ public interface BlobWriter {
     static <T> Either<SerializedValue<T>, PermanentBlobKey> serializeAndTryOffload(
             T value, JobID jobId, BlobWriter blobWriter) throws IOException {
         Preconditions.checkNotNull(value);
-        Preconditions.checkNotNull(jobId);
-        Preconditions.checkNotNull(blobWriter);
 
         final SerializedValue<T> serializedValue = new SerializedValue<>(value);
+
+        return tryOffload(serializedValue, jobId, blobWriter);
+    }
+
+    static <T> Either<SerializedValue<T>, PermanentBlobKey> tryOffload(
+            SerializedValue<T> serializedValue, JobID jobId, BlobWriter blobWriter) {
+        Preconditions.checkNotNull(serializedValue);
+        Preconditions.checkNotNull(jobId);
+        Preconditions.checkNotNull(blobWriter);
 
         if (serializedValue.getByteArray().length < blobWriter.getMinOffloadingSize()) {
             return Either.Left(serializedValue);
@@ -93,7 +108,7 @@ public interface BlobWriter {
 
                 return Either.Right(permanentBlobKey);
             } catch (IOException e) {
-                LOG.warn("Failed to offload value {} for job {} to BLOB store.", value, jobId, e);
+                LOG.warn("Failed to offload value for job {} to BLOB store.", jobId, e);
 
                 return Either.Left(serializedValue);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/VoidBlobWriter.java
@@ -44,6 +44,12 @@ public class VoidBlobWriter implements BlobWriter {
     }
 
     @Override
+    public boolean deletePermanent(JobID jobId, PermanentBlobKey key) {
+        throw new UnsupportedOperationException(
+                "The VoidBlobWriter cannot delete data from the BLOB store.");
+    }
+
+    @Override
     public int getMinOffloadingSize() {
         return Integer.MAX_VALUE;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -287,6 +287,10 @@ public final class TaskDeploymentDescriptor implements Serializable {
             serializedTaskInformation = new NonOffloaded<>(serializedValue);
         }
 
+        for (InputGateDeploymentDescriptor inputGate : inputGates) {
+            inputGate.loadBigData(blobService, jobId);
+        }
+
         // make sure that the serialized job and task information fields are filled
         Preconditions.checkNotNull(serializedJobInformation);
         Preconditions.checkNotNull(serializedTaskInformation);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1276,6 +1276,14 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     private void releasePartitions(final List<IntermediateResultPartitionID> releasablePartitions) {
         if (releasablePartitions.size() > 0) {
+
+            // Remove cached ShuffleDescriptor when partition is released
+            releasablePartitions.stream()
+                    .map(IntermediateResultPartitionID::getIntermediateDataSetID)
+                    .distinct()
+                    .map(intermediateResults::get)
+                    .forEach(IntermediateResult::notifyPartitionChanged);
+
             final List<ResultPartitionID> partitionIds =
                     releasablePartitions.stream()
                             .map(this::createResultPartitionId)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1466,6 +1466,17 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
     }
 
     @Override
+    public void deleteBlobs(List<PermanentBlobKey> blobKeys) {
+        CompletableFuture.runAsync(
+                () -> {
+                    for (PermanentBlobKey blobKey : blobKeys) {
+                        blobWriter.deletePermanent(getJobID(), blobKey);
+                    }
+                },
+                ioExecutor);
+    }
+
+    @Override
     public ShuffleMaster<?> getShuffleMaster() {
         return shuffleMaster;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResult.java
@@ -22,8 +22,12 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.util.SerializedValue;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -52,6 +56,9 @@ public class IntermediateResult {
 
     private final ResultPartitionType resultType;
 
+    private final Map<ConsumedPartitionGroup, SerializedValue<ShuffleDescriptor[]>>
+            shuffleDescriptorCache;
+
     public IntermediateResult(
             IntermediateDataSetID id,
             ExecutionJobVertex producer,
@@ -75,6 +82,8 @@ public class IntermediateResult {
 
         // The runtime type for this produced result
         this.resultType = checkNotNull(resultType);
+
+        this.shuffleDescriptorCache = new HashMap<>();
     }
 
     public void setPartition(int partitionNumber, IntermediateResultPartition partition) {
@@ -147,6 +156,26 @@ public class IntermediateResult {
         for (IntermediateResultPartition partition : partitions) {
             partition.resetForNewExecution();
         }
+    }
+
+    public SerializedValue<ShuffleDescriptor[]> getCachedShuffleDescriptors(
+            ConsumedPartitionGroup consumedPartitionGroup) {
+        return shuffleDescriptorCache.get(consumedPartitionGroup);
+    }
+
+    public void cacheShuffleDescriptors(
+            ConsumedPartitionGroup consumedPartitionGroup,
+            SerializedValue<ShuffleDescriptor[]> shuffleDescriptors) {
+        this.shuffleDescriptorCache.put(consumedPartitionGroup, shuffleDescriptors);
+    }
+
+    public void notifyPartitionChanged() {
+        // When partitions change, the cache of shuffle descriptors is no longer valid
+        // and need to be removed.
+        // Currently there are two scenarios:
+        // 1. The partitions are released
+        // 2. The producer encounters a failover
+        this.shuffleDescriptorCache.clear();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IntermediateResultPartition.java
@@ -94,6 +94,7 @@ public class IntermediateResultPartition {
             }
         }
         hasDataProduced = false;
+        totalResult.notifyPartitionChanged();
     }
 
     public void addConsumers(ConsumerVertexGroup consumers) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/InternalExecutionGraphAccessor.java
@@ -34,6 +34,7 @@ import org.apache.flink.util.SerializedValue;
 
 import javax.annotation.Nonnull;
 
+import java.util.List;
 import java.util.concurrent.Executor;
 
 /**
@@ -103,4 +104,6 @@ public interface InternalExecutionGraphAccessor {
     ExecutionVertex getExecutionVertexOrThrow(ExecutionVertexID id);
 
     IntermediateResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID id);
+
+    void deleteBlobs(List<PermanentBlobKey> blobKeys);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobWriter.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/** In memory implementation of {@link BlobWriter}. */
+public class TestingBlobWriter implements BlobWriter {
+
+    private final Map<Tuple2<JobID, PermanentBlobKey>, byte[]> blobs;
+    private int minOffloadingSize;
+
+    public TestingBlobWriter() {
+        this(0);
+    }
+
+    public TestingBlobWriter(int minOffloadingSize) {
+        this.blobs = new HashMap<>();
+        this.minOffloadingSize = minOffloadingSize;
+    }
+
+    @Override
+    public PermanentBlobKey putPermanent(JobID jobId, byte[] value) throws IOException {
+        PermanentBlobKey blobKey = new PermanentBlobKey();
+        Tuple2<JobID, PermanentBlobKey> tupleKey = Tuple2.of(jobId, blobKey);
+        if (blobs.containsKey(tupleKey)) {
+            throw new IllegalStateException("Duplicated key found in in memory blob");
+        }
+        blobs.put(tupleKey, value);
+        return blobKey;
+    }
+
+    @Override
+    public PermanentBlobKey putPermanent(JobID jobId, InputStream inputStream) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            int length;
+            byte[] buffer = new byte[1024];
+
+            while ((length = inputStream.read(buffer, 0, buffer.length)) != -1) {
+                baos.write(buffer, 0, length);
+            }
+            return this.putPermanent(jobId, baos.toByteArray());
+        }
+    }
+
+    @Override
+    public boolean deletePermanent(JobID jobId, PermanentBlobKey blobKey) {
+        return blobs.remove(Tuple2.of(jobId, blobKey)) != null;
+    }
+
+    @Override
+    public int getMinOffloadingSize() {
+        return minOffloadingSize;
+    }
+
+    public void setMinOffloadingSize(int minOffloadingSize) {
+        this.minOffloadingSize = minOffloadingSize;
+    }
+
+    public byte[] getBlob(JobID jobId, PermanentBlobKey blobKey) {
+        return blobs.get(Tuple2.of(jobId, blobKey));
+    }
+
+    public int numberOfBlobs() {
+        return blobs.size();
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactoryTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.VoidBlobWriter;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link TaskDeploymentDescriptorFactory}. */
+public class TaskDeploymentDescriptorFactoryTest extends TestLogger {
+
+    private static final int PARALLELISM = 4;
+
+    @Test
+    public void testCacheShuffleDescriptor() throws Exception {
+        final JobID jobId = new JobID();
+        final BlobWriter blobWriter = new VoidBlobWriter();
+
+        final ExecutionJobVertex ejv = setupExecutionGraphAndGetVertex(jobId, blobWriter);
+
+        final ExecutionVertex ev21 = ejv.getTaskVertices()[0];
+        createTaskDeploymentDescriptor(ev21);
+
+        // The ShuffleDescriptors should be cached
+        final IntermediateResult consumedResult = ejv.getInputs().get(0);
+        final SerializedValue<ShuffleDescriptor[]> compressedSerializedValue =
+                consumedResult.getCachedShuffleDescriptors(ev21.getConsumedPartitionGroup(0));
+
+        final ShuffleDescriptor[] cachedShuffleDescriptors =
+                deserializeShuffleDescriptors(compressedSerializedValue);
+
+        // Check if the ShuffleDescriptors are cached correctly
+        assertEquals(ev21.getConsumedPartitionGroup(0).size(), cachedShuffleDescriptors.length);
+
+        int idx = 0;
+        for (IntermediateResultPartitionID consumedPartitionId :
+                ev21.getConsumedPartitionGroup(0)) {
+            assertEquals(
+                    consumedPartitionId,
+                    cachedShuffleDescriptors[idx++].getResultPartitionID().getPartitionId());
+        }
+    }
+
+    private ExecutionJobVertex setupExecutionGraphAndGetVertex(JobID jobId, BlobWriter blobWriter)
+            throws JobException, JobExecutionException {
+        final JobVertex v1 = createJobVertex("v1", PARALLELISM);
+        final JobVertex v2 = createJobVertex("v2", PARALLELISM);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        final List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+
+        final ExecutionGraph executionGraph = createExecutionGraph(jobId, ordered, blobWriter);
+
+        return executionGraph.getJobVertex(v2.getID());
+    }
+
+    // ============== Utils ==============
+
+    private static JobVertex createJobVertex(String vertexName, int parallelism) {
+        JobVertex jobVertex = new JobVertex(vertexName);
+        jobVertex.setParallelism(parallelism);
+        jobVertex.setInvokableClass(AbstractInvokable.class);
+        return jobVertex;
+    }
+
+    private static ExecutionGraph createExecutionGraph(
+            final JobID jobId, final List<JobVertex> jobVertices, final BlobWriter blobWriter)
+            throws JobException, JobExecutionException {
+
+        final JobGraph jobGraph =
+                JobGraphBuilder.newBatchJobGraphBuilder()
+                        .setJobId(jobId)
+                        .addJobVertices(jobVertices)
+                        .build();
+
+        return TestingDefaultExecutionGraphBuilder.newBuilder()
+                .setJobGraph(jobGraph)
+                .setBlobWriter(blobWriter)
+                .build();
+    }
+
+    private static void createTaskDeploymentDescriptor(ExecutionVertex ev) throws IOException {
+
+        TaskDeploymentDescriptorFactory.fromExecutionVertex(ev, 0)
+                .createDeploymentDescriptor(new AllocationID(), null, Collections.emptyList());
+    }
+
+    public static ShuffleDescriptor[] deserializeShuffleDescriptors(
+            SerializedValue<ShuffleDescriptor[]> compressedSerializedValue)
+            throws IOException, ClassNotFoundException {
+
+        return compressedSerializedValue.deserializeValue(ClassLoader.getSystemClassLoader());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -54,6 +55,8 @@ import org.apache.flink.runtime.scheduler.SchedulerNG;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.TestingPhysicalSlotProvider;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -224,7 +227,18 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
 
         assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
         assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
-        assertEquals(10, iteratorConsumedPartitions.next().getShuffleDescriptors().length);
+
+        ShuffleDescriptor[] shuffleDescriptors =
+                iteratorConsumedPartitions.next().getShuffleDescriptors();
+        assertEquals(10, shuffleDescriptors.length);
+
+        Iterator<ConsumedPartitionGroup> iteratorConsumedPartitionGroup =
+                vertex.getAllConsumedPartitionGroups().iterator();
+        int idx = 0;
+        for (IntermediateResultPartitionID partitionId : iteratorConsumedPartitionGroup.next()) {
+            assertEquals(
+                    partitionId, shuffleDescriptors[idx++].getResultPartitionID().getPartitionId());
+        }
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/RemoveCachedShuffleDescriptorTest.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.failover.flip1.TestRestartBackoffTimeStrategy;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
+import org.apache.flink.runtime.taskmanager.TaskExecutionState;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactoryTest.deserializeShuffleDescriptors;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for removing cached {@link ShuffleDescriptor}s when the related partitions are no longer
+ * valid. Currently there are two scenarios as illustrated in {@link
+ * IntermediateResult#notifyPartitionChanged}.
+ */
+public class RemoveCachedShuffleDescriptorTest extends TestLogger {
+
+    private static final int PARALLELISM = 4;
+
+    private ScheduledExecutorService scheduledExecutorService;
+    private ComponentMainThreadExecutor mainThreadExecutor;
+
+    @Before
+    public void setup() {
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        mainThreadExecutor =
+                ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                        scheduledExecutorService);
+    }
+
+    @After
+    public void teardown() {
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testRemoveShuffleDescriptorCacheAfterFinished() throws Exception {
+
+        final JobVertex v1 = createJobVertex("v1", PARALLELISM);
+        final JobVertex v2 = createJobVertex("v2", PARALLELISM);
+
+        final DefaultScheduler scheduler = createSchedulerAndDeploy(v1, v2, mainThreadExecutor);
+        final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+
+        // ShuffleDescriptors should be cached during the deployment
+        final ShuffleDescriptor[] shuffleDescriptors =
+                deserializeShuffleDescriptors(
+                        getConsumedCachedShuffleDescriptor(executionGraph, v2));
+        assertEquals(PARALLELISM, shuffleDescriptors.length);
+
+        CompletableFuture.runAsync(
+                        () -> transitionTasksToFinished(executionGraph, v2.getID()),
+                        mainThreadExecutor)
+                .join();
+
+        // Cache should be removed when partitions are released
+        assertNull(getConsumedCachedShuffleDescriptor(executionGraph, v2));
+    }
+
+    @Test
+    public void testCacheRemovedCorrectlyAfterFailover() throws Exception {
+
+        final JobVertex v1 = createJobVertex("v1", PARALLELISM);
+        final JobVertex v2 = createJobVertex("v2", PARALLELISM);
+
+        final DefaultScheduler scheduler = createSchedulerAndDeploy(v1, v2, mainThreadExecutor);
+        final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+
+        // ShuffleDescriptors should be cached during the deployment
+        final ShuffleDescriptor[] shuffleDescriptors =
+                deserializeShuffleDescriptors(
+                        getConsumedCachedShuffleDescriptor(executionGraph, v2));
+        assertEquals(PARALLELISM, shuffleDescriptors.length);
+
+        triggerExceptionAndComplete(scheduler, v1);
+
+        // Cache should be removed during ExecutionVertex#resetForNewExecution
+        assertNull(getConsumedCachedShuffleDescriptor(executionGraph, v2));
+    }
+
+    private static DefaultScheduler createSchedulerAndDeploy(
+            JobVertex v1, JobVertex v2, ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception {
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        final List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+        final DefaultScheduler scheduler = createScheduler(ordered, mainThreadExecutor);
+        final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+        final TestingLogicalSlotBuilder slotBuilder = new TestingLogicalSlotBuilder();
+
+        CompletableFuture.runAsync(
+                        () -> {
+                            try {
+                                // Deploy upstream source vertices
+                                deployTasks(executionGraph, v1.getID(), slotBuilder);
+                                // Transition upstream vertices into FINISHED
+                                transitionTasksToFinished(executionGraph, v1.getID());
+                                // Deploy downstream sink vertices
+                                deployTasks(executionGraph, v2.getID(), slotBuilder);
+                            } catch (Exception e) {
+                                throw new RuntimeException("Exceptions shouldn't happen here.", e);
+                            }
+                        },
+                        mainThreadExecutor)
+                .join();
+
+        return scheduler;
+    }
+
+    private void triggerExceptionAndComplete(DefaultScheduler scheduler, JobVertex upstream)
+            throws TimeoutException {
+
+        final Throwable t = new Exception();
+        final ExecutionGraph executionGraph = scheduler.getExecutionGraph();
+
+        CompletableFuture.runAsync(
+                        () -> {
+                            // Trigger a failover
+                            scheduler.handleGlobalFailure(t);
+                            // Finish the cancellation of downstream tasks and restart tasks
+                            for (ExecutionVertex ev : executionGraph.getAllExecutionVertices()) {
+                                ev.getCurrentExecutionAttempt().completeCancelling();
+                            }
+                        },
+                        mainThreadExecutor)
+                .join();
+
+        // Wait until all the upstream vertices finish restarting
+        for (ExecutionVertex ev :
+                Objects.requireNonNull(executionGraph.getJobVertex(upstream.getID()))
+                        .getTaskVertices()) {
+            ExecutionGraphTestUtils.waitUntilExecutionVertexState(
+                    ev, ExecutionState.DEPLOYING, 1000);
+        }
+    }
+
+    // ============== Utils ==============
+
+    private static JobVertex createJobVertex(String vertexName, int parallelism) {
+        JobVertex jobVertex = new JobVertex(vertexName);
+        jobVertex.setParallelism(parallelism);
+        jobVertex.setInvokableClass(AbstractInvokable.class);
+        return jobVertex;
+    }
+
+    private static DefaultScheduler createScheduler(
+            final List<JobVertex> jobVertices, final ComponentMainThreadExecutor mainThreadExecutor)
+            throws Exception {
+        final JobGraph jobGraph =
+                JobGraphBuilder.newBatchJobGraphBuilder().addJobVertices(jobVertices).build();
+
+        return SchedulerTestingUtils.newSchedulerBuilder(jobGraph, mainThreadExecutor)
+                .setRestartBackoffTimeStrategy(new TestRestartBackoffTimeStrategy(true, 0))
+                .build();
+    }
+
+    private static void deployTasks(
+            ExecutionGraph executionGraph,
+            JobVertexID jobVertexID,
+            TestingLogicalSlotBuilder slotBuilder)
+            throws JobException, ExecutionException, InterruptedException {
+
+        for (ExecutionVertex vertex :
+                Objects.requireNonNull(executionGraph.getJobVertex(jobVertexID))
+                        .getTaskVertices()) {
+            LogicalSlot slot = slotBuilder.createTestingLogicalSlot();
+
+            Execution execution = vertex.getCurrentExecutionAttempt();
+            execution.registerProducedPartitions(slot.getTaskManagerLocation(), true).get();
+
+            vertex.tryAssignResource(slot);
+            vertex.deploy();
+        }
+    }
+
+    private static void transitionTasksToFinished(
+            ExecutionGraph executionGraph, JobVertexID jobVertexID) {
+
+        for (ExecutionVertex vertex :
+                Objects.requireNonNull(executionGraph.getJobVertex(jobVertexID))
+                        .getTaskVertices()) {
+            executionGraph.updateState(
+                    new TaskExecutionStateTransition(
+                            new TaskExecutionState(
+                                    vertex.getCurrentExecutionAttempt().getAttemptId(),
+                                    ExecutionState.FINISHED)));
+        }
+    }
+
+    private static SerializedValue<ShuffleDescriptor[]> getConsumedCachedShuffleDescriptor(
+            ExecutionGraph executionGraph, JobVertex vertex) {
+
+        final ExecutionJobVertex ejv = executionGraph.getJobVertex(vertex.getID());
+        final List<IntermediateResult> consumedResults = Objects.requireNonNull(ejv).getInputs();
+        final IntermediateResult consumedResult = consumedResults.get(0);
+
+        return consumedResult.getCachedShuffleDescriptors(
+                ejv.getTaskVertices()[0].getConsumedPartitionGroup(0));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -934,7 +934,8 @@ public class SingleInputGateTest extends InputGateTestBase {
     private static Map<InputGateID, SingleInputGate> createInputGateWithLocalChannels(
             NettyShuffleEnvironment network,
             int numberOfGates,
-            @SuppressWarnings("SameParameterValue") int numberOfLocalChannels) {
+            @SuppressWarnings("SameParameterValue") int numberOfLocalChannels)
+            throws IOException {
         ShuffleDescriptor[] channelDescs = new NettyShuffleDescriptor[numberOfLocalChannels];
         for (int i = 0; i < numberOfLocalChannels; i++) {
             channelDescs[i] =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -69,6 +69,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -926,6 +927,12 @@ public class ExecutingTest extends TestLogger {
         @Override
         public IntermediateResultPartition getResultPartitionOrThrow(
                 IntermediateResultPartitionID id) {
+            throw new UnsupportedOperationException(
+                    "This method is not supported by the MockInternalExecutionGraphAccessor.");
+        }
+
+        @Override
+        public void deleteBlobs(List<PermanentBlobKey> blobKeys) {
             throw new UnsupportedOperationException(
                     "This method is not supported by the MockInternalExecutionGraphAccessor.");
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -131,7 +132,8 @@ public class NettyShuffleUtilsTest extends TestLogger {
     private SingleInputGate createInputGate(
             NettyShuffleEnvironment network,
             ResultPartitionType resultPartitionType,
-            int numInputChannels) {
+            int numInputChannels)
+            throws IOException {
 
         ShuffleDescriptor[] shuffleDescriptors = new NettyShuffleDescriptor[numInputChannels];
         for (int i = 0; i < numInputChannels; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -234,7 +235,8 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
     }
 
     private InputGateDeploymentDescriptor createInputGateDeploymentDescriptor(
-            TaskManagerLocation senderLocation, int gateIndex, ResourceID localLocation) {
+            TaskManagerLocation senderLocation, int gateIndex, ResourceID localLocation)
+            throws IOException {
 
         final ShuffleDescriptor[] channelDescriptors = new ShuffleDescriptor[channels];
         for (int channelIndex = 0; channelIndex < channels; ++channelIndex) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request is the second part of optimizing the deployment of tasks. In this pull request, we propose to distribute the cached ShuffleDescriptors via the blob server if their overall size has exceeded the threshold. For more details please check FLINK-23218. The first part of the optimization is located at #16314.*

*In this pull request we remove the cache from blob server on JobManager once it's no longer required. To remove the cache from the blob cache located on TaskManager, please check #16498.*

## Brief change log

  - *The cached ShuffleDescriptors are stored in the blob server if its size exceeded the threshold.*
  - *The cached ShuffleDescriptors will be removed from the blob server once it's no longer used on JobManager.*
  - *TaskManagers can retrieve the ShuffleDescriptors from the blob cache.*

## Verifying this change

  - *Added unit tests to test the ShuffleDescriptors are cached and removed correctly.*
  - *Added unit tests to verify that deleting files on blob server works as expected.*
  - *Manually verified the change by running an end-to-end test. The job has two JobVertices. One is source, while the other is sink. The parallelism is 8k and 16k. They are connected with an all-to-all edge. Both streaming mode and batch mode are tested.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
