### PR TITLE
[FLINK-23429][state-processor-api] Use Path instead of Path.getPath()…

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/FileCopyFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/FileCopyFunction.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 /** This output format copies files from an existing savepoint into a new directory. */
 @Internal
-public final class FileCopyFunction implements OutputFormat<String> {
+public final class FileCopyFunction implements OutputFormat<Path> {
 
     private static final long serialVersionUID = 1L;
 
@@ -52,8 +52,7 @@ public final class FileCopyFunction implements OutputFormat<String> {
     }
 
     @Override
-    public void writeRecord(String record) throws IOException {
-        Path sourcePath = new Path(record);
+    public void writeRecord(Path sourcePath) throws IOException {
         Path destPath = new Path(path, sourcePath.getName());
         try (FSDataOutputStream os =
                         destPath.getFileSystem()

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/StatePathExtractor.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/StatePathExtractor.java
@@ -34,18 +34,18 @@ import javax.annotation.Nullable;
 
 /** Extracts all file paths that are part of the provided {@link OperatorState}. */
 @Internal
-public class StatePathExtractor implements FlatMapFunction<OperatorState, String> {
+public class StatePathExtractor implements FlatMapFunction<OperatorState, Path> {
 
     private static final long serialVersionUID = 1L;
 
     @Override
-    public void flatMap(OperatorState operatorState, Collector<String> out) throws Exception {
+    public void flatMap(OperatorState operatorState, Collector<Path> out) throws Exception {
         for (OperatorSubtaskState subTaskState : operatorState.getSubtaskStates().values()) {
             // managed operator state
             for (OperatorStateHandle operatorStateHandle : subTaskState.getManagedOperatorState()) {
                 Path path = getStateFilePathFromStreamStateHandle(operatorStateHandle);
                 if (path != null) {
-                    out.collect(path.getPath());
+                    out.collect(path);
                 }
             }
             // managed keyed state
@@ -55,7 +55,7 @@ public class StatePathExtractor implements FlatMapFunction<OperatorState, String
                             getStateFilePathFromStreamStateHandle(
                                     (KeyGroupsStateHandle) keyedStateHandle);
                     if (path != null) {
-                        out.collect(path.getPath());
+                        out.collect(path);
                     }
                 }
             }
@@ -63,7 +63,7 @@ public class StatePathExtractor implements FlatMapFunction<OperatorState, String
             for (OperatorStateHandle operatorStateHandle : subTaskState.getRawOperatorState()) {
                 Path path = getStateFilePathFromStreamStateHandle(operatorStateHandle);
                 if (path != null) {
-                    out.collect(path.getPath());
+                    out.collect(path);
                 }
             }
             // raw keyed state
@@ -73,7 +73,7 @@ public class StatePathExtractor implements FlatMapFunction<OperatorState, String
                             getStateFilePathFromStreamStateHandle(
                                     (KeyGroupsStateHandle) keyedStateHandle);
                     if (path != null) {
-                        out.collect(path.getPath());
+                        out.collect(path);
                     }
                 }
             }


### PR DESCRIPTION
… to preserve FileSystem info

## What is the purpose of the change

Fix an FileNotFoundException in State Processor API when working with savepoints on cloud storage

## Brief change log

- Use Path instead of a String Path.getPath() in StatePathExtractor to preserve FileSystem info such that FileCopyFunction can copy files even if they are on cloud storage.


## Verifying this change

I've tested this fix with Azure blob storage and AWS S3. 

This change added tests and can be verified as follows:

- Manually create an S3 bucket or an Azure blob container
- Configure a Flink cluster with s3-fs-presto or azure-fs-haoop plugin enabled
- Start a Flink a job and create a savepoint on S3/azure
- Use state processor API to transform the savepoint to a new one and store it in a new location on S3/azure
- There should not FileNotFoundException

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
