### PR TITLE
[FLINK-23255][test] Introduce JUnit 5 dependencies

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -49,10 +49,10 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>compile</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-kafka-test_${scala.binary.version}</artifactId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -45,9 +45,8 @@ under the License.
 			<artifactId>flink-shaded-jackson</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
@@ -42,8 +42,9 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<!--using hbase shade jar to execute end-to-end test-->

--- a/flink-end-to-end-tests/flink-glue-schema-registry-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-test/pom.xml
@@ -181,8 +181,9 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -66,9 +66,8 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
 

--- a/flink-table/flink-sql-parser-hive/pom.xml
+++ b/flink-table/flink-sql-parser-hive/pom.xml
@@ -86,23 +86,6 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
-		<!-- Because Calcite tests use Junit5 and we extend from its SqlParserTest,
-			 we need the Junit5 runner. -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- As we switched to JUnit5 runner to use the Calcite tests infrastructure we need
-		 	 to add this dependency to make our own Junit4 tests compatible with the Junit5
-		 	 environment.-->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -187,23 +187,6 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
-		<!-- Because Calcite tests use Junit5 and we extend from its SqlParserTest,
-			 we need the Junit5 runner. -->
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- As we switched to JUnit5 runner to use the Calcite tests infrastructure we need
-		 	 to add this dependency to make our own Junit4 tests compatible with the Junit5
-		 	 environment.-->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -49,9 +49,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -53,5 +53,11 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -36,21 +36,23 @@ under the License.
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>compile</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<scope>compile</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -42,6 +42,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>compile</scope>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -79,9 +79,8 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>
 		</dependency>
 

--- a/flink-tests/src/test/java/org/apache/flink/test/junit5/JUnitJupiterTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/junit5/JUnitJupiterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.junit5;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** Temporary JUnit 5 tests for validating JUnit jupiter engine truly works. */
+public class JUnitJupiterTest {
+    @Test
+    @DisplayName("Assumption and Assertion Test")
+    public void assumptionAssertionTest() {
+        assumeTrue(true, "This case is absolutely true");
+        assertTrue(true, "This case is absolutely true");
+    }
+
+    @ParameterizedTest
+    @DisplayName("Parameterized Test")
+    @ValueSource(strings = {"racecar", "radar", "able was I ere I saw elba"})
+    public void parameterizedTest(String word) {
+        assertTrue(isPalindrome(word), "The string in parameter should be palindrome");
+    }
+
+    @TestFactory
+    @DisplayName("Dynamic Test")
+    Collection<DynamicTest> dynamicTest() {
+        String word = "madam";
+        String anotherWord = "flink";
+        return Arrays.asList(
+                DynamicTest.dynamicTest("1st dynamic test", () -> assertTrue(isPalindrome(word))),
+                DynamicTest.dynamicTest(
+                        "2nd dynamic test", () -> assertFalse(isPalindrome(anotherWord))));
+    }
+
+    private boolean isPalindrome(String word) {
+        return StringUtils.reverse(word).equals(word);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,8 @@ under the License.
 		<avro.version>1.10.0</avro.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
-		<junit.version>4.13.2</junit.version>
+		<junit4.version>4.13.2</junit4.version>
+		<junit5.version>5.7.2</junit5.version>
 		<mockito.version>2.21.0</mockito.version>
 		<powermock.version>2.0.4</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
@@ -185,11 +186,15 @@ under the License.
 		</dependency>
 
 		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<type>jar</type>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 
@@ -560,9 +565,17 @@ under the License.
 
 			<!-- For dependency convergence -->
 			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit5.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>${junit.version}</version>
+				<version>${junit4.version}</version>
 			</dependency>
 
 			<!-- Make sure we use a consistent commons-cli version throughout the project -->
@@ -1520,7 +1533,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<forkCount>${flink.forkCount}</forkCount>
 					<reuseForks>${flink.reuseForks}</reuseForks>


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces JUnit 5 dependencies into Flink project so that developers can write JUnit 5 style test cases. 

## Brief change log

- Add ```junit-jupiter``` dependency in root pom
- Add ```junit-vintage-engine``` and ```junit-jupiter-migrationsupport``` dependency for supporting existing JUnit 4 test cases.


## Verifying this change

This change is already covered by all existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
