### PR TITLE
[FLINK-23217][table-planner] Support StreamExecValues json serialization/deserialization

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecValues.java
@@ -31,6 +31,6 @@ import java.util.List;
 public class BatchExecValues extends CommonExecValues implements BatchExecNode<RowData> {
 
     public BatchExecValues(List<List<RexLiteral>> tuples, RowType outputType, String description) {
-        super(tuples, outputType, description);
+        super(tuples, getNewNodeId(), outputType, description);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecValues.java
@@ -23,14 +23,28 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecValues;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.apache.calcite.rex.RexLiteral;
 
 import java.util.List;
 
 /** Stream {@link ExecNode} that read records from given values. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamExecValues extends CommonExecValues implements StreamExecNode<RowData> {
 
     public StreamExecValues(List<List<RexLiteral>> tuples, RowType outputType, String description) {
-        super(tuples, outputType, description);
+        this(tuples, getNewNodeId(), outputType, description);
+    }
+
+    @JsonCreator
+    public StreamExecValues(
+            @JsonProperty(FIELD_NAME_TUPLES) List<List<RexLiteral>> tuples,
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(tuples, id, outputType, description);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/JsonSerdeCoverageTest.java
@@ -45,8 +45,7 @@ public class JsonSerdeCoverageTest {
                     "StreamExecGroupTableAggregate",
                     "StreamExecPythonGroupTableAggregate",
                     "StreamExecSort",
-                    "StreamExecMultipleInput",
-                    "StreamExecValues");
+                    "StreamExecMultipleInput");
 
     @SuppressWarnings({"rawtypes"})
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.stream;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.utils.StreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Test json serialization/deserialization for values. */
+public class ValuesJsonPlanTest extends TableTestBase {
+
+    private StreamTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void setup() {
+        util = streamTestUtil(TableConfig.getDefault());
+        tEnv = util.getTableEnv();
+        String sinkTableDdl =
+                "CREATE TABLE MySink (\n"
+                        + "  a BIGINT,\n"
+                        + "  b BIGINT not null,\n"
+                        + "  c VARCHAR\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'sink-insert-only' = 'false',\n"
+                        + "  'table-sink-class' = 'DEFAULT')";
+        tEnv.executeSql(sinkTableDdl);
+    }
+
+    @Test
+    public void testValues() {
+        util.verifyJsonPlan("INSERT INTO MySink SELECT * FROM (VALUES (1, 2, 'Hi'))");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest.java
@@ -50,6 +50,7 @@ public class ValuesJsonPlanTest extends TableTestBase {
 
     @Test
     public void testValues() {
-        util.verifyJsonPlan("INSERT INTO MySink SELECT * FROM (VALUES (1, 2, 'Hi'))");
+        util.verifyJsonPlan(
+                "INSERT INTO MySink SELECT * FROM (VALUES (1, 2, 'Hi'), (3, 4, 'Hello'))");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
@@ -1,0 +1,42 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/** Test for values json plan. */
+public class ValuesJsonPlanITCase extends JsonPlanTestBase {
+
+    @Test
+    public void testValues() throws Exception {
+        createTestValuesSinkTable("MySink", "b INT", "a INT", "c VARCHAR");
+        String jsonPlan =
+                tableEnv.getJsonPlan("INSERT INTO MySink SELECT * from (VALUES (1, 2, 'Hi'))");
+        tableEnv.executeJsonPlan(jsonPlan).await();
+
+        List<String> result = TestValuesTableFactory.getResults("MySink");
+        assertResult(Arrays.asList("+I[1, 2, Hi]"), result);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/ValuesJsonPlanITCase.java
@@ -33,10 +33,11 @@ public class ValuesJsonPlanITCase extends JsonPlanTestBase {
     public void testValues() throws Exception {
         createTestValuesSinkTable("MySink", "b INT", "a INT", "c VARCHAR");
         String jsonPlan =
-                tableEnv.getJsonPlan("INSERT INTO MySink SELECT * from (VALUES (1, 2, 'Hi'))");
+                tableEnv.getJsonPlan(
+                        "INSERT INTO MySink SELECT * from (VALUES (1, 2, 'Hi'), (3, 4, 'Hello'))");
         tableEnv.executeJsonPlan(jsonPlan).await();
 
         List<String> result = TestValuesTableFactory.getResults("MySink");
-        assertResult(Arrays.asList("+I[1, 2, Hi]"), result);
+        assertResult(Arrays.asList("+I[1, 2, Hi]", "+I[3, 4, Hello]"), result);
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest_jsonplan/testValues.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest_jsonplan/testValues.out
@@ -1,0 +1,182 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecValues",
+    "tuples" : [ [ {
+      "kind" : "LITERAL",
+      "value" : "1",
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "LITERAL",
+      "value" : "2",
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "LITERAL",
+      "value" : "Hi",
+      "type" : {
+        "typeName" : "CHAR",
+        "nullable" : false,
+        "precision" : 2
+      }
+    } ] ],
+    "id" : 1,
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "EXPR$0" : "INT NOT NULL"
+      }, {
+        "EXPR$1" : "INT NOT NULL"
+      }, {
+        "EXPR$2" : "CHAR(2) NOT NULL"
+      } ]
+    },
+    "description" : "Values(tuples=[[{ 1, 2, _UTF-16LE'Hi' }]])",
+    "inputProperties" : [ ]
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
+    "projection" : [ {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "CAST",
+        "kind" : "CAST",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 0,
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "CAST",
+        "kind" : "CAST",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 1,
+        "type" : {
+          "typeName" : "INTEGER",
+          "nullable" : false
+        }
+      } ],
+      "type" : {
+        "typeName" : "BIGINT",
+        "nullable" : true
+      }
+    }, {
+      "kind" : "REX_CALL",
+      "operator" : {
+        "name" : "CAST",
+        "kind" : "CAST",
+        "syntax" : "SPECIAL"
+      },
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 2,
+        "type" : {
+          "typeName" : "CHAR",
+          "nullable" : false,
+          "precision" : 2
+        }
+      } ],
+      "type" : {
+        "typeName" : "VARCHAR",
+        "nullable" : true,
+        "precision" : 2147483647
+      }
+    } ],
+    "condition" : null,
+    "id" : 2,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
+    "description" : "Calc(select=[CAST(EXPR$0) AS a, CAST(EXPR$1) AS b, CAST(EXPR$2) AS c])"
+  }, {
+    "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink",
+    "dynamicTableSink" : {
+      "identifier" : {
+        "catalogName" : "default_catalog",
+        "databaseName" : "default_database",
+        "tableName" : "MySink"
+      },
+      "catalogTable" : {
+        "sink-insert-only" : "false",
+        "table-sink-class" : "DEFAULT",
+        "schema.2.data-type" : "VARCHAR(2147483647)",
+        "connector" : "values",
+        "schema.0.data-type" : "BIGINT",
+        "schema.2.name" : "c",
+        "schema.1.name" : "b",
+        "schema.0.name" : "a",
+        "schema.1.data-type" : "BIGINT NOT NULL"
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "id" : 3,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : {
+      "type" : "ROW",
+      "nullable" : true,
+      "fields" : [ {
+        "a" : "BIGINT"
+      }, {
+        "b" : "BIGINT"
+      }, {
+        "c" : "VARCHAR(2147483647)"
+      } ]
+    },
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest_jsonplan/testValues.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ValuesJsonPlanTest_jsonplan/testValues.out
@@ -24,6 +24,28 @@
         "nullable" : false,
         "precision" : 2
       }
+    } ], [ {
+      "kind" : "LITERAL",
+      "value" : "3",
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "LITERAL",
+      "value" : "4",
+      "type" : {
+        "typeName" : "INTEGER",
+        "nullable" : false
+      }
+    }, {
+      "kind" : "LITERAL",
+      "value" : "Hello",
+      "type" : {
+        "typeName" : "CHAR",
+        "nullable" : false,
+        "precision" : 5
+      }
     } ] ],
     "id" : 1,
     "outputType" : {
@@ -34,10 +56,10 @@
       }, {
         "EXPR$1" : "INT NOT NULL"
       }, {
-        "EXPR$2" : "CHAR(2) NOT NULL"
+        "EXPR$2" : "VARCHAR(5) NOT NULL"
       } ]
     },
-    "description" : "Values(tuples=[[{ 1, 2, _UTF-16LE'Hi' }]])",
+    "description" : "Values(tuples=[[{ 1, 2, _UTF-16LE'Hi' }, { 3, 4, _UTF-16LE'Hello' }]])",
     "inputProperties" : [ ]
   }, {
     "class" : "org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc",
@@ -90,9 +112,9 @@
         "kind" : "INPUT_REF",
         "inputIndex" : 2,
         "type" : {
-          "typeName" : "CHAR",
+          "typeName" : "VARCHAR",
           "nullable" : false,
-          "precision" : 2
+          "precision" : 5
         }
       } ],
       "type" : {


### PR DESCRIPTION
## What is the purpose of the change

Support StreamExecValues json serialization/deserialization

## Brief change log

  - *Support StreamExecValues json serialization/deserialization*

## Verifying this change

This change added tests and can be verified as follows:

  - Added test `ValuesJsonPlanTest.java` to ensure the plan as expected
  - Added test `ValuesJsonPlanITCase.java` that validates that serialized exec node can be executed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
