### PR TITLE
[FLINK-23441] Remove CheckpointOptions from Snapshotable#snapshot

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
@@ -46,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Base implementation of KeyedStateBackend. The state can be checkpointed to streams using {@link
- * #snapshot(long, long, CheckpointStreamFactory, CheckpointOptions)}.
+ * #snapshot(long, long, CheckpointStreamFactory, CheckpointType)}.
  *
  * @param <K> Type of the key by which state is keyed.
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
 
@@ -225,10 +225,10 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions)
+            @Nonnull CheckpointType checkpointType)
             throws Exception {
         return snapshotStrategyRunner.snapshot(
-                checkpointId, timestamp, streamFactory, checkpointOptions);
+                checkpointId, timestamp, streamFactory, checkpointType);
     }
 
     private <S> ListState<S> getListState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 
 import javax.annotation.Nonnull;
@@ -104,7 +104,7 @@ class DefaultOperatorStateBackendSnapshotStrategy
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions) {
+            @Nonnull CheckpointType checkpointType) {
 
         Map<String, PartitionableListState<?>> registeredOperatorStatesDeepCopies =
                 syncPartResource.getRegisteredOperatorStatesDeepCopies();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -137,7 +137,7 @@ public interface KeyedStateBackend<K>
      */
     boolean deregisterKeySelectionListener(KeySelectionListener<K> listener);
 
-    default boolean isStateImmutableInStateBackend(CheckpointType checkpointOptions) {
+    default boolean isStateImmutableInStateBackend(CheckpointType checkpointType) {
         return false;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SavepointSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SavepointSnapshotStrategy.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -63,7 +62,7 @@ public class SavepointSnapshotStrategy<K>
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions) {
+            @Nonnull CheckpointType checkpointType) {
 
         if (savepointResources.getMetaInfoSnapshots().isEmpty()) {
             if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategy.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.Nonnull;
@@ -57,7 +57,7 @@ public interface SnapshotStrategy<S extends StateObject, SR extends SnapshotReso
      * @param checkpointId The ID of the checkpoint.
      * @param timestamp The timestamp of the checkpoint.
      * @param streamFactory The factory that we can use for writing our state to streams.
-     * @param checkpointOptions Options for how to perform this checkpoint.
+     * @param checkpointType Checkpoint Type to snapshot.
      * @return A supplier that will yield a {@link StateObject}.
      */
     SnapshotResultSupplier<S> asyncSnapshot(
@@ -65,7 +65,7 @@ public interface SnapshotStrategy<S extends StateObject, SR extends SnapshotReso
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions);
+            @Nonnull CheckpointType checkpointType);
 
     /**
      * A supplier for a {@link SnapshotResult} with an access to a {@link CloseableRegistry} for io

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategyRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategyRunner.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,18 +71,14 @@ public final class SnapshotStrategyRunner<T extends StateObject, SR extends Snap
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions)
+            @Nonnull CheckpointType checkpointType)
             throws Exception {
         long startTime = System.currentTimeMillis();
         SR snapshotResources = snapshotStrategy.syncPrepareResources(checkpointId);
         logCompletedInternal(LOG_SYNC_COMPLETED_TEMPLATE, streamFactory, startTime);
         SnapshotStrategy.SnapshotResultSupplier<T> asyncSnapshot =
                 snapshotStrategy.asyncSnapshot(
-                        snapshotResources,
-                        checkpointId,
-                        timestamp,
-                        streamFactory,
-                        checkpointOptions);
+                        snapshotResources, checkpointId, timestamp, streamFactory, checkpointType);
 
         FutureTask<SnapshotResult<T>> asyncSnapshotTask =
                 new AsyncSnapshotCallable<SnapshotResult<T>>() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/Snapshotable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/Snapshotable.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 
 import javax.annotation.Nonnull;
 
@@ -48,7 +48,7 @@ public interface Snapshotable<S extends StateObject> {
      * @param checkpointId The ID of the checkpoint.
      * @param timestamp The timestamp of the checkpoint.
      * @param streamFactory The factory that we can use for writing our state to streams.
-     * @param checkpointOptions Options for how to perform this checkpoint.
+     * @param checkpointType checkpoint type
      * @return A runnable future that will yield a {@link StateObject}.
      */
     @Nonnull
@@ -56,6 +56,6 @@ public interface Snapshotable<S extends StateObject> {
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions)
+            @Nonnull CheckpointType checkpointType)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -28,7 +28,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -303,7 +303,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             final long checkpointId,
             final long timestamp,
             @Nonnull final CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions)
+            @Nonnull CheckpointType checkpointType)
             throws Exception {
 
         SnapshotStrategyRunner<KeyedStateHandle, ?> snapshotStrategyRunner =
@@ -313,7 +313,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                         cancelStreamRegistry,
                         snapshotExecutionType);
         return snapshotStrategyRunner.snapshot(
-                checkpointId, timestamp, streamFactory, checkpointOptions);
+                checkpointId, timestamp, streamFactory, checkpointType);
     }
 
     @Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -98,7 +98,7 @@ class HeapSnapshotStrategy<K>
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions) {
+            @Nonnull CheckpointType checkpointType) {
 
         List<StateMetaInfoSnapshot> metaInfoSnapshots = syncPartResource.getMetaInfoSnapshots();
         if (metaInfoSnapshots.isEmpty()) {
@@ -119,7 +119,7 @@ class HeapSnapshotStrategy<K>
         final SupplierWithException<CheckpointStreamWithResultProvider, Exception>
                 checkpointStreamSupplier =
                         localRecoveryConfig.isLocalRecoveryEnabled()
-                                        && !checkpointOptions.getCheckpointType().isSavepoint()
+                                        && !checkpointType.isSavepoint()
                                 ? () ->
                                         createDuplicatingStream(
                                                 checkpointId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
@@ -289,8 +289,7 @@ public class OperatorStateBackendTest {
 
         CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4096);
         RunnableFuture<SnapshotResult<OperatorStateHandle>> runnableFuture =
-                operatorStateBackend.snapshot(
-                        1, 1, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+                operatorStateBackend.snapshot(1, 1, streamFactory, CheckpointType.CHECKPOINT);
         FutureUtils.runIfNotDoneAndGet(runnableFuture);
 
         // make sure that the copy method has been called
@@ -412,11 +411,7 @@ public class OperatorStateBackendTest {
         CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4096);
 
         RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot =
-                operatorStateBackend.snapshot(
-                        0L,
-                        0L,
-                        streamFactory,
-                        CheckpointOptions.forCheckpointWithDefaultLocation());
+                operatorStateBackend.snapshot(0L, 0L, streamFactory, CheckpointType.CHECKPOINT);
 
         SnapshotResult<OperatorStateHandle> snapshotResult =
                 FutureUtils.runIfNotDoneAndGet(snapshot);
@@ -453,11 +448,7 @@ public class OperatorStateBackendTest {
 
         try {
             RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot =
-                    operatorStateBackend.snapshot(
-                            0L,
-                            0L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    operatorStateBackend.snapshot(0L, 0L, streamFactory, CheckpointType.CHECKPOINT);
 
             SnapshotResult<OperatorStateHandle> snapshotResult =
                     FutureUtils.runIfNotDoneAndGet(snapshot);
@@ -483,11 +474,7 @@ public class OperatorStateBackendTest {
             expected.remove(1);
 
             snapshot =
-                    operatorStateBackend.snapshot(
-                            1L,
-                            1L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    operatorStateBackend.snapshot(1L, 1L, streamFactory, CheckpointType.CHECKPOINT);
             snapshotResult = FutureUtils.runIfNotDoneAndGet(snapshot);
 
             stateHandle.discardState();
@@ -510,11 +497,7 @@ public class OperatorStateBackendTest {
             expected.clear();
 
             snapshot =
-                    operatorStateBackend.snapshot(
-                            2L,
-                            2L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    operatorStateBackend.snapshot(2L, 2L, streamFactory, CheckpointType.CHECKPOINT);
             snapshotResult = FutureUtils.runIfNotDoneAndGet(snapshot);
             if (stateHandle != null) {
                 stateHandle.discardState();
@@ -601,11 +584,7 @@ public class OperatorStateBackendTest {
 
         CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(2 * 4096);
         RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot =
-                operatorStateBackend.snapshot(
-                        1L,
-                        1L,
-                        streamFactory,
-                        CheckpointOptions.forCheckpointWithDefaultLocation());
+                operatorStateBackend.snapshot(1L, 1L, streamFactory, CheckpointType.CHECKPOINT);
 
         SnapshotResult<OperatorStateHandle> snapshotResult =
                 FutureUtils.runIfNotDoneAndGet(snapshot);
@@ -756,8 +735,7 @@ public class OperatorStateBackendTest {
         streamFactory.setBlockerLatch(blockerLatch);
 
         RunnableFuture<SnapshotResult<OperatorStateHandle>> runnableFuture =
-                operatorStateBackend.snapshot(
-                        1, 1, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+                operatorStateBackend.snapshot(1, 1, streamFactory, CheckpointType.CHECKPOINT);
 
         ExecutorService executorService = Executors.newFixedThreadPool(1);
 
@@ -910,8 +888,7 @@ public class OperatorStateBackendTest {
         streamFactory.setBlockerLatch(blockerLatch);
 
         RunnableFuture<SnapshotResult<OperatorStateHandle>> runnableFuture =
-                operatorStateBackend.snapshot(
-                        1, 1, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+                operatorStateBackend.snapshot(1, 1, streamFactory, CheckpointType.CHECKPOINT);
 
         ExecutorService executorService = Executors.newFixedThreadPool(1);
 
@@ -960,8 +937,7 @@ public class OperatorStateBackendTest {
         streamFactory.setBlockerLatch(blockerLatch);
 
         RunnableFuture<SnapshotResult<OperatorStateHandle>> runnableFuture =
-                operatorStateBackend.snapshot(
-                        1, 1, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+                operatorStateBackend.snapshot(1, 1, streamFactory, CheckpointType.CHECKPOINT);
 
         ExecutorService executorService = Executors.newFixedThreadPool(1);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -33,7 +33,7 @@ import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -177,11 +177,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -209,11 +205,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             // do another snapshot to verify the snapshot logic after migration
             snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    2L,
-                                    3L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(2L, 3L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             snapshot.discardState();
         } finally {
@@ -299,11 +291,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -340,11 +328,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             // do another snapshot to verify the snapshot logic after migration
             snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    2L,
-                                    3L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(2L, 3L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             snapshot.discardState();
 
@@ -447,11 +431,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -509,11 +489,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             // do another snapshot to verify the snapshot logic after migration
             snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    2L,
-                                    3L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(2L, 3L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             snapshot.discardState();
 
@@ -544,11 +520,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -632,11 +604,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -655,11 +623,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             // do another snapshot to verify the snapshot logic after migration
             snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    2L,
-                                    3L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(2L, 3L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             snapshot.discardState();
         } finally {
@@ -737,11 +701,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
 
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // test incompatible namespace serializer; start with a freshly restored backend
@@ -764,11 +724,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             // do another snapshot to verify the snapshot logic after migration
             snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    2L,
-                                    3L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(2L, 3L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             snapshot.discardState();
         } finally {
@@ -840,12 +796,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             state.add(new TestType("bar", 278));
 
             OperatorStateHandle snapshot =
-                    runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()));
+                    runSnapshot(backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT));
             backend.dispose();
 
             backend = restoreOperatorStateBackend(snapshot);
@@ -926,12 +877,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             state.add(new TestType("bar", 278));
 
             OperatorStateHandle snapshot =
-                    runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()));
+                    runSnapshot(backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT));
             backend.dispose();
 
             backend = restoreOperatorStateBackend(snapshot);
@@ -1069,12 +1015,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             state.put(5, new TestType("bar", 278));
 
             OperatorStateHandle snapshot =
-                    runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()));
+                    runSnapshot(backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT));
             backend.dispose();
 
             backend = restoreOperatorStateBackend(snapshot);
@@ -1109,12 +1050,7 @@ public abstract class StateBackendMigrationTestBase<B extends AbstractStateBacke
             state.put(new TestType("bar", 278), 5);
 
             OperatorStateHandle snapshot =
-                    runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()));
+                    runSnapshot(backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT));
             backend.dispose();
 
             backend = restoreOperatorStateBackend(snapshot);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -56,7 +56,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -537,10 +537,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 // backends that lazily serializes (such as memory state backend) will fail here
                 runSnapshot(
                         backend.snapshot(
-                                682375462378L,
-                                2,
-                                streamFactory,
-                                CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                         sharedStateRegistry);
             } catch (ExpectedKryoTestException e) {
                 numExceptions++;
@@ -611,10 +608,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 // backends that lazily serializes (such as memory state backend) will fail here
                 runSnapshot(
                         backend.snapshot(
-                                682375462378L,
-                                2,
-                                streamFactory,
-                                CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                         sharedStateRegistry);
             } catch (ExpectedKryoTestException e) {
                 numExceptions++;
@@ -678,10 +672,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 // backends that lazily serializes (such as memory state backend) will fail here
                 runSnapshot(
                         backend.snapshot(
-                                682375462378L,
-                                2,
-                                streamFactory,
-                                CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                         sharedStateRegistry);
             } catch (ExpectedKryoTestException e) {
                 numExceptions++;
@@ -748,10 +739,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 // backends that lazily serializes (such as memory state backend) will fail here
                 runSnapshot(
                         backend.snapshot(
-                                682375462378L,
-                                2,
-                                streamFactory,
-                                CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                         sharedStateRegistry);
             } catch (ExpectedKryoTestException e) {
                 numExceptions++;
@@ -811,10 +799,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             IOUtils.closeQuietly(backend);
@@ -888,10 +873,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -921,10 +903,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot2 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             snapshot.discardState();
@@ -1013,10 +992,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -1044,10 +1020,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot2 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             snapshot.discardState();
@@ -1150,10 +1123,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -1204,11 +1174,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             // this tests backends that lazily serialize, such as memory state backend
             runSnapshot(
-                    backend.snapshot(
-                            682375462378L,
-                            2,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation()),
+                    backend.snapshot(682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                     sharedStateRegistry);
 
             snapshot.discardState();
@@ -1264,10 +1230,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -1303,11 +1266,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
             // this tests backends that lazily serialize, such as memory state backend
             runSnapshot(
-                    backend.snapshot(
-                            682375462378L,
-                            2,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation()),
+                    backend.snapshot(682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                     sharedStateRegistry);
 
             snapshot.discardState();
@@ -1379,10 +1338,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // make some more modifications
@@ -1397,10 +1353,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot2 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462379L,
-                                    4,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462379L, 4, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // validate the original state
@@ -1719,10 +1672,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -1811,10 +1761,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -1898,10 +1845,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // make some more modifications
@@ -1918,10 +1862,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot2 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462379L,
-                                    4,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462379L, 4, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // validate the original state
@@ -2460,10 +2401,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // make some more modifications
@@ -2478,10 +2416,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot2 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462379L,
-                                    4,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462379L, 4, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // validate the original state
@@ -3245,10 +3180,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // make some more modifications
@@ -3270,10 +3202,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot2 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462379L,
-                                    4,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462379L, 4, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             // validate the original state
@@ -3739,11 +3668,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             // take a snapshot, and then restore backend with snapshot
             KeyedStateHandle snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    1L,
-                                    2L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(1L, 2L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -3752,11 +3677,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             // now take a snapshot again without accessing the state
             snapshot =
                     runSnapshot(
-                            backend.snapshot(
-                                    2L,
-                                    3L,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                            backend.snapshot(2L, 3L, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             backend.dispose();
 
@@ -3900,11 +3821,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                 // snapshot
                 snapshots.add(
                         runSnapshot(
-                                backend.snapshot(
-                                        0,
-                                        0,
-                                        streamFactory,
-                                        CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                backend.snapshot(0, 0, streamFactory, CheckpointType.CHECKPOINT),
                                 sharedStateRegistry));
             } finally {
                 IOUtils.closeQuietly(backend);
@@ -3983,10 +3900,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
         } finally {
             IOUtils.closeQuietly(backend);
@@ -4030,10 +3944,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -4088,10 +3999,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -4148,10 +4056,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -4210,10 +4115,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot1 =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462378L,
-                                    2,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462378L, 2, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -4481,10 +4383,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462379L,
-                                    4,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462379L, 4, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
 
             backend.dispose();
@@ -4534,10 +4433,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             KeyedStateHandle snapshot =
                     runSnapshot(
                             backend.snapshot(
-                                    682375462379L,
-                                    1,
-                                    streamFactory,
-                                    CheckpointOptions.forCheckpointWithDefaultLocation()),
+                                    682375462379L, 1, streamFactory, CheckpointType.CHECKPOINT),
                             sharedStateRegistry);
             assertNull(snapshot);
             backend.dispose();
@@ -4637,11 +4533,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             }
 
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot1 =
-                    backend.snapshot(
-                            0L,
-                            0L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    backend.snapshot(0L, 0L, streamFactory, CheckpointType.CHECKPOINT);
 
             Thread runner1 = new Thread(snapshot1, "snapshot-1-runner");
             runner1.start();
@@ -4659,11 +4551,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             streamFactory.setBlockerLatch(null);
 
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot2 =
-                    backend.snapshot(
-                            1L,
-                            1L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    backend.snapshot(1L, 1L, streamFactory, CheckpointType.CHECKPOINT);
 
             Thread runner2 = new Thread(snapshot2, "snapshot-2-runner");
             runner2.start();
@@ -4724,11 +4612,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             }
 
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
-                    backend.snapshot(
-                            0L,
-                            0L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    backend.snapshot(0L, 0L, streamFactory, CheckpointType.CHECKPOINT);
             Thread runner = new Thread(snapshot);
             runner.start();
             for (int i = 0; i < 20; ++i) {
@@ -4948,11 +4832,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
             }
 
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
-                    backend.snapshot(
-                            0L,
-                            0L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    backend.snapshot(0L, 0L, streamFactory, CheckpointType.CHECKPOINT);
 
             Thread runner = new Thread(snapshot);
             runner.start();
@@ -5078,7 +4958,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                                         checkpointID++,
                                         System.currentTimeMillis(),
                                         streamFactory,
-                                        CheckpointOptions.forCheckpointWithDefaultLocation())));
+                                        CheckpointType.CHECKPOINT)));
             }
 
             for (Future future : futureList) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
@@ -151,11 +151,7 @@ public class StateSnapshotCompressionTest extends TestLogger {
             state.update("45");
             CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4 * 1024 * 1024);
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
-                    stateBackend.snapshot(
-                            0L,
-                            0L,
-                            streamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                    stateBackend.snapshot(0L, 0L, streamFactory, CheckpointType.CHECKPOINT);
             snapshot.run();
             SnapshotResult<KeyedStateHandle> snapshotResult = snapshot.get();
             stateHandle = snapshotResult.getJobManagerOwnedSnapshot();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.SingleThreadAccessCheckingTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
@@ -65,14 +65,11 @@ class StateSnapshotTransformerTest {
                 state.setToRandomValue();
             }
 
-            CheckpointOptions checkpointOptions =
-                    CheckpointOptions.forCheckpointWithDefaultLocation();
-
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot1 =
-                    backend.snapshot(1L, 0L, streamFactory, checkpointOptions);
+                    backend.snapshot(1L, 0L, streamFactory, CheckpointType.CHECKPOINT);
 
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot2 =
-                    backend.snapshot(2L, 0L, streamFactory, checkpointOptions);
+                    backend.snapshot(2L, 0L, streamFactory, CheckpointType.CHECKPOINT);
 
             Thread runner1 = new Thread(snapshot1, "snapshot1");
             runner1.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendSnapshotMigrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackendSnapshotMigrationTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.state.heap;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
@@ -122,7 +122,7 @@ public class HeapKeyedStateBackendSnapshotMigrationTest extends HeapStateBackend
                             1L,
                             1L,
                             new MemCheckpointStreamFactory(4 * 1024 * 1024),
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            CheckpointType.CHECKPOINT);
 
             snapshot.run();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -158,7 +158,10 @@ public abstract class StateBackendTestContext {
     RunnableFuture<SnapshotResult<KeyedStateHandle>> triggerSnapshot() throws Exception {
         RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshotRunnableFuture =
                 keyedStateBackend.snapshot(
-                        682375462392L, 10L, checkpointStreamFactory, checkpointOptions);
+                        682375462392L,
+                        10L,
+                        checkpointStreamFactory,
+                        checkpointOptions.getCheckpointType());
         if (!snapshotRunnableFuture.isDone()) {
             snapshotRunnableFuture.run();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockKeyedStateBackend.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -218,7 +218,7 @@ public class MockKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions) {
+            @Nonnull CheckpointType checkpointType) {
         return new FutureTask<>(
                 () ->
                         SnapshotResult.of(

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -312,7 +312,7 @@ public class ChangelogKeyedStateBackend<K>
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions)
+            @Nonnull CheckpointType checkpointType)
             throws Exception {
         // The range to upload may overlap with the previous one(s). To reuse them, we could store
         // the previous results either here in the backend or in the writer. However,
@@ -387,8 +387,8 @@ public class ChangelogKeyedStateBackend<K>
     }
 
     @Override
-    public boolean isStateImmutableInStateBackend(CheckpointType checkpointOptions) {
-        return keyedStateBackend.isStateImmutableInStateBackend(checkpointOptions);
+    public boolean isStateImmutableInStateBackend(CheckpointType checkpointType) {
+        return keyedStateBackend.isStateImmutableInStateBackend(checkpointType);
     }
 
     @Nonnull

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -35,7 +35,6 @@ import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersMana
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
@@ -527,7 +526,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
      * @param checkpointId The Id of the checkpoint.
      * @param timestamp The timestamp of the checkpoint.
      * @param streamFactory The factory that we can use for writing our state to streams.
-     * @param checkpointOptions Options for how to perform this checkpoint.
+     * @param checkpointType Checkpoint type for snapshot.
      * @return Future to the state handle of the snapshot data.
      * @throws Exception indicating a problem in the synchronous part of the checkpoint.
      */
@@ -537,7 +536,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
             final long checkpointId,
             final long timestamp,
             @Nonnull final CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions)
+            @Nonnull CheckpointType checkpointType)
             throws Exception {
 
         // flush everything into db before taking a snapshot
@@ -548,7 +547,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                         checkpointSnapshotStrategy,
                         cancelStreamRegistry,
                         ASYNCHRONOUS)
-                .snapshot(checkpointId, timestamp, streamFactory, checkpointOptions);
+                .snapshot(checkpointId, timestamp, streamFactory, checkpointType);
     }
 
     @Nonnull

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -24,7 +24,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBStateUploader;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -166,7 +166,7 @@ public class RocksIncrementalSnapshotStrategy<K>
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory checkpointStreamFactory,
-            @Nonnull CheckpointOptions checkpointOptions) {
+            @Nonnull CheckpointType checkpointType) {
 
         if (snapshotResources.stateMetaInfoSnapshots.isEmpty()) {
             if (LOG.isDebugEnabled()) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.ConfigurableStateBackend;
@@ -343,10 +343,7 @@ public class EmbeddedRocksDBStateBackendTest
         try {
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                     keyedStateBackend.snapshot(
-                            0L,
-                            0L,
-                            testStreamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            0L, 0L, testStreamFactory, CheckpointType.CHECKPOINT);
 
             RocksDB spyDB = keyedStateBackend.db;
 
@@ -385,10 +382,7 @@ public class EmbeddedRocksDBStateBackendTest
         try {
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                     keyedStateBackend.snapshot(
-                            0L,
-                            0L,
-                            testStreamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            0L, 0L, testStreamFactory, CheckpointType.CHECKPOINT);
             snapshot.cancel(true);
             verifyRocksObjectsReleased();
         } finally {
@@ -404,10 +398,7 @@ public class EmbeddedRocksDBStateBackendTest
         try {
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                     keyedStateBackend.snapshot(
-                            0L,
-                            0L,
-                            testStreamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            0L, 0L, testStreamFactory, CheckpointType.CHECKPOINT);
             snapshot.cancel(true);
             Thread asyncSnapshotThread = new Thread(snapshot);
             asyncSnapshotThread.start();
@@ -432,10 +423,7 @@ public class EmbeddedRocksDBStateBackendTest
         try {
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                     keyedStateBackend.snapshot(
-                            0L,
-                            0L,
-                            testStreamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            0L, 0L, testStreamFactory, CheckpointType.CHECKPOINT);
             Thread asyncSnapshotThread = new Thread(snapshot);
             asyncSnapshotThread.start();
             waiter.await(); // wait for snapshot to run
@@ -469,10 +457,7 @@ public class EmbeddedRocksDBStateBackendTest
         try {
             RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
                     keyedStateBackend.snapshot(
-                            0L,
-                            0L,
-                            testStreamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            0L, 0L, testStreamFactory, CheckpointType.CHECKPOINT);
             Thread asyncSnapshotThread = new Thread(snapshot);
             asyncSnapshotThread.start();
             waiter.await(); // wait for snapshot to run
@@ -564,7 +549,7 @@ public class EmbeddedRocksDBStateBackendTest
                                     checkpointId,
                                     checkpointId,
                                     createStreamFactory(),
-                                    CheckpointOptions.forCheckpointWithDefaultLocation());
+                                    CheckpointType.CHECKPOINT);
 
                     snapshot.run();
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -432,7 +433,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
                             checkpointId,
                             timestamp,
                             new TestCheckpointStreamFactory(() -> outputStream),
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            CheckpointType.CHECKPOINT);
 
             try {
                 FutureUtils.runIfNotDoneAndGet(snapshotFuture);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -224,7 +224,10 @@ public class StreamOperatorStateHandler {
             if (null != operatorStateBackend) {
                 snapshotInProgress.setOperatorStateManagedFuture(
                         operatorStateBackend.snapshot(
-                                checkpointId, timestamp, factory, checkpointOptions));
+                                checkpointId,
+                                timestamp,
+                                factory,
+                                checkpointOptions.getCheckpointType()));
             }
 
             if (null != keyedStateBackend) {
@@ -234,12 +237,18 @@ public class StreamOperatorStateHandler {
 
                     snapshotInProgress.setKeyedStateManagedFuture(
                             snapshotRunner.snapshot(
-                                    checkpointId, timestamp, factory, checkpointOptions));
+                                    checkpointId,
+                                    timestamp,
+                                    factory,
+                                    checkpointOptions.getCheckpointType()));
 
                 } else {
                     snapshotInProgress.setKeyedStateManagedFuture(
                             keyedStateBackend.snapshot(
-                                    checkpointId, timestamp, factory, checkpointOptions));
+                                    checkpointId,
+                                    timestamp,
+                                    factory,
+                                    checkpointOptions.getCheckpointType()));
                 }
             }
         } catch (Exception snapshotException) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -268,7 +268,7 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
             long checkpointId,
             long timestamp,
             @Nonnull CheckpointStreamFactory streamFactory,
-            @Nonnull CheckpointOptions checkpointOptions) {
+            @Nonnull CheckpointType checkpointType) {
         throw new UnsupportedOperationException(
                 "Snapshotting is not supported in BATCH runtime mode.");
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedureTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedureTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
@@ -93,10 +93,7 @@ public class BackendRestorerProcedureTest extends TestLogger {
 
             RunnableFuture<SnapshotResult<OperatorStateHandle>> snapshot =
                     originalBackend.snapshot(
-                            0L,
-                            0L,
-                            checkpointStreamFactory,
-                            CheckpointOptions.forCheckpointWithDefaultLocation());
+                            0L, 0L, checkpointStreamFactory, CheckpointType.CHECKPOINT);
 
             snapshot.run();
             snapshotResult = snapshot.get();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
@@ -19,7 +19,7 @@
 package org.apache.flink.streaming.api.operators.sorted.state;
 
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
@@ -49,10 +49,6 @@ public class BatchExecutionStateBackendVerificationTest extends TestLogger {
 
         long checkpointId = 0L;
         CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(10);
-        stateBackend.snapshot(
-                checkpointId,
-                0L,
-                streamFactory,
-                CheckpointOptions.forCheckpointWithDefaultLocation());
+        stateBackend.snapshot(checkpointId, 0L, streamFactory, CheckpointType.CHECKPOINT);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -302,7 +303,7 @@ public class StreamTaskTerminationTest extends TestLogger {
                             anyLong(),
                             anyLong(),
                             any(CheckpointStreamFactory.class),
-                            any(CheckpointOptions.class)))
+                            any(CheckpointType.class)))
                     .thenReturn(new FutureTask<>(new BlockingCallable()));
 
             return operatorStateBackend;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -325,7 +326,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
                                 long checkpointId,
                                 long timestamp,
                                 @Nonnull CheckpointStreamFactory streamFactory,
-                                @Nonnull CheckpointOptions checkpointOptions)
+                                @Nonnull CheckpointType checkpointType)
                                 throws Exception {
 
                             throw new Exception("Sync part snapshot exception.");
@@ -393,7 +394,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
                                     long checkpointId,
                                     long timestamp,
                                     @Nonnull CheckpointStreamFactory streamFactory,
-                                    @Nonnull CheckpointOptions checkpointOptions) {
+                                    @Nonnull CheckpointType checkpointType) {
                                 return (snapshotCloseableRegistry) -> {
                                     throw new Exception("Async part snapshot exception.");
                                 };

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureManager;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -158,7 +158,7 @@ public class CheckpointFailureManagerITCase extends TestLogger {
                                     long checkpointId,
                                     long timestamp,
                                     @Nonnull CheckpointStreamFactory streamFactory,
-                                    @Nonnull CheckpointOptions checkpointOptions) {
+                                    @Nonnull CheckpointType checkpointType) {
                                 return (closeableRegistry) -> {
                                     throw new Exception("Expected async snapshot exception.");
                                 };

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -34,8 +34,8 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.PerJobCheckpointRecoveryFactory;
@@ -338,7 +338,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
                 long checkpointId,
                 long timestamp,
                 @Nonnull CheckpointStreamFactory streamFactory,
-                @Nonnull CheckpointOptions checkpointOptions) {
+                @Nonnull CheckpointType checkpointType) {
             if (checkpointId == DECLINE_CHECKPOINT_ID) {
                 return (snapshotCloseableRegistry) -> {
                     throw new ExpectedTestException();

--- a/flink-tests/src/test/java/org/apache/flink/test/state/SavepointStateBackendSwitchTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/SavepointStateBackendSwitchTestBase.java
@@ -24,10 +24,8 @@ import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
-import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.FullSnapshotResources;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -241,9 +239,7 @@ public abstract class SavepointStateBackendSwitchTestBase {
                         0L,
                         0L,
                         new MemCheckpointStreamFactory(4 * 1024 * 1024),
-                        new CheckpointOptions(
-                                CheckpointType.SAVEPOINT,
-                                CheckpointStorageLocationReference.getDefault()));
+                        CheckpointType.SAVEPOINT);
 
         snapshot.run();
 


### PR DESCRIPTION
## What is the purpose of the change

CheckpointOptions contain many fields that are not related to the backend snapshot (materialization in changelog).

In the future, if we want to separate checkpointing away from materialization (conceptually, they are indeed two different pieces as well), we do not need to provide such CheckpointOptions for each snapshotting.

## Brief change log

- Remove CheckpointOptions from Snapshotable#snapshot
- For now, CheckpointType is the only info needed; in the future, CheckpointType can be removed as well, when materialization is entirely separated from checkpointing.

## Verifying this change

Existing Tests