### PR TITLE
[FLINK-23417][tests] Harden MiniClusterITCase.testHandleBatchJobsWhenNotEnoughSlot

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>resourcemanager.standalone.start-up-time</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Long</td>
-            <td>Time in milliseconds of the start-up period of a standalone cluster. During this time, resource manager of the standalone cluster expects new task executors to be registered, and will not fail slot requests that can not be satisfied by any current registered slots. After this time, it will fail pending and new coming requests immediately that can not be satisfied by registered slots. If not set, 'slotmanager.request-timeout' will be used by default.</td>
+            <td>Time in milliseconds of the start-up period of a standalone cluster. During this time, resource manager of the standalone cluster expects new task executors to be registered, and will not fail slot requests that can not be satisfied by any current registered slots. After this time, it will fail pending and new coming requests immediately that can not be satisfied by registered slots. If not set, <span markdown="span">`slot.request.timeout`</span> will be used by default.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.taskmanager-timeout</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.TextElement;
 
 /** The set of configuration options relating to the ResourceManager. */
 @PublicEvolving
@@ -99,13 +100,19 @@ public class ResourceManagerOptions {
      */
     public static final ConfigOption<Long> STANDALONE_CLUSTER_STARTUP_PERIOD_TIME =
             ConfigOptions.key("resourcemanager.standalone.start-up-time")
+                    .longType()
                     .defaultValue(-1L)
                     .withDescription(
-                            "Time in milliseconds of the start-up period of a standalone cluster. During this time, "
-                                    + "resource manager of the standalone cluster expects new task executors to be registered, and will not "
-                                    + "fail slot requests that can not be satisfied by any current registered slots. After this time, it will "
-                                    + "fail pending and new coming requests immediately that can not be satisfied by registered slots. If not "
-                                    + "set, 'slotmanager.request-timeout' will be used by default.");
+                            Description.builder()
+                                    .text(
+                                            "Time in milliseconds of the start-up period of a standalone cluster. During this time, "
+                                                    + "resource manager of the standalone cluster expects new task executors to be registered, and will not "
+                                                    + "fail slot requests that can not be satisfied by any current registered slots. After this time, it will "
+                                                    + "fail pending and new coming requests immediately that can not be satisfied by registered slots. If not "
+                                                    + "set, %s will be used by default.",
+                                            TextElement.code(
+                                                    JobManagerOptions.SLOT_REQUEST_TIMEOUT.key()))
+                                    .build());
 
     /**
      * The timeout for an idle task manager to be released, in milliseconds.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -159,6 +160,8 @@ public class MiniClusterITCase extends TestLogger {
     private void runHandleJobsWhenNotEnoughSlots(final JobGraph jobGraph) throws Exception {
         final Configuration configuration = getDefaultConfiguration();
         configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 100L);
+        configuration.setLong(
+                ResourceManagerOptions.STANDALONE_CLUSTER_STARTUP_PERIOD_TIME, 10000L);
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()


### PR DESCRIPTION
This commit hardens the MiniClusterITCase.testHandleBatchJobsWhenNotEnoughSlot by configuring
a higher ResourceManagerOptions.STANDALONE_CLUSTER_STARTUP_PERIOD_TIME than JobManagerOptions.
SLOT_REQUEST_TIMEOUT. This ensures that the slot request times out instead of being failed by
the SlotManager.