### PR TITLE
[FLINK-23352][streaming-java] Add configuration for batch size and socket timeout of collect sink

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -280,7 +280,8 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
                                 + "but max bytes per batch is only "
                                 + maxBytesPerBatch
                                 + " bytes. "
-                                + "Please consider increasing max bytes per batch value.");
+                                + "Please consider increasing max bytes per batch value by setting "
+                                + CollectSinkOperatorFactory.MAX_BATCH_SIZE.key());
             }
 
             if (currentBufferBytes + invokingRecordBytes > bufferSizeLimitBytes) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -192,7 +192,8 @@ abstract class PlannerBase(
 
       case collectModifyOperation: CollectModifyOperation =>
         val input = getRelBuilder.queryOperation(modifyOperation.getChild).build()
-        DynamicSinkUtils.convertCollectToRel(getRelBuilder, input, collectModifyOperation)
+        DynamicSinkUtils.convertCollectToRel(
+          getRelBuilder, input, collectModifyOperation, getTableConfig.getConfiguration)
 
       case catalogSink: CatalogSinkModifyOperation =>
         val input = getRelBuilder.queryOperation(modifyOperation.getChild).build()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
@@ -92,7 +92,9 @@ class TableSinkITCase extends BatchTestBase {
       case e: Exception =>
         MatcherAssert.assertThat(
           e,
-          FlinkMatchers.containsMessage("Record size is too large for CollectSinkFunction"))
+          FlinkMatchers.containsMessage(
+            "Please consider increasing max bytes per batch value " +
+              "by setting collect-sink.batch-size.max"))
     }
 
     tEnv.getConfig.getConfiguration.set(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
@@ -83,7 +83,8 @@ class TableSinkITCase extends BatchTestBase {
 
   @Test
   def testCollectSinkConfiguration(): Unit = {
-    tEnv.getConfig.getConfiguration.set(CollectSinkOperatorFactory.MAX_BATCH_SIZE, MemorySize.parse("1b"))
+    tEnv.getConfig.getConfiguration.set(
+      CollectSinkOperatorFactory.MAX_BATCH_SIZE, MemorySize.parse("1b"))
     try {
       checkResult("SELECT 1", Seq(row(1)))
       Assert.fail("Expecting exception thrown from collect sink")
@@ -94,7 +95,8 @@ class TableSinkITCase extends BatchTestBase {
           FlinkMatchers.containsMessage("Record size is too large for CollectSinkFunction"))
     }
 
-    tEnv.getConfig.getConfiguration.set(CollectSinkOperatorFactory.MAX_BATCH_SIZE, MemorySize.parse("1kb"))
+    tEnv.getConfig.getConfiguration.set(
+      CollectSinkOperatorFactory.MAX_BATCH_SIZE, MemorySize.parse("1kb"))
     checkResult("SELECT 1", Seq(row(1)))
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
@@ -18,12 +18,17 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
+import org.apache.flink.configuration.MemorySize
+import org.apache.flink.core.testutils.FlinkMatchers
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory
 import org.apache.flink.table.api.config.TableConfigOptions
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils.TestData.smallData3
 import org.apache.flink.table.planner.runtime.utils.{BatchAbstractTestBase, BatchTestBase}
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.utils.TableTestUtil
 
+import org.hamcrest.MatcherAssert
 import org.junit.{Assert, Test}
 
 class TableSinkITCase extends BatchTestBase {
@@ -76,4 +81,20 @@ class TableSinkITCase extends BatchTestBase {
     Assert.assertEquals(expected.sorted, result2.sorted)
   }
 
+  @Test
+  def testCollectSinkConfiguration(): Unit = {
+    tEnv.getConfig.getConfiguration.set(CollectSinkOperatorFactory.MAX_BATCH_SIZE, MemorySize.parse("1b"))
+    try {
+      checkResult("SELECT 1", Seq(row(1)))
+      Assert.fail("Expecting exception thrown from collect sink")
+    } catch {
+      case e: Exception =>
+        MatcherAssert.assertThat(
+          e,
+          FlinkMatchers.containsMessage("Record size is too large for CollectSinkFunction"))
+    }
+
+    tEnv.getConfig.getConfiguration.set(CollectSinkOperatorFactory.MAX_BATCH_SIZE, MemorySize.parse("1kb"))
+    checkResult("SELECT 1", Seq(row(1)))
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Collect sink has a batch size which is currently not configurable. By the user request in FLINK-23352 we're making it configurable in this PR to support user with super large row size.

Note that these configuration are only available for table APIs. As we cannot read user config in data stream API, data stream users will have to write their own Java code to create collect sink explicitly if they want to configure these.

## Brief change log

 - Add configuration for batch size and socket timeout of collect sink

## Verifying this change

This change added tests and can be verified by running the added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
